### PR TITLE
EDGEAI-1048: Add NMS mode selection and end-to-end model support

### DIFF
--- a/crates/decoder/benches/decoder_benchmark.rs
+++ b/crates/decoder/benches/decoder_benchmark.rs
@@ -5,7 +5,7 @@
 
 use divan::black_box_drop;
 use edgefirst_decoder::{
-    Quantization, XYWH,
+    Nms, Quantization, XYWH,
     byte::{nms_int, postprocess_boxes_quant},
     dequant_detect_box, dequantize_cpu, dequantize_cpu_chunked, dequantize_ndarray,
     float::{nms_float, postprocess_boxes_float},
@@ -34,6 +34,7 @@ fn decoder_yolo_quant(bencher: divan::Bencher) {
             (out.view(), quant),
             score_threshold,
             iou_threshold,
+            Some(Nms::ClassAgnostic),
             &mut output_boxes,
         );
     });
@@ -117,6 +118,7 @@ fn decoder_yolo_f32(bencher: divan::Bencher) {
                 out.view(),
                 score_threshold,
                 iou_threshold,
+                Some(Nms::ClassAgnostic),
                 &mut output_boxes,
             );
             black_box_drop(output_boxes);
@@ -373,6 +375,7 @@ fn decoder_masks(bencher: divan::Bencher) {
             protos.view(),
             score_threshold,
             iou_threshold,
+            Some(Nms::ClassAgnostic),
             &mut output_boxes,
             &mut output_masks,
         );
@@ -409,6 +412,7 @@ fn decoder_masks_i8(bencher: divan::Bencher) {
             (protos.view(), quant_protos),
             score_threshold,
             iou_threshold,
+            Some(Nms::ClassAgnostic),
             &mut output_boxes,
             &mut output_masks,
         );

--- a/crates/decoder/src/byte.rs
+++ b/crates/decoder/src/byte.rs
@@ -182,7 +182,8 @@ pub fn nms_extra_int<SCORE: PrimInt + AsPrimitive<f32> + Send + Sync, E: Send + 
     boxes.into_iter().filter(|b| b.0.score > min_val).collect()
 }
 
-/// Class-aware NMS for quantized boxes: only suppress boxes with the same label.
+/// Class-aware NMS for quantized boxes: only suppress boxes with the same
+/// label.
 ///
 /// Sorts boxes by score, then greedily selects a subset of boxes in descending
 /// order of score. Unlike class-agnostic NMS, boxes are only suppressed if they
@@ -219,13 +220,17 @@ pub fn nms_class_aware_int<SCORE: PrimInt + AsPrimitive<f32> + Send + Sync>(
     boxes.into_iter().filter(|b| b.score > min_val).collect()
 }
 
-/// Class-aware NMS for quantized boxes with extra data: only suppress boxes with the same label.
+/// Class-aware NMS for quantized boxes with extra data: only suppress boxes
+/// with the same label.
 ///
-/// This is same as `nms_class_aware_int` but will also include extra information
-/// along with each box, such as the index.
+/// This is same as `nms_class_aware_int` but will also include extra
+/// information along with each box, such as the index.
 #[doc(hidden)]
 #[must_use]
-pub fn nms_extra_class_aware_int<SCORE: PrimInt + AsPrimitive<f32> + Send + Sync, E: Send + Sync>(
+pub fn nms_extra_class_aware_int<
+    SCORE: PrimInt + AsPrimitive<f32> + Send + Sync,
+    E: Send + Sync,
+>(
     iou: f32,
     mut boxes: Vec<(DetectBoxQuantized<SCORE>, E)>,
 ) -> Vec<(DetectBoxQuantized<SCORE>, E)> {

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -5342,7 +5342,8 @@ outputs:
             .with_nms(None) // User wants to handle NMS themselves
             .build()
             .unwrap();
-        // Should still be traditional YoloDet, not end-to-end
+        // nms=None with 84 features (80 classes) -> traditional YoloDet (user handles
+        // NMS)
         assert!(matches!(decoder.model_type, ModelType::YoloDet { .. }));
     }
 
@@ -5365,7 +5366,7 @@ outputs:
             .with_config_yaml_str(yaml.to_string())
             .build()
             .unwrap();
-        // Should still be traditional YoloDet, not end-to-end
+        // 6 features with (batch, N, features) layout -> end-to-end detection
         assert!(matches!(
             decoder.model_type,
             ModelType::YoloEndToEndDet { .. }
@@ -5393,7 +5394,7 @@ outputs:
             .with_config_yaml_str(yaml.to_string())
             .build()
             .unwrap();
-        // Should still be traditional YoloDet, not end-to-end
+        // 7 features with protos -> end-to-end segmentation detection
         assert!(matches!(
             decoder.model_type,
             ModelType::YoloEndToEndSegDet { .. }
@@ -5413,7 +5414,8 @@ outputs:
             .with_config_yaml_str(yaml.to_string())
             .build()
             .unwrap();
-        // Should still be traditional YoloDet, not end-to-end
+        // 6 features -> traditional YOLO detection (needs num_classes > 0 for
+        // end-to-end)
         assert!(matches!(decoder.model_type, ModelType::YoloDet { .. }));
 
         let yaml = r#"
@@ -5439,7 +5441,7 @@ outputs:
             .with_config_yaml_str(yaml.to_string())
             .build()
             .unwrap();
-        // Should still be traditional YoloDet, not end-to-end
+        // 38 features (4+2+32) with protos -> traditional YOLO segmentation detection
         assert!(matches!(decoder.model_type, ModelType::YoloSegDet { .. }));
     }
 

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -399,8 +399,10 @@ pub mod configs {
         pub dshape: Vec<(DimName, usize)>,
         /// Whether box coordinates are normalized to [0,1] range.
         /// - `Some(true)`: Coordinates in [0,1] range relative to model input
-        /// - `Some(false)`: Pixel coordinates relative to model input (letterboxed)
-        /// - `None`: Unknown, caller must infer (e.g., check if any coordinate > 1.0)
+        /// - `Some(false)`: Pixel coordinates relative to model input
+        ///   (letterboxed)
+        /// - `None`: Unknown, caller must infer (e.g., check if any coordinate
+        ///   > 1.0)
         #[serde(default)]
         pub normalized: Option<bool>,
     }
@@ -427,8 +429,10 @@ pub mod configs {
         pub dshape: Vec<(DimName, usize)>,
         /// Whether box coordinates are normalized to [0,1] range.
         /// - `Some(true)`: Coordinates in [0,1] range relative to model input
-        /// - `Some(false)`: Pixel coordinates relative to model input (letterboxed)
-        /// - `None`: Unknown, caller must infer (e.g., check if any coordinate > 1.0)
+        /// - `Some(false)`: Pixel coordinates relative to model input
+        ///   (letterboxed)
+        /// - `None`: Unknown, caller must infer (e.g., check if any coordinate
+        ///   > 1.0)
         #[serde(default)]
         pub normalized: Option<bool>,
     }
@@ -526,15 +530,16 @@ pub mod configs {
     /// NMS (Non-Maximum Suppression) mode for filtering overlapping detections.
     ///
     /// This enum is used with `Option<Nms>`:
-    /// - `Some(Nms::ClassAgnostic)` — class-agnostic NMS (default): suppress overlapping boxes
-    ///   regardless of class label
-    /// - `Some(Nms::ClassAware)` — class-aware NMS: only suppress boxes that share the same
-    ///   class label AND overlap above the IoU threshold
+    /// - `Some(Nms::ClassAgnostic)` — class-agnostic NMS (default): suppress
+    ///   overlapping boxes regardless of class label
+    /// - `Some(Nms::ClassAware)` — class-aware NMS: only suppress boxes that
+    ///   share the same class label AND overlap above the IoU threshold
     /// - `None` — bypass NMS entirely (for end-to-end models with embedded NMS)
     #[derive(Debug, PartialEq, Serialize, Deserialize, Clone, Copy, Hash, Eq, Default)]
     #[serde(rename_all = "snake_case")]
     pub enum Nms {
-        /// Suppress overlapping boxes regardless of class label (default HAL behavior)
+        /// Suppress overlapping boxes regardless of class label (default HAL
+        /// behavior)
         #[default]
         ClassAgnostic,
         /// Only suppress boxes with the same class label that overlap
@@ -580,10 +585,11 @@ pub mod configs {
             protos: Protos,
         },
         /// End-to-end YOLO detection (post-NMS output from model)
-        /// Input shape: (1, N, 6+) where columns are [x1, y1, x2, y2, conf, class, ...]
+        /// Input shape: (1, N, 6+) where columns are [x1, y1, x2, y2, conf,
+        /// class, ...]
         YoloEndToEndDet,
-        /// End-to-end YOLO detection + segmentation (post-NMS output from model)
-        /// Input shape: (1, N, 6 + num_protos) where columns are
+        /// End-to-end YOLO detection + segmentation (post-NMS output from
+        /// model) Input shape: (1, N, 6 + num_protos) where columns are
         /// [x1, y1, x2, y2, conf, class, mask_coeff_0, ..., mask_coeff_31]
         YoloEndToEndSegDet {
             protos: Protos,
@@ -614,7 +620,8 @@ pub struct DecoderBuilder {
     config_src: Option<ConfigSource>,
     iou_threshold: f32,
     score_threshold: f32,
-    /// NMS mode: Some(mode) applies NMS, None bypasses NMS (for end-to-end models)
+    /// NMS mode: Some(mode) applies NMS, None bypasses NMS (for end-to-end
+    /// models)
     nms: Option<configs::Nms>,
 }
 
@@ -1155,7 +1162,8 @@ impl DecoderBuilder {
         self
     }
 
-    /// Sets the IOU threshold of the decoder
+    /// Sets the IOU threshold of the decoder. Has no effect when NMS is set to
+    /// `None`
     ///
     /// # Examples
     /// ```rust
@@ -1177,10 +1185,10 @@ impl DecoderBuilder {
 
     /// Sets the NMS mode for the decoder.
     ///
-    /// - `Some(Nms::ClassAgnostic)` — class-agnostic NMS (default): suppress overlapping
-    ///   boxes regardless of class label
-    /// - `Some(Nms::ClassAware)` — class-aware NMS: only suppress boxes that share the
-    ///   same class label AND overlap above the IoU threshold
+    /// - `Some(Nms::ClassAgnostic)` — class-agnostic NMS (default): suppress
+    ///   overlapping boxes regardless of class label
+    /// - `Some(Nms::ClassAware)` — class-aware NMS: only suppress boxes that
+    ///   share the same class label AND overlap above the IoU threshold
     /// - `None` — bypass NMS entirely (for end-to-end models with embedded NMS)
     ///
     /// # Examples
@@ -2007,12 +2015,14 @@ pub struct Decoder {
     model_type: ModelType,
     pub iou_threshold: f32,
     pub score_threshold: f32,
-    /// NMS mode: Some(mode) applies NMS, None bypasses NMS (for end-to-end models)
+    /// NMS mode: Some(mode) applies NMS, None bypasses NMS (for end-to-end
+    /// models)
     pub nms: Option<configs::Nms>,
     /// Whether decoded boxes are in normalized [0,1] coordinates.
     /// - `Some(true)`: Coordinates in [0,1] range
     /// - `Some(false)`: Pixel coordinates
-    /// - `None`: Unknown, caller must infer (e.g., check if any coordinate > 1.0)
+    /// - `None`: Unknown, caller must infer (e.g., check if any coordinate >
+    ///   1.0)
     normalized: Option<bool>,
 }
 
@@ -2164,11 +2174,12 @@ impl Decoder {
     ///
     /// - `Some(true)`: Boxes are in normalized [0,1] coordinates
     /// - `Some(false)`: Boxes are in pixel coordinates relative to model input
-    /// - `None`: Unknown, caller must infer (e.g., check if any coordinate > 1.0)
+    /// - `None`: Unknown, caller must infer (e.g., check if any coordinate >
+    ///   1.0)
     ///
-    /// This is determined by the model config's `normalized` field, not the NMS mode.
-    /// When coordinates are in pixels or unknown, the caller may need to normalize
-    /// using the model input dimensions.
+    /// This is determined by the model config's `normalized` field, not the NMS
+    /// mode. When coordinates are in pixels or unknown, the caller may need
+    /// to normalize using the model input dimensions.
     ///
     /// # Examples
     ///
@@ -3010,9 +3021,9 @@ impl Decoder {
 
     /// Decodes end-to-end YOLO detection outputs (post-NMS from model).
     ///
-    /// Input shape: (1, N, 6+) where columns are [x1, y1, x2, y2, conf, class, ...]
-    /// Boxes are output directly from model (may be normalized or pixel coords
-    /// depending on config).
+    /// Input shape: (1, N, 6+) where columns are [x1, y1, x2, y2, conf, class,
+    /// ...] Boxes are output directly from model (may be normalized or
+    /// pixel coords depending on config).
     fn decode_yolo_end_to_end_det_float<T>(
         &self,
         outputs: &[ArrayViewD<T>],
@@ -3050,11 +3061,12 @@ impl Decoder {
         Ok(())
     }
 
-    /// Decodes end-to-end YOLO detection + segmentation outputs (post-NMS from model).
+    /// Decodes end-to-end YOLO detection + segmentation outputs (post-NMS from
+    /// model).
     ///
     /// Input shapes:
-    /// - detection: (1, N, 6 + num_protos) where columns are
-    ///   [x1, y1, x2, y2, conf, class, mask_coeff_0, ..., mask_coeff_31]
+    /// - detection: (1, N, 6 + num_protos) where columns are [x1, y1, x2, y2,
+    ///   conf, class, mask_coeff_0, ..., mask_coeff_31]
     /// - protos: (1, proto_height, proto_width, num_protos)
     fn decode_yolo_end_to_end_segdet_float<T>(
         &self,

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -3149,7 +3149,7 @@ impl Decoder {
             det_tensor,
             self.score_threshold,
             output_boxes,
-        );
+        )?;
         Ok(())
     }
 
@@ -3194,7 +3194,7 @@ impl Decoder {
             self.score_threshold,
             output_boxes,
             output_masks,
-        );
+        )?;
         Ok(())
     }
 

--- a/crates/decoder/src/float.rs
+++ b/crates/decoder/src/float.rs
@@ -174,8 +174,16 @@ pub fn nms_extra_float<E: Send + Sync>(
 /// ```
 /// # use edgefirst_decoder::{BoundingBox, DetectBox, float::nms_class_aware_float};
 /// let boxes = vec![
-///     DetectBox { bbox: BoundingBox::new(0.0, 0.0, 0.5, 0.5), score: 0.9, label: 0 },
-///     DetectBox { bbox: BoundingBox::new(0.1, 0.1, 0.6, 0.6), score: 0.8, label: 1 },  // different class
+///     DetectBox {
+///         bbox: BoundingBox::new(0.0, 0.0, 0.5, 0.5),
+///         score: 0.9,
+///         label: 0,
+///     },
+///     DetectBox {
+///         bbox: BoundingBox::new(0.1, 0.1, 0.6, 0.6),
+///         score: 0.8,
+///         label: 1,
+///     }, // different class
 /// ];
 /// // Both boxes survive because they have different labels
 /// let result = nms_class_aware_float(0.3, boxes);
@@ -208,8 +216,8 @@ pub fn nms_class_aware_float(iou: f32, mut boxes: Vec<DetectBox>) -> Vec<DetectB
 
 /// Class-aware NMS with extra data: only suppress boxes with the same label.
 ///
-/// This is same as `nms_class_aware_float` but will also include extra information
-/// along with each box, such as the index.
+/// This is same as `nms_class_aware_float` but will also include extra
+/// information along with each box, such as the index.
 #[must_use]
 pub fn nms_extra_class_aware_float<E: Send + Sync>(
     iou: f32,

--- a/crates/decoder/src/float.rs
+++ b/crates/decoder/src/float.rs
@@ -83,6 +83,9 @@ pub fn postprocess_boxes_index_float<
         .collect()
 }
 
+
+
+
 /// Uses NMS to filter boxes based on the score and iou. Sorts boxes by score,
 /// then greedily selects a subset of boxes in descending order of score.
 #[must_use]

--- a/crates/decoder/src/float.rs
+++ b/crates/decoder/src/float.rs
@@ -83,9 +83,6 @@ pub fn postprocess_boxes_index_float<
         .collect()
 }
 
-
-
-
 /// Uses NMS to filter boxes based on the score and iou. Sorts boxes by score,
 /// then greedily selects a subset of boxes in descending order of score.
 #[must_use]

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -82,6 +82,7 @@ pub use decoder::*;
 
 pub use error::{DecoderError, DecoderResult};
 pub use configs::Nms;
+pub use configs::DecoderVersion;
 
 use crate::{
     decoder::configs::QuantTuple, modelpack::modelpack_segmentation_to_mask,

--- a/crates/decoder/src/modelpack.rs
+++ b/crates/decoder/src/modelpack.rs
@@ -530,6 +530,7 @@ mod modelpack_tests {
                 (DimName::Width, 17),
                 (DimName::NumAnchorsXFeatures, 18),
             ],
+            normalized: Some(true),
         };
         let config = ModelPackDetectionConfig::try_from(&det).unwrap();
         assert_eq!(
@@ -551,6 +552,7 @@ mod modelpack_tests {
                 (DimName::Width, 17),
                 (DimName::NumAnchorsXFeatures, 18),
             ],
+            normalized: Some(true),
         };
         let result = ModelPackDetectionConfig::try_from(&det);
         assert!(

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -344,16 +344,34 @@ pub fn decode_yolo_split_segdet_float<T>(
 /// Coordinates may be normalized [0,1] or pixel values depending on model
 /// config. The caller should check `decoder.normalized_boxes()` to determine
 /// which.
+/// Decodes end-to-end YOLO detection outputs (post-NMS from model).
+///
+/// Input shape: (6, N) where rows are [x1, y1, x2, y2, conf, class]
+/// Boxes are output directly without NMS (model already applied NMS).
+///
+/// # Errors
+///
+/// Returns `DecoderError::InvalidShape` if output has fewer than 6 rows.
 pub fn decode_yolo_end_to_end_det_float<T>(
     output: ArrayView2<T>,
     score_threshold: f32,
     output_boxes: &mut Vec<DetectBox>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     T: Float + AsPrimitive<f32> + Send + Sync + 'static,
     f32: AsPrimitive<T>,
 {
-    let boxes = output.slice(s![0..4, ..]);
-    let scores = output.slice(s![4..5, ..]);
+    // Validate input shape: need at least 6 rows (x1, y1, x2, y2, conf, class)
+    if output.shape()[0] < 6 {
+        return Err(crate::DecoderError::InvalidShape(format!(
+            "End-to-end detection output requires at least 6 rows, got {}",
+            output.shape()[0]
+        )));
+    }
+
+    // Input shape: (6, N) -> transpose to (N, 4) for boxes and (N, 1) for scores
+    let boxes = output.slice(s![0..4, ..]).reversed_axes();
+    let scores = output.slice(s![4..5, ..]).reversed_axes();
     let classes = output.slice(s![5, ..]);
     let mut boxes =
         postprocess_boxes_index_float::<XYXY, _, _>(score_threshold.as_(), boxes, scores);
@@ -364,6 +382,7 @@ pub fn decode_yolo_end_to_end_det_float<T>(
         output_boxes.push(b);
     }
     // No NMS — model output is already post-NMS
+    Ok(())
 }
 
 /// Decodes end-to-end YOLO detection + segmentation outputs (post-NMS from
@@ -377,20 +396,45 @@ pub fn decode_yolo_end_to_end_det_float<T>(
 /// Boxes are output directly without NMS (model already applied NMS).
 /// Coordinates may be normalized [0,1] or pixel values depending on model
 /// config.
+///
+/// # Errors
+///
+/// Returns `DecoderError::InvalidShape` if:
+/// - output has fewer than 7 rows (6 base + at least 1 mask coefficient)
+/// - protos shape doesn't match mask coefficients count
 pub fn decode_yolo_end_to_end_segdet_float<T>(
     output: ArrayView2<T>,
     protos: ArrayView3<T>,
     score_threshold: f32,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<crate::Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     T: Float + AsPrimitive<f32> + Send + Sync + 'static,
     f32: AsPrimitive<T>,
 {
-    let boxes = output.slice(s![0..4, ..]);
-    let scores = output.slice(s![4..5, ..]);
+    // Validate input shape: need at least 7 rows (6 base + at least 1 mask coeff)
+    if output.shape()[0] < 7 {
+        return Err(crate::DecoderError::InvalidShape(format!(
+            "End-to-end segdet output requires at least 7 rows, got {}",
+            output.shape()[0]
+        )));
+    }
+
+    let num_mask_coeffs = output.shape()[0] - 6;
+    let num_protos = protos.shape()[2];
+    if num_mask_coeffs != num_protos {
+        return Err(crate::DecoderError::InvalidShape(format!(
+            "Mask coefficients count ({}) doesn't match protos count ({})",
+            num_mask_coeffs, num_protos
+        )));
+    }
+
+    // Input shape: (6+num_protos, N) -> transpose for postprocessing
+    let boxes = output.slice(s![0..4, ..]).reversed_axes();
+    let scores = output.slice(s![4..5, ..]).reversed_axes();
     let classes = output.slice(s![5, ..]);
-    let mask_coeff = output.slice(s![6.., ..]);
+    let mask_coeff = output.slice(s![6.., ..]).reversed_axes();
     let mut boxes =
         postprocess_boxes_index_float::<XYXY, _, _>(score_threshold.as_(), boxes, scores);
     boxes.truncate(output_boxes.capacity());
@@ -415,6 +459,7 @@ pub fn decode_yolo_end_to_end_segdet_float<T>(
             segmentation: m,
         });
     }
+    Ok(())
 }
 /// Internal implementation of YOLO decoding for quantized tensors.
 ///
@@ -1012,15 +1057,421 @@ where
 /// The output mask will have shape (H, W), with values 0 or 1 based on the
 /// threshold.
 ///
-/// # Panics
-/// Panics if the input segmentation does not have shape (H, W, 1).
-pub fn yolo_segmentation_to_mask(segmentation: ArrayView3<u8>, threshold: u8) -> Array2<u8> {
-    assert_eq!(
-        segmentation.shape()[2],
-        1,
-        "Yolo Instance Segmentation should have shape (H, W, 1)"
-    );
-    segmentation
+/// # Errors
+///
+/// Returns `DecoderError::InvalidShape` if the input segmentation does not
+/// have shape (H, W, 1).
+pub fn yolo_segmentation_to_mask(
+    segmentation: ArrayView3<u8>,
+    threshold: u8,
+) -> Result<Array2<u8>, crate::DecoderError> {
+    if segmentation.shape()[2] != 1 {
+        return Err(crate::DecoderError::InvalidShape(format!(
+            "Yolo Instance Segmentation should have shape (H, W, 1), got (H, W, {})",
+            segmentation.shape()[2]
+        )));
+    }
+    Ok(segmentation
         .slice(s![.., .., 0])
-        .map(|x| if *x >= threshold { 1 } else { 0 })
+        .map(|x| if *x >= threshold { 1 } else { 0 }))
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use ndarray::Array2;
+
+    // ========================================================================
+    // Tests for decode_yolo_end_to_end_det_float
+    // ========================================================================
+
+    #[test]
+    fn test_end_to_end_det_basic_filtering() {
+        // Create synthetic end-to-end detection output: (6, N) where rows are
+        // [x1, y1, x2, y2, conf, class]
+        // 3 detections: one above threshold, two below
+        let data: Vec<f32> = vec![
+            // Detection 0: high score (0.9)
+            0.1, 0.2, 0.3, // x1 values
+            0.1, 0.2, 0.3, // y1 values
+            0.5, 0.6, 0.7, // x2 values
+            0.5, 0.6, 0.7, // y2 values
+            0.9, 0.1, 0.2, // confidence scores
+            0.0, 1.0, 2.0, // class indices
+        ];
+        let output = Array2::from_shape_vec((6, 3), data).unwrap();
+
+        let mut boxes = Vec::with_capacity(10);
+        decode_yolo_end_to_end_det_float(output.view(), 0.5, &mut boxes).unwrap();
+
+        // Only 1 detection should pass threshold of 0.5
+        assert_eq!(boxes.len(), 1);
+        assert_eq!(boxes[0].label, 0);
+        assert!((boxes[0].score - 0.9).abs() < 0.01);
+        assert!((boxes[0].bbox.xmin - 0.1).abs() < 0.01);
+        assert!((boxes[0].bbox.ymin - 0.1).abs() < 0.01);
+        assert!((boxes[0].bbox.xmax - 0.5).abs() < 0.01);
+        assert!((boxes[0].bbox.ymax - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_end_to_end_det_all_pass_threshold() {
+        // All detections above threshold
+        let data: Vec<f32> = vec![
+            10.0, 20.0, // x1
+            10.0, 20.0, // y1
+            50.0, 60.0, // x2
+            50.0, 60.0, // y2
+            0.8, 0.7, // conf (both above 0.5)
+            1.0, 2.0, // class
+        ];
+        let output = Array2::from_shape_vec((6, 2), data).unwrap();
+
+        let mut boxes = Vec::with_capacity(10);
+        decode_yolo_end_to_end_det_float(output.view(), 0.5, &mut boxes).unwrap();
+
+        assert_eq!(boxes.len(), 2);
+        assert_eq!(boxes[0].label, 1);
+        assert_eq!(boxes[1].label, 2);
+    }
+
+    #[test]
+    fn test_end_to_end_det_none_pass_threshold() {
+        // All detections below threshold
+        let data: Vec<f32> = vec![
+            10.0, 20.0, // x1
+            10.0, 20.0, // y1
+            50.0, 60.0, // x2
+            50.0, 60.0, // y2
+            0.1, 0.2, // conf (both below 0.5)
+            1.0, 2.0, // class
+        ];
+        let output = Array2::from_shape_vec((6, 2), data).unwrap();
+
+        let mut boxes = Vec::with_capacity(10);
+        decode_yolo_end_to_end_det_float(output.view(), 0.5, &mut boxes).unwrap();
+
+        assert_eq!(boxes.len(), 0);
+    }
+
+    #[test]
+    fn test_end_to_end_det_capacity_limit() {
+        // Test that output is truncated to capacity
+        let data: Vec<f32> = vec![
+            0.1, 0.2, 0.3, 0.4, 0.5, // x1
+            0.1, 0.2, 0.3, 0.4, 0.5, // y1
+            0.5, 0.6, 0.7, 0.8, 0.9, // x2
+            0.5, 0.6, 0.7, 0.8, 0.9, // y2
+            0.9, 0.9, 0.9, 0.9, 0.9, // conf (all pass)
+            0.0, 1.0, 2.0, 3.0, 4.0, // class
+        ];
+        let output = Array2::from_shape_vec((6, 5), data).unwrap();
+
+        let mut boxes = Vec::with_capacity(2); // Only allow 2 boxes
+        decode_yolo_end_to_end_det_float(output.view(), 0.5, &mut boxes).unwrap();
+
+        assert_eq!(boxes.len(), 2);
+    }
+
+    #[test]
+    fn test_end_to_end_det_empty_output() {
+        // Test with zero detections
+        let output = Array2::<f32>::zeros((6, 0));
+
+        let mut boxes = Vec::with_capacity(10);
+        decode_yolo_end_to_end_det_float(output.view(), 0.5, &mut boxes).unwrap();
+
+        assert_eq!(boxes.len(), 0);
+    }
+
+    #[test]
+    fn test_end_to_end_det_pixel_coordinates() {
+        // Test with pixel coordinates (non-normalized)
+        let data: Vec<f32> = vec![
+            100.0, // x1
+            200.0, // y1
+            300.0, // x2
+            400.0, // y2
+            0.95,  // conf
+            5.0,   // class
+        ];
+        let output = Array2::from_shape_vec((6, 1), data).unwrap();
+
+        let mut boxes = Vec::with_capacity(10);
+        decode_yolo_end_to_end_det_float(output.view(), 0.5, &mut boxes).unwrap();
+
+        assert_eq!(boxes.len(), 1);
+        assert_eq!(boxes[0].label, 5);
+        assert!((boxes[0].bbox.xmin - 100.0).abs() < 0.01);
+        assert!((boxes[0].bbox.ymin - 200.0).abs() < 0.01);
+        assert!((boxes[0].bbox.xmax - 300.0).abs() < 0.01);
+        assert!((boxes[0].bbox.ymax - 400.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_end_to_end_det_invalid_shape() {
+        // Test with too few rows (needs at least 6)
+        let output = Array2::<f32>::zeros((5, 3));
+
+        let mut boxes = Vec::with_capacity(10);
+        let result = decode_yolo_end_to_end_det_float(output.view(), 0.5, &mut boxes);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(crate::DecoderError::InvalidShape(s)) if s.contains("at least 6 rows")
+        ));
+    }
+
+    // ========================================================================
+    // Tests for decode_yolo_end_to_end_segdet_float
+    // ========================================================================
+
+    #[test]
+    fn test_end_to_end_segdet_basic() {
+        // Create synthetic segdet output: (6 + num_protos, N)
+        // Detection format: [x1, y1, x2, y2, conf, class, mask_coeff_0..31]
+        let num_protos = 32;
+        let num_detections = 2;
+        let num_features = 6 + num_protos;
+
+        // Build detection tensor
+        let mut data = vec![0.0f32; num_features * num_detections];
+        // Detection 0: passes threshold
+        data[0] = 0.1; // x1[0]
+        data[1] = 0.5; // x1[1]
+        data[num_detections] = 0.1; // y1[0]
+        data[num_detections + 1] = 0.5; // y1[1]
+        data[2 * num_detections] = 0.4; // x2[0]
+        data[2 * num_detections + 1] = 0.9; // x2[1]
+        data[3 * num_detections] = 0.4; // y2[0]
+        data[3 * num_detections + 1] = 0.9; // y2[1]
+        data[4 * num_detections] = 0.9; // conf[0] - passes
+        data[4 * num_detections + 1] = 0.3; // conf[1] - fails
+        data[5 * num_detections] = 1.0; // class[0]
+        data[5 * num_detections + 1] = 2.0; // class[1]
+        // Fill mask coefficients with small values
+        for i in 6..num_features {
+            data[i * num_detections] = 0.1;
+            data[i * num_detections + 1] = 0.1;
+        }
+
+        let output = Array2::from_shape_vec((num_features, num_detections), data).unwrap();
+
+        // Create protos tensor: (proto_height, proto_width, num_protos)
+        let protos = Array3::<f32>::zeros((16, 16, num_protos));
+
+        let mut boxes = Vec::with_capacity(10);
+        let mut masks = Vec::with_capacity(10);
+        decode_yolo_end_to_end_segdet_float(
+            output.view(),
+            protos.view(),
+            0.5,
+            &mut boxes,
+            &mut masks,
+        )
+        .unwrap();
+
+        // Only detection 0 should pass
+        assert_eq!(boxes.len(), 1);
+        assert_eq!(masks.len(), 1);
+        assert_eq!(boxes[0].label, 1);
+        assert!((boxes[0].score - 0.9).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_end_to_end_segdet_mask_coordinates() {
+        // Test that mask coordinates match box coordinates
+        let num_protos = 32;
+        let num_features = 6 + num_protos;
+
+        let mut data = vec![0.0f32; num_features];
+        data[0] = 0.2; // x1
+        data[1] = 0.2; // y1
+        data[2] = 0.8; // x2
+        data[3] = 0.8; // y2
+        data[4] = 0.95; // conf
+        data[5] = 3.0; // class
+
+        let output = Array2::from_shape_vec((num_features, 1), data).unwrap();
+        let protos = Array3::<f32>::zeros((16, 16, num_protos));
+
+        let mut boxes = Vec::with_capacity(10);
+        let mut masks = Vec::with_capacity(10);
+        decode_yolo_end_to_end_segdet_float(
+            output.view(),
+            protos.view(),
+            0.5,
+            &mut boxes,
+            &mut masks,
+        )
+        .unwrap();
+
+        assert_eq!(boxes.len(), 1);
+        assert_eq!(masks.len(), 1);
+
+        // Verify mask coordinates match box coordinates
+        assert!((masks[0].xmin - boxes[0].bbox.xmin).abs() < 0.01);
+        assert!((masks[0].ymin - boxes[0].bbox.ymin).abs() < 0.01);
+        assert!((masks[0].xmax - boxes[0].bbox.xmax).abs() < 0.01);
+        assert!((masks[0].ymax - boxes[0].bbox.ymax).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_end_to_end_segdet_empty_output() {
+        let num_protos = 32;
+        let output = Array2::<f32>::zeros((6 + num_protos, 0));
+        let protos = Array3::<f32>::zeros((16, 16, num_protos));
+
+        let mut boxes = Vec::with_capacity(10);
+        let mut masks = Vec::with_capacity(10);
+        decode_yolo_end_to_end_segdet_float(
+            output.view(),
+            protos.view(),
+            0.5,
+            &mut boxes,
+            &mut masks,
+        )
+        .unwrap();
+
+        assert_eq!(boxes.len(), 0);
+        assert_eq!(masks.len(), 0);
+    }
+
+    #[test]
+    fn test_end_to_end_segdet_capacity_limit() {
+        let num_protos = 32;
+        let num_detections = 5;
+        let num_features = 6 + num_protos;
+
+        let mut data = vec![0.0f32; num_features * num_detections];
+        // All detections pass threshold
+        for i in 0..num_detections {
+            data[i] = 0.1 * (i as f32); // x1
+            data[num_detections + i] = 0.1 * (i as f32); // y1
+            data[2 * num_detections + i] = 0.1 * (i as f32) + 0.2; // x2
+            data[3 * num_detections + i] = 0.1 * (i as f32) + 0.2; // y2
+            data[4 * num_detections + i] = 0.9; // conf
+            data[5 * num_detections + i] = i as f32; // class
+        }
+
+        let output = Array2::from_shape_vec((num_features, num_detections), data).unwrap();
+        let protos = Array3::<f32>::zeros((16, 16, num_protos));
+
+        let mut boxes = Vec::with_capacity(2); // Limit to 2
+        let mut masks = Vec::with_capacity(2);
+        decode_yolo_end_to_end_segdet_float(
+            output.view(),
+            protos.view(),
+            0.5,
+            &mut boxes,
+            &mut masks,
+        )
+        .unwrap();
+
+        assert_eq!(boxes.len(), 2);
+        assert_eq!(masks.len(), 2);
+    }
+
+    #[test]
+    fn test_end_to_end_segdet_invalid_shape_too_few_rows() {
+        // Test with too few rows (needs at least 7: 6 base + 1 mask coeff)
+        let output = Array2::<f32>::zeros((6, 3));
+        let protos = Array3::<f32>::zeros((16, 16, 32));
+
+        let mut boxes = Vec::with_capacity(10);
+        let mut masks = Vec::with_capacity(10);
+        let result = decode_yolo_end_to_end_segdet_float(
+            output.view(),
+            protos.view(),
+            0.5,
+            &mut boxes,
+            &mut masks,
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(crate::DecoderError::InvalidShape(s)) if s.contains("at least 7 rows")
+        ));
+    }
+
+    #[test]
+    fn test_end_to_end_segdet_invalid_shape_protos_mismatch() {
+        // Test with mismatched mask coefficients and protos count
+        let num_protos = 32;
+        let output = Array2::<f32>::zeros((6 + 16, 3)); // 16 mask coeffs
+        let protos = Array3::<f32>::zeros((16, 16, num_protos)); // 32 protos
+
+        let mut boxes = Vec::with_capacity(10);
+        let mut masks = Vec::with_capacity(10);
+        let result = decode_yolo_end_to_end_segdet_float(
+            output.view(),
+            protos.view(),
+            0.5,
+            &mut boxes,
+            &mut masks,
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(crate::DecoderError::InvalidShape(s)) if s.contains("doesn't match protos count")
+        ));
+    }
+
+    // ========================================================================
+    // Tests for yolo_segmentation_to_mask
+    // ========================================================================
+
+    #[test]
+    fn test_segmentation_to_mask_basic() {
+        // Create a 4x4x1 segmentation with values above and below threshold
+        let data: Vec<u8> = vec![
+            100, 200, 50, 150, // row 0
+            10, 255, 128, 64, // row 1
+            0, 127, 128, 255, // row 2
+            64, 64, 192, 192, // row 3
+        ];
+        let segmentation = Array3::from_shape_vec((4, 4, 1), data).unwrap();
+
+        let mask = yolo_segmentation_to_mask(segmentation.view(), 128).unwrap();
+
+        // Values >= 128 should be 1, others 0
+        assert_eq!(mask[[0, 0]], 0); // 100 < 128
+        assert_eq!(mask[[0, 1]], 1); // 200 >= 128
+        assert_eq!(mask[[0, 2]], 0); // 50 < 128
+        assert_eq!(mask[[0, 3]], 1); // 150 >= 128
+        assert_eq!(mask[[1, 1]], 1); // 255 >= 128
+        assert_eq!(mask[[1, 2]], 1); // 128 >= 128
+        assert_eq!(mask[[2, 0]], 0); // 0 < 128
+        assert_eq!(mask[[2, 1]], 0); // 127 < 128
+    }
+
+    #[test]
+    fn test_segmentation_to_mask_all_above() {
+        let segmentation = Array3::from_elem((4, 4, 1), 255u8);
+        let mask = yolo_segmentation_to_mask(segmentation.view(), 128).unwrap();
+        assert!(mask.iter().all(|&x| x == 1));
+    }
+
+    #[test]
+    fn test_segmentation_to_mask_all_below() {
+        let segmentation = Array3::from_elem((4, 4, 1), 64u8);
+        let mask = yolo_segmentation_to_mask(segmentation.view(), 128).unwrap();
+        assert!(mask.iter().all(|&x| x == 0));
+    }
+
+    #[test]
+    fn test_segmentation_to_mask_invalid_shape() {
+        let segmentation = Array3::from_elem((4, 4, 3), 128u8);
+        let result = yolo_segmentation_to_mask(segmentation.view(), 128);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(crate::DecoderError::InvalidShape(s)) if s.contains("(H, W, 1)")
+        ));
+    }
 }

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -337,21 +337,19 @@ pub fn decode_yolo_split_segdet_float<T>(
 }
 
 /// Decodes end-to-end YOLO detection outputs (post-NMS from model).
+/// Expects an array of shape `(6, N)`, where the first dimension (rows)
+/// corresponds to the 6 per-detection features
+/// `[x1, y1, x2, y2, conf, class]` and the second dimension (columns)
+/// indexes the `N` detections.
+/// Boxes are output directly without NMS (the model already applied NMS).
 ///
-/// Input shape: (6, N),  where columns are [x1, y1, x2, y2, conf, class, ...]
-/// Boxes are output directly without NMS (model already applied NMS).
-///
-/// Coordinates may be normalized [0,1] or pixel values depending on model
-/// config. The caller should check `decoder.normalized_boxes()` to determine
-/// which.
-/// Decodes end-to-end YOLO detection outputs (post-NMS from model).
-///
-/// Input shape: (6, N) where rows are [x1, y1, x2, y2, conf, class]
-/// Boxes are output directly without NMS (model already applied NMS).
+/// Coordinates may be normalized `[0, 1]` or absolute pixel values depending
+/// on the model configuration. The caller should check
+/// `decoder.normalized_boxes()` to determine which.
 ///
 /// # Errors
 ///
-/// Returns `DecoderError::InvalidShape` if output has fewer than 6 rows.
+/// Returns `DecoderError::InvalidShape` if `output` has fewer than 6 rows.
 pub fn decode_yolo_end_to_end_det_float<T>(
     output: ArrayView2<T>,
     score_threshold: f32,

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -1,10 +1,20 @@
 import numpy as np
 import numpy.typing as npt
-from typing import Literal, Union, Tuple, List
+from typing import Literal, Optional, Union, Tuple, List
 import enum
 import sys
 
 """EdgeFirst HAL Python bindings."""
+
+
+class Nms(enum.Enum):
+    """Non-Maximum Suppression mode for object detection.
+    
+    ClassAgnostic: Suppresses all boxes based on IoU regardless of class.
+    ClassAware: Only suppresses boxes of the same class.
+    """
+    ClassAgnostic: Nms
+    ClassAware: Nms
 DetectionOutput = Tuple[
     npt.NDArray[np.float32], npt.NDArray[np.float32], npt.NDArray[np.uintp]
 ]
@@ -33,28 +43,49 @@ A tuple containing:
 
 class Decoder:
     def __init__(
-        self, config: dict, score_threshold: float = 0.1, iou_threshold: float = 0.7
+        self, config: dict, score_threshold: float = 0.1, iou_threshold: float = 0.7,
+        nms: Optional[Nms] = Nms.ClassAgnostic
     ) -> None:
         """
         Create a new Decoder instance from a dictionary configuration describing the model outputs.
+        
+        Args:
+            config: Model output configuration dictionary.
+            score_threshold: Minimum confidence score for detections.
+            iou_threshold: IoU threshold for non-maximum suppression.
+            nms: NMS mode - Nms.ClassAgnostic (default), Nms.ClassAware, or None to bypass NMS.
         """
         ...
 
     @staticmethod
     def new_from_json_str(
-        json_str: str, score_threshold: float = 0.1, iou_threshold: float = 0.7
+        json_str: str, score_threshold: float = 0.1, iou_threshold: float = 0.7,
+        nms: Optional[Nms] = Nms.ClassAgnostic
     ) -> Decoder:
         """
         Create a new Decoder instance from a JSON configuration string describing the model outputs.
+        
+        Args:
+            json_str: JSON configuration string.
+            score_threshold: Minimum confidence score for detections.
+            iou_threshold: IoU threshold for non-maximum suppression.
+            nms: NMS mode - Nms.ClassAgnostic (default), Nms.ClassAware, or None to bypass NMS.
         """
         ...
 
     @staticmethod
     def new_from_yaml_str(
-        yaml_str: str, score_threshold: float = 0.1, iou_threshold=0.7
+        yaml_str: str, score_threshold: float = 0.1, iou_threshold: float = 0.7,
+        nms: Optional[Nms] = Nms.ClassAgnostic
     ) -> Decoder:
         """
         Create a new Decoder instance from a YAML configuration string describing the model outputs.
+        
+        Args:
+            yaml_str: YAML configuration string.
+            score_threshold: Minimum confidence score for detections.
+            iou_threshold: IoU threshold for non-maximum suppression.
+            nms: NMS mode - Nms.ClassAgnostic (default), Nms.ClassAware, or None to bypass NMS.
         """
         ...
 
@@ -82,6 +113,7 @@ class Decoder:
         quant_boxes: Tuple[float, int] = (1.0, 0),
         score_threshold: float = 0.1,
         iou_threshold: float = 0.7,
+        nms: Optional[Nms] = Nms.ClassAgnostic,
         max_boxes: int = 100,
     ) -> DetectionOutput:
         """
@@ -90,6 +122,14 @@ class Decoder:
 
         The accepted types are `np.uint8`, `np.int8`, `np.float32` and `np.float64`. All outputs must be
         the same type.
+        
+        Args:
+            model_output: YOLO model output tensor.
+            quant_boxes: Quantization parameters (scale, zero_point) for boxes.
+            score_threshold: Minimum confidence score for detections.
+            iou_threshold: IoU threshold for non-maximum suppression.
+            nms: NMS mode - Nms.ClassAgnostic (default), Nms.ClassAware, or None to bypass NMS.
+            max_boxes: Maximum number of boxes to return.
         """
         ...
 
@@ -105,6 +145,7 @@ class Decoder:
         quant_protos: Tuple[float, int] = (1.0, 0),
         score_threshold: float = 0.1,
         iou_threshold: float = 0.7,
+        nms: Optional[Nms] = Nms.ClassAgnostic,
         max_boxes: int = 100,
     ) -> SegDetOutput:
         """
@@ -113,6 +154,16 @@ class Decoder:
 
         The accepted types are `np.uint8`, `np.int8`, `np.float32` and `np.float64`. All outputs must be
         the same type.
+        
+        Args:
+            boxes: YOLO box output tensor.
+            protos: YOLO proto output tensor.
+            quant_boxes: Quantization parameters (scale, zero_point) for boxes.
+            quant_protos: Quantization parameters (scale, zero_point) for protos.
+            score_threshold: Minimum confidence score for detections.
+            iou_threshold: IoU threshold for non-maximum suppression.
+            nms: NMS mode - Nms.ClassAgnostic (default), Nms.ClassAware, or None to bypass NMS.
+            max_boxes: Maximum number of boxes to return.
         """
         ...
 
@@ -210,6 +261,22 @@ class Decoder:
 
     @iou_threshold.setter
     def iou_threshold(self, value: float): ...
+
+    @property
+    def nms(self) -> Optional[Nms]:
+        """
+        NMS mode used when decoding detections with the `decode` method.
+        Returns Nms.ClassAgnostic, Nms.ClassAware, or None if NMS is bypassed.
+        """
+        ...
+
+    @property
+    def normalized_boxes(self) -> Optional[bool]:
+        """
+        Whether decoded bounding boxes are normalized to [0, 1] range.
+        Returns True if normalized, False if pixel coordinates, or None if unknown.
+        """
+        ...
 
 
 class TensorMemory(enum.Enum):

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -180,8 +180,13 @@ class Decoder:
         ...
 
     @staticmethod
-    def segmentation_to_mask(segmentation: npt.NDArray[np.uint8]) -> None:
-        """Converts a 3D segmentation tensor into a 2D mask."""
+    def segmentation_to_mask(segmentation: npt.NDArray[np.uint8]) -> npt.NDArray[np.uint8]:
+        """
+        Converts a 3D segmentation tensor into a 2D mask.
+        
+        Raises:
+            ValueError: If the segmentation tensor has an invalid shape.
+        """
         ...
 
     @property

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -9,10 +9,13 @@ use edgefirst::decoder::{
 
 /// NMS (Non-Maximum Suppression) mode for filtering overlapping detections.
 ///
-/// - `ClassAgnostic` — suppress overlapping boxes regardless of class label (default)
-/// - `ClassAware` — only suppress boxes that share the same class label AND overlap
+/// - `ClassAgnostic` — suppress overlapping boxes regardless of class label
+///   (default)
+/// - `ClassAware` — only suppress boxes that share the same class label AND
+///   overlap
 ///
-/// Pass `None` to bypass NMS entirely (for end-to-end models with embedded NMS).
+/// Pass `None` to bypass NMS entirely (for end-to-end models with embedded
+/// NMS).
 #[pyo3::pyclass(name = "Nms", eq, eq_int)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PyNms {
@@ -210,9 +213,10 @@ impl PyDecoder {
     ///
     /// Args:
     ///     config: Model output configuration dictionary
-    ///     score_threshold: Score threshold for filtering detections (default: 0.1)
-    ///     iou_threshold: IoU threshold for NMS (default: 0.7)
-    ///     nms: NMS mode - Nms.ClassAgnostic (default), Nms.ClassAware, or None to bypass NMS
+    ///     score_threshold: Score threshold for filtering detections (default:
+    /// 0.1)     iou_threshold: IoU threshold for NMS (default: 0.7)
+    ///     nms: NMS mode - Nms.ClassAgnostic (default), Nms.ClassAware, or None
+    /// to bypass NMS
     #[new]
     #[pyo3(signature = (config, score_threshold=0.1, iou_threshold=0.7, nms=PyNms::ClassAgnostic))]
     pub fn new(
@@ -759,9 +763,11 @@ impl PyDecoder {
     ///
     /// - `True`: Boxes are in normalized [0,1] coordinates
     /// - `False`: Boxes are in pixel coordinates relative to model input
-    /// - `None`: Unknown, caller must infer (e.g., check if any coordinate > 1.0)
+    /// - `None`: Unknown, caller must infer (e.g., check if any coordinate >
+    ///   1.0)
     ///
-    /// This is determined by the model config's `normalized` field, not the NMS mode.
+    /// This is determined by the model config's `normalized` field, not the NMS
+    /// mode.
     #[getter(normalized_boxes)]
     fn get_normalized_boxes(&self) -> Option<bool> {
         self.decoder.normalized_boxes()

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -726,8 +726,10 @@ impl PyDecoder {
     #[pyo3(signature = (segmentation))]
     pub fn segmentation_to_mask<'py>(
         segmentation: PyReadonlyArray3<'py, u8>,
-    ) -> Bound<'py, PyArray2<u8>> {
-        segmentation_to_mask(segmentation.as_array()).to_pyarray(segmentation.py())
+    ) -> PyResult<Bound<'py, PyArray2<u8>>> {
+        let result = segmentation_to_mask(segmentation.as_array())
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(result.to_pyarray(segmentation.py()))
     }
 
     #[getter(score_threshold)]

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -50,6 +50,7 @@ pub mod edgefirst_hal {
         m.add_class::<image::PyTensorImage>()?;
         m.add_class::<image::PyTensorMemory>()?;
         m.add_class::<decoder::PyDecoder>()?;
+        m.add_class::<decoder::PyNms>()?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Add `Nms` enum with `ClassAgnostic` and `ClassAware` variants for NMS mode selection
- Add `Option<Nms>` support to bypass NMS entirely (for end-to-end models with embedded NMS)
- Add class-aware NMS functions that only suppress boxes with the same class label
- Add end-to-end YOLO detection and segmentation decoding (`YoloEndToEndDet`, `YoloEndToEndSegDet`)
- Add `normalized_boxes` property to indicate if boxes are in [0,1] or pixel coordinates
- Expose `PyNms` enum and `nms` parameter in Python bindings
- Add `iou >= 1.0` early-return optimization to all quantized NMS functions
- Add `#[must_use]` annotations to NMS functions
- Add division-by-zero guard in segmentation mask generation

## Test plan

- [x] All existing tests pass (48 tests)
- [x] New tests for class-aware NMS behavior
- [x] New tests for NMS mode configuration
- [x] New tests for `normalized_boxes` accessor
- [ ] Integration testing with end-to-end YOLO models