### PR TITLE
EDGEAI-1088: PBO tensor backend, surfaceless EGL, and create_image() factory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@ testdata/*.png filter=lfs diff=lfs merge=lfs -text
 testdata/*.rgb filter=lfs diff=lfs merge=lfs -text
 testdata/*.rgba filter=lfs diff=lfs merge=lfs -text
 testdata/*.yuyv filter=lfs diff=lfs merge=lfs -text
+testdata/*.vyuy filter=lfs diff=lfs merge=lfs -text
 testdata/*.nv12 filter=lfs diff=lfs merge=lfs -text
 testdata/*.nv16 filter=lfs diff=lfs merge=lfs -text
 testdata/*.nv21 filter=lfs diff=lfs merge=lfs -text

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EdgeFirst Hardware Abstraction Layer - Architecture
 
-**Version:** 2.2
-**Last Updated:** February 25, 2026
+**Version:** 2.3
+**Last Updated:** February 27, 2026
 **Status:** Production
 **Audience:** Developers contributing to EdgeFirst HAL or integrating it into applications
 
@@ -73,15 +73,21 @@ classDiagram
     class MemTensor~T~ {
         Standard heap allocation
     }
-    
+
+    class PboTensor~T~ {
+        OpenGL Pixel Buffer Object
+    }
+
     TensorTrait <|.. DmaTensor
     TensorTrait <|.. ShmTensor
     TensorTrait <|.. MemTensor
+    TensorTrait <|.. PboTensor
 ```
 
 **Key Features**:
 - Generic over numeric types (u8, i8, u16, i16, u32, i32, u64, i64, f32, f64)
 - Automatic memory type selection with fallback chain: DMA → Shared Memory → Heap
+- PBO (Pixel Buffer Object) tensors for GPU-accelerated image processing
 - Memory mapping with `TensorMap<T>` for safe access
 - File descriptor sharing for zero-copy IPC
 - Cross-platform support (Linux optimized, macOS/Windows via heap memory)
@@ -105,6 +111,23 @@ flowchart TD
     style UseShm fill:#87ceeb
     style UseMem fill:#ffeb9c
 ```
+
+**PBO Tensor Memory (`PboTensor<T>`)**:
+
+PBO tensors are a GPU-native memory type created by the OpenGL backend when
+`ImageProcessor::create_image()` is called and DMA-buf is not available. Unlike
+the other tensor types, PBO tensors are not allocated by the tensor crate
+directly — they are OpenGL Pixel Buffer Objects managed by the GL thread. The
+tensor crate provides the `PboTensor` wrapper and the `PboOps` trait that the
+GL backend implements to perform map/unmap/delete operations.
+
+PBO tensors use a `WeakSender` to communicate with the GL thread. This is a
+critical design choice: if `PboTensor` held a strong `Sender`, any surviving
+PBO tensor would keep the GL thread's message channel alive, preventing
+`GLProcessorThreaded::drop()` from joining the GL thread at shutdown. The
+`WeakSender` pattern allows the GL thread to exit cleanly when the
+`ImageProcessor` is dropped, even if PBO tensors still exist — subsequent
+PBO operations on orphaned tensors return `PboDisconnected`.
 
 ### 2. Image HAL (`edgefirst_image`)
 
@@ -176,6 +199,61 @@ flowchart TD
     style GL fill:#87ceeb
     style CPU fill:#ffeb9c
     style Output fill:#e8f5e9
+```
+
+**GPU-Optimal Image Creation (`ImageProcessor::create_image()`)**:
+
+`create_image()` is the preferred way to allocate images for use with
+`ImageProcessor::convert()`. It probes the GPU at initialization time and
+selects the best available memory backend in priority order:
+
+```mermaid
+flowchart TD
+    Create["ImageProcessor::create_image(w, h, fourcc)"]
+    DMA{DMA-buf roundtrip<br/>verified at init?}
+    PBO{OpenGL PBO<br/>available?}
+    Mem[MemTensor<br/>heap fallback]
+
+    Create --> DMA
+    DMA -->|Yes| UseDMA["DmaTensor<br/>Zero-copy EGLImage import"]
+    DMA -->|No| PBO
+    PBO -->|Yes| UsePBO["PboTensor<br/>Zero-copy GL buffer binding"]
+    PBO -->|No| Mem
+
+    style UseDMA fill:#90ee90
+    style UsePBO fill:#87ceeb
+    style Mem fill:#ffeb9c
+```
+
+| Backend | When selected | GPU transfer method | Platforms |
+|---------|---------------|---------------------|-----------|
+| DMA-buf | GPU supports EGLImage import from DMA-buf FDs | Zero-copy: `EGL_EXT_image_dma_buf_import` — the GPU reads/writes the DMA buffer directly via EGLImage, no pixel copies | NXP i.MX 8M Plus (Vivante), NXP i.MX 95 (Mali/Panfrost) |
+| PBO | OpenGL ES 3.0 available but DMA-buf roundtrip fails | Zero-copy GL binding: `GL_PIXEL_UNPACK_BUFFER` for upload, `GL_PIXEL_PACK_BUFFER` for readback — data stays in GPU-accessible memory | NVIDIA desktop GPUs, systems without DMA-buf permissions |
+| Mem | No GPU or OpenGL not available | CPU `memcpy` via `glTexImage2D`/`glReadnPixels` with mapped host pointers | All platforms (fallback) |
+
+**Why PBO matters**: On desktop Linux with NVIDIA GPUs, DMA-buf allocation
+succeeds (via `/dev/dma_heap/system`) but the NVIDIA EGL driver cannot import
+those buffers — the `verify_dma_buf_roundtrip()` check catches this at
+initialization. Without PBO, every `convert()` call would fall back to CPU
+`memcpy` for upload and readback. PBO keeps the data in GPU-accessible buffers,
+enabling the same zero-copy shader pipeline used on DMA platforms.
+
+**PBO Convert Dispatch**:
+
+When `convert()` is called with PBO-backed images, the GL thread must not call
+`tensor.map()` on those images — doing so would send a message back to itself
+and deadlock. Instead, the convert path dispatches to specialized methods:
+
+```
+┌─────────────────────────────┬──────────────────────────────────────────┐
+│ Source → Destination        │ Method                                    │
+├─────────────────────────────┼──────────────────────────────────────────┤
+│ DMA → DMA                   │ convert_dest_dma (EGLImage both sides)   │
+│ PBO → PBO                   │ convert_pbo_to_pbo (UNPACK + PACK)       │
+│ Mem/DMA → PBO               │ convert_any_to_pbo (texture + PACK)      │
+│ PBO → Mem                   │ convert_pbo_to_mem (UNPACK + ReadnPixels) │
+│ Mem/DMA → Mem/DMA           │ convert_dest_non_dma (texture + memcpy)  │
+└─────────────────────────────┴──────────────────────────────────────────┘
 ```
 
 ### 3. Decoder HAL (`edgefirst_decoder`)
@@ -338,19 +416,18 @@ flowchart LR
 ### Pattern 1: Basic Image Conversion
 
 ```rust
-use edgefirst_hal::image::{TensorImage, ImageProcessor, RGBA, RGB};
-use edgefirst_hal::tensor::TensorMemory;
+use edgefirst_hal::image::{TensorImage, ImageProcessor, RGB};
 
 // Load image from JPEG
 let input = TensorImage::load("testdata/zidane.jpg", Some(RGB), None)?;
 
-// Create converter (auto-selects G2D or CPU)
+// Create converter (auto-selects best backend: G2D, OpenGL, CPU)
 let mut converter = ImageProcessor::new()?;
 
-// Create output buffer
-let mut output = TensorImage::new(640, 640, RGB, Some(TensorMemory::Dma))?;
+// Create output buffer with optimal GPU memory (DMA > PBO > Mem)
+let mut output = converter.create_image(640, 640, RGB)?;
 
-// Convert and resize
+// Convert and resize — zero-copy if DMA or PBO backend is active
 converter.convert(&input, &mut output, Default::default())?;
 ```
 
@@ -428,8 +505,8 @@ tensor_img = ef.TensorImage.load("testdata/zidane.jpg", ef.FourCC.RGB)
 # Create converter
 converter = ef.ImageProcessor()
 
-# Create output image
-output = ef.TensorImage(640, 640)
+# Create output image with optimal GPU memory (DMA > PBO > Mem)
+output = converter.create_image(640, 640, ef.FourCC.RGB)
 
 # Resize with hardware acceleration
 converter.convert(tensor_img, output)
@@ -705,6 +782,7 @@ Consistent error handling throughout:
 | Feature | Linux (i.MX) | Linux (Generic) | macOS | Windows |
 |---------|--------------|-----------------|-------|---------|
 | DMA Tensors | ✅ | ✅ | ❌ | ❌ |
+| PBO Tensors (GPU) | ✅ | ✅ | ❌ | ❌ |
 | Shared Memory Tensors | ✅ | ✅ | ✅ | ✅ |
 | Heap Tensors | ✅ | ✅ | ✅ | ✅ |
 | G2D Acceleration | ✅ | ❌ | ❌ | ❌ |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -611,8 +611,10 @@ All GPU and DMA resources must be properly released. Specifically:
 - **EGL displays**: `eglTerminate` must be called in `GlContext::drop`. The
   EGL spec ref-counts display connections, so each `eglTerminate` decrements
   the count and only tears down state when it reaches zero.
-- **EGL contexts and surfaces**: `eglDestroyContext` and `eglDestroySurface`
-  must be called before `eglTerminate`.
+- **EGL contexts**: `eglDestroyContext` must be called before `eglTerminate`.
+  No EGL surfaces are created — the HAL uses surfaceless contexts
+  (`EGL_KHR_surfaceless_context` + `EGL_KHR_no_config_context`) and renders
+  exclusively through FBOs backed by EGLImages imported from DMA-buf.
 - **DMA buffers**: Closed via file descriptor `close()` in `Drop`.
 - **G2D contexts**: `g2d_close` via `G2DProcessor::drop`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **PBO (Pixel Buffer Object) tensor backend** (`edgefirst-tensor`):
+  `PboTensor<T>` provides GPU-native buffer storage for platforms where DMA-buf
+  is unavailable (e.g. NVIDIA desktop GPUs). PBO tensors are managed by the
+  OpenGL thread via a `WeakSender` channel that allows clean shutdown without
+  blocking on orphaned tensors.
+
+- **`ImageProcessor::create_image()`** factory method that probes GPU
+  capabilities at initialization and selects the optimal memory backend:
+  DMA-buf > PBO > heap memory. This is now the preferred way to allocate
+  images for use with `convert()`. Available in Rust, Python
+  (`ImageProcessor.create_image()`), and C
+  (`hal_image_processor_create_image()`).
+
+- **PBO convert paths** for all source/destination combinations:
+  `convert_pbo_to_pbo()` (both PBO), `convert_any_to_pbo()` (Mem/DMA source
+  to PBO destination), and `convert_pbo_to_mem()` (PBO source to Mem
+  destination). All paths use direct GL buffer bindings
+  (`GL_PIXEL_UNPACK_BUFFER` / `GL_PIXEL_PACK_BUFFER`) to avoid the deadlock
+  that would occur if the GL thread called `tensor.map()` on a PBO tensor.
+
+- **`hal_image_processor_create_image()`** C API function with documentation,
+  null-safety checks, and errno-based error reporting
+
+- **Python `ImageProcessor.create_image()`** method with format parameter
+  defaulting to RGBA
+
+- Python tests: `test_create_image`, `test_create_image_formats`,
+  `test_create_image_convert`, `test_create_image_roundtrip`
+
+- C API tests: `test_image_processor_create_image`,
+  `test_image_processor_create_image_null_params`,
+  `test_image_processor_create_image_convert`
+
+- Rust integration test: `test_convert_pbo_to_pbo` exercising PBO-to-PBO
+  conversion with SSIM comparison against CPU reference
+
+### Fixed
+
+- **GL thread shutdown hang**: `GlPboOps` used a strong `Sender` clone that
+  kept the GL thread's message channel alive after `GLProcessorThreaded` was
+  dropped, causing `handle.join()` to block indefinitely. Changed to
+  `WeakSender` so the channel closes when the last `ImageProcessor` reference
+  is dropped.
+
+- **PBO-to-PBO deadlock**: `convert_pbo_to_pbo()` called `draw_src_texture()`
+  which invoked `tensor.map()` on the GL thread, sending a message back to
+  itself. Added `draw_src_texture_from_pbo()` that binds the source PBO as
+  `GL_PIXEL_UNPACK_BUFFER` with a NULL `glTexImage2D` pointer for zero-copy
+  upload.
+
+- **Mixed PBO/Mem deadlock**: `convert_dest_non_dma()` called
+  `dst.tensor().map()` on the GL thread for PBO destinations. Added dedicated
+  `convert_any_to_pbo()` and `convert_pbo_to_mem()` methods that use GL buffer
+  bindings instead of tensor mapping.
+
+### Changed
+
+- ARCHITECTURE.md updated to v2.3: documents PBO tensor architecture,
+  `create_image()` backend selection, PBO convert dispatch table, and
+  `WeakSender` shutdown design
+
+- README.md updated: `create_image()` presented as preferred image allocation
+  method with usage guidance for Rust, Python, and C; DMA-buf permission
+  requirements; platform GPU support table
+
 ## [0.8.0] - 2026-02-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-gbm"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0b69de3318098ed618db4873804c38fdacf664e708cb7ab8ab0e163c9afaeb"
+checksum = "4dd6165adfc3801870e0671ba026f050030383604afc0c84e3ba25a094584857"
 dependencies = [
  "bitflags",
  "drm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ fast_image_resize = { version = "5.2.0", features = ["image", "rayon"] }
 four-char-code = "2.3.0"
 g2d-sys = "1.2.0"
 
-gbm = { package = "edgefirst-gbm", version = "0.18.1", default-features = false, features = ["dynamic", "drm-support"] }
+gbm = { package = "edgefirst-gbm", version = "0.18.2", default-features = false, features = ["dynamic", "drm-support"] }
 gls = "0.1.6"
 half = "2.7.1"
 image = { version = "0.25.6", default-features = false, features = ["png"] }

--- a/NOTICE
+++ b/NOTICE
@@ -55,7 +55,7 @@ that require attribution:
   * dtor-proc-macro 0.0.5 (Apache-2.0, MIT)
   * edgefirst-bench 0.8.0 (Apache-2.0)
   * edgefirst-decoder 0.8.0 (Apache-2.0)
-  * edgefirst-gbm 0.18.1 (MIT)
+  * edgefirst-gbm 0.18.2 (MIT)
   * edgefirst-gbm-sys 0.4.1 (MIT)
   * edgefirst-hal 0.8.0 (Apache-2.0)
   * edgefirst-hal-capi 0.8.0 (Apache-2.0)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import edgefirst_hal as ef
 # Load and process image
 img = ef.TensorImage.load("image.jpg", ef.FourCC.RGB)
 converter = ef.ImageProcessor()
-output = ef.TensorImage(640, 640)
+output = converter.create_image(640, 640, ef.FourCC.RGB)
 converter.convert(img, output)
 
 # Decode YOLO outputs
@@ -53,18 +53,22 @@ boxes, scores, classes = decoder.decode([output0, output1])
 
 #### Rust
 ```rust
-use edgefirst_hal::image::{TensorImage, ImageProcessor};
-use edgefirst_hal::decoder::Decoder;
+use edgefirst_hal::image::{TensorImage, ImageProcessor, RGB};
 
 // Load and process image
 let input = TensorImage::load("image.jpg", Some(RGB), None)?;
 let mut converter = ImageProcessor::new()?;
-let mut output = TensorImage::new(640, 640, RGB, None)?;
+let mut output = converter.create_image(640, 640, RGB)?;
 converter.convert(&input, &mut output, Default::default())?;
+```
 
-// Decode model outputs
-let decoder = Decoder::new(config, 0.5, 0.45)?;
-let (boxes, scores, classes) = decoder.decode_detection(&outputs)?;
+#### C
+```c
+#include <edgefirst/hal.h>
+
+struct hal_image_processor *proc = hal_image_processor_new();
+struct hal_tensor_image *dst = hal_image_processor_create_image(proc, 640, 640, HAL_FOURCC_RGB);
+hal_image_processor_convert(proc, src, dst, HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
 ```
 
 ## System Architecture
@@ -378,6 +382,100 @@ flowchart LR
 - IOCTL interface for DMA buffer operations
 - Version detection and capability queries
 
+## Creating GPU-Optimal Images
+
+`ImageProcessor::create_image()` is the **preferred way** to allocate images
+for use with `convert()`. It automatically selects the fastest available memory
+backend for the current GPU:
+
+| Priority | Backend | Transfer Method | Platforms |
+|----------|---------|-----------------|-----------|
+| 1st | **DMA-buf** | Zero-copy EGLImage import | NXP i.MX 8M Plus, i.MX 95 |
+| 2nd | **PBO** (Pixel Buffer Object) | Zero-copy GL buffer binding | NVIDIA desktop GPUs |
+| 3rd | **Mem** (heap) | CPU memcpy fallback | All platforms |
+
+The backend is selected once at `ImageProcessor::new()` time based on a
+runtime GPU capability probe. All subsequent `create_image()` calls use the
+same backend.
+
+**Best practice**: Create your output images once and reuse them across your
+pipeline loop. Creating images is relatively expensive (GPU buffer allocation,
+format negotiation); reusing them amortizes that cost over thousands of frames.
+
+### Rust
+```rust
+let mut converter = ImageProcessor::new()?;
+
+// Create reusable output buffer — allocated once
+let mut output = converter.create_image(640, 640, RGB)?;
+
+for frame in camera_frames {
+    // Reuse output buffer each iteration — no allocation
+    converter.convert(&frame, &mut output, Default::default())?;
+    run_inference(&output)?;
+}
+```
+
+### Python
+```python
+converter = ef.ImageProcessor()
+
+# Create reusable output buffer — allocated once
+output = converter.create_image(640, 640, ef.FourCC.RGB)
+
+for frame in camera_frames:
+    # Reuse output buffer each iteration — no allocation
+    converter.convert(frame, output)
+    run_inference(output)
+```
+
+### C
+```c
+struct hal_image_processor *proc = hal_image_processor_new();
+
+/* Create reusable output buffer — allocated once */
+struct hal_tensor_image *output = hal_image_processor_create_image(
+    proc, 640, 640, HAL_FOURCC_RGB);
+
+for (;;) {
+    /* Reuse output buffer each iteration — no allocation */
+    hal_image_processor_convert(proc, frame, output,
+        HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
+    run_inference(output);
+}
+
+hal_tensor_image_free(output);
+hal_image_processor_free(proc);
+```
+
+### DMA-buf Permissions
+
+For the DMA-buf backend to be selected, the process needs access to
+`/dev/dma_heap/linux,cma` (or `/dev/dma_heap/system` on some kernels) and a
+DRM render node (`/dev/dri/renderD128`). On embedded Linux systems, this
+typically requires one of:
+
+- Running as root
+- Adding the user to the `video` and `render` groups:
+  ```bash
+  sudo usermod -aG video,render $USER
+  ```
+- Setting appropriate udev rules for the DMA heap and DRI devices
+
+If DMA-buf allocation fails (insufficient permissions, no CMA region, or the
+GPU driver cannot import the resulting buffers), `create_image()` transparently
+falls back to PBO or heap memory with no API change required.
+
+### Platform GPU Support
+
+| Platform | GPU | `create_image()` backend | Notes |
+|----------|-----|--------------------------|-------|
+| NXP i.MX 8M Plus | Vivante GC7000UL | DMA-buf | Full zero-copy via EGLImage + G2D |
+| NXP i.MX 95 | Mali G310 (Panfrost) | DMA-buf | Full zero-copy via EGLImage |
+| NVIDIA Desktop | GeForce (proprietary) | PBO | DMA-buf alloc works but EGL import fails; PBO provides GPU-native buffers |
+| Generic x86_64 | Mesa (llvmpipe/iris) | DMA-buf or PBO | Depends on driver DMA-buf support |
+| No GPU / macOS | N/A | Mem | CPU fallback, still functional |
+
 ## Advanced Examples
 
 <details>
@@ -386,17 +484,16 @@ flowchart LR
 ### Image Conversion
 
 ```rust
-use edgefirst_hal::image::{TensorImage, ImageProcessor, RGBA, RGB};
-use edgefirst_hal::tensor::TensorMemory;
+use edgefirst_hal::image::{TensorImage, ImageProcessor, RGB};
 
 // Load image from JPEG
 let input = TensorImage::load("testdata/zidane.jpg", Some(RGB), None)?;
 
-// Create converter (auto-selects G2D or CPU)
+// Create converter (auto-selects best backend: G2D, OpenGL, CPU)
 let mut converter = ImageProcessor::new()?;
 
-// Create output buffer
-let mut output = TensorImage::new(640, 640, RGB, Some(TensorMemory::Dma))?;
+// Create output buffer with optimal GPU memory (DMA > PBO > Mem)
+let mut output = converter.create_image(640, 640, RGB)?;
 
 // Convert and resize
 converter.convert(&input, &mut output, Default::default())?;
@@ -469,8 +566,8 @@ tensor_img = ef.TensorImage.load("testdata/zidane.jpg", ef.FourCC.RGB)
 # Create converter
 converter = ef.ImageProcessor()
 
-# Create output image
-output = ef.TensorImage(640, 640)
+# Create output image with optimal GPU memory (DMA > PBO > Mem)
+output = converter.create_image(640, 640, ef.FourCC.RGB)
 
 # Resize with hardware acceleration
 converter.convert(tensor_img, output)
@@ -574,6 +671,7 @@ Consistent error handling throughout:
 | Feature | Linux (i.MX) | Linux (Generic) | macOS | Windows |
 |---------|--------------|-----------------|-------|---------|
 | DMA Tensors | ✅ | ✅ | ❌ | ❌ |
+| PBO Tensors (GPU) | ✅ | ✅ | ❌ | ❌ |
 | Shared Memory Tensors | ✅ | ✅ | ✅ | ✅ |
 | Heap Tensors | ✅ | ✅ | ✅ | ✅ |
 | G2D Acceleration | ✅ | ❌ | ❌ | ❌ |

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -1416,6 +1416,27 @@ int hal_image_processor_set_class_colors(struct hal_image_processor *processor,
                                          size_t num_colors);
 
 /**
+ * Create a new tensor image using the processor's optimal memory backend.
+ *
+ * Selects the best available backing storage based on hardware capabilities:
+ * DMA-buf > PBO (GPU buffer) > system memory. Images created this way benefit
+ * from zero-copy GPU paths when used with the same processor's convert().
+ *
+ * @param processor Image processor handle
+ * @param width Image width in pixels
+ * @param height Image height in pixels
+ * @param fourcc Pixel format (HAL_FOURCC_*)
+ * @return New tensor image handle on success, NULL on error
+ * @par Errors (errno):
+ * - EINVAL: Invalid argument (NULL processor, zero dimensions)
+ * - ENOMEM: Memory allocation failed
+ */
+struct hal_tensor_image *hal_image_processor_create_image(struct hal_image_processor *processor,
+                                                          size_t width,
+                                                          size_t height,
+                                                          enum hal_fourcc fourcc);
+
+/**
  * Free an image processor.
  *
  * @param processor Image processor handle to free (can be NULL, no-op)

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -276,6 +276,10 @@ typedef enum hal_tensor_memory {
    * POSIX Shared Memory allocation (Linux only, for IPC)
    */
   HAL_TENSOR_MEMORY_SHM = 2,
+  /**
+   * GPU Pixel Buffer Object allocation (zero-copy GPU upload/readback)
+   */
+  HAL_TENSOR_MEMORY_PBO = 3,
 } hal_tensor_memory;
 
 /**

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -936,6 +936,40 @@ pub unsafe extern "C" fn hal_image_processor_set_class_colors(
     0
 }
 
+/// Create a new tensor image using the processor's optimal memory backend.
+///
+/// Selects the best available backing storage based on hardware capabilities:
+/// DMA-buf > PBO (GPU buffer) > system memory. Images created this way benefit
+/// from zero-copy GPU paths when used with the same processor's convert().
+///
+/// @param processor Image processor handle
+/// @param width Image width in pixels
+/// @param height Image height in pixels
+/// @param fourcc Pixel format (HAL_FOURCC_*)
+/// @return New tensor image handle on success, NULL on error
+/// @par Errors (errno):
+/// - EINVAL: Invalid argument (NULL processor, zero dimensions)
+/// - ENOMEM: Memory allocation failed
+#[no_mangle]
+pub unsafe extern "C" fn hal_image_processor_create_image(
+    processor: *mut HalImageProcessor,
+    width: size_t,
+    height: size_t,
+    fourcc: HalFourcc,
+) -> *mut HalTensorImage {
+    if processor.is_null() || width == 0 || height == 0 {
+        return set_error_null(libc::EINVAL);
+    }
+
+    let image = try_or_null!(
+        unsafe { &(*processor) }
+            .inner
+            .create_image(width, height, fourcc.to_fourcc()),
+        libc::ENOMEM
+    );
+    Box::into_raw(Box::new(HalTensorImage { inner: image }))
+}
+
 /// Free an image processor.
 ///
 /// @param processor Image processor handle to free (can be NULL, no-op)
@@ -1628,6 +1662,109 @@ mod tests {
             let fourcc = format.to_fourcc();
             let back = HalFourcc::from_fourcc(fourcc);
             assert_eq!(back, Some(format), "Roundtrip failed for {:?}", format);
+        }
+    }
+
+    #[test]
+    fn test_image_processor_create_image_null_params() {
+        unsafe {
+            // NULL processor
+            let img =
+                hal_image_processor_create_image(std::ptr::null_mut(), 640, 480, HalFourcc::Rgba);
+            assert!(img.is_null());
+
+            // Zero width
+            let processor = hal_image_processor_new();
+            if processor.is_null() {
+                return;
+            }
+            let img = hal_image_processor_create_image(processor, 0, 480, HalFourcc::Rgba);
+            assert!(img.is_null());
+
+            // Zero height
+            let img = hal_image_processor_create_image(processor, 640, 0, HalFourcc::Rgba);
+            assert!(img.is_null());
+
+            hal_image_processor_free(processor);
+        }
+    }
+
+    #[test]
+    fn test_image_processor_create_image() {
+        use crate::tensor::{hal_tensor_map_data_const, hal_tensor_map_size, hal_tensor_map_unmap};
+
+        unsafe {
+            let processor = hal_image_processor_new();
+            if processor.is_null() {
+                eprintln!("SKIPPED: test_image_processor_create_image — no processor available");
+                return;
+            }
+
+            let formats = [
+                (HalFourcc::Rgb, 3),
+                (HalFourcc::Rgba, 4),
+                (HalFourcc::Grey, 1),
+            ];
+
+            for (fourcc, channels) in formats {
+                let img = hal_image_processor_create_image(processor, 320, 240, fourcc);
+                assert!(
+                    !img.is_null(),
+                    "create_image failed for {:?}",
+                    fourcc
+                );
+
+                assert_eq!(hal_tensor_image_width(img), 320);
+                assert_eq!(hal_tensor_image_height(img), 240);
+                assert_eq!(hal_tensor_image_fourcc(img), fourcc);
+
+                // Verify the image is mappable
+                let map = hal_tensor_image_map_create(img);
+                assert!(!map.is_null(), "map failed for {:?}", fourcc);
+                assert_eq!(hal_tensor_map_size(map), 320 * 240 * channels);
+                assert!(!hal_tensor_map_data_const(map).is_null());
+                hal_tensor_map_unmap(map);
+
+                hal_tensor_image_free(img);
+            }
+
+            hal_image_processor_free(processor);
+        }
+    }
+
+    #[test]
+    fn test_image_processor_create_image_convert() {
+        unsafe {
+            let processor = hal_image_processor_new();
+            if processor.is_null() {
+                eprintln!(
+                    "SKIPPED: test_image_processor_create_image_convert — no processor available"
+                );
+                return;
+            }
+
+            // Create source image via create_image (may be PBO or Mem)
+            let src = hal_image_processor_create_image(processor, 320, 240, HalFourcc::Rgba);
+            assert!(!src.is_null());
+
+            // Create destination image via create_image
+            let dst = hal_image_processor_create_image(processor, 160, 120, HalFourcc::Rgba);
+            assert!(!dst.is_null());
+
+            // Convert should succeed regardless of backing (PBO, DMA, or Mem)
+            let ret = hal_image_processor_convert(
+                processor,
+                src,
+                dst,
+                HalRotation::None,
+                HalFlip::None,
+                std::ptr::null(),
+            );
+            assert_eq!(ret, 0, "convert() with create_image tensors failed");
+
+            hal_tensor_image_free(src);
+            hal_tensor_image_free(dst);
+            hal_image_processor_free(processor);
         }
     }
 }

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -1708,11 +1708,7 @@ mod tests {
 
             for (fourcc, channels) in formats {
                 let img = hal_image_processor_create_image(processor, 320, 240, fourcc);
-                assert!(
-                    !img.is_null(),
-                    "create_image failed for {:?}",
-                    fourcc
-                );
+                assert!(!img.is_null(), "create_image failed for {:?}", fourcc);
 
                 assert_eq!(hal_tensor_image_width(img), 320);
                 assert_eq!(hal_tensor_image_height(img), 240);

--- a/crates/capi/src/tensor.rs
+++ b/crates/capi/src/tensor.rs
@@ -93,6 +93,9 @@ impl From<TensorMemory> for HalTensorMemory {
             TensorMemory::Dma => HalTensorMemory::Dma,
             #[cfg(unix)]
             TensorMemory::Shm => HalTensorMemory::Shm,
+            // PBO tensors are GPU-only and not representable in the C API;
+            // report as Mem so callers can still inspect the memory type.
+            TensorMemory::Pbo => HalTensorMemory::Mem,
         }
     }
 }

--- a/crates/capi/src/tensor.rs
+++ b/crates/capi/src/tensor.rs
@@ -69,6 +69,8 @@ pub enum HalTensorMemory {
     Dma = 1,
     /// POSIX Shared Memory allocation (Linux only, for IPC)
     Shm = 2,
+    /// GPU Pixel Buffer Object allocation (zero-copy GPU upload/readback)
+    Pbo = 3,
 }
 
 impl From<HalTensorMemory> for Option<TensorMemory> {
@@ -79,6 +81,7 @@ impl From<HalTensorMemory> for Option<TensorMemory> {
             HalTensorMemory::Dma => Some(TensorMemory::Dma),
             #[cfg(target_os = "linux")]
             HalTensorMemory::Shm => Some(TensorMemory::Shm),
+            HalTensorMemory::Pbo => Some(TensorMemory::Pbo),
             #[cfg(not(target_os = "linux"))]
             _ => Some(TensorMemory::Mem),
         }
@@ -93,9 +96,7 @@ impl From<TensorMemory> for HalTensorMemory {
             TensorMemory::Dma => HalTensorMemory::Dma,
             #[cfg(unix)]
             TensorMemory::Shm => HalTensorMemory::Shm,
-            // PBO tensors are GPU-only and not representable in the C API;
-            // report as Mem so callers can still inspect the memory type.
-            TensorMemory::Pbo => HalTensorMemory::Mem,
+            TensorMemory::Pbo => HalTensorMemory::Pbo,
         }
     }
 }

--- a/crates/decoder/benches/decoder_benchmark.rs
+++ b/crates/decoder/benches/decoder_benchmark.rs
@@ -378,7 +378,8 @@ fn decoder_masks(bencher: divan::Bencher) {
             Some(Nms::ClassAgnostic),
             &mut output_boxes,
             &mut output_masks,
-        );
+        )
+        .unwrap();
         black_box_drop(output_boxes);
         black_box_drop(output_masks);
     });
@@ -415,7 +416,8 @@ fn decoder_masks_i8(bencher: divan::Bencher) {
             Some(Nms::ClassAgnostic),
             &mut output_boxes,
             &mut output_masks,
-        );
+        )
+        .unwrap();
         black_box_drop(output_boxes);
         black_box_drop(output_masks);
     });

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -733,9 +733,9 @@ enum ConfigSource {
 
 impl Default for DecoderBuilder {
     /// Creates a default DecoderBuilder with no configuration and 0.5 score
-    /// threshold and 0.5 OU threshold.
+    /// threshold and 0.5 IoU threshold.
     ///
-    /// A valid confguration must be provided before building the Decoder.
+    /// A valid configuration must be provided before building the Decoder.
     ///
     /// # Examples
     /// ```rust
@@ -763,9 +763,9 @@ impl Default for DecoderBuilder {
 
 impl DecoderBuilder {
     /// Creates a default DecoderBuilder with no configuration and 0.5 score
-    /// threshold and 0.5 OU threshold.
+    /// threshold and 0.5 IoU threshold.
     ///
-    /// A valid confguration must be provided before building the Decoder.
+    /// A valid configuration must be provided before building the Decoder.
     ///
     /// # Examples
     /// ```rust
@@ -1705,7 +1705,8 @@ impl DecoderBuilder {
             ],
         )?;
 
-        let protos_count = Self::get_protos_count(&protos.dshape).unwrap_or(protos.shape[3]);
+        let protos_count = Self::get_protos_count(&protos.dshape)
+            .unwrap_or_else(|| protos.shape[1].min(protos.shape[3]));
         log::debug!("Protos count: {}", protos_count);
         log::debug!("Detection dshape: {:?}", detection.dshape);
         let classes = if !detection.dshape.is_empty() {
@@ -1758,7 +1759,8 @@ impl DecoderBuilder {
             ],
         )?;
 
-        let protos_count = Self::get_protos_count(&protos.dshape).unwrap_or(protos.shape[3]);
+        let protos_count = Self::get_protos_count(&protos.dshape)
+            .unwrap_or_else(|| protos.shape[1].min(protos.shape[3]));
         log::debug!("Protos count: {}", protos_count);
         log::debug!("Detection dshape: {:?}", detection.dshape);
 
@@ -1894,7 +1896,7 @@ impl DecoderBuilder {
                 DecoderError::InvalidConfig("Could not find num_protos in config".to_string())
             })?
         } else {
-            protos.shape[3]
+            protos.shape[1].min(protos.shape[3])
         };
 
         if boxes_num != scores_num {
@@ -3248,6 +3250,7 @@ impl Decoder {
 
                 let protos_tensor = Self::swap_axes_if_needed(p, protos.into());
                 let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+                let protos_tensor = Self::protos_to_hwc(protos_tensor, protos);
                 decode_yolo_segdet_quant(
                     (box_tensor, quant_boxes),
                     (protos_tensor, quant_protos),
@@ -3374,6 +3377,7 @@ impl Decoder {
 
                 let protos_tensor = Self::swap_axes_if_needed(p, protos.into());
                 let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+                let protos_tensor = Self::protos_to_hwc(protos_tensor, protos);
                 impl_yolo_split_segdet_quant_process_masks::<_, _>(
                     boxes,
                     (mask_tensor, quant_masks),
@@ -3528,6 +3532,7 @@ impl Decoder {
 
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+        let protos_tensor = Self::protos_to_hwc(protos_tensor, protos);
         decode_yolo_segdet_float(
             boxes_tensor,
             protos_tensor,
@@ -3607,6 +3612,7 @@ impl Decoder {
         let (protos_tensor, _) = Self::find_outputs_with_shape(&protos.shape, outputs, &skip)?;
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+        let protos_tensor = Self::protos_to_hwc(protos_tensor, protos);
         decode_yolo_split_segdet_float(
             boxes_tensor,
             scores_tensor,
@@ -3682,6 +3688,7 @@ impl Decoder {
             Self::find_outputs_with_shape(&protos_config.shape, outputs, &[det_ind])?;
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos_config.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+        let protos_tensor = Self::protos_to_hwc(protos_tensor, protos_config);
 
         crate::yolo::decode_yolo_end_to_end_segdet_float(
             det_tensor,
@@ -3875,6 +3882,7 @@ impl Decoder {
             Self::find_outputs_with_shape(&protos_config.shape, outputs, &skip)?;
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos_config.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+        let protos_tensor = Self::protos_to_hwc(protos_tensor, protos_config);
 
         crate::yolo::decode_yolo_split_end_to_end_segdet_float(
             boxes_tensor,
@@ -4079,6 +4087,7 @@ impl Decoder {
 
                 let protos_tensor = Self::swap_axes_if_needed(p, protos.into());
                 let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+                let protos_tensor = Self::protos_to_hwc(protos_tensor, protos);
                 crate::yolo::impl_yolo_segdet_quant_proto::<XYWH, _, _>(
                     (box_tensor, quant_boxes),
                     (protos_tensor, quant_protos),
@@ -4110,6 +4119,7 @@ impl Decoder {
         let (protos_tensor, _) = Self::find_outputs_with_shape(&protos.shape, outputs, &[ind])?;
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+        let protos_tensor = Self::protos_to_hwc(protos_tensor, protos);
 
         Ok(crate::yolo::impl_yolo_segdet_float_proto::<XYWH, _, _>(
             boxes_tensor,
@@ -4194,6 +4204,7 @@ impl Decoder {
 
                 let protos_tensor = Self::swap_axes_if_needed(p, protos.into());
                 let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+                let protos_tensor = Self::protos_to_hwc(protos_tensor, protos);
 
                 crate::yolo::extract_proto_data_quant(
                     det_indices,
@@ -4241,6 +4252,7 @@ impl Decoder {
         let (protos_tensor, _) = Self::find_outputs_with_shape(&protos.shape, outputs, &skip)?;
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+        let protos_tensor = Self::protos_to_hwc(protos_tensor, protos);
 
         Ok(crate::yolo::impl_yolo_split_segdet_float_proto::<
             XYWH,
@@ -4286,6 +4298,7 @@ impl Decoder {
             Self::find_outputs_with_shape(&protos_config.shape, outputs, &[det_ind])?;
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos_config.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+        let protos_tensor = Self::protos_to_hwc(protos_tensor, protos_config);
 
         crate::yolo::decode_yolo_end_to_end_segdet_float_proto(
             det_tensor,
@@ -4399,6 +4412,7 @@ impl Decoder {
             Self::find_outputs_with_shape(&protos_config.shape, outputs, &skip)?;
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos_config.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
+        let protos_tensor = Self::protos_to_hwc(protos_tensor, protos_config);
 
         crate::yolo::decode_yolo_split_end_to_end_segdet_float_proto(
             boxes_tensor,
@@ -4689,6 +4703,42 @@ impl Decoder {
             (ConfigOutputRef::Protos(_), _) => Self::yolo_protos_order,
             (ConfigOutputRef::MaskCoefficients(_), _) => Self::yolo_maskcoefficients_order,
             (ConfigOutputRef::Classes(_), _) => Self::yolo_scores_order,
+        }
+    }
+
+    /// Ensure a 3D protos tensor is in HWC order.  When dshape is set,
+    /// `swap_axes_if_needed` already reorders the 4D tensor to NHWC before
+    /// the batch-dim slice, so the resulting 3D view is already HWC.
+    ///
+    /// When dshape is empty (no named dimensions), we detect the layout by
+    /// comparing axis sizes: the channel/proto count (e.g. 32) is always
+    /// smaller than the spatial dimensions (e.g. 160×160).  If axis 0 is
+    /// the smallest, the tensor is CHW and needs permutation to HWC;
+    /// otherwise it is already HWC.
+    ///
+    /// **Known limitations**: the heuristic fails when the channel count is
+    /// not strictly the smallest dimension (e.g. protos shape `(32, 1, 1)`
+    /// or `(160, 5, 5)`).  Set `dshape` in the config for reliable axis
+    /// ordering in these edge cases.
+    fn protos_to_hwc<'a, T>(
+        protos: ArrayView<'a, T, ndarray::Ix3>,
+        config: &configs::Protos,
+    ) -> ArrayView<'a, T, ndarray::Ix3> {
+        if config.dshape.is_empty() {
+            let (d0, d1, d2) = protos.dim();
+            log::warn!(
+                "protos_to_hwc: no dshape configured, using size heuristic on \
+                 shape ({d0}, {d1}, {d2}); set dshape in config for reliable ordering"
+            );
+            if d0 < d1 && d0 < d2 {
+                // CHW (from NCHW) → permute to HWC
+                protos.permuted_axes([1, 2, 0])
+            } else {
+                // Already HWC (from NHWC) or ambiguous — keep as-is
+                protos
+            }
+        } else {
+            protos
         }
     }
 

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -3259,11 +3259,9 @@ impl Decoder {
                     self.nms,
                     output_boxes,
                     output_masks,
-                );
-            });
-        });
-
-        Ok(())
+                )
+            })
+        })
     }
 
     fn decode_yolo_split_det_quantized(
@@ -3386,9 +3384,7 @@ impl Decoder {
                     output_masks,
                 )
             })
-        });
-
-        Ok(())
+        })
     }
 
     fn decode_modelpack_det_split_float<D>(
@@ -3541,8 +3537,7 @@ impl Decoder {
             self.nms,
             output_boxes,
             output_masks,
-        );
-        Ok(())
+        )
     }
 
     fn decode_yolo_split_det_float<T>(
@@ -3623,8 +3618,7 @@ impl Decoder {
             self.nms,
             output_boxes,
             output_masks,
-        );
-        Ok(())
+        )
     }
 
     /// Decodes end-to-end YOLO detection outputs (post-NMS from model).

--- a/crates/decoder/src/float.rs
+++ b/crates/decoder/src/float.rs
@@ -142,26 +142,26 @@ pub fn nms_extra_float<E: Send + Sync>(
 
     // Outer loop over all boxes.
     for i in 0..boxes.len() {
-        if boxes[i].0.score <= 0.0 {
+        if boxes[i].0.score < 0.0 {
             // this box was merged with a different box earlier
             continue;
         }
         for j in (i + 1)..boxes.len() {
             // Inner loop over boxes with lower score (later in the list).
 
-            if boxes[j].0.score <= 0.0 {
+            if boxes[j].0.score < 0.0 {
                 // this box was suppressed by different box earlier
                 continue;
             }
             if jaccard(&boxes[j].0.bbox, &boxes[i].0.bbox, iou) {
                 // max_box(boxes[j].bbox, &mut boxes[i].bbox);
-                boxes[j].0.score = 0.0;
+                boxes[j].0.score = -1.0;
             }
         }
     }
 
-    // Filter out boxes with a score of 0.0.
-    boxes.into_iter().filter(|b| b.0.score > 0.0).collect()
+    // Filter out suppressed boxes.
+    boxes.into_iter().filter(|b| b.0.score >= 0.0).collect()
 }
 
 /// Class-aware NMS: only suppress boxes with the same label.
@@ -232,22 +232,22 @@ pub fn nms_extra_class_aware_float<E: Send + Sync>(
     }
 
     for i in 0..boxes.len() {
-        if boxes[i].0.score <= 0.0 {
+        if boxes[i].0.score < 0.0 {
             continue;
         }
         for j in (i + 1)..boxes.len() {
-            if boxes[j].0.score <= 0.0 {
+            if boxes[j].0.score < 0.0 {
                 continue;
             }
             // Only suppress if same class AND overlapping
             if boxes[j].0.label == boxes[i].0.label
                 && jaccard(&boxes[j].0.bbox, &boxes[i].0.bbox, iou)
             {
-                boxes[j].0.score = 0.0;
+                boxes[j].0.score = -1.0;
             }
         }
     }
-    boxes.into_iter().filter(|b| b.0.score > 0.0).collect()
+    boxes.into_iter().filter(|b| b.0.score >= 0.0).collect()
 }
 
 /// Returns true if the IOU of the given bounding boxes is greater than the iou

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -1592,7 +1592,8 @@ mod decoder_tests {
             Some(configs::Nms::ClassAgnostic),
             &mut output_boxes,
             &mut output_masks,
-        );
+        )
+        .unwrap();
         assert_eq!(output_boxes.len(), 2);
         assert_eq!(output_boxes.len(), output_masks.len());
 
@@ -1682,7 +1683,8 @@ mod decoder_tests {
             Some(configs::Nms::ClassAgnostic),
             &mut ref_boxes,
             &mut ref_masks,
-        );
+        )
+        .unwrap();
         assert_eq!(ref_boxes.len(), 2);
 
         // ---- Config-driven path: NCHW protos, no dshape ----
@@ -1815,7 +1817,8 @@ mod decoder_tests {
             Some(configs::Nms::ClassAgnostic),
             &mut output_boxes,
             &mut output_masks,
-        );
+        )
+        .unwrap();
 
         let mut output_boxes1: Vec<_> = Vec::with_capacity(500);
         let mut output_masks1: Vec<_> = Vec::with_capacity(500);
@@ -1841,7 +1844,8 @@ mod decoder_tests {
             Some(configs::Nms::ClassAgnostic),
             &mut output_boxes_f32,
             &mut output_masks_f32,
-        );
+        )
+        .unwrap();
 
         let mut output_boxes1_f32: Vec<_> = Vec::with_capacity(500);
         let mut output_masks1_f32: Vec<_> = Vec::with_capacity(500);
@@ -2047,7 +2051,8 @@ mod decoder_tests {
             Some(configs::Nms::ClassAgnostic),
             &mut output_boxes_f32,
             &mut output_masks_f32,
-        );
+        )
+        .unwrap();
 
         let mut output_boxes1: Vec<_> = Vec::with_capacity(500);
         let mut output_masks1: Vec<_> = Vec::with_capacity(500);
@@ -2171,7 +2176,8 @@ mod decoder_tests {
             Some(configs::Nms::ClassAgnostic),
             &mut output_boxes_f32,
             &mut output_masks_f32,
-        );
+        )
+        .unwrap();
 
         assert_eq!(output_boxes.len(), output_boxes_f32.len());
         assert_eq!(output_masks.len(), output_masks_f32.len());

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -1644,6 +1644,117 @@ mod decoder_tests {
         );
     }
 
+    /// Regression test: config-driven path with NCHW protos (no dshape).
+    /// Simulates YOLOv8-seg ONNX outputs where protos are (1, 32, 160, 160)
+    /// and the YAML config has no dshape field — the exact scenario from
+    /// hal_mask_matmul_bug.md.
+    #[test]
+    fn test_decoder_masks_nchw_protos() {
+        let score_threshold = 0.45;
+        let iou_threshold = 0.45;
+
+        // Load test data — boxes as [116, 8400]
+        let boxes_raw = include_bytes!("../../../testdata/yolov8_boxes_116x8400.bin");
+        let boxes_raw =
+            unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
+        let boxes_2d = ndarray::Array2::from_shape_vec((116, 8400), boxes_raw.to_vec()).unwrap();
+        let quant_boxes = Quantization::new(0.021287761628627777, 31);
+
+        // Load protos as HWC [160, 160, 32] (file layout) then dequantize
+        let protos_raw = include_bytes!("../../../testdata/yolov8_protos_160x160x32.bin");
+        let protos_raw = unsafe {
+            std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
+        };
+        let protos_hwc =
+            ndarray::Array3::from_shape_vec((160, 160, 32), protos_raw.to_vec()).unwrap();
+        let quant_protos = Quantization::new(0.02491161972284317, -117);
+        let protos_f32_hwc = dequantize_ndarray::<_, _, f32>(protos_hwc.view(), quant_protos);
+
+        // ---- Reference: direct call with HWC protos (known working) ----
+        let seg = dequantize_ndarray::<_, _, f32>(boxes_2d.view(), quant_boxes);
+        let mut ref_boxes: Vec<_> = Vec::with_capacity(10);
+        let mut ref_masks: Vec<_> = Vec::with_capacity(10);
+        decode_yolo_segdet_float(
+            seg.view(),
+            protos_f32_hwc.view(),
+            score_threshold,
+            iou_threshold,
+            Some(configs::Nms::ClassAgnostic),
+            &mut ref_boxes,
+            &mut ref_masks,
+        );
+        assert_eq!(ref_boxes.len(), 2);
+
+        // ---- Config-driven path: NCHW protos, no dshape ----
+        // Permute protos to NCHW [1, 32, 160, 160] as an ONNX model would output
+        let protos_f32_chw = protos_f32_hwc.permuted_axes([2, 0, 1]); // [32, 160, 160]
+        let protos_nchw = protos_f32_chw.insert_axis(ndarray::Axis(0)); // [1, 32, 160, 160]
+
+        // Build boxes as [1, 116, 8400] f32
+        let seg_3d = seg.insert_axis(ndarray::Axis(0)); // [1, 116, 8400]
+
+        // Build decoder from config with no dshape on protos
+        let decoder = DecoderBuilder::default()
+            .with_config_yolo_segdet(
+                configs::Detection {
+                    decoder: configs::DecoderType::Ultralytics,
+                    quantization: None,
+                    shape: vec![1, 116, 8400],
+                    dshape: vec![],
+                    normalized: Some(true),
+                    anchors: None,
+                },
+                configs::Protos {
+                    decoder: configs::DecoderType::Ultralytics,
+                    quantization: None,
+                    shape: vec![1, 32, 160, 160],
+                    dshape: vec![], // No dshape — simulates YAML without dshape
+                },
+                None, // decoder version
+            )
+            .with_score_threshold(score_threshold)
+            .with_iou_threshold(iou_threshold)
+            .build()
+            .unwrap();
+
+        let mut cfg_boxes: Vec<_> = Vec::with_capacity(10);
+        let mut cfg_masks: Vec<_> = Vec::with_capacity(10);
+        decoder
+            .decode_float(
+                &[seg_3d.view().into_dyn(), protos_nchw.view().into_dyn()],
+                &mut cfg_boxes,
+                &mut cfg_masks,
+            )
+            .unwrap();
+
+        // Must produce the same number of detections
+        assert_eq!(
+            cfg_boxes.len(),
+            ref_boxes.len(),
+            "config path produced {} boxes, reference produced {}",
+            cfg_boxes.len(),
+            ref_boxes.len()
+        );
+
+        // Boxes must match
+        for (i, (cb, rb)) in cfg_boxes.iter().zip(&ref_boxes).enumerate() {
+            assert!(
+                cb.equal_within_delta(rb, 0.01),
+                "box {i} mismatch: config={cb:?}, reference={rb:?}"
+            );
+        }
+
+        // Masks must match pixel-for-pixel
+        for (i, (cm, rm)) in cfg_masks.iter().zip(&ref_masks).enumerate() {
+            let cm_arr = segmentation_to_mask(cm.segmentation.view()).unwrap();
+            let rm_arr = segmentation_to_mask(rm.segmentation.view()).unwrap();
+            assert_eq!(
+                cm_arr, rm_arr,
+                "mask {i} pixel mismatch between config-driven and reference paths"
+            );
+        }
+    }
+
     #[test]
     fn test_decoder_masks_i8() {
         let score_threshold = 0.45;

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -7,7 +7,6 @@ use ndarray::{
     parallel::prelude::{IntoParallelIterator, ParallelIterator},
     s, Array2, Array3, ArrayView1, ArrayView2, ArrayView3,
 };
-use ndarray_stats::QuantileExt;
 use num_traits::{AsPrimitive, Float, PrimInt, Signed};
 
 use crate::{
@@ -742,7 +741,8 @@ pub fn impl_yolo_segdet_quant<
     f32: AsPrimitive<BOX>,
 {
     let (boxes, quant_boxes) = boxes;
-    let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes);
+    let num_protos = protos.0.dim().2;
+    let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes, num_protos);
 
     let boxes = impl_yolo_split_segdet_quant_get_boxes::<B, _, _>(
         (boxes_tensor.reversed_axes(), quant_boxes),
@@ -786,7 +786,8 @@ pub fn impl_yolo_segdet_float<
 ) where
     f32: AsPrimitive<BOX>,
 {
-    let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes);
+    let num_protos = protos.dim().2;
+    let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes, num_protos);
 
     let boxes = postprocess_boxes_index_float::<B, _, _>(
         score_threshold.as_(),
@@ -1013,8 +1014,9 @@ where
 {
     let (boxes_arr, quant_boxes) = boxes;
     let (protos_arr, quant_protos) = protos;
+    let num_protos = protos_arr.dim().2;
 
-    let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes_arr);
+    let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes_arr, num_protos);
 
     let det_indices = impl_yolo_split_segdet_quant_get_boxes::<B, _, _>(
         (boxes_tensor.reversed_axes(), quant_boxes),
@@ -1025,7 +1027,6 @@ where
         output_boxes.capacity(),
     );
 
-    let mask_tensor = mask_tensor.reversed_axes();
     extract_proto_data_quant(
         det_indices,
         mask_tensor,
@@ -1053,7 +1054,8 @@ pub fn impl_yolo_segdet_float_proto<
 where
     f32: AsPrimitive<BOX>,
 {
-    let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes);
+    let num_protos = protos.dim().2;
+    let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes, num_protos);
 
     let det_indices = postprocess_boxes_index_float::<B, _, _>(
         score_threshold.as_(),
@@ -1063,7 +1065,6 @@ where
     let mut det_indices = dispatch_nms_extra_float(nms, iou_threshold, det_indices);
     det_indices.truncate(output_boxes.capacity());
 
-    let mask_tensor = mask_tensor.reversed_axes();
     extract_proto_data_float(det_indices, mask_tensor, protos, output_boxes)
 }
 
@@ -1326,9 +1327,15 @@ fn postprocess_yolo<'a, T>(
 
 fn postprocess_yolo_seg<'a, T>(
     output: &'a ArrayView2<'_, T>,
+    num_protos: usize,
 ) -> (ArrayView2<'a, T>, ArrayView2<'a, T>, ArrayView2<'a, T>) {
-    assert!(output.shape()[0] > 32 + 4, "Output shape is too short");
-    let num_classes = output.shape()[0] - 4 - 32;
+    assert!(
+        output.shape()[0] > num_protos + 4,
+        "Output shape is too short: {} <= {} + 4",
+        output.shape()[0],
+        num_protos
+    );
+    let num_classes = output.shape()[0] - 4 - num_protos;
     let boxes_tensor = output.slice(s![..4, ..,]).reversed_axes();
     let scores_tensor = output.slice(s![4..(num_classes + 4), ..,]).reversed_axes();
     let mask_tensor = output.slice(s![(num_classes + 4).., ..,]).reversed_axes();
@@ -1427,6 +1434,11 @@ fn protobox<'a, T>(
     (cropped, roi_norm)
 }
 
+/// Compute a single instance segmentation mask from mask coefficients and
+/// proto maps (float path).
+///
+/// Computes `sigmoid(coefficients · protos)` and maps to `[0, 255]`.
+/// Returns an `(H, W, 1)` u8 array.
 fn make_segmentation<
     MASK: Float + AsPrimitive<f32> + Send + Sync,
     PROTO: Float + AsPrimitive<f32> + Send + Sync,
@@ -1449,14 +1461,18 @@ fn make_segmentation<
         .into_shape_with_order((shape[0], shape[1], 1))
         .unwrap();
 
-    let min = *mask.min().unwrap_or(&0.0);
-    let max = *mask.max().unwrap_or(&1.0);
-    let max = max.max(-min);
-    let min = -max;
-    let u8_max = 256.0;
-    mask.map(|x| ((*x - min) / (max - min) * u8_max) as u8)
+    mask.map(|x| {
+        let sigmoid = 1.0 / (1.0 + (-*x).exp());
+        (sigmoid * 255.0).round() as u8
+    })
 }
 
+/// Compute a single instance segmentation mask from quantized mask
+/// coefficients and proto maps.
+///
+/// Dequantizes both inputs (subtracting zero-points), computes the dot
+/// product, applies sigmoid, and maps to `[0, 255]`.
+/// Returns an `(H, W, 1)` u8 array.
 fn make_segmentation_quant<
     MASK: PrimInt + AsPrimitive<DEST> + Send + Sync,
     PROTO: PrimInt + AsPrimitive<DEST> + Send + Sync,
@@ -1492,11 +1508,12 @@ where
         .into_shape_with_order((shape[0], shape[1], 1))
         .unwrap();
 
-    let min = *segmentation.min().unwrap_or(&DEST::zero());
-    let max = *segmentation.max().unwrap_or(&DEST::one());
-    let max = max.max(-min);
-    let min = -max;
-    segmentation.map(|x| ((*x - min).as_() / (max - min).as_() * 256.0) as u8)
+    let combined_scale = quant_masks.scale * quant_protos.scale;
+    segmentation.map(|x| {
+        let val: f32 = (*x).as_() * combined_scale;
+        let sigmoid = 1.0 / (1.0 + (-val).exp());
+        (sigmoid * 255.0).round() as u8
+    })
 }
 
 /// Converts Yolo Instance Segmentation into a 2D mask.
@@ -1922,5 +1939,57 @@ mod tests {
             result,
             Err(crate::DecoderError::InvalidShape(s)) if s.contains("(H, W, 1)")
         ));
+    }
+
+    // ========================================================================
+    // Regression: impl_yolo_segdet_float_proto must not double-reverse mask_tensor
+    // ========================================================================
+
+    #[test]
+    fn test_segdet_float_proto_no_panic() {
+        // Simulates YOLOv8n-seg: output0 = [116, 8400] (4 box + 80 class + 32 mask coeff)
+        // output1 (protos) = [32, 160, 160]
+        let num_proposals = 100; // enough to produce idx >= 32
+        let num_classes = 80;
+        let num_mask_coeffs = 32;
+        let rows = 4 + num_classes + num_mask_coeffs; // 116
+
+        // Fill boxes with valid xywh data so some detections pass the threshold.
+        // Layout is [116, num_proposals] row-major: row 0=cx, 1=cy, 2=w, 3=h,
+        // rows 4..84=class scores, rows 84..116=mask coefficients.
+        let mut data = vec![0.0f32; rows * num_proposals];
+        for i in 0..num_proposals {
+            let row = |r: usize| r * num_proposals + i;
+            data[row(0)] = 320.0; // cx
+            data[row(1)] = 320.0; // cy
+            data[row(2)] = 50.0; // w
+            data[row(3)] = 50.0; // h
+            data[row(4)] = 0.9; // class-0 score
+        }
+        let boxes = ndarray::Array2::from_shape_vec((rows, num_proposals), data).unwrap();
+
+        // Protos must be in HWC order (decoder.rs protos_to_hwc converts
+        // before calling into these functions).
+        let protos = ndarray::Array3::<f32>::zeros((160, 160, num_mask_coeffs));
+
+        let mut output_boxes = Vec::with_capacity(300);
+
+        // This panicked before fix: mask_tensor.row(idx) with idx >= 32
+        let proto_data = impl_yolo_segdet_float_proto::<XYWH, _, _>(
+            boxes.view(),
+            protos.view(),
+            0.5,
+            0.7,
+            Some(Nms::default()),
+            &mut output_boxes,
+        );
+
+        // Should produce detections (NMS will collapse many overlapping boxes)
+        assert!(!output_boxes.is_empty());
+        assert_eq!(proto_data.mask_coefficients.len(), output_boxes.len());
+        // Each mask coefficient vector should have 32 elements
+        for coeffs in &proto_data.mask_coefficients {
+            assert_eq!(coeffs.len(), num_mask_coeffs);
+        }
     }
 }

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -121,8 +121,8 @@ pub fn decode_yolo_det_float<T>(
 /// - boxes: (4 + num_classes + num_protos, num_boxes)
 /// - protos: (proto_height, proto_width, num_protos)
 ///
-/// # Panics
-/// Panics if shapes don't match the expected dimensions.
+/// # Errors
+/// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
 pub fn decode_yolo_segdet_quant<
     BOX: PrimInt + AsPrimitive<i64> + AsPrimitive<i128> + AsPrimitive<f32> + Send + Sync,
     PROTO: PrimInt + AsPrimitive<i64> + AsPrimitive<i128> + AsPrimitive<f32> + Send + Sync,
@@ -134,7 +134,8 @@ pub fn decode_yolo_segdet_quant<
     nms: Option<Nms>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     f32: AsPrimitive<BOX>,
 {
     impl_yolo_segdet_quant::<XYWH, _, _>(
@@ -145,7 +146,7 @@ pub fn decode_yolo_segdet_quant<
         nms,
         output_boxes,
         output_masks,
-    );
+    )
 }
 
 /// Decodes YOLO detection and segmentation outputs from float tensors into
@@ -157,8 +158,8 @@ pub fn decode_yolo_segdet_quant<
 /// - boxes: (4 + num_classes + num_protos, num_boxes)
 /// - protos: (proto_height, proto_width, num_protos)
 ///
-/// # Panics
-/// Panics if shapes don't match the expected dimensions.
+/// # Errors
+/// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
 pub fn decode_yolo_segdet_float<T>(
     boxes: ArrayView2<T>,
     protos: ArrayView3<T>,
@@ -167,7 +168,8 @@ pub fn decode_yolo_segdet_float<T>(
     nms: Option<Nms>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     T: Float + AsPrimitive<f32> + Send + Sync + 'static,
     f32: AsPrimitive<T>,
 {
@@ -179,7 +181,7 @@ pub fn decode_yolo_segdet_float<T>(
         nms,
         output_boxes,
         output_masks,
-    );
+    )
 }
 
 /// Decodes YOLO split detection outputs from quantized tensors into detection
@@ -259,8 +261,8 @@ pub fn decode_yolo_split_det_float<T>(
 /// - mask_tensor: (num_protos, num_boxes)
 /// - protos: (proto_height, proto_width, num_protos)
 ///
-/// # Panics
-/// Panics if shapes don't match the expected dimensions.
+/// # Errors
+/// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
 #[allow(clippy::too_many_arguments)]
 pub fn decode_yolo_split_segdet<
     BOX: PrimInt + AsPrimitive<f32> + Send + Sync,
@@ -277,7 +279,8 @@ pub fn decode_yolo_split_segdet<
     nms: Option<Nms>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     f32: AsPrimitive<SCORE>,
 {
     impl_yolo_split_segdet_quant::<XYWH, _, _, _, _>(
@@ -290,7 +293,7 @@ pub fn decode_yolo_split_segdet<
         nms,
         output_boxes,
         output_masks,
-    );
+    )
 }
 
 /// Decodes YOLO split detection segmentation outputs from float tensors
@@ -304,8 +307,8 @@ pub fn decode_yolo_split_segdet<
 /// - mask_tensor: (num_protos, num_boxes)
 /// - protos: (proto_height, proto_width, num_protos)
 ///
-/// # Panics
-/// Panics if shapes don't match the expected dimensions.
+/// # Errors
+/// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
 #[allow(clippy::too_many_arguments)]
 pub fn decode_yolo_split_segdet_float<T>(
     boxes: ArrayView2<T>,
@@ -317,7 +320,8 @@ pub fn decode_yolo_split_segdet_float<T>(
     nms: Option<Nms>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     T: Float + AsPrimitive<f32> + Send + Sync + 'static,
     f32: AsPrimitive<T>,
 {
@@ -331,7 +335,7 @@ pub fn decode_yolo_split_segdet_float<T>(
         nms,
         output_boxes,
         output_masks,
-    );
+    )
 }
 
 /// Decodes end-to-end YOLO detection outputs (post-NMS from model).
@@ -441,7 +445,7 @@ where
 
     // No NMS — model output is already post-NMS
 
-    let boxes = decode_segdet_f32(boxes, mask_coeff, protos);
+    let boxes = decode_segdet_f32(boxes, mask_coeff, protos)?;
 
     output_boxes.clear();
     output_masks.clear();
@@ -560,7 +564,7 @@ where
     }
 
     // Process masks using existing infrastructure
-    let result = decode_segdet_f32(qualifying, mask_coeff, protos);
+    let result = decode_segdet_f32(qualifying, mask_coeff, protos)?;
 
     output_boxes.clear();
     output_masks.clear();
@@ -723,8 +727,8 @@ pub fn impl_yolo_split_float<
 /// - boxes: (4 + num_classes + num_protos, num_boxes)
 /// - protos: (proto_height, proto_width, num_protos)
 ///
-/// # Panics
-/// Panics if shapes don't match the expected dimensions.
+/// # Errors
+/// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
 pub fn impl_yolo_segdet_quant<
     B: BBoxTypeTrait,
     BOX: PrimInt + AsPrimitive<i64> + AsPrimitive<i128> + AsPrimitive<f32> + Send + Sync,
@@ -737,7 +741,8 @@ pub fn impl_yolo_segdet_quant<
     nms: Option<Nms>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     f32: AsPrimitive<BOX>,
 {
     let (boxes, quant_boxes) = boxes;
@@ -759,7 +764,7 @@ pub fn impl_yolo_segdet_quant<
         protos,
         output_boxes,
         output_masks,
-    );
+    )
 }
 
 /// Internal implementation of YOLO detection segmentation decoding for
@@ -783,7 +788,8 @@ pub fn impl_yolo_segdet_float<
     nms: Option<Nms>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     f32: AsPrimitive<BOX>,
 {
     let num_protos = protos.dim().2;
@@ -796,7 +802,7 @@ pub fn impl_yolo_segdet_float<
     );
     let mut boxes = dispatch_nms_extra_float(nms, iou_threshold, boxes);
     boxes.truncate(output_boxes.capacity());
-    let boxes = decode_segdet_f32(boxes, mask_tensor, protos);
+    let boxes = decode_segdet_f32(boxes, mask_tensor, protos)?;
     output_boxes.clear();
     output_masks.clear();
     for (b, m) in boxes.into_iter() {
@@ -809,6 +815,7 @@ pub fn impl_yolo_segdet_float<
             segmentation: m,
         });
     }
+    Ok(())
 }
 
 pub(crate) fn impl_yolo_split_segdet_quant_get_boxes<
@@ -858,13 +865,13 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
     protos: (ArrayView3<PROTO>, Quantization),
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) {
+) -> Result<(), crate::DecoderError> {
     let (masks, quant_masks) = mask_coeff;
     let (protos, quant_protos) = protos;
 
     let masks = masks.reversed_axes();
 
-    let boxes = decode_segdet_quant(boxes, masks, protos, quant_masks, quant_protos);
+    let boxes = decode_segdet_quant(boxes, masks, protos, quant_masks, quant_protos)?;
     output_boxes.clear();
     output_masks.clear();
     for (b, m) in boxes.into_iter() {
@@ -877,6 +884,7 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
             segmentation: m,
         });
     }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -889,8 +897,8 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
 /// - mask_tensor: (num_protos, num_boxes)
 /// - protos: (proto_height, proto_width, num_protos)
 ///
-/// # Panics
-/// Panics if shapes don't match the expected dimensions.
+/// # Errors
+/// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
 pub fn impl_yolo_split_segdet_quant<
     B: BBoxTypeTrait,
     BOX: PrimInt + AsPrimitive<f32> + Send + Sync,
@@ -907,7 +915,8 @@ pub fn impl_yolo_split_segdet_quant<
     nms: Option<Nms>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     f32: AsPrimitive<SCORE>,
 {
     let boxes = impl_yolo_split_segdet_quant_get_boxes::<B, _, _>(
@@ -925,7 +934,7 @@ pub fn impl_yolo_split_segdet_quant<
         protos,
         output_boxes,
         output_masks,
-    );
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -938,8 +947,8 @@ pub fn impl_yolo_split_segdet_quant<
 /// - mask_tensor: (num_protos, num_boxes)
 /// - protos: (proto_height, proto_width, num_protos)
 ///
-/// # Panics
-/// Panics if shapes don't match the expected dimensions.
+/// # Errors
+/// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
 pub fn impl_yolo_split_segdet_float<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Send + Sync,
@@ -956,7 +965,8 @@ pub fn impl_yolo_split_segdet_float<
     nms: Option<Nms>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
-) where
+) -> Result<(), crate::DecoderError>
+where
     f32: AsPrimitive<SCORE>,
 {
     let boxes_tensor = boxes_tensor.reversed_axes();
@@ -970,7 +980,7 @@ pub fn impl_yolo_split_segdet_float<
     );
     let mut boxes = dispatch_nms_extra_float(nms, iou_threshold, boxes);
     boxes.truncate(output_boxes.capacity());
-    let boxes = decode_segdet_f32(boxes, mask_tensor, protos);
+    let boxes = decode_segdet_f32(boxes, mask_tensor, protos)?;
     output_boxes.clear();
     output_masks.clear();
     for (b, m) in boxes.into_iter() {
@@ -983,6 +993,7 @@ pub fn impl_yolo_split_segdet_float<
             segmentation: m,
         });
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -1349,18 +1360,24 @@ fn decode_segdet_f32<
     boxes: Vec<(DetectBox, usize)>,
     masks: ArrayView2<MASK>,
     protos: ArrayView3<PROTO>,
-) -> Vec<(DetectBox, Array3<u8>)> {
+) -> Result<Vec<(DetectBox, Array3<u8>)>, crate::DecoderError> {
     if boxes.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
-    assert!(masks.shape()[1] == protos.shape()[2]);
+    if masks.shape()[1] != protos.shape()[2] {
+        return Err(crate::DecoderError::InvalidShape(format!(
+            "Mask coefficients count ({}) doesn't match protos channel count ({})",
+            masks.shape()[1],
+            protos.shape()[2],
+        )));
+    }
     boxes
         .into_par_iter()
         .map(|mut b| {
             let ind = b.1;
-            let (protos, roi) = protobox(&protos, &b.0.bbox);
+            let (protos, roi) = protobox(&protos, &b.0.bbox)?;
             b.0.bbox = roi;
-            (b.0, make_segmentation(masks.row(ind), protos.view()))
+            Ok((b.0, make_segmentation(masks.row(ind), protos.view())))
         })
         .collect()
 }
@@ -1374,18 +1391,24 @@ pub(crate) fn decode_segdet_quant<
     protos: ArrayView3<PROTO>,
     quant_masks: Quantization,
     quant_protos: Quantization,
-) -> Vec<(DetectBox, Array3<u8>)> {
+) -> Result<Vec<(DetectBox, Array3<u8>)>, crate::DecoderError> {
     if boxes.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
-    assert!(masks.shape()[1] == protos.shape()[2]);
+    if masks.shape()[1] != protos.shape()[2] {
+        return Err(crate::DecoderError::InvalidShape(format!(
+            "Mask coefficients count ({}) doesn't match protos channel count ({})",
+            masks.shape()[1],
+            protos.shape()[2],
+        )));
+    }
 
     let total_bits = MASK::zero().count_zeros() + PROTO::zero().count_zeros() + 5; // 32 protos is 2^5
     boxes
         .into_iter()
         .map(|mut b| {
             let i = b.1;
-            let (protos, roi) = protobox(&protos, &b.0.bbox.to_canonical());
+            let (protos, roi) = protobox(&protos, &b.0.bbox.to_canonical())?;
             b.0.bbox = roi;
             let seg = match total_bits {
                 0..=64 => make_segmentation_quant::<MASK, PROTO, i64>(
@@ -1400,9 +1423,13 @@ pub(crate) fn decode_segdet_quant<
                     quant_masks,
                     quant_protos,
                 ),
-                _ => panic!("Unsupported bit width for segmentation computation"),
+                _ => {
+                    return Err(crate::DecoderError::NotSupported(format!(
+                        "Unsupported bit width ({total_bits}) for segmentation computation"
+                    )));
+                }
             };
-            (b.0, seg)
+            Ok((b.0, seg))
         })
         .collect()
 }
@@ -1410,9 +1437,29 @@ pub(crate) fn decode_segdet_quant<
 fn protobox<'a, T>(
     protos: &'a ArrayView3<T>,
     roi: &BoundingBox,
-) -> (ArrayView3<'a, T>, BoundingBox) {
+) -> Result<(ArrayView3<'a, T>, BoundingBox), crate::DecoderError> {
     let width = protos.dim().1 as f32;
     let height = protos.dim().0 as f32;
+
+    // Detect un-normalized bounding boxes (pixel-space coordinates).
+    // protobox expects normalized coordinates in [0, 1]. ONNX models output
+    // pixel-space boxes (e.g. 0-640) which must be normalized before calling
+    // decode(). Without this check, pixel-space coordinates silently clamp to
+    // the proto boundary, producing empty (0, 0, C) masks for every detection.
+    const NORM_LIMIT: f32 = 1.01;
+    if roi.xmin > NORM_LIMIT
+        || roi.ymin > NORM_LIMIT
+        || roi.xmax > NORM_LIMIT
+        || roi.ymax > NORM_LIMIT
+    {
+        return Err(crate::DecoderError::InvalidShape(format!(
+            "Bounding box coordinates appear un-normalized (pixel-space). \
+             Got bbox=({:.2}, {:.2}, {:.2}, {:.2}) but expected values in [0, 1]. \
+             ONNX models output pixel-space boxes — normalize them by dividing by \
+             the input dimensions before calling decode().",
+            roi.xmin, roi.ymin, roi.xmax, roi.ymax,
+        )));
+    }
 
     let roi = [
         (roi.xmin * width).clamp(0.0, width) as usize,
@@ -1431,7 +1478,7 @@ fn protobox<'a, T>(
 
     let cropped = protos.slice(s![roi[1]..roi[3], roi[0]..roi[2], ..]);
 
-    (cropped, roi_norm)
+    Ok((cropped, roi_norm))
 }
 
 /// Compute a single instance segmentation mask from mask coefficients and

--- a/crates/gpu-probe/src/egl_context.rs
+++ b/crates/gpu-probe/src/egl_context.rs
@@ -4,10 +4,11 @@
 #![allow(dead_code)]
 //! EGL context bootstrap for headless GPU probing.
 //!
-//! Opens a DRM render node, creates a GBM device, obtains an EGL platform
-//! display, and initialises a GLES 3.0 PBuffer context. This is a standalone
-//! version of the HAL's `opengl_headless::GlContext` stripped down for
-//! diagnostic / benchmarking use only.
+//! Obtains an EGL display (via PlatformDevice or GBM fallback), creates a
+//! surfaceless GLES 3.0 context using `EGL_KHR_no_config_context`, and makes
+//! it current with `EGL_NO_SURFACE`. This is a standalone version of the
+//! HAL's `opengl_headless::GlContext` stripped down for diagnostic /
+//! benchmarking use only.
 
 use gbm::{
     drm::{control::Device as DrmControlDevice, Device as DrmDevice},
@@ -28,6 +29,11 @@ use std::{
 // ---------------------------------------------------------------------------
 
 const PLATFORM_GBM_KHR: u32 = 0x31D7;
+const PLATFORM_DEVICE_EXT: u32 = 0x313F;
+
+/// EGL_KHR_no_config_context: null config for eglCreateContext.
+const NO_CONFIG_KHR: egl::Config =
+    unsafe { std::mem::transmute(std::ptr::null_mut::<std::ffi::c_void>()) };
 
 #[allow(dead_code)]
 const LINUX_DMA_BUF: u32 = 0x3270;
@@ -111,89 +117,137 @@ impl Card {
 // GpuContext
 // ---------------------------------------------------------------------------
 
-/// Holds an initialised EGL display, GLES 3.0 context, and the backing GBM
-/// device. Provides helper methods for querying GL/EGL strings and creating
-/// EGLImages from DMA-buf file descriptors.
+/// Backing storage for the EGL display — keeps the underlying resource alive.
+enum DisplayBacking {
+    /// PlatformDevice display — no external resources needed.
+    Device,
+    /// GBM display — the GBM device must outlive the EGL display.
+    Gbm(Device<Card>),
+}
+
+/// Holds an initialised EGL display, surfaceless GLES 3.0 context, and the
+/// backing display resource. Provides helper methods for querying GL/EGL
+/// strings and creating EGLImages from DMA-buf file descriptors.
 pub struct GpuContext {
     egl: Egl,
     display: Display,
-    surface: egl::Surface,
     ctx: egl::Context,
-    // The GBM device must outlive the EGL display.
-    _gbm: Device<Card>,
+    _backing: DisplayBacking,
 }
 
 impl GpuContext {
-    /// Bootstrap a headless GLES 3.0 context via GBM + EGL.
+    /// Bootstrap a headless GLES 3.0 surfaceless context.
+    ///
+    /// Tries PlatformDevice first (zero external deps), falls back to GBM.
     pub fn new() -> Result<Self, String> {
-        // 1. Open DRM render node and create GBM device
-        let card = Card::open_any()?;
-        let gbm = Device::new(card).map_err(|e| format!("GBM device creation failed: {e}"))?;
-        debug!("GBM device: {gbm:?}");
-
-        // 2. Load EGL
         let egl: Egl = unsafe {
             Instance::<Dynamic<_, EGL1_4>>::load_required_from(get_egl_lib()?)
                 .map_err(|e| format!("EGL instance load failed: {e}"))?
         };
 
-        // 3. Get platform display (EGL 1.5 -> EXT fallback)
+        // Try PlatformDevice first
+        match Self::get_platform_device_display(&egl) {
+            Ok((display, backing)) => {
+                return Self::init_surfaceless(egl, display, backing);
+            }
+            Err(e) => debug!("PlatformDevice not available: {e}"),
+        }
+
+        // Fall back to GBM
+        let (display, backing) = Self::get_gbm_display(&egl)?;
+        Self::init_surfaceless(egl, display, backing)
+    }
+
+    fn get_platform_device_display(egl: &Egl) -> Result<(Display, DisplayBacking), String> {
+        let client_exts = egl
+            .query_string(None, egl::EXTENSIONS)
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        if !client_exts.contains("EGL_EXT_device_enumeration") {
+            return Err("EGL_EXT_device_enumeration not available".into());
+        }
+        if !client_exts.contains("EGL_EXT_platform_device") {
+            return Err("EGL_EXT_platform_device not available".into());
+        }
+
+        let query_devices_fn = egl
+            .get_proc_address("eglQueryDevicesEXT")
+            .ok_or("eglQueryDevicesEXT not available")?;
+        let query_devices: unsafe extern "system" fn(
+            max_devices: egl::Int,
+            devices: *mut *mut c_void,
+            num_devices: *mut egl::Int,
+        ) -> egl::Boolean = unsafe { std::mem::transmute(query_devices_fn) };
+
+        let mut devices = [null_mut(); 10];
+        let mut num_devices: egl::Int = 0;
+        unsafe { query_devices(10, devices.as_mut_ptr(), &mut num_devices) };
+        if num_devices == 0 {
+            return Err("eglQueryDevicesEXT returned 0 devices".into());
+        }
+        debug!("EGL devices found: {num_devices}");
+
         let display = egl_get_platform_display_with_fallback(
-            &egl,
+            egl,
+            PLATFORM_DEVICE_EXT,
+            devices[0],
+            &[egl::ATTRIB_NONE],
+        )?;
+
+        Ok((display, DisplayBacking::Device))
+    }
+
+    fn get_gbm_display(egl: &Egl) -> Result<(Display, DisplayBacking), String> {
+        let card = Card::open_any()?;
+        let gbm = Device::new(card).map_err(|e| format!("GBM device creation failed: {e}"))?;
+        debug!("GBM device: {gbm:?}");
+
+        let display = egl_get_platform_display_with_fallback(
+            egl,
             PLATFORM_GBM_KHR,
             gbm.as_raw() as *mut c_void,
             &[egl::ATTRIB_NONE],
         )?;
+
+        Ok((display, DisplayBacking::Gbm(gbm)))
+    }
+
+    fn init_surfaceless(
+        egl: Egl,
+        display: Display,
+        backing: DisplayBacking,
+    ) -> Result<Self, String> {
         debug!("EGL display: {display:?}");
 
-        // 4. Initialise EGL
         egl.initialize(display)
             .map_err(|e| format!("eglInitialize failed: {e}"))?;
 
-        // 5. Choose config: GLES 3.0, RGBA8, PBUFFER
-        let attributes = [
-            egl::SURFACE_TYPE,
-            egl::PBUFFER_BIT,
-            egl::RENDERABLE_TYPE,
-            egl::OPENGL_ES3_BIT,
-            egl::RED_SIZE,
-            8,
-            egl::GREEN_SIZE,
-            8,
-            egl::BLUE_SIZE,
-            8,
-            egl::ALPHA_SIZE,
-            8,
-            egl::NONE,
-        ];
-        let config = egl
-            .choose_first_config(display, &attributes)
-            .map_err(|e| format!("eglChooseConfig failed: {e}"))?
-            .ok_or("no suitable EGL config found (GLES3 RGBA8 PBuffer)")?;
-        debug!("EGL config: {config:?}");
+        // Verify required extensions
+        let ext_str = egl
+            .query_string(Some(display), egl::EXTENSIONS)
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
 
-        // 6. Create 64x64 PBuffer surface
-        let surface = egl
-            .create_pbuffer_surface(
-                display,
-                config,
-                &[egl::WIDTH, 64, egl::HEIGHT, 64, egl::NONE],
-            )
-            .map_err(|e| format!("eglCreatePbufferSurface failed: {e}"))?;
+        if !ext_str.contains("EGL_KHR_surfaceless_context") {
+            return Err("EGL_KHR_surfaceless_context not supported".into());
+        }
+        if !ext_str.contains("EGL_KHR_no_config_context") {
+            return Err("EGL_KHR_no_config_context not supported".into());
+        }
 
-        // 7. Bind OPENGL_ES_API, create GLES 3.0 context, make current
         egl.bind_api(egl::OPENGL_ES_API)
             .map_err(|e| format!("eglBindAPI failed: {e}"))?;
 
         let context_attributes = [egl::CONTEXT_MAJOR_VERSION, 3, egl::NONE];
         let ctx = egl
-            .create_context(display, config, None, &context_attributes)
+            .create_context(display, NO_CONFIG_KHR, None, &context_attributes)
             .map_err(|e| format!("eglCreateContext failed: {e}"))?;
 
-        egl.make_current(display, Some(surface), Some(surface), Some(ctx))
-            .map_err(|e| format!("eglMakeCurrent failed: {e}"))?;
+        egl.make_current(display, None, None, Some(ctx))
+            .map_err(|e| format!("eglMakeCurrent (surfaceless) failed: {e}"))?;
 
-        // 8. Load GL function pointers
+        // Load GL function pointers
         gls::load_with(|s| {
             egl.get_proc_address(s)
                 .map_or(std::ptr::null(), |p| p as *const _)
@@ -202,9 +256,8 @@ impl GpuContext {
         Ok(GpuContext {
             egl,
             display,
-            surface,
             ctx,
-            _gbm: gbm,
+            _backing: backing,
         })
     }
 
@@ -391,14 +444,13 @@ impl GpuContext {
 
 impl Drop for GpuContext {
     fn drop(&mut self) {
-        // Defence-in-depth cleanup: destroy context, surface, and terminate
-        // the EGL display inside catch_unwind to absorb driver panics.
+        // Defence-in-depth cleanup: destroy context and terminate the EGL
+        // display inside catch_unwind to absorb driver panics.
         let prev_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(|_| {}));
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let _ = self.egl.make_current(self.display, None, None, None);
             let _ = self.egl.destroy_context(self.display, self.ctx);
-            let _ = self.egl.destroy_surface(self.display, self.surface);
             let _ = self.egl.terminate(self.display);
         }));
         std::panic::set_hook(prev_hook);

--- a/crates/image/benches/common.rs
+++ b/crates/image/benches/common.rs
@@ -4,7 +4,7 @@
 //! Shared utilities for image processing benchmarks.
 #![allow(dead_code, unused_imports)]
 
-use edgefirst_image::{NV12, PLANAR_RGB, PLANAR_RGB_INT8, RGB, RGBA, RGB_INT8, YUYV};
+use edgefirst_image::{NV12, PLANAR_RGB, PLANAR_RGB_INT8, RGB, RGBA, RGB_INT8, VYUY, YUYV};
 use four_char_code::FourCharCode;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -90,6 +90,8 @@ pub fn find_testdata_path(filename: &str) -> std::path::PathBuf {
 pub fn format_name(f: FourCharCode) -> &'static str {
     if f == YUYV {
         "YUYV"
+    } else if f == VYUY {
+        "VYUY"
     } else if f == NV12 {
         "NV12"
     } else if f == RGB {
@@ -199,7 +201,7 @@ impl BenchConfig {
     /// Calculate throughput in bytes based on input size.
     pub fn throughput(&self) -> u64 {
         let bytes = match self.in_fmt {
-            f if f == YUYV => self.in_w * self.in_h * 2,
+            f if f == YUYV || f == VYUY => self.in_w * self.in_h * 2,
             f if f == NV12 => self.in_w * self.in_h * 3 / 2,
             f if f == RGB || f == RGB_INT8 || f == PLANAR_RGB || f == PLANAR_RGB_INT8 => {
                 self.in_w * self.in_h * 3
@@ -218,7 +220,9 @@ impl BenchConfig {
 pub const CAMERA_1080P_YUYV: &[u8] = include_bytes!("../../../testdata/camera1080p.yuyv");
 pub const CAMERA_1080P_NV12: &[u8] = include_bytes!("../../../testdata/camera1080p.nv12");
 pub const CAMERA_1080P_RGB: &[u8] = include_bytes!("../../../testdata/camera1080p.rgb");
+pub const CAMERA_1080P_VYUY: &[u8] = include_bytes!("../../../testdata/camera1080p.vyuy");
 pub const CAMERA_4K_YUYV: &[u8] = include_bytes!("../../../testdata/camera4k.yuyv");
+pub const CAMERA_4K_VYUY: &[u8] = include_bytes!("../../../testdata/camera4k.vyuy");
 pub const CAMERA_4K_NV12: &[u8] = include_bytes!("../../../testdata/camera4k.nv12");
 pub const CAMERA_4K_RGB: &[u8] = include_bytes!("../../../testdata/camera4k.rgb");
 
@@ -226,9 +230,11 @@ pub const CAMERA_4K_RGB: &[u8] = include_bytes!("../../../testdata/camera4k.rgb"
 pub fn get_test_data(width: usize, height: usize, format: FourCharCode) -> &'static [u8] {
     match (width, height, format) {
         (1920, 1080, f) if f == YUYV => CAMERA_1080P_YUYV,
+        (1920, 1080, f) if f == VYUY => CAMERA_1080P_VYUY,
         (1920, 1080, f) if f == NV12 => CAMERA_1080P_NV12,
         (1920, 1080, f) if f == RGB => CAMERA_1080P_RGB,
         (3840, 2160, f) if f == YUYV => CAMERA_4K_YUYV,
+        (3840, 2160, f) if f == VYUY => CAMERA_4K_VYUY,
         (3840, 2160, f) if f == NV12 => CAMERA_4K_NV12,
         (3840, 2160, f) if f == RGB => CAMERA_4K_RGB,
         _ => panic!("No test data for {}x{} {:?}", width, height, format),

--- a/crates/image/benches/pipeline_benchmark.rs
+++ b/crates/image/benches/pipeline_benchmark.rs
@@ -28,7 +28,7 @@ mod common;
 use common::{calculate_letterbox, get_test_data, run_bench, BenchConfig};
 
 use edgefirst_image::{CPUProcessor, Crop, Flip, ImageProcessorTrait, Rect, Rotation, TensorImage};
-use edgefirst_image::{NV12, PLANAR_RGB_INT8, RGB, RGBA, RGB_INT8, YUYV};
+use edgefirst_image::{NV12, PLANAR_RGB_INT8, RGB, RGBA, RGB_INT8, VYUY, YUYV};
 #[cfg(target_os = "linux")]
 use edgefirst_tensor::TensorMemory;
 use edgefirst_tensor::{TensorMapTrait, TensorTrait};
@@ -78,9 +78,9 @@ fn bench_letterbox(configs: &[BenchConfig]) {
             result.print_summary_with_throughput(throughput);
         }
 
-        // HAL G2D (for YUYV/NV12 input → RGBA/RGB output only)
+        // HAL G2D (for YUYV/VYUY/NV12 input → RGBA/RGB output only)
         #[cfg(target_os = "linux")]
-        if (config.in_fmt == YUYV || config.in_fmt == NV12)
+        if (config.in_fmt == YUYV || config.in_fmt == VYUY || config.in_fmt == NV12)
             && (config.out_fmt == RGBA || config.out_fmt == RGB)
         {
             use edgefirst_image::G2DProcessor;
@@ -115,6 +115,12 @@ fn bench_letterbox(configs: &[BenchConfig]) {
             };
             let mut proc = ManuallyDrop::new(proc);
 
+            // Pre-flight: skip if format is not supported by G2D
+            if let Err(e) = proc.convert(&src, &mut dst, Rotation::None, Flip::None, crop) {
+                println!("  {:50} [skipped: {}]", name, e);
+                continue;
+            }
+
             let result = run_bench(&name, WARMUP, ITERATIONS, || {
                 proc.convert(&src, &mut dst, Rotation::None, Flip::None, crop)
                     .unwrap();
@@ -122,9 +128,9 @@ fn bench_letterbox(configs: &[BenchConfig]) {
             result.print_summary_with_throughput(throughput);
         }
 
-        // HAL OpenGL (for YUYV/NV12 → RGBA/RGB/RGB_INT8/PLANAR_RGB_INT8 output)
+        // HAL OpenGL (for YUYV/VYUY/NV12 → RGBA/RGB/RGB_INT8/PLANAR_RGB_INT8 output)
         #[cfg(all(target_os = "linux", feature = "opengl"))]
-        if (config.in_fmt == YUYV || config.in_fmt == NV12)
+        if (config.in_fmt == YUYV || config.in_fmt == VYUY || config.in_fmt == NV12)
             && (config.out_fmt == RGBA
                 || config.out_fmt == RGB
                 || config.out_fmt == RGB_INT8
@@ -157,6 +163,12 @@ fn bench_letterbox(configs: &[BenchConfig]) {
                 println!("  {:50} [skipped: OpenGL unavailable]", name);
                 continue;
             };
+
+            // Pre-flight: skip if format/path is not supported
+            if let Err(e) = proc.convert(&src, &mut dst, Rotation::None, Flip::None, crop) {
+                println!("  {:50} [skipped: {}]", name, e);
+                continue;
+            }
 
             let result = run_bench(&name, WARMUP, ITERATIONS, || {
                 proc.convert(&src, &mut dst, Rotation::None, Flip::None, crop)
@@ -323,9 +335,9 @@ fn bench_convert(configs: &[BenchConfig]) {
             result.print_summary_with_throughput(throughput);
         }
 
-        // HAL G2D (for YUYV/NV12 input → RGBA/RGB output only)
+        // HAL G2D (for YUYV/VYUY/NV12 input → RGBA/RGB output only)
         #[cfg(target_os = "linux")]
-        if (config.in_fmt == YUYV || config.in_fmt == NV12)
+        if (config.in_fmt == YUYV || config.in_fmt == VYUY || config.in_fmt == NV12)
             && (config.out_fmt == RGBA || config.out_fmt == RGB)
         {
             use edgefirst_image::G2DProcessor;
@@ -360,6 +372,14 @@ fn bench_convert(configs: &[BenchConfig]) {
             };
             let mut proc = ManuallyDrop::new(proc);
 
+            // Pre-flight: skip if format is not supported by G2D
+            if let Err(e) =
+                proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+            {
+                println!("  {:50} [skipped: {}]", name, e);
+                continue;
+            }
+
             let result = run_bench(&name, WARMUP, ITERATIONS, || {
                 proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
                     .unwrap();
@@ -367,9 +387,9 @@ fn bench_convert(configs: &[BenchConfig]) {
             result.print_summary_with_throughput(throughput);
         }
 
-        // HAL OpenGL (for YUYV/NV12 → RGBA/RGB/RGB_INT8/PLANAR_RGB_INT8)
+        // HAL OpenGL (for YUYV/VYUY/NV12 → RGBA/RGB/RGB_INT8/PLANAR_RGB_INT8)
         #[cfg(all(target_os = "linux", feature = "opengl"))]
-        if (config.in_fmt == YUYV || config.in_fmt == NV12)
+        if (config.in_fmt == YUYV || config.in_fmt == VYUY || config.in_fmt == NV12)
             && (config.out_fmt == RGBA
                 || config.out_fmt == RGB
                 || config.out_fmt == RGB_INT8
@@ -402,6 +422,14 @@ fn bench_convert(configs: &[BenchConfig]) {
                 println!("  {:50} [skipped: OpenGL unavailable]", name);
                 continue;
             };
+
+            // Pre-flight: skip if format/path is not supported
+            if let Err(e) =
+                proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+            {
+                println!("  {:50} [skipped: {}]", name, e);
+                continue;
+            }
 
             let result = run_bench(&name, WARMUP, ITERATIONS, || {
                 proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
@@ -595,6 +623,14 @@ fn bench_resize(configs: &[BenchConfig]) {
                 println!("  {:50} [skipped: OpenGL unavailable]", name);
                 continue;
             };
+
+            // Pre-flight: skip if format/path is not supported
+            if let Err(e) =
+                proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+            {
+                println!("  {:50} [skipped: {}]", name, e);
+                continue;
+            }
 
             let result = run_bench(&name, WARMUP, ITERATIONS, || {
                 proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
@@ -812,6 +848,8 @@ fn main() {
         BenchConfig::new(1920, 1080, 640, 640, YUYV, RGB),
         BenchConfig::new(1920, 1080, 640, 640, YUYV, RGB_INT8),
         BenchConfig::new(1920, 1080, 640, 640, YUYV, PLANAR_RGB_INT8),
+        BenchConfig::new(1920, 1080, 640, 640, VYUY, RGBA),
+        BenchConfig::new(1920, 1080, 640, 640, VYUY, RGB),
         BenchConfig::new(1920, 1080, 640, 640, NV12, RGBA),
         // 4K camera → YOLO standard (640x640)
         BenchConfig::new(3840, 2160, 640, 640, YUYV, RGBA),
@@ -832,6 +870,8 @@ fn main() {
         BenchConfig::new(1920, 1080, 1920, 1080, YUYV, RGBA),
         BenchConfig::new(1920, 1080, 1920, 1080, YUYV, RGB),
         BenchConfig::new(1920, 1080, 1920, 1080, YUYV, RGB_INT8),
+        BenchConfig::new(1920, 1080, 1920, 1080, VYUY, RGBA),
+        BenchConfig::new(1920, 1080, 1920, 1080, VYUY, RGB),
         BenchConfig::new(1920, 1080, 1920, 1080, NV12, RGBA),
         BenchConfig::new(1920, 1080, 1920, 1080, NV12, RGB),
         BenchConfig::new(1920, 1080, 1920, 1080, RGB, RGBA),

--- a/crates/image/src/cpu.rs
+++ b/crates/image/src/cpu.rs
@@ -2175,11 +2175,15 @@ impl ImageProcessorTrait for CPUProcessor {
         for (det, coeff) in detect.iter().zip(proto_data.mask_coefficients.iter()) {
             let start_x = (output_width as f32 * det.bbox.xmin).round() as usize;
             let start_y = (output_height as f32 * det.bbox.ymin).round() as usize;
-            let end_x = ((output_width as f32 * det.bbox.xmax).round() as usize).min(output_width);
-            let end_y =
-                ((output_height as f32 * det.bbox.ymax).round() as usize).min(output_height);
-            let bbox_w = end_x.saturating_sub(start_x).max(1);
-            let bbox_h = end_y.saturating_sub(start_y).max(1);
+            // Use span-based rounding to match the numpy reference convention.
+            let bbox_w = ((det.bbox.xmax - det.bbox.xmin) * output_width as f32)
+                .round()
+                .max(1.0) as usize;
+            let bbox_h = ((det.bbox.ymax - det.bbox.ymin) * output_height as f32)
+                .round()
+                .max(1.0) as usize;
+            let bbox_w = bbox_w.min(output_width.saturating_sub(start_x));
+            let bbox_h = bbox_h.min(output_height.saturating_sub(start_y));
 
             let mut pixels = vec![0u8; bbox_w * bbox_h];
 

--- a/crates/image/src/cpu.rs
+++ b/crates/image/src/cpu.rs
@@ -1752,20 +1752,16 @@ impl ImageProcessorTrait for CPUProcessor {
         flip: Flip,
         crop: Crop,
     ) -> Result<()> {
-        // Int8 formats: delegate to uint8 pipeline, then apply XOR 0x80
+        // Int8 formats: convert directly into dst as uint8 (layouts are
+        // identical), then XOR 0x80 in-place. Avoids a temporary allocation.
         if fourcc_is_int8(dst.fourcc()) {
-            let uint8_fourcc = fourcc_uint8_equivalent(dst.fourcc());
-            let mut tmp = TensorImage::new(
-                dst.width(),
-                dst.height(),
-                uint8_fourcc,
-                Some(edgefirst_tensor::TensorMemory::Mem),
-            )?;
-            self.convert(src, &mut tmp, rotation, flip, crop)?;
-            let src_map = tmp.tensor().map()?;
+            let int8_fourcc = dst.fourcc();
+            dst.set_fourcc(fourcc_uint8_equivalent(int8_fourcc));
+            self.convert(src, dst, rotation, flip, crop)?;
+            dst.set_fourcc(int8_fourcc);
             let mut dst_map = dst.tensor().map()?;
-            for (d, s) in dst_map.iter_mut().zip(src_map.iter()) {
-                *d = s ^ 0x80;
+            for byte in dst_map.iter_mut() {
+                *byte ^= 0x80;
             }
             return Ok(());
         }

--- a/crates/image/src/cpu.rs
+++ b/crates/image/src/cpu.rs
@@ -4,7 +4,7 @@
 use crate::{
     fourcc_is_int8, fourcc_uint8_equivalent, Crop, Error, Flip, FunctionTimer, ImageProcessorTrait,
     Rect, Result, Rotation, TensorImage, TensorImageDst, TensorImageRef, GREY, NV12, NV16,
-    PLANAR_RGB, PLANAR_RGBA, RGB, RGBA, YUYV,
+    PLANAR_RGB, PLANAR_RGBA, RGB, RGBA, VYUY, YUYV,
 };
 #[cfg(feature = "decoder")]
 use edgefirst_decoder::{DetectBox, ProtoData, Segmentation};
@@ -297,6 +297,102 @@ impl CPUProcessor {
         for ((s, y), uv) in src_chunks.iter().zip(y_plane).zip(uv_plane) {
             *y = s[0];
             *uv = s[1];
+        }
+        Ok(())
+    }
+
+    fn convert_vyuy_to_rgb(src: &TensorImage, dst: &mut TensorImage) -> Result<()> {
+        assert_eq!(src.fourcc(), VYUY);
+        assert_eq!(dst.fourcc(), RGB);
+        let src = yuv::YuvPackedImage::<u8> {
+            yuy: &src.tensor.map()?,
+            yuy_stride: src.row_stride() as u32,
+            width: src.width() as u32,
+            height: src.height() as u32,
+        };
+
+        Ok(yuv::vyuy422_to_rgb(
+            &src,
+            dst.tensor.map()?.as_mut_slice(),
+            dst.width() as u32 * 3,
+            yuv::YuvRange::Limited,
+            yuv::YuvStandardMatrix::Bt709,
+        )?)
+    }
+
+    fn convert_vyuy_to_rgba(src: &TensorImage, dst: &mut TensorImage) -> Result<()> {
+        assert_eq!(src.fourcc(), VYUY);
+        assert_eq!(dst.fourcc(), RGBA);
+        let src = yuv::YuvPackedImage::<u8> {
+            yuy: &src.tensor.map()?,
+            yuy_stride: src.row_stride() as u32,
+            width: src.width() as u32,
+            height: src.height() as u32,
+        };
+
+        Ok(yuv::vyuy422_to_rgba(
+            &src,
+            dst.tensor.map()?.as_mut_slice(),
+            dst.row_stride() as u32,
+            yuv::YuvRange::Limited,
+            yuv::YuvStandardMatrix::Bt709,
+        )?)
+    }
+
+    fn convert_vyuy_to_8bps(src: &TensorImage, dst: &mut TensorImage) -> Result<()> {
+        assert_eq!(src.fourcc(), VYUY);
+        assert_eq!(dst.fourcc(), PLANAR_RGB);
+        let mut tmp = TensorImage::new(src.width(), src.height(), RGB, None)?;
+        Self::convert_vyuy_to_rgb(src, &mut tmp)?;
+        Self::convert_rgb_to_8bps(&tmp, dst)
+    }
+
+    fn convert_vyuy_to_prgba(src: &TensorImage, dst: &mut TensorImage) -> Result<()> {
+        assert_eq!(src.fourcc(), VYUY);
+        assert_eq!(dst.fourcc(), PLANAR_RGBA);
+        let mut tmp = TensorImage::new(src.width(), src.height(), RGB, None)?;
+        Self::convert_vyuy_to_rgb(src, &mut tmp)?;
+        Self::convert_rgb_to_prgba(&tmp, dst)
+    }
+
+    fn convert_vyuy_to_grey(src: &TensorImage, dst: &mut TensorImage) -> Result<()> {
+        assert_eq!(src.fourcc(), VYUY);
+        assert_eq!(dst.fourcc(), GREY);
+        let src_map = src.tensor.map()?;
+        let mut dst_map = dst.tensor.map()?;
+        // VYUY byte order: [V, Y0, U, Y1] — Y at offsets 1, 3
+        let src_chunks = src_map.as_chunks::<16>();
+        let dst_chunks = dst_map.as_chunks_mut::<8>();
+        for (s, d) in src_chunks.0.iter().zip(dst_chunks.0) {
+            for (di, si) in (1..16).step_by(2).enumerate() {
+                d[di] = limit_to_full(s[si]);
+            }
+        }
+
+        for (di, si) in (1..src_chunks.1.len()).step_by(2).enumerate() {
+            dst_chunks.1[di] = limit_to_full(src_chunks.1[si]);
+        }
+
+        Ok(())
+    }
+
+    fn convert_vyuy_to_nv16(src: &TensorImage, dst: &mut TensorImage) -> Result<()> {
+        assert_eq!(src.fourcc(), VYUY);
+        assert_eq!(dst.fourcc(), NV16);
+        let src_map = src.tensor.map()?;
+        let mut dst_map = dst.tensor.map()?;
+
+        // VYUY byte order: [V, Y0, U, Y1] — per 4-byte macropixel
+        let src_chunks = src_map.as_chunks::<4>().0;
+        let (y_plane, uv_plane) = dst_map.split_at_mut(dst.row_stride() * dst.height());
+        let y_pairs = y_plane.as_chunks_mut::<2>().0;
+        let uv_pairs = uv_plane.as_chunks_mut::<2>().0;
+
+        for ((s, y), uv) in src_chunks.iter().zip(y_pairs).zip(uv_pairs) {
+            y[0] = s[1]; // Y0
+            y[1] = s[3]; // Y1
+            uv[0] = s[2]; // U
+            uv[1] = s[0]; // V
         }
         Ok(())
     }
@@ -965,6 +1061,13 @@ impl CPUProcessor {
                 | (YUYV, PLANAR_RGB)
                 | (YUYV, PLANAR_RGBA)
                 | (YUYV, NV16)
+                | (VYUY, RGB)
+                | (VYUY, RGBA)
+                | (VYUY, GREY)
+                | (VYUY, VYUY)
+                | (VYUY, PLANAR_RGB)
+                | (VYUY, PLANAR_RGBA)
+                | (VYUY, NV16)
                 | (RGBA, RGB)
                 | (RGBA, RGBA)
                 | (RGBA, GREY)
@@ -1010,6 +1113,13 @@ impl CPUProcessor {
             (YUYV, PLANAR_RGB) => Self::convert_yuyv_to_8bps(src, dst),
             (YUYV, PLANAR_RGBA) => Self::convert_yuyv_to_prgba(src, dst),
             (YUYV, NV16) => Self::convert_yuyv_to_nv16(src, dst),
+            (VYUY, RGB) => Self::convert_vyuy_to_rgb(src, dst),
+            (VYUY, RGBA) => Self::convert_vyuy_to_rgba(src, dst),
+            (VYUY, GREY) => Self::convert_vyuy_to_grey(src, dst),
+            (VYUY, VYUY) => Self::copy_image(src, dst),
+            (VYUY, PLANAR_RGB) => Self::convert_vyuy_to_8bps(src, dst),
+            (VYUY, PLANAR_RGBA) => Self::convert_vyuy_to_prgba(src, dst),
+            (VYUY, NV16) => Self::convert_vyuy_to_nv16(src, dst),
             (RGBA, RGB) => Self::convert_rgba_to_rgb(src, dst),
             (RGBA, RGBA) => Self::copy_image(src, dst),
             (RGBA, GREY) => Self::convert_rgba_to_grey(src, dst),
@@ -1783,6 +1893,13 @@ impl ImageProcessorTrait for CPUProcessor {
             (YUYV, PLANAR_RGB) => RGB,
             (YUYV, PLANAR_RGBA) => RGBA,
             (YUYV, NV16) => RGBA,
+            (VYUY, RGB) => RGB,
+            (VYUY, RGBA) => RGBA,
+            (VYUY, GREY) => GREY,
+            (VYUY, VYUY) => RGBA, // RGBA intermediary for VYUY dest resize/convert/rotation/flip
+            (VYUY, PLANAR_RGB) => RGB,
+            (VYUY, PLANAR_RGBA) => RGBA,
+            (VYUY, NV16) => RGBA,
             (RGBA, RGB) => RGBA,
             (RGBA, RGBA) => RGBA,
             (RGBA, GREY) => GREY,
@@ -1934,6 +2051,11 @@ impl ImageProcessorTrait for CPUProcessor {
             (YUYV, GREY) => GREY,
             (YUYV, PLANAR_RGB) => RGB,
             (YUYV, PLANAR_RGBA) => RGBA,
+            (VYUY, RGB) => RGB,
+            (VYUY, RGBA) => RGBA,
+            (VYUY, GREY) => GREY,
+            (VYUY, PLANAR_RGB) => RGB,
+            (VYUY, PLANAR_RGBA) => RGBA,
             (RGBA, RGB) => RGBA,
             (RGBA, RGBA) => RGBA,
             (RGBA, GREY) => GREY,

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -147,6 +147,8 @@ impl ImageProcessorTrait for G2DProcessor {
             (YUYV, RGBA) => {}
             (YUYV, YUYV) => {}
             (YUYV, RGB) => {}
+            // VYUY: i.MX8MP G2D hardware rejects VYUY blits (only YUYV/UYVY
+            // among packed YUV 4:2:2). ImageProcessor falls through to CPU.
             (NV12, RGBA) => {}
             (NV12, YUYV) => {}
             (NV12, RGB) => {}

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -1438,21 +1438,27 @@ impl ImageProcessor {
         height: usize,
         fourcc: four_char_code::FourCharCode,
     ) -> Result<TensorImage> {
-        // Try DMA (if GL backend uses DmaBuf)
+        // Try DMA first on Linux — skip only when GL has explicitly selected PBO
+        // as the preferred transfer path (PBO is better than DMA in that case).
         #[cfg(target_os = "linux")]
-        #[cfg(feature = "opengl")]
-        if self
-            .opengl
-            .as_ref()
-            .is_some_and(|gl| gl.transfer_backend() == opengl_headless::TransferBackend::DmaBuf)
         {
-            if let Ok(img) = TensorImage::new(
-                width,
-                height,
-                fourcc,
-                Some(edgefirst_tensor::TensorMemory::Dma),
-            ) {
-                return Ok(img);
+            #[cfg(feature = "opengl")]
+            let gl_uses_pbo = self
+                .opengl
+                .as_ref()
+                .is_some_and(|gl| gl.transfer_backend() == opengl_headless::TransferBackend::Pbo);
+            #[cfg(not(feature = "opengl"))]
+            let gl_uses_pbo = false;
+
+            if !gl_uses_pbo {
+                if let Ok(img) = TensorImage::new(
+                    width,
+                    height,
+                    fourcc,
+                    Some(edgefirst_tensor::TensorMemory::Dma),
+                ) {
+                    return Ok(img);
+                }
             }
         }
 

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -1404,6 +1404,67 @@ impl ImageProcessor {
         }
         Ok(())
     }
+
+    /// Create a `TensorImage` with the best available memory backend.
+    ///
+    /// Priority: DMA-buf → PBO → system memory.
+    ///
+    /// # Arguments
+    ///
+    /// * `width` - Image width in pixels
+    /// * `height` - Image height in pixels
+    /// * `fourcc` - Pixel format as a FourCC code
+    ///
+    /// # Returns
+    ///
+    /// A `TensorImage` backed by the highest-performance memory type
+    /// available on this system.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if all allocation strategies fail.
+    pub fn create_image(
+        &self,
+        width: usize,
+        height: usize,
+        fourcc: four_char_code::FourCharCode,
+    ) -> Result<TensorImage> {
+        // Try DMA (if GL backend uses DmaBuf)
+        #[cfg(target_os = "linux")]
+        #[cfg(feature = "opengl")]
+        if self
+            .opengl
+            .as_ref()
+            .is_some_and(|gl| gl.transfer_backend() == opengl_headless::TransferBackend::DmaBuf)
+        {
+            if let Ok(img) = TensorImage::new(
+                width,
+                height,
+                fourcc,
+                Some(edgefirst_tensor::TensorMemory::Dma),
+            ) {
+                return Ok(img);
+            }
+        }
+
+        // Try PBO (if GL available)
+        #[cfg(target_os = "linux")]
+        #[cfg(feature = "opengl")]
+        if let Some(gl) = &self.opengl {
+            match gl.create_pbo_image(width, height, fourcc) {
+                Ok(img) => return Ok(img),
+                Err(e) => log::debug!("PBO image creation failed, falling back to Mem: {e:?}"),
+            }
+        }
+
+        // Fallback to Mem
+        TensorImage::new(
+            width,
+            height,
+            fourcc,
+            Some(edgefirst_tensor::TensorMemory::Mem),
+        )
+    }
 }
 
 impl ImageProcessorTrait for ImageProcessor {

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -643,6 +643,13 @@ impl TensorImage {
         self.fourcc
     }
 
+    /// Override the FourCC format tag without touching the underlying tensor.
+    /// Used internally for int8 ↔ uint8 format aliasing where the pixel layout
+    /// is identical and only the interpretation differs.
+    pub(crate) fn set_fourcc(&mut self, fourcc: FourCharCode) {
+        self.fourcc = fourcc;
+    }
+
     /// # Examples
     /// ```rust
     /// use edgefirst_image::{RGB, TensorImage};

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -4390,8 +4390,7 @@ mod image_tests {
             .unwrap();
 
         // Verify: compare with CPU-only conversion of the same input
-        let mut cpu_dst =
-            TensorImage::new(dst_w, dst_h, RGBA, Some(TensorMemory::Mem)).unwrap();
+        let mut cpu_dst = TensorImage::new(dst_w, dst_h, RGBA, Some(TensorMemory::Mem)).unwrap();
         CPUProcessor::new()
             .convert(
                 &mem_src,

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -4310,4 +4310,92 @@ mod image_tests {
         assert!(!fourcc_is_packed_rgb(PLANAR_RGB));
         assert!(!fourcc_is_packed_rgb(RGBA));
     }
+
+    /// Integration test that exercises the PBO-to-PBO convert path.
+    /// Uses ImageProcessor::create_image() to allocate PBO-backed tensors,
+    /// then converts between them. Skipped when GL is unavailable or the
+    /// backend is not PBO (e.g. DMA-buf systems).
+    #[cfg(target_os = "linux")]
+    #[cfg(feature = "opengl")]
+    #[test]
+    fn test_convert_pbo_to_pbo() {
+        let mut converter = ImageProcessor::new().unwrap();
+
+        // Skip if GL is not available or backend is not PBO
+        let is_pbo = converter
+            .opengl
+            .as_ref()
+            .is_some_and(|gl| gl.transfer_backend() == opengl_headless::TransferBackend::Pbo);
+        if !is_pbo {
+            eprintln!("Skipping test_convert_pbo_to_pbo: backend is not PBO");
+            return;
+        }
+
+        let src_w = 640;
+        let src_h = 480;
+        let dst_w = 320;
+        let dst_h = 240;
+
+        // Create PBO-backed source image
+        let pbo_src = converter.create_image(src_w, src_h, RGBA).unwrap();
+        assert_eq!(
+            pbo_src.tensor().memory(),
+            TensorMemory::Pbo,
+            "create_image should produce a PBO tensor"
+        );
+
+        // Fill source PBO with test pattern: load JPEG then convert Mem→PBO
+        let file = include_bytes!("../../../testdata/zidane.jpg").to_vec();
+        let jpeg_src = TensorImage::load_jpeg(&file, Some(RGBA), None).unwrap();
+
+        // Resize JPEG into a Mem temp of the right size, then copy into PBO
+        let mut mem_src = TensorImage::new(src_w, src_h, RGBA, Some(TensorMemory::Mem)).unwrap();
+        CPUProcessor::new()
+            .convert(
+                &jpeg_src,
+                &mut mem_src,
+                Rotation::None,
+                Flip::None,
+                Crop::no_crop(),
+            )
+            .unwrap();
+
+        // Copy pixel data into the PBO source by mapping it
+        {
+            let src_data = mem_src.tensor().map().unwrap();
+            let mut pbo_map = pbo_src.tensor().map().unwrap();
+            pbo_map.copy_from_slice(&src_data);
+        }
+
+        // Create PBO-backed destination image
+        let mut pbo_dst = converter.create_image(dst_w, dst_h, RGBA).unwrap();
+        assert_eq!(pbo_dst.tensor().memory(), TensorMemory::Pbo);
+
+        // Convert PBO→PBO (this exercises convert_pbo_to_pbo)
+        converter
+            .convert(
+                &pbo_src,
+                &mut pbo_dst,
+                Rotation::None,
+                Flip::None,
+                Crop::no_crop(),
+            )
+            .unwrap();
+
+        // Verify: compare with CPU-only conversion of the same input
+        let mut cpu_dst =
+            TensorImage::new(dst_w, dst_h, RGBA, Some(TensorMemory::Mem)).unwrap();
+        CPUProcessor::new()
+            .convert(
+                &mem_src,
+                &mut cpu_dst,
+                Rotation::None,
+                Flip::None,
+                Crop::no_crop(),
+            )
+            .unwrap();
+
+        compare_images(&pbo_dst, &cpu_dst, 0.95, function!());
+        log::info!("test_convert_pbo_to_pbo: PASS — PBO-to-PBO convert matches CPU reference");
+    }
 }

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -108,6 +108,8 @@ mod opengl_headless;
 
 /// 8 bit interleaved YUV422, limited range
 pub const YUYV: FourCharCode = four_char_code!("YUYV");
+/// 8 bit interleaved YUV422 (VYUY byte order), limited range
+pub const VYUY: FourCharCode = four_char_code!("VYUY");
 /// 8 bit planar YUV420, limited range
 pub const NV12: FourCharCode = four_char_code!("NV12");
 /// 8 bit planar YUV422, limited range
@@ -1770,12 +1772,12 @@ impl ImageProcessorTrait for ImageProcessor {
 
 fn fourcc_channels(fourcc: FourCharCode) -> Result<usize> {
     match fourcc {
-        RGBA => Ok(4), // RGBA has 4 channels (R, G, B, A)
-        RGB => Ok(3),  // RGB has 3 channels (R, G, B)
-        YUYV => Ok(2), // YUYV has 2 channels (Y and UV)
-        GREY => Ok(1), // Y800 has 1 channel (Y)
-        NV12 => Ok(2), // NV12 has 2 channel. 2nd channel is half empty
-        NV16 => Ok(2), // NV16 has 2 channel. 2nd channel is full size
+        RGBA => Ok(4),        // RGBA has 4 channels (R, G, B, A)
+        RGB => Ok(3),         // RGB has 3 channels (R, G, B)
+        YUYV | VYUY => Ok(2), // YUYV/VYUY has 2 channels (Y and UV)
+        GREY => Ok(1),        // Y800 has 1 channel (Y)
+        NV12 => Ok(2),        // NV12 has 2 channel. 2nd channel is half empty
+        NV16 => Ok(2),        // NV16 has 2 channel. 2nd channel is full size
         PLANAR_RGB => Ok(3),
         PLANAR_RGBA => Ok(4),
         RGB_INT8 => Ok(3),
@@ -1789,14 +1791,14 @@ fn fourcc_channels(fourcc: FourCharCode) -> Result<usize> {
 
 fn fourcc_planar(fourcc: FourCharCode) -> Result<bool> {
     match fourcc {
-        RGBA => Ok(false),       // RGBA has 4 channels (R, G, B, A)
-        RGB => Ok(false),        // RGB has 3 channels (R, G, B)
-        YUYV => Ok(false),       // YUYV has 2 channels (Y and UV)
-        GREY => Ok(false),       // Y800 has 1 channel (Y)
-        NV12 => Ok(true),        // Planar YUV
-        NV16 => Ok(true),        // Planar YUV
-        PLANAR_RGB => Ok(true),  // Planar RGB
-        PLANAR_RGBA => Ok(true), // Planar RGBA
+        RGBA => Ok(false),        // RGBA has 4 channels (R, G, B, A)
+        RGB => Ok(false),         // RGB has 3 channels (R, G, B)
+        YUYV | VYUY => Ok(false), // YUYV/VYUY has 2 channels (Y and UV)
+        GREY => Ok(false),        // Y800 has 1 channel (Y)
+        NV12 => Ok(true),         // Planar YUV
+        NV16 => Ok(true),         // Planar YUV
+        PLANAR_RGB => Ok(true),   // Planar RGB
+        PLANAR_RGBA => Ok(true),  // Planar RGBA
         RGB_INT8 => Ok(false),
         PLANAR_RGB_INT8 => Ok(true),
         _ => Err(Error::NotSupported(format!(
@@ -3690,6 +3692,221 @@ mod image_tests {
             )
             .unwrap();
         compare_images(&dst_gl, &dst_cpu, 0.98, function!());
+    }
+
+    #[test]
+    fn test_vyuy_to_rgba_cpu() {
+        let file = include_bytes!("../../../testdata/camera720p.vyuy").to_vec();
+        let src = TensorImage::new(1280, 720, VYUY, None).unwrap();
+        src.tensor()
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(&file);
+
+        let mut dst = TensorImage::new(1280, 720, RGBA, None).unwrap();
+        let mut cpu_converter = CPUProcessor::new();
+
+        cpu_converter
+            .convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+            .unwrap();
+
+        let target_image = TensorImage::new(1280, 720, RGBA, None).unwrap();
+        target_image
+            .tensor()
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(include_bytes!("../../../testdata/camera720p.rgba"));
+
+        compare_images(&dst, &target_image, 0.98, function!());
+    }
+
+    #[test]
+    fn test_vyuy_to_rgb_cpu() {
+        let file = include_bytes!("../../../testdata/camera720p.vyuy").to_vec();
+        let src = TensorImage::new(1280, 720, VYUY, None).unwrap();
+        src.tensor()
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(&file);
+
+        let mut dst = TensorImage::new(1280, 720, RGB, None).unwrap();
+        let mut cpu_converter = CPUProcessor::new();
+
+        cpu_converter
+            .convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+            .unwrap();
+
+        let target_image = TensorImage::new(1280, 720, RGB, None).unwrap();
+        target_image
+            .tensor()
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .as_chunks_mut::<3>()
+            .0
+            .iter_mut()
+            .zip(
+                include_bytes!("../../../testdata/camera720p.rgba")
+                    .as_chunks::<4>()
+                    .0,
+            )
+            .for_each(|(dst, src)| *dst = [src[0], src[1], src[2]]);
+
+        compare_images(&dst, &target_image, 0.98, function!());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_vyuy_to_rgba_g2d() {
+        if !is_g2d_available() {
+            eprintln!("SKIPPED: test_vyuy_to_rgba_g2d - G2D library (libg2d.so.2) not available");
+            return;
+        }
+        if !is_dma_available() {
+            eprintln!(
+                "SKIPPED: test_vyuy_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
+            );
+            return;
+        }
+
+        let src = load_bytes_to_tensor(
+            1280,
+            720,
+            VYUY,
+            None,
+            include_bytes!("../../../testdata/camera720p.vyuy"),
+        )
+        .unwrap();
+
+        let mut dst = TensorImage::new(1280, 720, RGBA, Some(TensorMemory::Dma)).unwrap();
+        let mut g2d_converter = G2DProcessor::new().unwrap();
+
+        match g2d_converter.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop()) {
+            Err(Error::G2D(_)) => {
+                eprintln!("SKIPPED: test_vyuy_to_rgba_g2d - G2D does not support VYUY format");
+                return;
+            }
+            r => r.unwrap(),
+        }
+
+        let target_image = TensorImage::new(1280, 720, RGBA, None).unwrap();
+        target_image
+            .tensor()
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(include_bytes!("../../../testdata/camera720p.rgba"));
+
+        compare_images(&dst, &target_image, 0.98, function!());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_vyuy_to_rgb_g2d() {
+        if !is_g2d_available() {
+            eprintln!("SKIPPED: test_vyuy_to_rgb_g2d - G2D library (libg2d.so.2) not available");
+            return;
+        }
+        if !is_dma_available() {
+            eprintln!(
+                "SKIPPED: test_vyuy_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
+            );
+            return;
+        }
+
+        let src = load_bytes_to_tensor(
+            1280,
+            720,
+            VYUY,
+            None,
+            include_bytes!("../../../testdata/camera720p.vyuy"),
+        )
+        .unwrap();
+
+        let mut g2d_dst = TensorImage::new(1280, 720, RGB, Some(TensorMemory::Dma)).unwrap();
+        let mut g2d_converter = G2DProcessor::new().unwrap();
+
+        match g2d_converter.convert(
+            &src,
+            &mut g2d_dst,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        ) {
+            Err(Error::G2D(_)) => {
+                eprintln!("SKIPPED: test_vyuy_to_rgb_g2d - G2D does not support VYUY format");
+                return;
+            }
+            r => r.unwrap(),
+        }
+
+        let mut cpu_dst = TensorImage::new(1280, 720, RGB, None).unwrap();
+        let mut cpu_converter: CPUProcessor = CPUProcessor::new();
+
+        cpu_converter
+            .convert(
+                &src,
+                &mut cpu_dst,
+                Rotation::None,
+                Flip::None,
+                Crop::no_crop(),
+            )
+            .unwrap();
+
+        compare_images(&g2d_dst, &cpu_dst, 0.98, function!());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[cfg(feature = "opengl")]
+    fn test_vyuy_to_rgba_opengl() {
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        if !is_dma_available() {
+            eprintln!(
+                "SKIPPED: {} - DMA memory allocation not available (permission denied or no DMA-BUF support)",
+                function!()
+            );
+            return;
+        }
+
+        let src = load_bytes_to_tensor(
+            1280,
+            720,
+            VYUY,
+            Some(TensorMemory::Dma),
+            include_bytes!("../../../testdata/camera720p.vyuy"),
+        )
+        .unwrap();
+
+        let mut dst = TensorImage::new(1280, 720, RGBA, Some(TensorMemory::Dma)).unwrap();
+        let mut gl_converter = GLProcessorThreaded::new(None).unwrap();
+
+        match gl_converter.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop()) {
+            Err(Error::NotSupported(_)) => {
+                eprintln!(
+                    "SKIPPED: {} - OpenGL does not support VYUY DMA format",
+                    function!()
+                );
+                return;
+            }
+            r => r.unwrap(),
+        }
+
+        let target_image = TensorImage::new(1280, 720, RGBA, None).unwrap();
+        target_image
+            .tensor()
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(include_bytes!("../../../testdata/camera720p.rgba"));
+
+        compare_images(&dst, &target_image, 0.98, function!());
     }
 
     #[test]

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -143,10 +143,7 @@ fn probe_display_extensions(egl: &Egl, display: egl::Display) -> bool {
     };
     let exts = ext_str.to_string_lossy();
 
-    let required = [
-        "EGL_KHR_surfaceless_context",
-        "EGL_KHR_no_config_context",
-    ];
+    let required = ["EGL_KHR_surfaceless_context", "EGL_KHR_no_config_context"];
 
     for r in &required {
         if !exts.contains(r) {
@@ -716,6 +713,61 @@ enum GLProcessorMessage {
         usize,
         tokio::sync::oneshot::Sender<Result<Vec<MaskResult>, Error>>,
     ),
+    PboCreate(
+        usize, // buffer size in bytes
+        tokio::sync::oneshot::Sender<Result<u32, Error>>,
+    ),
+    PboMap(
+        u32,   // buffer_id
+        usize, // size
+        tokio::sync::oneshot::Sender<Result<edgefirst_tensor::PboMapping, Error>>,
+    ),
+    PboUnmap(
+        u32, // buffer_id
+        tokio::sync::oneshot::Sender<Result<(), Error>>,
+    ),
+    PboDelete(u32), // fire-and-forget, no reply
+}
+
+/// Implements PboOps by sending commands to the GL thread.
+struct GlPboOps {
+    sender: Sender<GLProcessorMessage>,
+}
+
+impl edgefirst_tensor::PboOps for GlPboOps {
+    fn map_buffer(
+        &self,
+        buffer_id: u32,
+        size: usize,
+    ) -> edgefirst_tensor::Result<edgefirst_tensor::PboMapping> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.sender
+            .blocking_send(GLProcessorMessage::PboMap(buffer_id, size, tx))
+            .map_err(|_| edgefirst_tensor::Error::PboDisconnected)?;
+        rx.blocking_recv()
+            .map_err(|_| edgefirst_tensor::Error::PboDisconnected)?
+            .map_err(|e| {
+                edgefirst_tensor::Error::NotImplemented(format!("GL PBO map failed: {e:?}"))
+            })
+    }
+
+    fn unmap_buffer(&self, buffer_id: u32) -> edgefirst_tensor::Result<()> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.sender
+            .blocking_send(GLProcessorMessage::PboUnmap(buffer_id, tx))
+            .map_err(|_| edgefirst_tensor::Error::PboDisconnected)?;
+        rx.blocking_recv()
+            .map_err(|_| edgefirst_tensor::Error::PboDisconnected)?
+            .map_err(|e| {
+                edgefirst_tensor::Error::NotImplemented(format!("GL PBO unmap failed: {e:?}"))
+            })
+    }
+
+    fn delete_buffer(&self, buffer_id: u32) {
+        let _ = self
+            .sender
+            .blocking_send(GLProcessorMessage::PboDelete(buffer_id));
+    }
 }
 
 /// OpenGL multi-threaded image converter. The actual conversion is done in a
@@ -813,6 +865,62 @@ impl GLProcessorThreaded {
                         );
                         let _ = resp.send(res);
                     }
+                    GLProcessorMessage::PboCreate(size, resp) => {
+                        let result = unsafe {
+                            let mut id: u32 = 0;
+                            gls::gl::GenBuffers(1, &mut id);
+                            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, id);
+                            gls::gl::BufferData(
+                                gls::gl::PIXEL_PACK_BUFFER,
+                                size as isize,
+                                std::ptr::null(),
+                                gls::gl::STREAM_COPY,
+                            );
+                            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, 0);
+                            match check_gl_error("PboCreate", 0) {
+                                Ok(()) => Ok(id),
+                                Err(e) => {
+                                    gls::gl::DeleteBuffers(1, &id);
+                                    Err(e)
+                                }
+                            }
+                        };
+                        let _ = resp.send(result);
+                    }
+                    GLProcessorMessage::PboMap(buffer_id, size, resp) => {
+                        let result = unsafe {
+                            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, buffer_id);
+                            let ptr = gls::gl::MapBufferRange(
+                                gls::gl::PIXEL_PACK_BUFFER,
+                                0,
+                                size as isize,
+                                gls::gl::MAP_READ_BIT | gls::gl::MAP_WRITE_BIT,
+                            );
+                            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, 0);
+                            if ptr.is_null() {
+                                Err(crate::Error::OpenGl(
+                                    "glMapBufferRange returned null".to_string(),
+                                ))
+                            } else {
+                                Ok(edgefirst_tensor::PboMapping {
+                                    ptr: ptr as *mut u8,
+                                    size,
+                                })
+                            }
+                        };
+                        let _ = resp.send(result);
+                    }
+                    GLProcessorMessage::PboUnmap(buffer_id, resp) => {
+                        unsafe {
+                            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, buffer_id);
+                            gls::gl::UnmapBuffer(gls::gl::PIXEL_PACK_BUFFER);
+                            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, 0);
+                        }
+                        let _ = resp.send(Ok(()));
+                    }
+                    GLProcessorMessage::PboDelete(buffer_id) => unsafe {
+                        gls::gl::DeleteBuffers(1, &buffer_id);
+                    },
                 }
             }
         };
@@ -1037,6 +1145,56 @@ impl GLProcessorThreaded {
         resp_recv.blocking_recv().map_err(|_| {
             Error::Internal("GL converter error messaging closed without update".to_string())
         })?
+    }
+
+    /// Create a PBO-backed TensorImage on the GL thread.
+    pub fn create_pbo_image(
+        &self,
+        width: usize,
+        height: usize,
+        fourcc: four_char_code::FourCharCode,
+    ) -> Result<crate::TensorImage, Error> {
+        let sender = self
+            .sender
+            .as_ref()
+            .ok_or(Error::OpenGl("GL processor is shutting down".to_string()))?;
+
+        let channels = crate::fourcc_channels(fourcc)?;
+        let size = width * height * channels;
+        if size == 0 {
+            return Err(Error::OpenGl("Invalid image dimensions".to_string()));
+        }
+
+        // Allocate PBO on the GL thread
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        sender
+            .blocking_send(GLProcessorMessage::PboCreate(size, tx))
+            .map_err(|_| Error::OpenGl("GL thread channel closed".to_string()))?;
+        let buffer_id = rx
+            .blocking_recv()
+            .map_err(|_| Error::OpenGl("GL thread did not respond".to_string()))??;
+
+        let ops: std::sync::Arc<dyn edgefirst_tensor::PboOps> = std::sync::Arc::new(GlPboOps {
+            sender: sender.clone(),
+        });
+
+        let shape = if crate::fourcc_planar(fourcc)? {
+            vec![channels, height, width]
+        } else {
+            vec![height, width, channels]
+        };
+
+        let pbo_tensor =
+            edgefirst_tensor::PboTensor::<u8>::from_pbo(buffer_id, size, &shape, None, ops);
+        let tensor = edgefirst_tensor::Tensor::Pbo(pbo_tensor);
+        crate::TensorImage::from_tensor(tensor, fourcc)
+            .map_err(|e| Error::OpenGl(format!("Failed to wrap PBO tensor as image: {e:?}")))
+    }
+
+    /// Returns the active transfer backend.
+    #[allow(dead_code)]
+    pub(crate) fn transfer_backend(&self) -> TransferBackend {
+        self.transfer_backend
     }
 }
 
@@ -1672,12 +1830,8 @@ impl GLProcessorST {
 
         // Verify DMA-buf actually works (catches NVIDIA discrete GPUs where
         // EGLImage creation succeeds but rendered data is all zeros)
-        if converter.gl_context.transfer_backend.is_dma()
-            && !converter.verify_dma_buf_roundtrip()
-        {
-            log::info!(
-                "DMA-buf verification failed — falling back to synchronous transfers"
-            );
+        if converter.gl_context.transfer_backend.is_dma() && !converter.verify_dma_buf_roundtrip() {
+            log::info!("DMA-buf verification failed — falling back to synchronous transfers");
             converter.gl_context.transfer_backend = TransferBackend::Sync;
             // RGB direct rendering also requires DMA, so disable it
             converter.support_rgb_direct = false;
@@ -1821,13 +1975,9 @@ impl GLProcessorST {
         };
 
         // Run the full DMA-buf EGLImage render pipeline
-        if let Err(e) = self.convert_dest_dma(
-            &mut dst,
-            &src,
-            Rotation::None,
-            Flip::None,
-            Crop::no_crop(),
-        ) {
+        if let Err(e) =
+            self.convert_dest_dma(&mut dst, &src, Rotation::None, Flip::None, Crop::no_crop())
+        {
             log::info!("verify_dma_buf_roundtrip: convert_dest_dma failed: {e}");
             return false;
         }
@@ -2296,9 +2446,7 @@ impl GLProcessorST {
                 .to_string()
         };
         log::debug!("GL Extensions: {extensions}");
-        let required_ext = [
-            "GL_OES_EGL_image_external_essl3",
-        ];
+        let required_ext = ["GL_OES_EGL_image_external_essl3"];
         let extensions = extensions.split_ascii_whitespace().collect::<BTreeSet<_>>();
         for required in required_ext {
             if !extensions.contains(required) {
@@ -3480,6 +3628,11 @@ impl GLProcessorST {
             edgefirst_tensor::Tensor::Mem(_) => {
                 return Err(Error::NotImplemented(
                     "OpenGL EGLImage doesn't support MEM".to_string(),
+                ));
+            }
+            edgefirst_tensor::Tensor::Pbo(_) => {
+                return Err(Error::NotImplemented(
+                    "OpenGL EGLImage doesn't support PBO".to_string(),
                 ));
             }
         };

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -447,7 +447,11 @@ impl GlContext {
             ));
         }
 
-        // just use the first device?
+        if devices.is_empty() {
+            return Err(Error::GLVersion(
+                "EGL_EXT_device_enumeration returned 0 devices".to_string(),
+            ));
+        }
         let disp = Self::egl_get_platform_display_with_fallback(
             egl,
             egl_ext::PLATFORM_DEVICE_EXT,
@@ -483,7 +487,6 @@ impl GlContext {
                 "EGL does not support eglDestroyImageKHR function".to_string(),
             ));
         }
-        // Err(crate::Error::GLVersion("EGL Version too low".to_string()))
         Ok(())
     }
 

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -613,12 +613,11 @@ impl Drop for GlContext {
                 .egl
                 .destroy_context(self.display.as_display(), self.ctx);
 
-            // Note: eglTerminate is intentionally NOT called here. While the
-            // EGL spec says eglInitialize/eglTerminate are ref-counted, some
-            // drivers (notably Vivante) invalidate all resources on the display
-            // when any thread calls eglTerminate. This breaks multi-threaded
-            // use where multiple GlContext instances share the same underlying
-            // DRM render node. EGL resources are cleaned up on process exit.
+            // eglTerminate is ref-counted per the EGL spec: each eglInitialize
+            // increments a counter and each eglTerminate decrements it. The
+            // display is only truly torn down when the last reference is
+            // released. catch_unwind absorbs any driver-side misbehaviour.
+            let _ = self.egl.terminate(self.display.as_display());
         }));
         std::panic::set_hook(prev_hook);
 
@@ -1254,14 +1253,22 @@ struct CachedEglImage {
     guard: std::sync::Weak<()>,
     /// Optional GL renderbuffer backed by this EGLImage (used by direct RGB path).
     renderbuffer: Option<u32>,
+    /// Monotonic access counter for LRU eviction.
+    last_used: u64,
 }
 
 /// EGLImage cache owned by GLProcessorST.
+///
+/// Uses a HashMap with a monotonic counter for LRU eviction: each access
+/// updates the entry's `last_used` timestamp, and eviction removes the entry
+/// with the smallest `last_used` value.
 struct EglImageCache {
     entries: std::collections::HashMap<u64, CachedEglImage>,
     capacity: usize,
     hits: u64,
     misses: u64,
+    /// Monotonic counter incremented on each access for LRU tracking.
+    access_counter: u64,
 }
 
 impl EglImageCache {
@@ -1271,6 +1278,28 @@ impl EglImageCache {
             capacity,
             hits: 0,
             misses: 0,
+            access_counter: 0,
+        }
+    }
+
+    /// Allocate a new LRU timestamp.
+    fn next_timestamp(&mut self) -> u64 {
+        self.access_counter += 1;
+        self.access_counter
+    }
+
+    /// Evict the least recently used entry.
+    fn evict_lru(&mut self) {
+        if let Some((&evict_id, _)) = self
+            .entries
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used)
+        {
+            if let Some(evicted) = self.entries.remove(&evict_id) {
+                if let Some(rbo) = evicted.renderbuffer {
+                    unsafe { gls::gl::DeleteRenderbuffers(1, &rbo) };
+                }
+            }
         }
     }
 
@@ -4297,22 +4326,18 @@ impl GLProcessorST {
                 CacheKind::Src => &mut self.src_egl_cache,
                 CacheKind::Dst => &mut self.dst_egl_cache,
             };
-            if let Some(cached) = egl_cache.entries.get(&id) {
+            let ts = egl_cache.next_timestamp();
+            if let Some(cached) = egl_cache.entries.get_mut(&id) {
                 egl_cache.hits += 1;
+                cached.last_used = ts;
                 log::trace!("EglImageCache {:?} hit: id={id:#x}", cache);
                 return Ok(cached.egl_image.egl_image);
             }
             egl_cache.misses += 1;
             log::trace!("EglImageCache {:?} miss: id={id:#x}", cache);
-            // Evict oldest entry if at capacity.
+            // Evict least-recently-used entry if at capacity.
             if egl_cache.entries.len() >= egl_cache.capacity {
-                if let Some(&evict_id) = egl_cache.entries.keys().next() {
-                    if let Some(evicted) = egl_cache.entries.remove(&evict_id) {
-                        if let Some(rbo) = evicted.renderbuffer {
-                            unsafe { gls::gl::DeleteRenderbuffers(1, &rbo) };
-                        }
-                    }
-                }
+                egl_cache.evict_lru();
             }
         }
 
@@ -4323,12 +4348,14 @@ impl GLProcessorST {
             CacheKind::Src => &mut self.src_egl_cache,
             CacheKind::Dst => &mut self.dst_egl_cache,
         };
+        let ts = egl_cache.next_timestamp();
         egl_cache.entries.insert(
             id,
             CachedEglImage {
                 egl_image: egl_image_obj,
                 guard,
                 renderbuffer: None,
+                last_used: ts,
             },
         );
         Ok(handle)
@@ -4389,8 +4416,10 @@ impl GLProcessorST {
         let id = img.buffer_identity().id();
         self.dst_egl_cache.sweep();
 
-        if let Some(cached) = self.dst_egl_cache.entries.get(&id) {
+        let ts = self.dst_egl_cache.next_timestamp();
+        if let Some(cached) = self.dst_egl_cache.entries.get_mut(&id) {
             self.dst_egl_cache.hits += 1;
+            cached.last_used = ts;
             log::trace!("EglImageCache dst (RGB) hit: id={id:#x}");
             return Ok(cached.egl_image.egl_image);
         }
@@ -4398,24 +4427,20 @@ impl GLProcessorST {
         log::trace!("EglImageCache dst (RGB) miss: id={id:#x}");
 
         if self.dst_egl_cache.entries.len() >= self.dst_egl_cache.capacity {
-            if let Some(&evict_id) = self.dst_egl_cache.entries.keys().next() {
-                if let Some(evicted) = self.dst_egl_cache.entries.remove(&evict_id) {
-                    if let Some(rbo) = evicted.renderbuffer {
-                        unsafe { gls::gl::DeleteRenderbuffers(1, &rbo) };
-                    }
-                }
-            }
+            self.dst_egl_cache.evict_lru();
         }
 
         let egl_image_obj = self.create_egl_image_with_dims(img, width, height, drm_format, bpp)?;
         let handle = egl_image_obj.egl_image;
         let guard = img.buffer_identity().weak();
+        let ts = self.dst_egl_cache.next_timestamp();
         self.dst_egl_cache.entries.insert(
             id,
             CachedEglImage {
                 egl_image: egl_image_obj,
                 guard,
                 renderbuffer: None,
+                last_used: ts,
             },
         );
         Ok(handle)
@@ -4435,9 +4460,11 @@ impl GLProcessorST {
         self.dst_egl_cache.sweep();
 
         // Check cache for existing entry with renderbuffer
-        if let Some(cached) = self.dst_egl_cache.entries.get(&id) {
+        let ts = self.dst_egl_cache.next_timestamp();
+        if let Some(cached) = self.dst_egl_cache.entries.get_mut(&id) {
             if let Some(rbo) = cached.renderbuffer {
                 self.dst_egl_cache.hits += 1;
+                cached.last_used = ts;
                 log::trace!("EglImageCache dst (rgb_direct) hit: id={id:#x}");
                 return Ok((rbo, width, height));
             }
@@ -4445,15 +4472,9 @@ impl GLProcessorST {
         self.dst_egl_cache.misses += 1;
         log::trace!("EglImageCache dst (rgb_direct) miss: id={id:#x}");
 
-        // Evict if at capacity
+        // Evict least-recently-used entry if at capacity
         if self.dst_egl_cache.entries.len() >= self.dst_egl_cache.capacity {
-            if let Some(&evict_id) = self.dst_egl_cache.entries.keys().next() {
-                if let Some(evicted) = self.dst_egl_cache.entries.remove(&evict_id) {
-                    if let Some(rbo) = evicted.renderbuffer {
-                        unsafe { gls::gl::DeleteRenderbuffers(1, &rbo) };
-                    }
-                }
-            }
+            self.dst_egl_cache.evict_lru();
         }
 
         // Create EGLImage from BGR888 DMA-buf
@@ -4478,12 +4499,14 @@ impl GLProcessorST {
 
         // Cache both
         let guard = dst.buffer_identity().weak();
+        let ts = self.dst_egl_cache.next_timestamp();
         self.dst_egl_cache.entries.insert(
             id,
             CachedEglImage {
                 egl_image: egl_image_obj,
                 guard,
                 renderbuffer: Some(rbo),
+                last_used: ts,
             },
         );
 
@@ -5895,23 +5918,28 @@ void main(){
 "
 }
 
-/// Int8 variant of [`generate_planar_rgb_shader`]. Applies `fract(v + 0.5)` to
-/// each channel, which is the GL-safe equivalent of XOR 0x80 for converting
-/// unsigned [0,255] texel values to signed int8 representation.
+/// Int8 variant of [`generate_planar_rgb_shader`]. Applies XOR 0x80 bias
+/// to each RGB channel (uint8 → int8 conversion) using the bit-exact
+/// quantize+mod approach: `floor(v * 255 + 0.5) + 128 mod 256 / 255`.
 fn generate_planar_rgb_int8_shader() -> &'static str {
     "\
 #version 300 es
 #extension GL_OES_EGL_image_external_essl3 : require
-precision mediump float;
+precision highp float;
 uniform samplerExternalOES tex;
 in vec3 fragPos;
 in vec2 tc;
 
 out vec4 color;
 
+vec3 int8_bias(vec3 v) {
+    vec3 q = floor(v * 255.0 + 0.5);
+    return mod(q + 128.0, 256.0) / 255.0;
+}
+
 void main(){
     vec4 c = texture(tex, tc);
-    color = vec4(fract(c.r + 0.5), fract(c.g + 0.5), fract(c.b + 0.5), c.a);
+    color = vec4(int8_bias(c.rgb), c.a);
 }
 "
 }
@@ -6429,9 +6457,8 @@ void main() {
 /// Packed RGB -> RGBA8 packing shader with int8 XOR 0x80 bias (2D source, pass 2).
 ///
 /// Same packing logic as [`generate_packed_rgba8_shader_2d`] but applies
-/// `fract(v + 0.5)` to each channel value before writing. In normalised
-/// float space this is equivalent to XOR 0x80 on the uint8 representation,
-/// converting unsigned [0, 255] to signed [-128, 127] (two's-complement).
+/// bit-exact XOR 0x80 bias via quantize+mod: `floor(v * 255 + 0.5) + 128
+/// mod 256 / 255`. This matches the CPU `byte ^ 0x80` operation exactly.
 fn generate_packed_rgba8_int8_shader_2d() -> &'static str {
     "\
 #version 300 es
@@ -6439,6 +6466,12 @@ precision highp float;
 precision highp int;
 uniform sampler2D tex;
 out vec4 color;
+
+vec4 int8_bias(vec4 v) {
+    vec4 q = floor(v * 255.0 + 0.5);
+    return mod(q + 128.0, 256.0) / 255.0;
+}
+
 void main() {
     // gl_FragCoord is at pixel center (n+0.5). Use floor() for robust
     // integer pixel index on all GPUs (Vivante, Mali, Adreno).
@@ -6453,11 +6486,11 @@ void main() {
     // Extract channels based on phase (base % 3), then apply int8 bias
     int phase = base - px0 * 3;
     if (phase == 0) {
-        color = fract(vec4(s0.r, s0.g, s0.b, s1.r) + 0.5);
+        color = int8_bias(vec4(s0.r, s0.g, s0.b, s1.r));
     } else if (phase == 1) {
-        color = fract(vec4(s0.g, s0.b, s1.r, s1.g) + 0.5);
+        color = int8_bias(vec4(s0.g, s0.b, s1.r, s1.g));
     } else {
-        color = fract(vec4(s0.b, s1.r, s1.g, s1.b) + 0.5);
+        color = int8_bias(vec4(s0.b, s1.r, s1.g, s1.b));
     }
 }
 "

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -222,8 +222,32 @@ pub fn probe_egl_displays() -> Result<Vec<EglDisplayInfo>, Error> {
     Ok(results)
 }
 
+/// Tracks which data-transfer method is active for moving pixels
+/// between CPU memory and GPU textures/framebuffers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransferBackend {
+    /// Zero-copy via EGLImage imported from DMA-buf file descriptors.
+    /// Available on i.MX8 (Vivante), i.MX95 (Mali), Jetson, and any
+    /// platform where `EGL_EXT_image_dma_buf_import` is present AND
+    /// the GPU can actually render through DMA-buf-backed textures.
+    DmaBuf,
+
+    /// Synchronous `glTexSubImage2D` upload + `glReadnPixels` readback.
+    /// Used when DMA-buf is unavailable or when the DMA-buf verification
+    /// probe fails (e.g. NVIDIA discrete GPUs where EGLImage creation
+    /// succeeds but rendered data is all zeros).
+    Sync,
+}
+
+impl TransferBackend {
+    /// Returns `true` if DMA-buf zero-copy is available.
+    pub(crate) fn is_dma(self) -> bool {
+        self == TransferBackend::DmaBuf
+    }
+}
+
 pub(crate) struct GlContext {
-    pub(crate) support_dma: bool,
+    pub(crate) transfer_backend: TransferBackend,
     pub(crate) display: EglDisplayType,
     pub(crate) ctx: egl::Context,
     /// Wrapped in ManuallyDrop because the khronos-egl Dynamic instance's
@@ -338,12 +362,17 @@ impl GlContext {
         // goes through FBOs backed by EGLImages.
         egl.make_current(display.as_display(), None, None, Some(ctx))?;
 
-        let support_dma = Self::egl_check_support_dma(&egl).is_ok();
+        let has_dma_extensions = Self::egl_check_support_dma(&egl).is_ok();
+        let transfer_backend = if has_dma_extensions {
+            TransferBackend::DmaBuf
+        } else {
+            TransferBackend::Sync
+        };
         Ok(GlContext {
             display,
             ctx,
             egl: ManuallyDrop::new(egl),
-            support_dma,
+            transfer_backend,
         })
     }
 
@@ -700,7 +729,7 @@ pub struct GLProcessorThreaded {
 
     // This is only None when the converter is being dropped.
     sender: Option<Sender<GLProcessorMessage>>,
-    support_dma: bool,
+    transfer_backend: TransferBackend,
 }
 
 unsafe impl Send for GLProcessorThreaded {}
@@ -728,7 +757,7 @@ impl GLProcessorThreaded {
                     return;
                 }
             };
-            let _ = create_ctx_send.send(Ok(gl_converter.gl_context.support_dma));
+            let _ = create_ctx_send.send(Ok(gl_converter.gl_context.transfer_backend));
             while let Some(msg) = recv.blocking_recv() {
                 match msg {
                     GLProcessorMessage::ImageConvert(src, mut dst, rotation, flip, crop, resp) => {
@@ -791,20 +820,20 @@ impl GLProcessorThreaded {
         // let handle = tokio::task::spawn(func());
         let handle = std::thread::spawn(func);
 
-        let support_dma = match create_ctx_recv.blocking_recv() {
+        let transfer_backend = match create_ctx_recv.blocking_recv() {
             Ok(Err(e)) => return Err(e),
             Err(_) => {
                 return Err(Error::Internal(
                     "GL converter error messaging closed without update".to_string(),
                 ));
             }
-            Ok(Ok(supports_dma)) => supports_dma,
+            Ok(Ok(tb)) => tb,
         };
 
         Ok(Self {
             handle: Some(handle),
             sender: Some(send),
-            support_dma,
+            transfer_backend,
         })
     }
 }
@@ -819,14 +848,14 @@ impl ImageProcessorTrait for GLProcessorThreaded {
         crop: Crop,
     ) -> crate::Result<()> {
         crop.check_crop(src, dst)?;
-        if !GLProcessorST::check_src_format_supported(self.support_dma, src) {
+        if !GLProcessorST::check_src_format_supported(self.transfer_backend, src) {
             return Err(crate::Error::NotSupported(format!(
                 "Opengl doesn't support {} source texture",
                 src.fourcc().display()
             )));
         }
 
-        if !GLProcessorST::check_dst_format_supported(self.support_dma, dst) {
+        if !GLProcessorST::check_dst_format_supported(self.transfer_backend, dst) {
             return Err(crate::Error::NotSupported(format!(
                 "Opengl doesn't support {} destination texture",
                 dst.fourcc().display()
@@ -1211,14 +1240,14 @@ impl ImageProcessorTrait for GLProcessorST {
         crop: Crop,
     ) -> crate::Result<()> {
         crop.check_crop(src, dst)?;
-        if !Self::check_src_format_supported(self.gl_context.support_dma, src) {
+        if !Self::check_src_format_supported(self.gl_context.transfer_backend, src) {
             return Err(crate::Error::NotSupported(format!(
                 "Opengl doesn't support {} source texture",
                 src.fourcc().display()
             )));
         }
 
-        if !Self::check_dst_format_supported(self.gl_context.support_dma, dst) {
+        if !Self::check_dst_format_supported(self.gl_context.transfer_backend, dst) {
             return Err(crate::Error::NotSupported(format!(
                 "Opengl doesn't support {} destination texture",
                 dst.fourcc().display()
@@ -1230,7 +1259,7 @@ impl ImageProcessorTrait for GLProcessorST {
             src.tensor().memory()
         );
         check_gl_error(function!(), line!())?;
-        if self.gl_context.support_dma && dst.tensor().memory() == TensorMemory::Dma {
+        if self.gl_context.transfer_backend.is_dma() && dst.tensor().memory() == TensorMemory::Dma {
             // Packed RGB is now supported via DMA with buffer reinterpretation
             let res = self.convert_dest_dma(dst, src, rotation, flip, crop);
             return res;
@@ -1652,7 +1681,7 @@ impl GLProcessorST {
     /// backed renderbuffer. Creates a small test FBO and checks completeness.
     /// Returns `false` on any failure (DMA unavailable, EGLImage rejected, FBO incomplete).
     fn probe_rgb_direct_support(&self) -> bool {
-        if !self.gl_context.support_dma {
+        if !self.gl_context.transfer_backend.is_dma() {
             log::debug!("probe_rgb_direct: no DMA support");
             return false;
         }
@@ -2123,8 +2152,8 @@ impl GLProcessorST {
         Ok(results)
     }
 
-    fn check_src_format_supported(support_dma: bool, img: &TensorImage) -> bool {
-        if support_dma && img.tensor().memory() == TensorMemory::Dma {
+    fn check_src_format_supported(backend: TransferBackend, img: &TensorImage) -> bool {
+        if backend.is_dma() && img.tensor().memory() == TensorMemory::Dma {
             // EGLImage supports RGBA, GREY, YUYV, and NV12 for DMA buffers
             matches!(img.fourcc(), RGBA | GREY | YUYV | NV12)
         } else {
@@ -2132,8 +2161,8 @@ impl GLProcessorST {
         }
     }
 
-    fn check_dst_format_supported(support_dma: bool, img: &TensorImage) -> bool {
-        if support_dma && img.tensor().memory() == TensorMemory::Dma {
+    fn check_dst_format_supported(backend: TransferBackend, img: &TensorImage) -> bool {
+        if backend.is_dma() && img.tensor().memory() == TensorMemory::Dma {
             matches!(
                 img.fourcc(),
                 RGBA | GREY | PLANAR_RGB | RGB | RGB_INT8 | PLANAR_RGB_INT8
@@ -2229,7 +2258,7 @@ impl GLProcessorST {
         flip: Flip,
         crop: Crop,
     ) -> crate::Result<()> {
-        assert!(self.gl_context.support_dma);
+        assert!(self.gl_context.transfer_backend.is_dma());
         if fourcc_is_packed_rgb(dst.fourcc()) {
             if self.support_rgb_direct {
                 self.convert_to_rgb_direct(src, dst, rotation, flip, crop)
@@ -2446,7 +2475,7 @@ impl GLProcessorST {
             crate::Rotation::Rotate180 => 2,
             crate::Rotation::CounterClockwise90 => 3,
         };
-        if self.gl_context.support_dma && src.tensor().memory() == TensorMemory::Dma {
+        if self.gl_context.transfer_backend.is_dma() && src.tensor().memory() == TensorMemory::Dma {
             match self.get_or_create_egl_image(CacheKind::Src, src) {
                 Ok(src_egl) => self.draw_camera_texture_eglimage(
                     src,

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -229,6 +229,10 @@ pub(crate) enum TransferBackend {
     /// the GPU can actually render through DMA-buf-backed textures.
     DmaBuf,
 
+    /// GPU buffer via Pixel Buffer Object. Used when DMA-buf is unavailable
+    /// but OpenGL is present. Data stays in GPU-accessible memory.
+    Pbo,
+
     /// Synchronous `glTexSubImage2D` upload + `glReadnPixels` readback.
     /// Used when DMA-buf is unavailable or when the DMA-buf verification
     /// probe fails (e.g. NVIDIA discrete GPUs where EGLImage creation
@@ -240,6 +244,12 @@ impl TransferBackend {
     /// Returns `true` if DMA-buf zero-copy is available.
     pub(crate) fn is_dma(self) -> bool {
         self == TransferBackend::DmaBuf
+    }
+
+    /// Returns `true` if PBO transfer is active.
+    #[allow(dead_code)]
+    pub(crate) fn is_pbo(self) -> bool {
+        self == TransferBackend::Pbo
     }
 }
 
@@ -1831,10 +1841,16 @@ impl GLProcessorST {
         // Verify DMA-buf actually works (catches NVIDIA discrete GPUs where
         // EGLImage creation succeeds but rendered data is all zeros)
         if converter.gl_context.transfer_backend.is_dma() && !converter.verify_dma_buf_roundtrip() {
-            log::info!("DMA-buf verification failed — falling back to synchronous transfers");
-            converter.gl_context.transfer_backend = TransferBackend::Sync;
+            log::info!("DMA-buf verification failed — falling back to PBO transfers");
+            converter.gl_context.transfer_backend = TransferBackend::Pbo;
             // RGB direct rendering also requires DMA, so disable it
             converter.support_rgb_direct = false;
+        }
+
+        // If DMA-buf failed/unavailable but GL is alive, use PBO transfers
+        if converter.gl_context.transfer_backend == TransferBackend::Sync {
+            log::info!("Upgrading transfer backend from Sync to Pbo (GL context available)");
+            converter.gl_context.transfer_backend = TransferBackend::Pbo;
         }
 
         log::debug!(

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -570,7 +570,7 @@ impl GlContext {
         }
     }
 
-    fn egl_destory_image_with_fallback(
+    fn egl_destroy_image_with_fallback(
         egl: &Egl,
         display: Display,
         image: egl::Image,
@@ -936,12 +936,19 @@ impl GLProcessorThreaded {
                         let _ = resp.send(result);
                     }
                     GLProcessorMessage::PboUnmap(buffer_id, resp) => {
-                        unsafe {
+                        let result = unsafe {
                             gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, buffer_id);
-                            gls::gl::UnmapBuffer(gls::gl::PIXEL_PACK_BUFFER);
+                            let ok = gls::gl::UnmapBuffer(gls::gl::PIXEL_PACK_BUFFER);
                             gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, 0);
-                        }
-                        let _ = resp.send(Ok(()));
+                            if ok == gls::gl::FALSE {
+                                Err(Error::OpenGl(
+                                    "PBO data was corrupted during mapping".into(),
+                                ))
+                            } else {
+                                check_gl_error("PboUnmap", 0)
+                            }
+                        };
+                        let _ = resp.send(result);
                     }
                     GLProcessorMessage::PboDelete(buffer_id) => unsafe {
                         gls::gl::DeleteBuffers(1, &buffer_id);
@@ -1293,11 +1300,7 @@ impl EglImageCache {
 
     /// Evict the least recently used entry.
     fn evict_lru(&mut self) {
-        if let Some((&evict_id, _)) = self
-            .entries
-            .iter()
-            .min_by_key(|(_, entry)| entry.last_used)
-        {
+        if let Some((&evict_id, _)) = self.entries.iter().min_by_key(|(_, entry)| entry.last_used) {
             if let Some(evicted) = self.entries.remove(&evict_id) {
                 if let Some(rbo) = evicted.renderbuffer {
                     unsafe { gls::gl::DeleteRenderbuffers(1, &rbo) };
@@ -2282,6 +2285,8 @@ impl GLProcessorST {
                     &proto_data.mask_coefficients,
                     output_width,
                     output_height,
+                    width,
+                    height,
                 )
             }
             ProtoTensor::Float(protos_f32) => {
@@ -2329,6 +2334,8 @@ impl GLProcessorST {
                     &proto_data.mask_coefficients,
                     output_width,
                     output_height,
+                    width,
+                    height,
                 )
             }
         }
@@ -2351,6 +2358,7 @@ impl GLProcessorST {
     /// For each detection: clear FBO, set coefficients, render quad, read back
     /// the bounding-box region as R8 pixels.
     #[cfg(feature = "decoder")]
+    #[allow(clippy::too_many_arguments)]
     fn render_mask_quads(
         &self,
         program: &GlProgram,
@@ -2358,6 +2366,8 @@ impl GLProcessorST {
         mask_coefficients: &[Vec<f32>],
         output_width: usize,
         output_height: usize,
+        _proto_width: usize,
+        _proto_height: usize,
     ) -> crate::Result<Vec<MaskResult>> {
         let mut results = Vec::with_capacity(detect.len());
 
@@ -2392,31 +2402,42 @@ impl GLProcessorST {
             }
             program.load_uniform_4fv(c"mask_coeff", &packed_coeff)?;
 
-            // Compute bbox pixel coordinates, clamped to FBO bounds.
+            // Compute bbox pixel coordinates.  Use span-based rounding for
+            // dimensions to match the numpy reference (round((xmax-xmin)*W))
+            // rather than endpoint subtraction (round(xmax*W)-round(xmin*W)),
+            // which avoids off-by-one mismatches on small objects.
             let ow = output_width as i32;
             let oh = output_height as i32;
-            let bbox_x = (det.bbox.xmin * output_width as f32).round() as i32;
-            let bbox_y = (det.bbox.ymin * output_height as f32).round() as i32;
-            let bbox_x2 = (det.bbox.xmax * output_width as f32).round() as i32;
-            let bbox_y2 = (det.bbox.ymax * output_height as f32).round() as i32;
+            let owf = output_width as f32;
+            let ohf = output_height as f32;
+            let bbox_x = (det.bbox.xmin * owf).round() as i32;
+            let bbox_y = (det.bbox.ymin * ohf).round() as i32;
+            let bbox_w = ((det.bbox.xmax - det.bbox.xmin) * owf).round() as i32;
+            let bbox_h = ((det.bbox.ymax - det.bbox.ymin) * ohf).round() as i32;
             let bbox_x = bbox_x.max(0).min(ow);
             let bbox_y = bbox_y.max(0).min(oh);
-            let bbox_x2 = bbox_x2.max(bbox_x).min(ow);
-            let bbox_y2 = bbox_y2.max(bbox_y).min(oh);
-            let bbox_w = (bbox_x2 - bbox_x).max(1);
-            let bbox_h = (bbox_y2 - bbox_y).max(1);
+            let bbox_w = bbox_w.max(1).min(ow - bbox_x);
+            let bbox_h = bbox_h.max(1).min(oh - bbox_y);
 
-            // Compute NDC coordinates for the quad
-            let cvt = |normalized: f32| normalized * 2.0 - 1.0;
-            let dst_left = cvt(det.bbox.xmin);
-            let dst_right = cvt(det.bbox.xmax);
-            let dst_top = cvt(det.bbox.ymax);
-            let dst_bottom = cvt(det.bbox.ymin);
+            // Derive pixel-exact NDC coordinates from the readback region so
+            // the rasterized quad exactly covers every pixel we read back.
+            let dst_left = bbox_x as f32 / owf * 2.0 - 1.0;
+            let dst_right = (bbox_x + bbox_w) as f32 / owf * 2.0 - 1.0;
+            let dst_bottom = bbox_y as f32 / ohf * 2.0 - 1.0;
+            let dst_top = (bbox_y + bbox_h) as f32 / ohf * 2.0 - 1.0;
 
-            let src_left = det.bbox.xmin;
-            let src_right = det.bbox.xmax;
-            let src_top = 1.0 - det.bbox.ymin;
-            let src_bottom = 1.0 - det.bbox.ymax;
+            // Proto texture coords: tex row 0 = image top (data uploaded
+            // row-major where y=0 is image top; GL treats first data row as
+            // texture bottom, so texelFetch(y=0) returns image top).
+            // tc.y=0 → image top, tc.y=1 → image bottom.
+            // At NDC top (image bottom = ymax) we need tc.y = ymax.
+            // At NDC bottom (image top = ymin) we need tc.y = ymin.
+            // Use the readback pixel boundaries for the texture coordinates
+            // so the mapping is consistent with the rasterized quad.
+            let src_left = bbox_x as f32 / owf;
+            let src_right = (bbox_x + bbox_w) as f32 / owf;
+            let src_bottom = bbox_y as f32 / ohf;
+            let src_top = (bbox_y + bbox_h) as f32 / ohf;
 
             unsafe {
                 gls::gl::BindBuffer(gls::gl::ARRAY_BUFFER, self.vertex_buffer.id);
@@ -4177,7 +4198,7 @@ impl GLProcessorST {
             }
             width = src.width();
             height = src.height();
-            format = fourcc_to_drm(NV12);
+            format = fourcc_to_drm(NV12)?;
             channels = 1; // Y plane pitch is 1 byte per pixel
         } else if src.is_planar() {
             if !src.width().is_multiple_of(16) {
@@ -4208,7 +4229,7 @@ impl GLProcessorST {
             }
             width = src.width();
             height = src.height();
-            format = fourcc_to_drm(src.fourcc());
+            format = fourcc_to_drm(src.fourcc())?;
             channels = src.channels();
         }
 
@@ -5496,7 +5517,7 @@ impl Drop for EglImage {
 
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let e =
-                GlContext::egl_destory_image_with_fallback(&self.egl, self.display, self.egl_image);
+                GlContext::egl_destroy_image_with_fallback(&self.egl, self.display, self.egl_image);
             if let Err(e) = e {
                 error!("Could not destroy EGL image: {e:?}");
             }
@@ -5797,15 +5818,17 @@ fn check_gl_error(name: &str, line: u32) -> Result<(), Error> {
     Ok(())
 }
 
-fn fourcc_to_drm(fourcc: FourCharCode) -> DrmFourcc {
+fn fourcc_to_drm(fourcc: FourCharCode) -> Result<DrmFourcc, Error> {
     match fourcc {
-        RGBA => DrmFourcc::Abgr8888,
-        YUYV => DrmFourcc::Yuyv,
-        RGB | RGB_INT8 => DrmFourcc::Bgr888,
-        GREY => DrmFourcc::R8,
-        NV12 => DrmFourcc::Nv12,
-        PLANAR_RGB | PLANAR_RGB_INT8 => DrmFourcc::R8,
-        _ => todo!(),
+        RGBA => Ok(DrmFourcc::Abgr8888),
+        YUYV => Ok(DrmFourcc::Yuyv),
+        RGB | RGB_INT8 => Ok(DrmFourcc::Bgr888),
+        GREY => Ok(DrmFourcc::R8),
+        NV12 => Ok(DrmFourcc::Nv12),
+        PLANAR_RGB | PLANAR_RGB_INT8 => Ok(DrmFourcc::R8),
+        _ => Err(Error::NotSupported(format!(
+            "FourCC {fourcc:?} has no DRM format mapping"
+        ))),
     }
 }
 

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -58,25 +58,30 @@ use crate::MaskResult;
 
 /// Identifies the type of EGL display used for headless OpenGL ES rendering.
 ///
-/// The HAL probes displays in priority order: GBM first (direct GPU access),
-/// then platform device enumeration, then the default display. Use
+/// The HAL creates a surfaceless GLES 3.0 context
+/// (`EGL_KHR_surfaceless_context` + `EGL_KHR_no_config_context`) and
+/// renders exclusively through FBOs backed by EGLImages imported from
+/// DMA-buf file descriptors. No window or PBuffer surface is created.
+///
+/// Displays are probed in priority order: PlatformDevice first (zero
+/// external dependencies), then GBM, then Default. Use
 /// [`probe_egl_displays`] to discover which are available and
 /// [`ImageProcessorConfig::egl_display`](crate::ImageProcessorConfig::egl_display)
 /// to override the auto-detection.
 ///
 /// # Display Types
 ///
+/// - **`PlatformDevice`** — Uses `EGL_EXT_device_enumeration` to query
+///   available EGL devices via `eglQueryDevicesEXT`, then selects the first
+///   device with `eglGetPlatformDisplay(EGL_EXT_platform_device, ...)`.
+///   Headless and compositor-free with zero external library dependencies.
+///   Works on NVIDIA GPUs and newer Vivante drivers.
+///
 /// - **`Gbm`** — Opens a DRM render node (e.g. `/dev/dri/renderD128`) and
 ///   creates a GBM (Generic Buffer Manager) device, then calls
-///   `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, gbm_device)`. This is a
-///   direct GPU path through the DRM/KMS subsystem — no compositor required.
-///   Preferred for headless edge AI workloads. On some drivers (e.g. Vivante
-///   on i.MX8), this path may trigger heap corruption during process shutdown.
-///
-/// - **`PlatformDevice`** — Uses the `EGL_EXT_device_enumeration` extension
-///   to query available EGL devices via `eglQueryDevicesEXT`, then selects the
-///   first device with `eglGetPlatformDisplay(EGL_EXT_platform_device, ...)`.
-///   Also headless and compositor-free. Common on NVIDIA GPUs.
+///   `eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, gbm_device)`. Requires
+///   `libgbm` and a DRM render node. Needed on ARM Mali (i.MX95) and older
+///   Vivante drivers that do not expose `EGL_EXT_platform_device`.
 ///
 /// - **`Default`** — Calls `eglGetDisplay(EGL_DEFAULT_DISPLAY)`, letting the
 ///   EGL implementation choose the display. On Wayland systems this connects
@@ -127,38 +132,39 @@ fn get_egl_lib() -> Result<&'static libloading::Library, crate::Error> {
 
 type Egl = Instance<Dynamic<&'static libloading::Library, EGL1_4>>;
 
-/// Check whether an EGL display supports GLES3 RGBA8 PBuffer rendering.
+/// Check whether an EGL display supports the surfaceless + no-config context
+/// extensions required by the HAL's FBO-based rendering pipeline.
 ///
-/// Returns `true` if `eglChooseConfig` finds at least one matching config.
-fn probe_config_check(egl: &Egl, display: egl::Display) -> bool {
-    let attributes = [
-        egl::SURFACE_TYPE,
-        egl::PBUFFER_BIT,
-        egl::RENDERABLE_TYPE,
-        egl::OPENGL_ES3_BIT,
-        egl::RED_SIZE,
-        8,
-        egl::GREEN_SIZE,
-        8,
-        egl::BLUE_SIZE,
-        8,
-        egl::ALPHA_SIZE,
-        8,
-        egl::NONE,
+/// Queries `eglQueryString(display, EGL_EXTENSIONS)` and checks for
+/// `EGL_KHR_surfaceless_context` and `EGL_KHR_no_config_context`.
+fn probe_display_extensions(egl: &Egl, display: egl::Display) -> bool {
+    let Ok(ext_str) = egl.query_string(Some(display), egl::EXTENSIONS) else {
+        return false;
+    };
+    let exts = ext_str.to_string_lossy();
+
+    let required = [
+        "EGL_KHR_surfaceless_context",
+        "EGL_KHR_no_config_context",
     ];
-    egl.choose_first_config(display, &attributes)
-        .ok()
-        .flatten()
-        .is_some()
+
+    for r in &required {
+        if !exts.contains(r) {
+            log::debug!("Display missing required extension: {r}");
+            return false;
+        }
+    }
+
+    egl.bind_api(egl::OPENGL_ES_API).is_ok()
 }
 
 /// Probe for available EGL displays supporting headless OpenGL ES 3.0.
 ///
-/// Returns validated displays in priority order (GBM, PlatformDevice,
-/// Default). Each display is validated with `eglInitialize` +
-/// `eglChooseConfig` using the same GLES3 RGBA8 PBuffer attributes used by
-/// the image processor. Probed state is cleaned up with `eglTerminate` — no
-/// EGL resources are left alive.
+/// Returns validated displays in priority order (PlatformDevice, GBM,
+/// Default). Each display is validated with `eglInitialize` + extension
+/// checks for `EGL_KHR_surfaceless_context` and `EGL_KHR_no_config_context`.
+/// Probed state is cleaned up with `eglTerminate` — no EGL resources are
+/// left alive.
 ///
 /// An empty list means OpenGL is not available on this system.
 ///
@@ -171,25 +177,11 @@ pub fn probe_egl_displays() -> Result<Vec<EglDisplayInfo>, Error> {
 
     let mut results = Vec::new();
 
-    // GBM
-    if let Ok(display_type) = GlContext::egl_get_gbm_display(&egl) {
-        let display = display_type.as_display();
-        if egl.initialize(display).is_ok() {
-            if probe_config_check(&egl, display) {
-                results.push(EglDisplayInfo {
-                    kind: EglDisplayKind::Gbm,
-                    description: "GBM via /dev/dri/renderD128".to_string(),
-                });
-            }
-            let _ = egl.terminate(display);
-        }
-    }
-
-    // PlatformDevice
+    // PlatformDevice first (zero external deps, works on NVIDIA + newer Vivante)
     if let Ok(display_type) = GlContext::egl_get_platform_display_from_device(&egl) {
         let display = display_type.as_display();
         if egl.initialize(display).is_ok() {
-            if probe_config_check(&egl, display) {
+            if probe_display_extensions(&egl, display) {
                 results.push(EglDisplayInfo {
                     kind: EglDisplayKind::PlatformDevice,
                     description: "EGL platform device via EGL_EXT_device_enumeration".to_string(),
@@ -199,11 +191,25 @@ pub fn probe_egl_displays() -> Result<Vec<EglDisplayInfo>, Error> {
         }
     }
 
-    // Default
+    // GBM second (needed for Mali + old Vivante)
+    if let Ok(display_type) = GlContext::egl_get_gbm_display(&egl) {
+        let display = display_type.as_display();
+        if egl.initialize(display).is_ok() {
+            if probe_display_extensions(&egl, display) {
+                results.push(EglDisplayInfo {
+                    kind: EglDisplayKind::Gbm,
+                    description: "GBM via /dev/dri/renderD128".to_string(),
+                });
+            }
+            let _ = egl.terminate(display);
+        }
+    }
+
+    // Default last (needs compositor)
     if let Ok(display_type) = GlContext::egl_get_default_display(&egl) {
         let display = display_type.as_display();
         if egl.initialize(display).is_ok() {
-            if probe_config_check(&egl, display) {
+            if probe_display_extensions(&egl, display) {
                 results.push(EglDisplayInfo {
                     kind: EglDisplayKind::Default,
                     description: "EGL default display".to_string(),
@@ -218,7 +224,6 @@ pub fn probe_egl_displays() -> Result<Vec<EglDisplayInfo>, Error> {
 
 pub(crate) struct GlContext {
     pub(crate) support_dma: bool,
-    pub(crate) surface: Option<egl::Surface>,
     pub(crate) display: EglDisplayType,
     pub(crate) ctx: egl::Context,
     /// Wrapped in ManuallyDrop because the khronos-egl Dynamic instance's
@@ -263,15 +268,7 @@ impl GlContext {
             });
         }
 
-        // Try headless-friendly EGL methods first (GBM/DRM, device enumeration)
-        // before the default display, which may block if a compositor (Wayland)
-        // is expected but not running.
-        if let Ok(headless) = Self::try_initialize_egl(egl.clone(), Self::egl_get_gbm_display) {
-            return Ok(headless);
-        } else {
-            log::debug!("Didn't initialize EGL with GBM Display");
-        }
-
+        // Try PlatformDevice first (zero external deps, works on NVIDIA + newer Vivante)
         if let Ok(headless) =
             Self::try_initialize_egl(egl.clone(), Self::egl_get_platform_display_from_device)
         {
@@ -280,6 +277,14 @@ impl GlContext {
             log::debug!("Didn't initialize EGL with platform display from device enumeration");
         }
 
+        // GBM second (needed for Mali + old Vivante that lack EGL_EXT_platform_device)
+        if let Ok(headless) = Self::try_initialize_egl(egl.clone(), Self::egl_get_gbm_display) {
+            return Ok(headless);
+        } else {
+            log::debug!("Didn't initialize EGL with GBM Display");
+        }
+
+        // Default display last (needs compositor)
         if let Ok(headless) = Self::try_initialize_egl(egl.clone(), Self::egl_get_default_display) {
             return Ok(headless);
         } else {
@@ -298,56 +303,48 @@ impl GlContext {
         let display = display_fn(&egl)?;
         log::debug!("egl initialize with display: {:x?}", display.as_display());
         egl.initialize(display.as_display())?;
-        let attributes = [
-            egl::SURFACE_TYPE,
-            egl::PBUFFER_BIT,
-            egl::RENDERABLE_TYPE,
-            egl::OPENGL_ES3_BIT,
-            egl::RED_SIZE,
-            8,
-            egl::GREEN_SIZE,
-            8,
-            egl::BLUE_SIZE,
-            8,
-            egl::ALPHA_SIZE,
-            8,
-            egl::NONE,
-        ];
 
-        let config =
-            if let Some(config) = egl.choose_first_config(display.as_display(), &attributes)? {
-                config
-            } else {
-                return Err(crate::Error::NotImplemented(
-                    "Did not find valid OpenGL ES config".to_string(),
-                ));
-            };
+        // Verify required extensions for surfaceless + no-config context
+        let ext_str = egl.query_string(Some(display.as_display()), egl::EXTENSIONS)?;
+        let exts = ext_str.to_string_lossy();
 
-        debug!("config: {config:?}");
+        if !exts.contains("EGL_KHR_surfaceless_context") {
+            return Err(crate::Error::GLVersion(
+                "EGL display does not support EGL_KHR_surfaceless_context".to_string(),
+            ));
+        }
 
-        let surface = Some(egl.create_pbuffer_surface(
-            display.as_display(),
-            config,
-            &[egl::WIDTH, 64, egl::HEIGHT, 64, egl::NONE],
-        )?);
+        if !exts.contains("EGL_KHR_no_config_context") {
+            return Err(crate::Error::GLVersion(
+                "EGL display does not support EGL_KHR_no_config_context".to_string(),
+            ));
+        }
 
         egl.bind_api(egl::OPENGL_ES_API)?;
-        let context_attributes = [egl::CONTEXT_MAJOR_VERSION, 3, egl::NONE, egl::NONE];
 
-        let ctx = egl.create_context(display.as_display(), config, None, &context_attributes)?;
+        // No-config context: pass EGL_NO_CONFIG_KHR (null) instead of a
+        // real config. The context is not bound to any specific framebuffer
+        // format — it works with any FBO attachment format.
+        let context_attributes = [egl::CONTEXT_MAJOR_VERSION, 3, egl::NONE, egl::NONE];
+        let ctx = egl.create_context(
+            display.as_display(),
+            egl_ext::NO_CONFIG_KHR,
+            None,
+            &context_attributes,
+        )?;
         debug!("ctx: {ctx:?}");
 
-        egl.make_current(display.as_display(), surface, surface, Some(ctx))?;
+        // Surfaceless context: no PBuffer surface needed. All rendering
+        // goes through FBOs backed by EGLImages.
+        egl.make_current(display.as_display(), None, None, Some(ctx))?;
 
         let support_dma = Self::egl_check_support_dma(&egl).is_ok();
-        let headless = GlContext {
+        Ok(GlContext {
             display,
             ctx,
             egl: ManuallyDrop::new(egl),
-            surface,
             support_dma,
-        };
-        Ok(headless)
+        })
     }
 
     fn egl_get_default_display(egl: &Egl) -> Result<EglDisplayType, crate::Error> {
@@ -580,17 +577,12 @@ impl Drop for GlContext {
                 .egl
                 .destroy_context(self.display.as_display(), self.ctx);
 
-            if let Some(surface) = self.surface.take() {
-                let _ = self.egl.destroy_surface(self.display.as_display(), surface);
-            }
-
-            // eglTerminate decrements the ref count on the display connection.
-            // Since eglInitialize is ref-counted per the EGL spec, this only
-            // tears down internal state when the last reference is released.
-            // probe_egl_displays() already calls eglTerminate successfully on
-            // all platforms; catch_unwind provides a safety net for any driver
-            // that misbehaves.
-            let _ = self.egl.terminate(self.display.as_display());
+            // Note: eglTerminate is intentionally NOT called here. While the
+            // EGL spec says eglInitialize/eglTerminate are ref-counted, some
+            // drivers (notably Vivante) invalidate all resources on the display
+            // when any thread calls eglTerminate. This breaks multi-threaded
+            // use where multiple GlContext instances share the same underlying
+            // DRM render node. EGL resources are cleaned up on process exit.
         }));
         std::panic::set_hook(prev_hook);
 
@@ -598,8 +590,6 @@ impl Drop for GlContext {
         // khronos-egl Dynamic instance's Drop calls eglReleaseThread() which
         // panics if the EGL library has been unloaded (local/x86_64) or
         // causes heap corruption by calling into invalid memory (ARM).
-        // The Rc wrapper is a lightweight Rust-side object; the actual EGL
-        // display resources are released by eglTerminate above.
     }
 }
 
@@ -2176,7 +2166,6 @@ impl GLProcessorST {
         log::debug!("GL Extensions: {extensions}");
         let required_ext = [
             "GL_OES_EGL_image_external_essl3",
-            "GL_OES_surfaceless_context",
         ];
         let extensions = extensions.split_ascii_whitespace().collect::<BTreeSet<_>>();
         for required in required_ext {
@@ -4978,6 +4967,15 @@ mod egl_ext {
     pub(crate) const PLATFORM_GBM_KHR: u32 = 0x31D7;
 
     pub(crate) const PLATFORM_DEVICE_EXT: u32 = 0x313F;
+
+    /// EGL_KHR_no_config_context: null config for eglCreateContext.
+    /// Defined as ((EGLConfig)0) in the EGL spec.
+    ///
+    /// # Safety
+    /// The EGL spec defines EGL_NO_CONFIG_KHR as a null pointer. This is
+    /// a safe transmute since `Config` is a newtype wrapper around `*mut c_void`.
+    pub(crate) const NO_CONFIG_KHR: khronos_egl::Config =
+        unsafe { std::mem::transmute(std::ptr::null_mut::<std::ffi::c_void>()) };
 }
 
 fn generate_vertex_shader() -> &'static str {
@@ -6041,36 +6039,21 @@ mod gl_tests {
             eprintln!("  {:?}: {}", d.kind, d.description);
         }
 
-        // GBM requires /dev/dri/renderD128 — skip hardware-specific
-        // assertions when it is not present (CI runners, non-GPU hosts).
-        if !kinds.contains(&EglDisplayKind::Gbm) {
-            eprintln!(
-                "SKIPPED: {} - GBM not available (no /dev/dri/renderD128), got: {kinds:?}",
-                function!()
+        // Verify priority ordering: PlatformDevice > GBM > Default.
+        // Not all display types are available on every system, but the
+        // ones that are present must appear in this order.
+        let priority = |k: &EglDisplayKind| match k {
+            EglDisplayKind::PlatformDevice => 0,
+            EglDisplayKind::Gbm => 1,
+            EglDisplayKind::Default => 2,
+        };
+        for w in kinds.windows(2) {
+            assert!(
+                priority(&w[0]) < priority(&w[1]),
+                "Display ordering violated: {:?} should come after {:?}",
+                w[1],
+                w[0],
             );
-            return;
-        }
-
-        // On i.MX hardware at least two display types should be available
-        assert!(
-            displays.len() >= 2,
-            "Expected at least 2 display types, got {}: {kinds:?}",
-            displays.len()
-        );
-
-        // Verify ordering: GBM should come first (priority order)
-        assert_eq!(
-            displays[0].kind,
-            EglDisplayKind::Gbm,
-            "First display should be GBM (priority order)"
-        );
-
-        // Log which optional types are available
-        if !kinds.contains(&EglDisplayKind::PlatformDevice) {
-            eprintln!("Note: PlatformDevice not available on this system");
-        }
-        if !kinds.contains(&EglDisplayKind::Default) {
-            eprintln!("Note: Default display not available (no compositor running)");
         }
     }
 

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -1670,8 +1670,22 @@ impl GLProcessorST {
         // Probe GPU capability for direct RGB rendering
         converter.support_rgb_direct = converter.probe_rgb_direct_support();
 
+        // Verify DMA-buf actually works (catches NVIDIA discrete GPUs where
+        // EGLImage creation succeeds but rendered data is all zeros)
+        if converter.gl_context.transfer_backend.is_dma()
+            && !converter.verify_dma_buf_roundtrip()
+        {
+            log::info!(
+                "DMA-buf verification failed — falling back to synchronous transfers"
+            );
+            converter.gl_context.transfer_backend = TransferBackend::Sync;
+            // RGB direct rendering also requires DMA, so disable it
+            converter.support_rgb_direct = false;
+        }
+
         log::debug!(
-            "GLConverter created (rgb_direct={})",
+            "GLConverter created (transfer={:?}, rgb_direct={})",
+            converter.gl_context.transfer_backend,
             converter.support_rgb_direct
         );
         Ok(converter)
@@ -1761,6 +1775,95 @@ impl GLProcessorST {
 
         log::info!("probe_rgb_direct: BGR888 renderbuffer FBO support = {result}");
         result
+    }
+
+    /// Verify that DMA-buf EGLImage round-trip actually works on this GPU.
+    ///
+    /// Renders a solid red quad to a 64x64 DMA-buf-backed RGBA texture via
+    /// EGLImage, then reads it back and checks that the center pixel is red.
+    /// Returns `true` if the data round-trips correctly.
+    ///
+    /// This catches GPUs like NVIDIA discrete where `eglCreateImage` from
+    /// `dma_heap` fds succeeds but the rendered data is all zeros.
+    fn verify_dma_buf_roundtrip(&mut self) -> bool {
+        // Allocate a 64x64 RGBA DMA source tensor and fill it with solid red
+        let src = match TensorImage::new(64, 64, RGBA, Some(TensorMemory::Dma)) {
+            Ok(img) => img,
+            Err(e) => {
+                log::info!("verify_dma_buf_roundtrip: failed to allocate DMA source: {e}");
+                return false;
+            }
+        };
+
+        {
+            let mut map = match src.tensor().map() {
+                Ok(m) => m,
+                Err(e) => {
+                    log::info!("verify_dma_buf_roundtrip: failed to map DMA source: {e}");
+                    return false;
+                }
+            };
+            for pixel in map.chunks_exact_mut(4) {
+                pixel[0] = 255; // R
+                pixel[1] = 0; // G
+                pixel[2] = 0; // B
+                pixel[3] = 255; // A
+            }
+        }
+
+        // Allocate a 64x64 RGBA DMA destination tensor
+        let mut dst = match TensorImage::new(64, 64, RGBA, Some(TensorMemory::Dma)) {
+            Ok(img) => img,
+            Err(e) => {
+                log::info!("verify_dma_buf_roundtrip: failed to allocate DMA destination: {e}");
+                return false;
+            }
+        };
+
+        // Run the full DMA-buf EGLImage render pipeline
+        if let Err(e) = self.convert_dest_dma(
+            &mut dst,
+            &src,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        ) {
+            log::info!("verify_dma_buf_roundtrip: convert_dest_dma failed: {e}");
+            return false;
+        }
+
+        // Read back the center pixel at (32, 32) from the destination
+        let map = match dst.tensor().map() {
+            Ok(m) => m,
+            Err(e) => {
+                log::info!("verify_dma_buf_roundtrip: failed to map DMA destination: {e}");
+                return false;
+            }
+        };
+
+        let offset = (32 * 64 + 32) * 4;
+        if map.len() < offset + 4 {
+            log::info!("verify_dma_buf_roundtrip: destination buffer too small");
+            return false;
+        }
+
+        let r = map[offset];
+        let g = map[offset + 1];
+        let b = map[offset + 2];
+        let a = map[offset + 3];
+
+        let pass = r > 250 && g < 5 && b < 5 && a > 250;
+
+        if pass {
+            log::info!("verify_dma_buf_roundtrip: PASSED (center pixel RGBA={r},{g},{b},{a})");
+        } else {
+            log::info!(
+                "verify_dma_buf_roundtrip: FAILED (center pixel RGBA={r},{g},{b},{a}, \
+                 expected ~255,0,0,255)"
+            );
+        }
+
+        pass
     }
 
     /// Sets the interpolation mode for int8 proto textures.

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -27,7 +27,7 @@ use std::{
     thread::JoinHandle,
     time::Instant,
 };
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{Sender, WeakSender};
 
 macro_rules! function {
     () => {{
@@ -740,8 +740,13 @@ enum GLProcessorMessage {
 }
 
 /// Implements PboOps by sending commands to the GL thread.
+///
+/// Uses a `WeakSender` so that PBO images don't keep the GL thread's channel
+/// alive. When the `GLProcessorThreaded` is dropped, its `Sender` is the last
+/// strong reference — dropping it closes the channel and lets the GL thread
+/// exit. PBO operations after that return `PboDisconnected`.
 struct GlPboOps {
-    sender: Sender<GLProcessorMessage>,
+    sender: WeakSender<GLProcessorMessage>,
 }
 
 impl edgefirst_tensor::PboOps for GlPboOps {
@@ -750,8 +755,12 @@ impl edgefirst_tensor::PboOps for GlPboOps {
         buffer_id: u32,
         size: usize,
     ) -> edgefirst_tensor::Result<edgefirst_tensor::PboMapping> {
+        let sender = self
+            .sender
+            .upgrade()
+            .ok_or(edgefirst_tensor::Error::PboDisconnected)?;
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.sender
+        sender
             .blocking_send(GLProcessorMessage::PboMap(buffer_id, size, tx))
             .map_err(|_| edgefirst_tensor::Error::PboDisconnected)?;
         rx.blocking_recv()
@@ -762,8 +771,12 @@ impl edgefirst_tensor::PboOps for GlPboOps {
     }
 
     fn unmap_buffer(&self, buffer_id: u32) -> edgefirst_tensor::Result<()> {
+        let sender = self
+            .sender
+            .upgrade()
+            .ok_or(edgefirst_tensor::Error::PboDisconnected)?;
         let (tx, rx) = tokio::sync::oneshot::channel();
-        self.sender
+        sender
             .blocking_send(GLProcessorMessage::PboUnmap(buffer_id, tx))
             .map_err(|_| edgefirst_tensor::Error::PboDisconnected)?;
         rx.blocking_recv()
@@ -774,9 +787,9 @@ impl edgefirst_tensor::PboOps for GlPboOps {
     }
 
     fn delete_buffer(&self, buffer_id: u32) {
-        let _ = self
-            .sender
-            .blocking_send(GLProcessorMessage::PboDelete(buffer_id));
+        if let Some(sender) = self.sender.upgrade() {
+            let _ = sender.blocking_send(GLProcessorMessage::PboDelete(buffer_id));
+        }
     }
 }
 
@@ -1185,7 +1198,7 @@ impl GLProcessorThreaded {
             .map_err(|_| Error::OpenGl("GL thread did not respond".to_string()))??;
 
         let ops: std::sync::Arc<dyn edgefirst_tensor::PboOps> = std::sync::Arc::new(GlPboOps {
-            sender: sender.clone(),
+            sender: sender.downgrade(),
         });
 
         let shape = if crate::fourcc_planar(fourcc)? {
@@ -1432,10 +1445,24 @@ impl ImageProcessorTrait for GLProcessorST {
             let res = self.convert_dest_dma(dst, src, rotation, flip, crop);
             return res;
         }
-        // PBO-to-PBO: both tensors are PBO-backed, use GL buffer bindings for readback
+        // PBO-to-PBO: both tensors are PBO-backed, use GL buffer bindings for
+        // both upload and readback (zero CPU copy for both directions)
         if src.tensor().memory() == TensorMemory::Pbo && dst.tensor().memory() == TensorMemory::Pbo
         {
             return self.convert_pbo_to_pbo(dst, src, rotation, flip, crop);
+        }
+        // PBO dst with non-PBO src: use normal texture upload for src (which
+        // maps the Mem/DMA tensor), but PBO PACK readback for dst.
+        // This avoids the deadlock that would occur if convert_dest_non_dma
+        // tried to map() the PBO dst on the GL thread.
+        if dst.tensor().memory() == TensorMemory::Pbo {
+            return self.convert_any_to_pbo(dst, src, rotation, flip, crop);
+        }
+        // PBO src with non-PBO dst: the src tensor's map() would deadlock on
+        // the GL thread, so use PBO UNPACK upload. Readback goes to Mem dst
+        // via normal ReadnPixels into mapped memory.
+        if src.tensor().memory() == TensorMemory::Pbo {
+            return self.convert_pbo_to_mem(dst, src, rotation, flip, crop);
         }
         let start = Instant::now();
         let res = self.convert_dest_non_dma(dst, src, rotation, flip, crop);
@@ -3036,6 +3063,161 @@ impl GLProcessorST {
         }
 
         check_gl_error(function!(), line!())?;
+        Ok(())
+    }
+
+    /// Convert any source (Mem/DMA) to a PBO destination.
+    /// Source is uploaded via normal texture path (maps tensor for CPU upload).
+    /// Destination readback uses PBO PACK binding (no map on GL thread).
+    fn convert_any_to_pbo(
+        &mut self,
+        dst: &mut TensorImage,
+        src: &TensorImage,
+        rotation: crate::Rotation,
+        flip: Flip,
+        crop: Crop,
+    ) -> crate::Result<()> {
+        let dst_buffer_id = match &dst.tensor {
+            edgefirst_tensor::Tensor::Pbo(p) => {
+                if p.is_mapped() {
+                    return Err(crate::Error::OpenGl(
+                        "Cannot convert to a mapped PBO tensor".to_string(),
+                    ));
+                }
+                p.buffer_id()
+            }
+            _ => {
+                return Err(crate::Error::OpenGl(
+                    "convert_any_to_pbo: dst is not a PBO tensor".to_string(),
+                ))
+            }
+        };
+
+        self.setup_renderbuffer_non_dma(dst, crop)?;
+        let start = Instant::now();
+        if dst.is_planar() {
+            self.convert_to_planar(src, dst, rotation, flip, crop)?;
+        } else {
+            self.convert_to(src, dst, rotation, flip, crop)?;
+        }
+        log::debug!("any-to-PBO render takes {:?}", start.elapsed());
+
+        // PBO readback
+        let start_read = Instant::now();
+        let dest_format = match dst.fourcc() {
+            crate::RGB | crate::RGB_INT8 => gls::gl::RGB,
+            crate::RGBA => gls::gl::RGBA,
+            crate::GREY => gls::gl::RED,
+            _ => {
+                return Err(crate::Error::NotSupported(format!(
+                    "PBO readback not supported for {}",
+                    dst.fourcc().display()
+                )))
+            }
+        };
+        unsafe {
+            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, dst_buffer_id);
+            gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
+            gls::gl::ReadnPixels(
+                0,
+                0,
+                dst.width() as i32,
+                dst.height() as i32,
+                dest_format,
+                gls::gl::UNSIGNED_BYTE,
+                dst.tensor.len() as i32,
+                std::ptr::null_mut(),
+            );
+            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, 0);
+            gls::gl::Finish();
+        }
+        check_gl_error(function!(), line!())?;
+
+        if fourcc_is_int8(dst.fourcc()) {
+            unsafe {
+                gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, dst_buffer_id);
+                let ptr = gls::gl::MapBufferRange(
+                    gls::gl::PIXEL_PACK_BUFFER,
+                    0,
+                    dst.tensor.len() as isize,
+                    gls::gl::MAP_READ_BIT | gls::gl::MAP_WRITE_BIT,
+                );
+                if !ptr.is_null() {
+                    let slice = std::slice::from_raw_parts_mut(ptr as *mut u8, dst.tensor.len());
+                    for byte in slice.iter_mut() {
+                        *byte ^= 0x80;
+                    }
+                    gls::gl::UnmapBuffer(gls::gl::PIXEL_PACK_BUFFER);
+                }
+                gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, 0);
+            }
+            check_gl_error(function!(), line!())?;
+        }
+
+        log::debug!("any-to-PBO readback takes {:?}", start_read.elapsed());
+        Ok(())
+    }
+
+    /// Convert a PBO source to a non-PBO (Mem) destination.
+    /// Source is uploaded via PBO UNPACK binding (no map on GL thread).
+    /// Destination readback uses normal ReadnPixels into mapped Mem tensor.
+    fn convert_pbo_to_mem(
+        &mut self,
+        dst: &mut TensorImage,
+        src: &TensorImage,
+        rotation: crate::Rotation,
+        flip: Flip,
+        crop: Crop,
+    ) -> crate::Result<()> {
+        let src_buffer_id = match &src.tensor {
+            edgefirst_tensor::Tensor::Pbo(p) => {
+                if p.is_mapped() {
+                    return Err(crate::Error::OpenGl(
+                        "Cannot convert from a mapped PBO tensor".to_string(),
+                    ));
+                }
+                p.buffer_id()
+            }
+            _ => {
+                return Err(crate::Error::OpenGl(
+                    "convert_pbo_to_mem: src is not a PBO tensor".to_string(),
+                ))
+            }
+        };
+
+        self.setup_renderbuffer_non_dma(dst, crop)?;
+        let start = Instant::now();
+        self.draw_src_texture_from_pbo(src, src_buffer_id, dst, rotation, flip, crop)?;
+        log::debug!("PBO-to-mem render takes {:?}", start.elapsed());
+
+        // Normal readback into Mem dst
+        let start = Instant::now();
+        let dest_format = match dst.fourcc() {
+            crate::RGB | crate::RGB_INT8 => gls::gl::RGB,
+            crate::RGBA => gls::gl::RGBA,
+            crate::GREY => gls::gl::RED,
+            _ => unreachable!(),
+        };
+        unsafe {
+            let mut dst_map = dst.tensor().map()?;
+            gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
+            gls::gl::ReadnPixels(
+                0,
+                0,
+                dst.width() as i32,
+                dst.height() as i32,
+                dest_format,
+                gls::gl::UNSIGNED_BYTE,
+                dst.tensor.len() as i32,
+                dst_map.as_mut_ptr() as *mut c_void,
+            );
+            if fourcc_is_int8(dst.fourcc()) {
+                for byte in dst_map.iter_mut() {
+                    *byte ^= 0x80;
+                }
+            }
+        }
+        log::debug!("PBO-to-mem readback takes {:?}", start.elapsed());
         Ok(())
     }
 

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -1432,6 +1432,11 @@ impl ImageProcessorTrait for GLProcessorST {
             let res = self.convert_dest_dma(dst, src, rotation, flip, crop);
             return res;
         }
+        // PBO-to-PBO: both tensors are PBO-backed, use GL buffer bindings for readback
+        if src.tensor().memory() == TensorMemory::Pbo && dst.tensor().memory() == TensorMemory::Pbo
+        {
+            return self.convert_pbo_to_pbo(dst, src, rotation, flip, crop);
+        }
         let start = Instant::now();
         let res = self.convert_dest_non_dma(dst, src, rotation, flip, crop);
         log::debug!("convert_dest_non_dma takes {:?}", start.elapsed());
@@ -2672,6 +2677,105 @@ impl GLProcessorST {
             }
         }
         log::debug!("Read from framebuffer takes {:?}", start.elapsed());
+        Ok(())
+    }
+
+    /// Convert between two PBO-backed images.
+    ///
+    /// Source is uploaded via the normal texture path (maps the PBO for CPU access).
+    /// Destination uses GL_PIXEL_PACK_BUFFER for zero-copy readback into the PBO.
+    fn convert_pbo_to_pbo(
+        &mut self,
+        dst: &mut TensorImage,
+        src: &TensorImage,
+        rotation: crate::Rotation,
+        flip: Flip,
+        crop: Crop,
+    ) -> crate::Result<()> {
+        // Safety check: neither PBO must be mapped; extract dst buffer_id before releasing borrows
+        let dst_buffer_id = {
+            let src_pbo = match &src.tensor {
+                edgefirst_tensor::Tensor::Pbo(p) => p,
+                _ => {
+                    return Err(crate::Error::OpenGl(
+                        "convert_pbo_to_pbo: src is not a PBO tensor".to_string(),
+                    ))
+                }
+            };
+            let dst_pbo = match &dst.tensor {
+                edgefirst_tensor::Tensor::Pbo(p) => p,
+                _ => {
+                    return Err(crate::Error::OpenGl(
+                        "convert_pbo_to_pbo: dst is not a PBO tensor".to_string(),
+                    ))
+                }
+            };
+
+            if src_pbo.is_mapped() || dst_pbo.is_mapped() {
+                return Err(crate::Error::OpenGl(
+                    "Cannot convert PBO tensors while they are mapped".to_string(),
+                ));
+            }
+
+            dst_pbo.buffer_id()
+        };
+
+        // Setup renderbuffer (same as non-DMA path)
+        self.setup_renderbuffer_non_dma(dst, crop)?;
+
+        // Upload source and render using existing pipeline
+        // (convert_to maps the source tensor internally for texture upload)
+        let start = Instant::now();
+        if dst.is_planar() {
+            self.convert_to_planar(src, dst, rotation, flip, crop)?;
+        } else {
+            self.convert_to(src, dst, rotation, flip, crop)?;
+        }
+        log::debug!("PBO render takes {:?}", start.elapsed());
+
+        // Readback into destination PBO instead of CPU memory
+        let start_read = Instant::now();
+        let dest_format = match dst.fourcc() {
+            crate::RGB | crate::RGB_INT8 => gls::gl::RGB,
+            crate::RGBA => gls::gl::RGBA,
+            crate::GREY => gls::gl::RED,
+            _ => {
+                return Err(crate::Error::NotSupported(format!(
+                    "PBO readback not supported for {}",
+                    dst.fourcc().display()
+                )))
+            }
+        };
+
+        unsafe {
+            // Bind destination PBO as PACK buffer — glReadnPixels will write into it
+            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, dst_buffer_id);
+            gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
+            gls::gl::ReadnPixels(
+                0,
+                0,
+                dst.width() as i32,
+                dst.height() as i32,
+                dest_format,
+                gls::gl::UNSIGNED_BYTE,
+                dst.tensor.len() as i32,
+                std::ptr::null_mut(), // NULL pointer = write to bound PACK buffer
+            );
+            gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, 0);
+            gls::gl::Finish();
+        }
+
+        check_gl_error(function!(), line!())?;
+
+        // Handle int8 XOR if needed (must map PBO to do this)
+        if fourcc_is_int8(dst.fourcc()) {
+            let mut dst_map = dst.tensor().map()?;
+            for byte in dst_map.iter_mut() {
+                *byte ^= 0x80;
+            }
+        }
+
+        log::debug!("PBO readback takes {:?}", start_read.elapsed());
         Ok(())
     }
 

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -751,7 +751,11 @@ struct GlPboOps {
     sender: WeakSender<GLProcessorMessage>,
 }
 
-impl edgefirst_tensor::PboOps for GlPboOps {
+// SAFETY: GlPboOps sends all GL operations to the dedicated GL thread via a
+// channel. `map_buffer` returns a CPU-visible pointer from `glMapBufferRange`
+// that remains valid until `unmap_buffer` calls `glUnmapBuffer` on the GL thread.
+// `delete_buffer` sends a fire-and-forget deletion command to the GL thread.
+unsafe impl edgefirst_tensor::PboOps for GlPboOps {
     fn map_buffer(
         &self,
         buffer_id: u32,
@@ -1217,7 +1221,8 @@ impl GLProcessorThreaded {
         };
 
         let pbo_tensor =
-            edgefirst_tensor::PboTensor::<u8>::from_pbo(buffer_id, size, &shape, None, ops);
+            edgefirst_tensor::PboTensor::<u8>::from_pbo(buffer_id, size, &shape, None, ops)
+                .map_err(|e| Error::OpenGl(format!("PBO tensor creation failed: {e:?}")))?;
         let tensor = edgefirst_tensor::Tensor::Pbo(pbo_tensor);
         crate::TensorImage::from_tensor(tensor, fourcc)
             .map_err(|e| Error::OpenGl(format!("Failed to wrap PBO tensor as image: {e:?}")))
@@ -2768,8 +2773,9 @@ impl GLProcessorST {
 
     /// Convert between two PBO-backed images.
     ///
-    /// Source is uploaded via the normal texture path (maps the PBO for CPU access).
-    /// Destination uses GL_PIXEL_PACK_BUFFER for zero-copy readback into the PBO.
+    /// Source PBO is bound as `GL_PIXEL_UNPACK_BUFFER` for zero-copy texture upload
+    /// (avoids `tensor.map()` to prevent GL-thread deadlocks). Destination uses
+    /// `GL_PIXEL_PACK_BUFFER` for zero-copy readback into the PBO.
     fn convert_pbo_to_pbo(
         &mut self,
         dst: &mut TensorImage,

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -50,7 +50,7 @@ use crate::DEFAULT_COLORS;
 use crate::{
     fourcc_is_int8, fourcc_is_packed_rgb, CPUProcessor, Crop, Error, Flip, ImageProcessorTrait,
     Rect, Rotation, TensorImage, TensorImageRef, GREY, NV12, PLANAR_RGB, PLANAR_RGBA,
-    PLANAR_RGB_INT8, RGB, RGBA, RGB_INT8, YUYV,
+    PLANAR_RGB_INT8, RGB, RGBA, RGB_INT8, VYUY, YUYV,
 };
 
 #[cfg(feature = "decoder")]
@@ -2508,7 +2508,9 @@ impl GLProcessorST {
 
     fn check_src_format_supported(backend: TransferBackend, img: &TensorImage) -> bool {
         if backend.is_dma() && img.tensor().memory() == TensorMemory::Dma {
-            // EGLImage supports RGBA, GREY, YUYV, and NV12 for DMA buffers
+            // EGLImage supports RGBA, GREY, YUYV, and NV12 for DMA buffers.
+            // VYUY excluded: Vivante GPU accepts the DRM fourcc but produces
+            // incorrect output (similarity ~0.28 vs reference).
             matches!(img.fourcc(), RGBA | GREY | YUYV | NV12)
         } else {
             matches!(img.fourcc(), RGB | RGBA | GREY)
@@ -2615,7 +2617,11 @@ impl GLProcessorST {
             if self.support_rgb_direct {
                 self.convert_to_rgb_direct(src, dst, rotation, flip, crop)
             } else {
-                self.convert_to_packed_rgb(src, dst, rotation, flip, crop)
+                // Two-pass packed RGB is slower than G2D/CPU; decline so
+                // ImageProcessor falls through to a faster backend.
+                Err(crate::Error::NotSupported(
+                    "OpenGL two-pass packed RGB disabled (no direct RGB support)".into(),
+                ))
             }
         } else if dst.is_planar() {
             self.setup_renderbuffer_dma(dst)?;
@@ -4290,7 +4296,7 @@ impl GLProcessorST {
             ]);
         }
 
-        if matches!(src.fourcc(), YUYV | NV12) {
+        if matches!(src.fourcc(), YUYV | VYUY | NV12) {
             egl_img_attr.append(&mut vec![
                 egl_ext::YUV_COLOR_SPACE_HINT as Attrib,
                 egl_ext::ITU_REC709 as Attrib,
@@ -5822,6 +5828,7 @@ fn fourcc_to_drm(fourcc: FourCharCode) -> Result<DrmFourcc, Error> {
     match fourcc {
         RGBA => Ok(DrmFourcc::Abgr8888),
         YUYV => Ok(DrmFourcc::Yuyv),
+        VYUY => Ok(DrmFourcc::Vyuy),
         RGB | RGB_INT8 => Ok(DrmFourcc::Bgr888),
         GREY => Ok(DrmFourcc::R8),
         NV12 => Ok(DrmFourcc::Nv12),

--- a/crates/image/src/opengl_headless.rs
+++ b/crates/image/src/opengl_headless.rs
@@ -2692,8 +2692,8 @@ impl GLProcessorST {
         flip: Flip,
         crop: Crop,
     ) -> crate::Result<()> {
-        // Safety check: neither PBO must be mapped; extract dst buffer_id before releasing borrows
-        let dst_buffer_id = {
+        // Safety check: neither PBO must be mapped; extract buffer IDs before releasing borrows
+        let (src_buffer_id, dst_buffer_id) = {
             let src_pbo = match &src.tensor {
                 edgefirst_tensor::Tensor::Pbo(p) => p,
                 _ => {
@@ -2717,20 +2717,20 @@ impl GLProcessorST {
                 ));
             }
 
-            dst_pbo.buffer_id()
+            (src_pbo.buffer_id(), dst_pbo.buffer_id())
         };
 
         // Setup renderbuffer (same as non-DMA path)
         self.setup_renderbuffer_non_dma(dst, crop)?;
 
-        // Upload source and render using existing pipeline
-        // (convert_to maps the source tensor internally for texture upload)
+        // Upload source from PBO and render.
+        // We cannot call convert_to/draw_src_texture directly because they
+        // call src.tensor().map() which sends a message back to THIS thread,
+        // causing a deadlock. Instead, bind the source PBO as UNPACK buffer
+        // and upload to the texture with a NULL pointer — GL reads directly
+        // from the PBO, zero CPU copy.
         let start = Instant::now();
-        if dst.is_planar() {
-            self.convert_to_planar(src, dst, rotation, flip, crop)?;
-        } else {
-            self.convert_to(src, dst, rotation, flip, crop)?;
-        }
+        self.draw_src_texture_from_pbo(src, src_buffer_id, dst, rotation, flip, crop)?;
         log::debug!("PBO render takes {:?}", start.elapsed());
 
         // Readback into destination PBO instead of CPU memory
@@ -2767,15 +2767,275 @@ impl GLProcessorST {
 
         check_gl_error(function!(), line!())?;
 
-        // Handle int8 XOR if needed (must map PBO to do this)
+        // Handle int8 XOR if needed (must map PBO to do this on the GL thread
+        // directly, since we're already on the GL thread)
         if fourcc_is_int8(dst.fourcc()) {
-            let mut dst_map = dst.tensor().map()?;
-            for byte in dst_map.iter_mut() {
-                *byte ^= 0x80;
+            unsafe {
+                gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, dst_buffer_id);
+                let ptr = gls::gl::MapBufferRange(
+                    gls::gl::PIXEL_PACK_BUFFER,
+                    0,
+                    dst.tensor.len() as isize,
+                    gls::gl::MAP_READ_BIT | gls::gl::MAP_WRITE_BIT,
+                );
+                if !ptr.is_null() {
+                    let slice = std::slice::from_raw_parts_mut(ptr as *mut u8, dst.tensor.len());
+                    for byte in slice.iter_mut() {
+                        *byte ^= 0x80;
+                    }
+                    gls::gl::UnmapBuffer(gls::gl::PIXEL_PACK_BUFFER);
+                }
+                gls::gl::BindBuffer(gls::gl::PIXEL_PACK_BUFFER, 0);
             }
+            check_gl_error(function!(), line!())?;
         }
 
         log::debug!("PBO readback takes {:?}", start_read.elapsed());
+        Ok(())
+    }
+
+    /// Upload source image from a PBO and render to the current framebuffer.
+    /// This is the PBO equivalent of draw_src_texture — instead of mapping
+    /// the tensor to CPU and calling glTexImage2D with a data pointer, we
+    /// bind the source PBO as GL_PIXEL_UNPACK_BUFFER and pass NULL, causing
+    /// GL to read directly from the PBO (zero CPU copy).
+    fn draw_src_texture_from_pbo(
+        &mut self,
+        src: &TensorImage,
+        src_buffer_id: u32,
+        dst: &TensorImage,
+        rotation: crate::Rotation,
+        flip: Flip,
+        crop: Crop,
+    ) -> Result<(), Error> {
+        let texture_target = gls::gl::TEXTURE_2D;
+        let texture_format = match src.fourcc() {
+            crate::RGB | crate::RGB_INT8 => gls::gl::RGB,
+            crate::RGBA => gls::gl::RGBA,
+            crate::GREY => gls::gl::RED,
+            _ => {
+                return Err(Error::NotSupported(format!(
+                    "PBO upload not supported for {:?}",
+                    src.fourcc()
+                )));
+            }
+        };
+
+        let has_crop = crop.dst_rect.is_some_and(|x| {
+            x.left != 0 || x.top != 0 || x.width != dst.width() || x.height != dst.height()
+        });
+
+        // top and bottom are flipped because OpenGL uses 0,0 as bottom left
+        let src_roi = if let Some(crop) = crop.src_rect {
+            RegionOfInterest {
+                left: crop.left as f32 / src.width() as f32,
+                top: (crop.top + crop.height) as f32 / src.height() as f32,
+                right: (crop.left + crop.width) as f32 / src.width() as f32,
+                bottom: crop.top as f32 / src.height() as f32,
+            }
+        } else {
+            RegionOfInterest {
+                left: 0.,
+                top: 1.,
+                right: 1.,
+                bottom: 0.,
+            }
+        };
+
+        let cvt_screen_coord = |normalized| normalized * 2.0 - 1.0;
+        let mut dst_roi = if let Some(crop) = crop.dst_rect {
+            RegionOfInterest {
+                left: cvt_screen_coord(crop.left as f32 / dst.width() as f32),
+                top: cvt_screen_coord((crop.top + crop.height) as f32 / dst.height() as f32),
+                right: cvt_screen_coord((crop.left + crop.width) as f32 / dst.width() as f32),
+                bottom: cvt_screen_coord(crop.top as f32 / dst.height() as f32),
+            }
+        } else {
+            RegionOfInterest {
+                left: -1.,
+                top: 1.,
+                right: 1.,
+                bottom: -1.,
+            }
+        };
+
+        let rotation_offset = match rotation {
+            crate::Rotation::None => 0,
+            crate::Rotation::Clockwise90 => 1,
+            crate::Rotation::Rotate180 => 2,
+            crate::Rotation::CounterClockwise90 => 3,
+        };
+
+        unsafe {
+            if has_crop {
+                if let Some(dst_color) = crop.dst_color {
+                    gls::gl::ClearColor(
+                        dst_color[0] as f32 / 255.0,
+                        dst_color[1] as f32 / 255.0,
+                        dst_color[2] as f32 / 255.0,
+                        dst_color[3] as f32 / 255.0,
+                    );
+                    gls::gl::Clear(gls::gl::COLOR_BUFFER_BIT);
+                }
+            }
+
+            gls::gl::UseProgram(self.texture_program.id);
+            gls::gl::BindTexture(texture_target, self.camera_normal_texture.id);
+            gls::gl::ActiveTexture(gls::gl::TEXTURE0);
+            gls::gl::TexParameteri(
+                texture_target,
+                gls::gl::TEXTURE_MIN_FILTER,
+                gls::gl::LINEAR as i32,
+            );
+            gls::gl::TexParameteri(
+                texture_target,
+                gls::gl::TEXTURE_MAG_FILTER,
+                gls::gl::LINEAR as i32,
+            );
+            if src.fourcc() == crate::GREY {
+                for swizzle in [
+                    gls::gl::TEXTURE_SWIZZLE_R,
+                    gls::gl::TEXTURE_SWIZZLE_G,
+                    gls::gl::TEXTURE_SWIZZLE_B,
+                ] {
+                    gls::gl::TexParameteri(gls::gl::TEXTURE_2D, swizzle, gls::gl::RED as i32);
+                }
+            } else {
+                for (swizzle, src_component) in [
+                    (gls::gl::TEXTURE_SWIZZLE_R, gls::gl::RED),
+                    (gls::gl::TEXTURE_SWIZZLE_G, gls::gl::GREEN),
+                    (gls::gl::TEXTURE_SWIZZLE_B, gls::gl::BLUE),
+                ] {
+                    gls::gl::TexParameteri(gls::gl::TEXTURE_2D, swizzle, src_component as i32);
+                }
+            }
+
+            // Bind source PBO as UNPACK buffer — glTexImage2D reads from it
+            gls::gl::BindBuffer(gls::gl::PIXEL_UNPACK_BUFFER, src_buffer_id);
+            gls::gl::TexImage2D(
+                texture_target,
+                0,
+                texture_format as i32,
+                src.width() as i32,
+                src.height() as i32,
+                0,
+                texture_format,
+                gls::gl::UNSIGNED_BYTE,
+                std::ptr::null(), // NULL = read from bound UNPACK buffer
+            );
+            gls::gl::BindBuffer(gls::gl::PIXEL_UNPACK_BUFFER, 0);
+
+            // Force texture cache state to be rebuilt next call
+            self.camera_normal_texture.width = 0;
+
+            gls::gl::BindBuffer(gls::gl::ARRAY_BUFFER, self.vertex_buffer.id);
+            gls::gl::EnableVertexAttribArray(self.vertex_buffer.buffer_index);
+
+            match flip {
+                crate::Flip::None => {}
+                crate::Flip::Vertical => {
+                    std::mem::swap(&mut dst_roi.top, &mut dst_roi.bottom);
+                }
+                crate::Flip::Horizontal => {
+                    std::mem::swap(&mut dst_roi.left, &mut dst_roi.right);
+                }
+            }
+
+            let camera_vertices: [f32; 12] = [
+                dst_roi.left,
+                dst_roi.top,
+                0., // left top
+                dst_roi.right,
+                dst_roi.top,
+                0., // right top
+                dst_roi.right,
+                dst_roi.bottom,
+                0., // right bottom
+                dst_roi.left,
+                dst_roi.bottom,
+                0., // left bottom
+            ];
+            gls::gl::BufferData(
+                gls::gl::ARRAY_BUFFER,
+                (camera_vertices.len() * std::mem::size_of::<f32>()) as isize,
+                camera_vertices.as_ptr() as *const c_void,
+                gls::gl::STATIC_DRAW,
+            );
+            gls::gl::VertexAttribPointer(
+                self.vertex_buffer.buffer_index,
+                3,
+                gls::gl::FLOAT,
+                gls::gl::FALSE,
+                0,
+                std::ptr::null(),
+            );
+
+            let texture_coords: [[f32; 8]; 4] = [
+                [
+                    src_roi.left,
+                    src_roi.top,
+                    src_roi.right,
+                    src_roi.top,
+                    src_roi.right,
+                    src_roi.bottom,
+                    src_roi.left,
+                    src_roi.bottom,
+                ],
+                [
+                    src_roi.left,
+                    src_roi.bottom,
+                    src_roi.left,
+                    src_roi.top,
+                    src_roi.right,
+                    src_roi.top,
+                    src_roi.right,
+                    src_roi.bottom,
+                ],
+                [
+                    src_roi.right,
+                    src_roi.bottom,
+                    src_roi.left,
+                    src_roi.bottom,
+                    src_roi.left,
+                    src_roi.top,
+                    src_roi.right,
+                    src_roi.top,
+                ],
+                [
+                    src_roi.right,
+                    src_roi.top,
+                    src_roi.right,
+                    src_roi.bottom,
+                    src_roi.left,
+                    src_roi.bottom,
+                    src_roi.left,
+                    src_roi.top,
+                ],
+            ];
+            gls::gl::BindBuffer(gls::gl::ARRAY_BUFFER, self.texture_buffer.id);
+            gls::gl::EnableVertexAttribArray(self.texture_buffer.buffer_index);
+            gls::gl::BufferData(
+                gls::gl::ARRAY_BUFFER,
+                (texture_coords[0].len() * std::mem::size_of::<f32>()) as isize,
+                texture_coords[rotation_offset].as_ptr() as *const c_void,
+                gls::gl::STATIC_DRAW,
+            );
+            gls::gl::VertexAttribPointer(
+                self.texture_buffer.buffer_index,
+                2,
+                gls::gl::FLOAT,
+                gls::gl::FALSE,
+                0,
+                std::ptr::null(),
+            );
+            gls::gl::DrawArrays(gls::gl::TRIANGLE_FAN, 0, 4);
+            gls::gl::DisableVertexAttribArray(self.vertex_buffer.buffer_index);
+            gls::gl::DisableVertexAttribArray(self.texture_buffer.buffer_index);
+
+            gls::gl::Finish();
+        }
+
+        check_gl_error(function!(), line!())?;
         Ok(())
     }
 

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -624,6 +624,11 @@ class TensorMemory(enum.Enum):
         POSIX Shared Memory allocation. Suitable for inter-process
         communication, but not suitable for hardware acceleration.
         """
+    PBO: TensorMemory
+    """
+    GPU Pixel Buffer Object (PBO) allocation. Used for zero-copy GPU
+    upload/readback on platforms without DMA-buf support.
+    """
     MEM: TensorMemory
     """Regular system memory allocation"""
 

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -1018,11 +1018,15 @@ class Rect:
 class EglDisplayKind:
     """Identifies the type of EGL display used for headless OpenGL ES rendering.
 
-    Display types:
-        Gbm: Direct GPU access via DRM render node (/dev/dri/renderD128).
-            No compositor required. Preferred for headless edge AI.
+    The HAL creates a surfaceless GLES 3.0 context and renders exclusively
+    through FBOs. No window or PBuffer surface is created.
+
+    Display types (probed in priority order):
         PlatformDevice: EGL device enumeration via EGL_EXT_device_enumeration.
-            Also headless/compositor-free. Common on NVIDIA GPUs.
+            Headless/compositor-free with zero external deps. Works on NVIDIA
+            and newer Vivante drivers.
+        Gbm: Direct GPU access via DRM render node (/dev/dri/renderD128).
+            No compositor required. Needed on ARM Mali and older Vivante.
         Default: Uses eglGetDisplay(EGL_DEFAULT_DISPLAY). Connects to
             Wayland compositor or X server if available. May block on
             headless systems.
@@ -1048,8 +1052,9 @@ class EglDisplayInfo:
 def probe_egl_displays() -> list[EglDisplayInfo]:
     """Probe for available EGL displays supporting headless OpenGL ES 3.0.
 
-    Returns displays in priority order (GBM, PlatformDevice, Default).
-    Each display is validated with eglInitialize + eglChooseConfig.
+    Returns displays in priority order (PlatformDevice, GBM, Default).
+    Each display is validated with eglInitialize and checked for required
+    extensions (EGL_KHR_surfaceless_context, EGL_KHR_no_config_context).
     An empty list means OpenGL is not available on this system.
 
     Raises:

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -1173,7 +1173,8 @@ impl PyDecoder {
                     nms,
                     &mut output_boxes,
                     &mut output_masks,
-                );
+                )
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
             }
             (ReadOnlyArrayGeneric2::Int8(boxes), ReadOnlyArrayGeneric3::Int8(protos)) => {
                 edgefirst_hal::decoder::yolo::decode_yolo_segdet_quant(
@@ -1184,7 +1185,8 @@ impl PyDecoder {
                     nms,
                     &mut output_boxes,
                     &mut output_masks,
-                );
+                )
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
             }
             (ReadOnlyArrayGeneric2::Float32(boxes), ReadOnlyArrayGeneric3::Float32(protos)) => {
                 edgefirst_hal::decoder::yolo::decode_yolo_segdet_float(
@@ -1195,7 +1197,8 @@ impl PyDecoder {
                     nms,
                     &mut output_boxes,
                     &mut output_masks,
-                );
+                )
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
             }
             (ReadOnlyArrayGeneric2::Float64(boxes), ReadOnlyArrayGeneric3::Float64(protos)) => {
                 edgefirst_hal::decoder::yolo::decode_yolo_segdet_float(
@@ -1206,7 +1209,8 @@ impl PyDecoder {
                     nms,
                     &mut output_boxes,
                     &mut output_masks,
-                );
+                )
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
             }
             _ => {
                 return Err(pyo3::exceptions::PyRuntimeError::new_err(

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -157,7 +157,7 @@ impl TryFrom<&str> for FourCC {
             "YUYV" => Ok(FourCC::YUYV),
             "RGBA" => Ok(FourCC::RGBA),
             "RGB" | "RGB " => Ok(FourCC::RGB),
-            "NV12" => Ok(FourCC::RGB),
+            "NV12" => Ok(FourCC::NV12),
             "Y800" | "GREY" | "GRAY" => Ok(FourCC::GREY),
             "8BPS" => Ok(FourCC::PLANAR_RGB),
             _ => Err(Error::Format(value.to_string())),
@@ -1130,7 +1130,7 @@ pub enum PyRotation {
 impl PyRotation {
     #[staticmethod]
     pub fn degrees_clockwise(angle: usize) -> PyRotation {
-        match angle.rem_euclid(90) {
+        match angle.rem_euclid(360) {
             0 => PyRotation::Rotate0,
             90 => PyRotation::Clockwise90,
             180 => PyRotation::Rotate180,

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -1065,6 +1065,27 @@ impl PyImageProcessor {
         Ok(())
     }
 
+    /// Create an image with the processor's optimal memory backend.
+    ///
+    /// Selects the best available backing storage based on hardware capabilities:
+    /// DMA-buf > PBO (GPU buffer) > system memory. Images created this way benefit
+    /// from zero-copy GPU paths when used with this processor's convert().
+    #[pyo3(signature = (width, height, fourcc = FourCC::RGBA))]
+    pub fn create_image(
+        &self,
+        width: usize,
+        height: usize,
+        fourcc: FourCC,
+    ) -> Result<PyTensorImage> {
+        let fourcc: four_char_code::FourCharCode = fourcc.into();
+        let img = self
+            .0
+            .lock()
+            .map_err(|_| Error::InvalidArg("ImageProcessor lock poisoned".to_string()))?
+            .create_image(width, height, fourcc)?;
+        Ok(PyTensorImage(img))
+    }
+
     pub fn set_class_colors(&mut self, colors: Vec<[u8; 4]>) -> Result<()> {
         if let Ok(mut l) = self.0.lock() {
             l.set_class_colors(&colors)?

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -122,6 +122,7 @@ pub enum ImageDest3<'py> {
 #[allow(non_camel_case_types)]
 pub enum FourCC {
     YUYV,
+    VYUY,
     RGBA,
     RGB,
     NV12,
@@ -155,6 +156,7 @@ impl TryFrom<&str> for FourCC {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value.to_uppercase().as_str() {
             "YUYV" => Ok(FourCC::YUYV),
+            "VYUY" => Ok(FourCC::VYUY),
             "RGBA" => Ok(FourCC::RGBA),
             "RGB" | "RGB " => Ok(FourCC::RGB),
             "NV12" => Ok(FourCC::NV12),
@@ -169,6 +171,7 @@ impl From<FourCC> for FourCharCode {
     fn from(val: FourCC) -> Self {
         match val {
             FourCC::YUYV => image::YUYV,
+            FourCC::VYUY => image::VYUY,
             FourCC::RGBA => image::RGBA,
             FourCC::RGB => image::RGB,
             FourCC::NV12 => image::NV12,

--- a/crates/python/src/tensor.rs
+++ b/crates/python/src/tensor.rs
@@ -65,6 +65,7 @@ pub enum PyTensorMemory {
     DMA,
     #[cfg(unix)]
     SHM,
+    PBO,
     MEM,
 }
 
@@ -75,6 +76,7 @@ impl From<PyTensorMemory> for TensorMemory {
             PyTensorMemory::DMA => TensorMemory::Dma,
             #[cfg(unix)]
             PyTensorMemory::SHM => TensorMemory::Shm,
+            PyTensorMemory::PBO => TensorMemory::Pbo,
             PyTensorMemory::MEM => TensorMemory::Mem,
         }
     }
@@ -87,10 +89,8 @@ impl From<TensorMemory> for PyTensorMemory {
             TensorMemory::Dma => PyTensorMemory::DMA,
             #[cfg(unix)]
             TensorMemory::Shm => PyTensorMemory::SHM,
+            TensorMemory::Pbo => PyTensorMemory::PBO,
             TensorMemory::Mem => PyTensorMemory::MEM,
-            // PBO tensors are GPU-only and not representable in the Python API;
-            // report as MEM so callers can still inspect the memory type.
-            TensorMemory::Pbo => PyTensorMemory::MEM,
         }
     }
 }

--- a/crates/python/src/tensor.rs
+++ b/crates/python/src/tensor.rs
@@ -88,6 +88,9 @@ impl From<TensorMemory> for PyTensorMemory {
             #[cfg(unix)]
             TensorMemory::Shm => PyTensorMemory::SHM,
             TensorMemory::Mem => PyTensorMemory::MEM,
+            // PBO tensors are GPU-only and not representable in the Python API;
+            // report as MEM so callers can still inspect the memory type.
+            TensorMemory::Pbo => PyTensorMemory::MEM,
         }
     }
 }

--- a/crates/tensor/src/error.rs
+++ b/crates/tensor/src/error.rs
@@ -14,6 +14,10 @@ pub enum Error {
     #[cfg(target_os = "linux")]
     UnknownDeviceType(u64, u64),
     InvalidMemoryType(String),
+    /// The GL context backing a PBO tensor has been destroyed.
+    PboDisconnected,
+    /// The PBO buffer is currently mapped and cannot be used for GL operations.
+    PboMapped,
     #[cfg(feature = "ndarray")]
     NdArrayError(ndarray::ShapeError),
 }

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -31,12 +31,14 @@ mod dma;
 mod dmabuf;
 mod error;
 mod mem;
+mod pbo;
 #[cfg(unix)]
 mod shm;
 
 #[cfg(target_os = "linux")]
 pub use crate::dma::{DmaMap, DmaTensor};
 pub use crate::mem::{MemMap, MemTensor};
+pub use crate::pbo::{PboMapping, PboOps};
 #[cfg(unix)]
 pub use crate::shm::{ShmMap, ShmTensor};
 pub use error::{Error, Result};

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -38,7 +38,7 @@ mod shm;
 #[cfg(target_os = "linux")]
 pub use crate::dma::{DmaMap, DmaTensor};
 pub use crate::mem::{MemMap, MemTensor};
-pub use crate::pbo::{PboMapping, PboOps};
+pub use crate::pbo::{PboMap, PboMapping, PboOps, PboTensor};
 #[cfg(unix)]
 pub use crate::shm::{ShmMap, ShmTensor};
 pub use error::{Error, Result};
@@ -225,6 +225,10 @@ pub enum TensorMemory {
 
     /// Regular system memory allocation
     Mem,
+
+    /// OpenGL Pixel Buffer Object memory. Created by ImageProcessor
+    /// when DMA-buf is unavailable but OpenGL is present.
+    Pbo,
 }
 
 impl From<TensorMemory> for String {
@@ -235,6 +239,7 @@ impl From<TensorMemory> for String {
             #[cfg(unix)]
             TensorMemory::Shm => "shm".to_owned(),
             TensorMemory::Mem => "mem".to_owned(),
+            TensorMemory::Pbo => "pbo".to_owned(),
         }
     }
 }
@@ -249,6 +254,7 @@ impl TryFrom<&str> for TensorMemory {
             #[cfg(unix)]
             "shm" => Ok(TensorMemory::Shm),
             "mem" => Ok(TensorMemory::Mem),
+            "pbo" => Ok(TensorMemory::Pbo),
             _ => Err(Error::InvalidMemoryType(s.to_owned())),
         }
     }
@@ -264,6 +270,7 @@ where
     #[cfg(unix)]
     Shm(ShmTensor<T>),
     Mem(MemTensor<T>),
+    Pbo(PboTensor<T>),
 }
 
 impl<T> Tensor<T>
@@ -301,6 +308,9 @@ where
             #[cfg(unix)]
             Some(TensorMemory::Shm) => ShmTensor::<T>::new(shape, name).map(Tensor::Shm),
             Some(TensorMemory::Mem) => MemTensor::<T>::new(shape, name).map(Tensor::Mem),
+            Some(TensorMemory::Pbo) => Err(crate::error::Error::NotImplemented(
+                "PboTensor cannot be created via Tensor::new() — use ImageProcessor::create_image()".to_owned(),
+            )),
             None => {
                 if std::env::var("EDGEFIRST_TENSOR_FORCE_MEM")
                     .is_ok_and(|x| x != "0" && x.to_lowercase() != "false")
@@ -393,6 +403,7 @@ where
             Tensor::Dma(t) => t.clone_fd(),
             Tensor::Shm(t) => t.clone_fd(),
             Tensor::Mem(t) => t.clone_fd(),
+            Tensor::Pbo(t) => t.clone_fd(),
         }
     }
 
@@ -403,6 +414,7 @@ where
             #[cfg(unix)]
             Tensor::Shm(_) => TensorMemory::Shm,
             Tensor::Mem(_) => TensorMemory::Mem,
+            Tensor::Pbo(_) => TensorMemory::Pbo,
         }
     }
 
@@ -413,6 +425,7 @@ where
             #[cfg(unix)]
             Tensor::Shm(t) => t.name(),
             Tensor::Mem(t) => t.name(),
+            Tensor::Pbo(t) => t.name(),
         }
     }
 
@@ -423,6 +436,7 @@ where
             #[cfg(unix)]
             Tensor::Shm(t) => t.shape(),
             Tensor::Mem(t) => t.shape(),
+            Tensor::Pbo(t) => t.shape(),
         }
     }
 
@@ -433,6 +447,7 @@ where
             #[cfg(unix)]
             Tensor::Shm(t) => t.reshape(shape),
             Tensor::Mem(t) => t.reshape(shape),
+            Tensor::Pbo(t) => t.reshape(shape),
         }
     }
 
@@ -443,6 +458,7 @@ where
             #[cfg(unix)]
             Tensor::Shm(t) => t.map(),
             Tensor::Mem(t) => t.map(),
+            Tensor::Pbo(t) => t.map(),
         }
     }
 
@@ -453,6 +469,7 @@ where
             #[cfg(unix)]
             Tensor::Shm(t) => t.buffer_identity(),
             Tensor::Mem(t) => t.buffer_identity(),
+            Tensor::Pbo(t) => t.buffer_identity(),
         }
     }
 }
@@ -466,6 +483,7 @@ where
     #[cfg(unix)]
     Shm(ShmMap<T>),
     Mem(MemMap<T>),
+    Pbo(PboMap<T>),
 }
 
 impl<T> TensorMapTrait<T> for TensorMap<T>
@@ -479,6 +497,7 @@ where
             #[cfg(unix)]
             TensorMap::Shm(map) => map.shape(),
             TensorMap::Mem(map) => map.shape(),
+            TensorMap::Pbo(map) => map.shape(),
         }
     }
 
@@ -489,6 +508,7 @@ where
             #[cfg(unix)]
             TensorMap::Shm(map) => map.unmap(),
             TensorMap::Mem(map) => map.unmap(),
+            TensorMap::Pbo(map) => map.unmap(),
         }
     }
 
@@ -499,6 +519,7 @@ where
             #[cfg(unix)]
             TensorMap::Shm(map) => map.as_slice(),
             TensorMap::Mem(map) => map.as_slice(),
+            TensorMap::Pbo(map) => map.as_slice(),
         }
     }
 
@@ -509,6 +530,7 @@ where
             #[cfg(unix)]
             TensorMap::Shm(map) => map.as_mut_slice(),
             TensorMap::Mem(map) => map.as_mut_slice(),
+            TensorMap::Pbo(map) => map.as_mut_slice(),
         }
     }
 }
@@ -526,6 +548,7 @@ where
             #[cfg(unix)]
             TensorMap::Shm(map) => map.deref(),
             TensorMap::Mem(map) => map.deref(),
+            TensorMap::Pbo(map) => map.deref(),
         }
     }
 }
@@ -541,6 +564,7 @@ where
             #[cfg(unix)]
             TensorMap::Shm(map) => map.deref_mut(),
             TensorMap::Mem(map) => map.deref_mut(),
+            TensorMap::Pbo(map) => map.deref_mut(),
         }
     }
 }

--- a/crates/tensor/src/pbo.rs
+++ b/crates/tensor/src/pbo.rs
@@ -37,7 +37,15 @@ unsafe impl Send for PboMapping {}
 /// All methods are blocking — they send commands to the GL thread
 /// and wait for completion. Implementations must ensure GL context
 /// is current on the thread that executes the actual GL calls.
-pub trait PboOps: Send + Sync {
+///
+/// # Safety
+///
+/// Implementations must ensure:
+/// - `map_buffer` returns a valid, aligned pointer to `size` bytes of
+///   CPU-accessible memory that remains valid until `unmap_buffer` is called.
+/// - `unmap_buffer` invalidates the pointer and releases the mapping.
+/// - `delete_buffer` frees the GL buffer resources.
+pub unsafe trait PboOps: Send + Sync {
     /// Map the PBO for CPU read/write access.
     /// The returned PboMapping is valid until `unmap_buffer` is called.
     fn map_buffer(&self, buffer_id: u32, size: usize) -> Result<PboMapping>;
@@ -102,15 +110,31 @@ where
     ///
     /// Called by the image crate after creating the PBO on the GL thread.
     /// Users should not call this directly — use `ImageProcessor::create_image()`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::ShapeMismatch` if `size` does not equal
+    /// `shape.iter().product::<usize>() * std::mem::size_of::<T>()`.
+    /// Returns `Error::InvalidSize` if `size` is zero.
     pub fn from_pbo(
         buffer_id: u32,
         size: usize,
         shape: &[usize],
         name: Option<&str>,
         ops: Arc<dyn PboOps>,
-    ) -> Self {
+    ) -> Result<Self> {
+        let expected = shape.iter().product::<usize>() * std::mem::size_of::<T>();
+        if size != expected {
+            return Err(Error::ShapeMismatch(format!(
+                "PBO size {size} does not match shape {shape:?} * sizeof({}) = {expected}",
+                std::any::type_name::<T>(),
+            )));
+        }
+        if size == 0 {
+            return Err(Error::InvalidSize(0));
+        }
         let name = name.unwrap_or("pbo_tensor").to_owned();
-        Self {
+        Ok(Self {
             name,
             shape: shape.to_vec(),
             handle: Arc::new(PboHandle {
@@ -121,7 +145,7 @@ where
             }),
             identity: BufferIdentity::new(),
             _marker: PhantomData,
-        }
+        })
     }
 
     /// Returns the GL buffer ID for this PBO.
@@ -342,7 +366,9 @@ mod tests {
         }
     }
 
-    impl PboOps for MockPboOps {
+    // SAFETY: MockPboOps returns a valid pointer to a Vec<u8> that remains
+    // valid while the Mutex is held (tests are single-threaded).
+    unsafe impl PboOps for MockPboOps {
         fn map_buffer(&self, _buffer_id: u32, size: usize) -> Result<PboMapping> {
             let storage = self.storage.lock().expect("lock");
             assert_eq!(storage.len(), size);
@@ -362,7 +388,7 @@ mod tests {
     #[test]
     fn test_pbo_tensor_create_and_metadata() {
         let ops = MockPboOps::new(24);
-        let tensor = PboTensor::<u8>::from_pbo(42, 24, &[2, 3, 4], Some("test_pbo"), ops);
+        let tensor = PboTensor::<u8>::from_pbo(42, 24, &[2, 3, 4], Some("test_pbo"), ops).unwrap();
         assert_eq!(tensor.memory(), TensorMemory::Pbo);
         assert_eq!(tensor.name(), "test_pbo");
         assert_eq!(tensor.shape(), &[2, 3, 4]);
@@ -373,7 +399,7 @@ mod tests {
     #[test]
     fn test_pbo_tensor_map_write_read() {
         let ops = MockPboOps::new(12);
-        let tensor = PboTensor::<u8>::from_pbo(1, 12, &[3, 4], Some("rw_test"), ops);
+        let tensor = PboTensor::<u8>::from_pbo(1, 12, &[3, 4], Some("rw_test"), ops).unwrap();
         {
             let mut map = tensor.map().expect("map should succeed");
             assert_eq!(map.shape(), &[3, 4]);
@@ -387,7 +413,7 @@ mod tests {
     #[test]
     fn test_pbo_tensor_double_map_fails() {
         let ops = MockPboOps::new(8);
-        let tensor = PboTensor::<u8>::from_pbo(2, 8, &[8], None, ops);
+        let tensor = PboTensor::<u8>::from_pbo(2, 8, &[8], None, ops).unwrap();
         let _map1 = tensor.map().expect("first map should succeed");
         assert!(tensor.is_mapped());
         let result = tensor.map();
@@ -397,7 +423,7 @@ mod tests {
     #[test]
     fn test_pbo_tensor_reshape() {
         let ops = MockPboOps::new(24);
-        let mut tensor = PboTensor::<u8>::from_pbo(3, 24, &[2, 3, 4], None, ops);
+        let mut tensor = PboTensor::<u8>::from_pbo(3, 24, &[2, 3, 4], None, ops).unwrap();
         tensor
             .reshape(&[4, 6])
             .expect("compatible reshape should succeed");
@@ -410,8 +436,8 @@ mod tests {
     fn test_pbo_tensor_buffer_identity() {
         let ops1 = MockPboOps::new(8);
         let ops2 = MockPboOps::new(8);
-        let t1 = PboTensor::<u8>::from_pbo(1, 8, &[8], None, ops1);
-        let t2 = PboTensor::<u8>::from_pbo(2, 8, &[8], None, ops2);
+        let t1 = PboTensor::<u8>::from_pbo(1, 8, &[8], None, ops1).unwrap();
+        let t2 = PboTensor::<u8>::from_pbo(2, 8, &[8], None, ops2).unwrap();
         assert_ne!(t1.buffer_identity().id(), t2.buffer_identity().id());
     }
 
@@ -425,14 +451,28 @@ mod tests {
     #[test]
     fn test_pbo_tensor_fd_ops_return_error() {
         let ops = MockPboOps::new(8);
-        let tensor = PboTensor::<u8>::from_pbo(1, 8, &[8], None, ops);
+        let tensor = PboTensor::<u8>::from_pbo(1, 8, &[8], None, ops).unwrap();
         assert!(tensor.clone_fd().is_err());
+    }
+
+    #[test]
+    fn test_pbo_tensor_from_pbo_size_mismatch() {
+        let ops = MockPboOps::new(24);
+        let result = PboTensor::<u8>::from_pbo(1, 24, &[2, 3, 5], None, ops);
+        assert!(result.is_err(), "mismatched size/shape should fail");
+    }
+
+    #[test]
+    fn test_pbo_tensor_from_pbo_zero_size() {
+        let ops = MockPboOps::new(0);
+        let result = PboTensor::<u8>::from_pbo(1, 0, &[0], None, ops);
+        assert!(result.is_err(), "zero size should fail");
     }
 
     #[test]
     fn test_pbo_via_tensor_enum() {
         let ops = MockPboOps::new(12);
-        let pbo = PboTensor::<u8>::from_pbo(10, 12, &[3, 4], Some("enum_test"), ops);
+        let pbo = PboTensor::<u8>::from_pbo(10, 12, &[3, 4], Some("enum_test"), ops).unwrap();
         let tensor = crate::Tensor::Pbo(pbo);
         assert_eq!(tensor.memory(), TensorMemory::Pbo);
         assert_eq!(tensor.name(), "enum_test");

--- a/crates/tensor/src/pbo.rs
+++ b/crates/tensor/src/pbo.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::Result;
+
+/// Raw mapped pointer from a PBO. CPU-accessible while the buffer is mapped.
+/// The pointer is only valid between map and unmap calls.
+pub struct PboMapping {
+    pub ptr: *mut u8,
+    pub size: usize,
+}
+
+// SAFETY: PboMapping is only created by PboOps::map_buffer which runs on the
+// GL thread, but the resulting pointer is used on the caller's thread. This is
+// safe because glMapBufferRange returns a CPU-visible pointer that can be
+// accessed from any thread while the buffer remains mapped.
+unsafe impl Send for PboMapping {}
+
+/// Trait for PBO GL operations, implemented by the image crate.
+///
+/// All methods are blocking — they send commands to the GL thread
+/// and wait for completion. Implementations must ensure GL context
+/// is current on the thread that executes the actual GL calls.
+pub trait PboOps: Send + Sync {
+    /// Map the PBO for CPU read/write access.
+    /// The returned PboMapping is valid until `unmap_buffer` is called.
+    fn map_buffer(&self, buffer_id: u32, size: usize) -> Result<PboMapping>;
+
+    /// Unmap a previously mapped PBO. Must be called before GL operations
+    /// on this buffer (GLES 3.0 requirement).
+    fn unmap_buffer(&self, buffer_id: u32) -> Result<()>;
+
+    /// Delete the PBO. Fire-and-forget — no reply needed.
+    /// Called from PboTensor's Drop impl.
+    fn delete_buffer(&self, buffer_id: u32);
+}

--- a/crates/tensor/src/pbo.rs
+++ b/crates/tensor/src/pbo.rs
@@ -1,7 +1,23 @@
 // SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::Result;
+use crate::{
+    error::{Error, Result},
+    BufferIdentity, TensorMap, TensorMapTrait, TensorMemory, TensorTrait,
+};
+use log::trace;
+use num_traits::Num;
+use std::{
+    ffi::c_void,
+    fmt,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+};
 
 /// Raw mapped pointer from a PBO. CPU-accessible while the buffer is mapped.
 /// The pointer is only valid between map and unmap calls.
@@ -33,4 +49,263 @@ pub trait PboOps: Send + Sync {
     /// Delete the PBO. Fire-and-forget — no reply needed.
     /// Called from PboTensor's Drop impl.
     fn delete_buffer(&self, buffer_id: u32);
+}
+
+/// Opaque handle to a PBO's GL resources.
+struct PboHandle {
+    ops: Arc<dyn PboOps>,
+    buffer_id: u32,
+    size: usize,
+    mapped: AtomicBool,
+}
+
+impl Drop for PboHandle {
+    fn drop(&mut self) {
+        self.ops.delete_buffer(self.buffer_id);
+    }
+}
+
+/// A tensor backed by an OpenGL Pixel Buffer Object.
+pub struct PboTensor<T>
+where
+    T: Num + Clone + fmt::Debug + Send + Sync,
+{
+    pub name: String,
+    pub shape: Vec<usize>,
+    handle: Arc<PboHandle>,
+    identity: BufferIdentity,
+    _marker: PhantomData<T>,
+}
+
+impl<T> fmt::Debug for PboTensor<T>
+where
+    T: Num + Clone + fmt::Debug + Send + Sync,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PboTensor")
+            .field("name", &self.name)
+            .field("shape", &self.shape)
+            .field("buffer_id", &self.handle.buffer_id)
+            .field("size", &self.handle.size)
+            .finish()
+    }
+}
+
+unsafe impl<T> Send for PboTensor<T> where T: Num + Clone + fmt::Debug + Send + Sync {}
+unsafe impl<T> Sync for PboTensor<T> where T: Num + Clone + fmt::Debug + Send + Sync {}
+
+impl<T> PboTensor<T>
+where
+    T: Num + Clone + fmt::Debug + Send + Sync,
+{
+    /// Create a new PBO tensor from an already-allocated GL buffer.
+    ///
+    /// Called by the image crate after creating the PBO on the GL thread.
+    /// Users should not call this directly — use `ImageProcessor::create_image()`.
+    pub fn from_pbo(
+        buffer_id: u32,
+        size: usize,
+        shape: &[usize],
+        name: Option<&str>,
+        ops: Arc<dyn PboOps>,
+    ) -> Self {
+        let name = name.unwrap_or("pbo_tensor").to_owned();
+        Self {
+            name,
+            shape: shape.to_vec(),
+            handle: Arc::new(PboHandle {
+                ops,
+                buffer_id,
+                size,
+                mapped: AtomicBool::new(false),
+            }),
+            identity: BufferIdentity::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the GL buffer ID for this PBO.
+    pub fn buffer_id(&self) -> u32 {
+        self.handle.buffer_id
+    }
+
+    /// Returns true if the PBO is currently mapped for CPU access.
+    pub fn is_mapped(&self) -> bool {
+        self.handle.mapped.load(Ordering::Acquire)
+    }
+}
+
+impl<T> TensorTrait<T> for PboTensor<T>
+where
+    T: Num + Clone + fmt::Debug + Send + Sync,
+{
+    fn new(_shape: &[usize], _name: Option<&str>) -> Result<Self> {
+        Err(Error::NotImplemented(
+            "PboTensor cannot be created directly — use ImageProcessor::create_image()".to_owned(),
+        ))
+    }
+
+    #[cfg(unix)]
+    fn from_fd(_fd: std::os::fd::OwnedFd, _shape: &[usize], _name: Option<&str>) -> Result<Self> {
+        Err(Error::NotImplemented(
+            "PboTensor does not support from_fd".to_owned(),
+        ))
+    }
+
+    #[cfg(unix)]
+    fn clone_fd(&self) -> Result<std::os::fd::OwnedFd> {
+        Err(Error::NotImplemented(
+            "PboTensor does not support clone_fd".to_owned(),
+        ))
+    }
+
+    fn memory(&self) -> TensorMemory {
+        TensorMemory::Pbo
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn reshape(&mut self, shape: &[usize]) -> Result<()> {
+        if shape.is_empty() {
+            return Err(Error::InvalidSize(0));
+        }
+        let new_size = shape.iter().product::<usize>() * std::mem::size_of::<T>();
+        if new_size != self.handle.size {
+            return Err(Error::ShapeMismatch(format!(
+                "Cannot reshape incompatible shape: {:?} to {:?}",
+                self.shape, shape
+            )));
+        }
+        self.shape = shape.to_vec();
+        Ok(())
+    }
+
+    fn map(&self) -> Result<TensorMap<T>> {
+        if self.handle.mapped.swap(true, Ordering::AcqRel) {
+            return Err(Error::PboMapped);
+        }
+        match self
+            .handle
+            .ops
+            .map_buffer(self.handle.buffer_id, self.handle.size)
+        {
+            Ok(mapping) => {
+                let pbo_ptr = PboPtr(
+                    NonNull::new(mapping.ptr as *mut c_void)
+                        .ok_or(Error::InvalidSize(self.handle.size))?,
+                );
+                Ok(TensorMap::Pbo(PboMap {
+                    ptr: Arc::new(Mutex::new(pbo_ptr)),
+                    shape: self.shape.clone(),
+                    handle: Arc::clone(&self.handle),
+                    _marker: PhantomData,
+                }))
+            }
+            Err(e) => {
+                self.handle.mapped.store(false, Ordering::Release);
+                Err(e)
+            }
+        }
+    }
+
+    fn buffer_identity(&self) -> &BufferIdentity {
+        &self.identity
+    }
+}
+
+// -- PboMap --
+
+#[derive(Debug)]
+struct PboPtr(NonNull<c_void>);
+
+impl Deref for PboPtr {
+    type Target = NonNull<c_void>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+unsafe impl Send for PboPtr {}
+
+pub struct PboMap<T>
+where
+    T: Num + Clone + fmt::Debug,
+{
+    ptr: Arc<Mutex<PboPtr>>,
+    shape: Vec<usize>,
+    handle: Arc<PboHandle>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> fmt::Debug for PboMap<T>
+where
+    T: Num + Clone + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PboMap")
+            .field("shape", &self.shape)
+            .field("buffer_id", &self.handle.buffer_id)
+            .finish()
+    }
+}
+
+impl<T> TensorMapTrait<T> for PboMap<T>
+where
+    T: Num + Clone + fmt::Debug,
+{
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn unmap(&mut self) {
+        trace!("Unmapping PboMap buffer_id={}", self.handle.buffer_id);
+        if let Err(e) = self.handle.ops.unmap_buffer(self.handle.buffer_id) {
+            log::warn!("Failed to unmap PBO buffer {}: {e}", self.handle.buffer_id);
+        }
+        self.handle.mapped.store(false, Ordering::Release);
+    }
+
+    fn as_slice(&self) -> &[T] {
+        let ptr = self.ptr.lock().expect("Failed to lock PboMap pointer");
+        unsafe { std::slice::from_raw_parts(ptr.as_ptr() as *const T, self.len()) }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [T] {
+        let ptr = self.ptr.lock().expect("Failed to lock PboMap pointer");
+        unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut T, self.len()) }
+    }
+}
+
+impl<T> Deref for PboMap<T>
+where
+    T: Num + Clone + fmt::Debug,
+{
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> DerefMut for PboMap<T>
+where
+    T: Num + Clone + fmt::Debug,
+{
+    fn deref_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> Drop for PboMap<T>
+where
+    T: Num + Clone + fmt::Debug,
+{
+    fn drop(&mut self) {
+        self.unmap();
+    }
 }

--- a/crates/tensor/src/pbo.rs
+++ b/crates/tensor/src/pbo.rs
@@ -398,7 +398,9 @@ mod tests {
     fn test_pbo_tensor_reshape() {
         let ops = MockPboOps::new(24);
         let mut tensor = PboTensor::<u8>::from_pbo(3, 24, &[2, 3, 4], None, ops);
-        tensor.reshape(&[4, 6]).expect("compatible reshape should succeed");
+        tensor
+            .reshape(&[4, 6])
+            .expect("compatible reshape should succeed");
         assert_eq!(tensor.shape(), &[4, 6]);
         let result = tensor.reshape(&[100]);
         assert!(result.is_err(), "incompatible reshape should fail");

--- a/crates/tensor/src/pbo.rs
+++ b/crates/tensor/src/pbo.rs
@@ -309,3 +309,134 @@ where
         self.unmap();
     }
 }
+
+impl<T> Clone for PboTensor<T>
+where
+    T: Num + Clone + fmt::Debug + Send + Sync,
+{
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            shape: self.shape.clone(),
+            handle: Arc::clone(&self.handle),
+            identity: self.identity.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock PboOps that uses a Vec<u8> as backing storage instead of GL.
+    struct MockPboOps {
+        storage: Mutex<Vec<u8>>,
+    }
+
+    impl MockPboOps {
+        fn new(size: usize) -> Arc<Self> {
+            Arc::new(Self {
+                storage: Mutex::new(vec![0u8; size]),
+            })
+        }
+    }
+
+    impl PboOps for MockPboOps {
+        fn map_buffer(&self, _buffer_id: u32, size: usize) -> Result<PboMapping> {
+            let storage = self.storage.lock().expect("lock");
+            assert_eq!(storage.len(), size);
+            Ok(PboMapping {
+                ptr: storage.as_ptr() as *mut u8,
+                size,
+            })
+        }
+
+        fn unmap_buffer(&self, _buffer_id: u32) -> Result<()> {
+            Ok(())
+        }
+
+        fn delete_buffer(&self, _buffer_id: u32) {}
+    }
+
+    #[test]
+    fn test_pbo_tensor_create_and_metadata() {
+        let ops = MockPboOps::new(24);
+        let tensor = PboTensor::<u8>::from_pbo(42, 24, &[2, 3, 4], Some("test_pbo"), ops);
+        assert_eq!(tensor.memory(), TensorMemory::Pbo);
+        assert_eq!(tensor.name(), "test_pbo");
+        assert_eq!(tensor.shape(), &[2, 3, 4]);
+        assert_eq!(tensor.buffer_id(), 42);
+        assert!(!tensor.is_mapped());
+    }
+
+    #[test]
+    fn test_pbo_tensor_map_write_read() {
+        let ops = MockPboOps::new(12);
+        let tensor = PboTensor::<u8>::from_pbo(1, 12, &[3, 4], Some("rw_test"), ops);
+        {
+            let mut map = tensor.map().expect("map should succeed");
+            assert_eq!(map.shape(), &[3, 4]);
+            assert!(tensor.is_mapped());
+            map.as_mut_slice().fill(0xAB);
+            assert!(map.as_slice().iter().all(|&b| b == 0xAB));
+        }
+        assert!(!tensor.is_mapped());
+    }
+
+    #[test]
+    fn test_pbo_tensor_double_map_fails() {
+        let ops = MockPboOps::new(8);
+        let tensor = PboTensor::<u8>::from_pbo(2, 8, &[8], None, ops);
+        let _map1 = tensor.map().expect("first map should succeed");
+        assert!(tensor.is_mapped());
+        let result = tensor.map();
+        assert!(result.is_err(), "second map while mapped should fail");
+    }
+
+    #[test]
+    fn test_pbo_tensor_reshape() {
+        let ops = MockPboOps::new(24);
+        let mut tensor = PboTensor::<u8>::from_pbo(3, 24, &[2, 3, 4], None, ops);
+        tensor.reshape(&[4, 6]).expect("compatible reshape should succeed");
+        assert_eq!(tensor.shape(), &[4, 6]);
+        let result = tensor.reshape(&[100]);
+        assert!(result.is_err(), "incompatible reshape should fail");
+    }
+
+    #[test]
+    fn test_pbo_tensor_buffer_identity() {
+        let ops1 = MockPboOps::new(8);
+        let ops2 = MockPboOps::new(8);
+        let t1 = PboTensor::<u8>::from_pbo(1, 8, &[8], None, ops1);
+        let t2 = PboTensor::<u8>::from_pbo(2, 8, &[8], None, ops2);
+        assert_ne!(t1.buffer_identity().id(), t2.buffer_identity().id());
+    }
+
+    #[test]
+    fn test_pbo_tensor_new_returns_error() {
+        let result = PboTensor::<u8>::new(&[8], None);
+        assert!(result.is_err(), "PboTensor::new() should fail");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_pbo_tensor_fd_ops_return_error() {
+        let ops = MockPboOps::new(8);
+        let tensor = PboTensor::<u8>::from_pbo(1, 8, &[8], None, ops);
+        assert!(tensor.clone_fd().is_err());
+    }
+
+    #[test]
+    fn test_pbo_via_tensor_enum() {
+        let ops = MockPboOps::new(12);
+        let pbo = PboTensor::<u8>::from_pbo(10, 12, &[3, 4], Some("enum_test"), ops);
+        let tensor = crate::Tensor::Pbo(pbo);
+        assert_eq!(tensor.memory(), TensorMemory::Pbo);
+        assert_eq!(tensor.name(), "enum_test");
+        assert_eq!(tensor.shape(), &[3, 4]);
+        let mut map = tensor.map().expect("map via enum");
+        map.as_mut_slice().fill(42);
+        assert!(map.as_slice().iter().all(|&b| b == 42));
+    }
+}

--- a/testdata/camera1080p.vyuy
+++ b/testdata/camera1080p.vyuy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d28cde75b2a5c652dc516d64f91759b1033b9609a6cd2c5774833185e61aa061
+size 4147200

--- a/testdata/camera4k.vyuy
+++ b/testdata/camera4k.vyuy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81daa9abed51ba7471cfd5425ddb163cfe2960e35704078f6ff03ffb3351c90b
+size 16588800

--- a/testdata/camera720p.vyuy
+++ b/testdata/camera720p.vyuy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17ef13244dc2e63aa66c69ca350befed52ac5bc8984746c46c57d6badc909eaf
+size 1843200

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -181,3 +181,83 @@ def test_from_fd_shm():
             assert (data == 233).all()
     except Exception:
         os.close(fd)
+
+
+def test_create_image():
+    """Test ImageProcessor.create_image() returns a valid, mappable image."""
+    converter = ImageProcessor()
+    img = converter.create_image(320, 240, FourCC.RGBA)
+    assert img.width == 320
+    assert img.height == 240
+    assert img.format == FourCC.RGBA
+
+    # Image should be mappable
+    with img.map() as m:
+        data = np.frombuffer(m.view(), dtype=np.uint8)
+        assert len(data) == 320 * 240 * 4
+
+
+def test_create_image_formats():
+    """Test create_image with different pixel formats."""
+    converter = ImageProcessor()
+    for fourcc, channels in [(FourCC.RGB, 3), (FourCC.RGBA, 4), (FourCC.GREY, 1)]:
+        img = converter.create_image(160, 120, fourcc)
+        assert img.width == 160
+        assert img.height == 120
+        assert img.format == fourcc
+        with img.map() as m:
+            data = np.frombuffer(m.view(), dtype=np.uint8)
+            assert len(data) == 160 * 120 * channels
+
+
+def test_create_image_convert():
+    """Test that images from create_image() work with convert()."""
+    converter = ImageProcessor()
+
+    # Load a source image normally
+    src = TensorImage.load("testdata/zidane.jpg", FourCC.RGBA)
+
+    # Create destination via create_image (may use PBO, DMA, or Mem)
+    dst = converter.create_image(640, 640, FourCC.RGBA)
+
+    # Convert should succeed regardless of backing type
+    converter.convert(src, dst)
+
+    # Verify the result has actual pixel data (not all zeros)
+    n = np.zeros((640, 640, 3), dtype=np.uint8)
+    dst.normalize_to_numpy(n)
+    assert n.any(), "Destination image is all zeros after convert"
+
+    # Compare with standard TensorImage destination
+    dst_mem = TensorImage(640, 640, FourCC.RGBA)
+    converter.convert(src, dst_mem)
+    n_mem = np.zeros((640, 640, 3), dtype=np.uint8)
+    dst_mem.normalize_to_numpy(n_mem)
+
+    assert calculate_similarity_rms_u8(n, n_mem) > 0.95
+
+
+def test_create_image_roundtrip():
+    """Test create_image as both src and dst for convert()."""
+    converter = ImageProcessor()
+
+    # Create source via create_image and fill it
+    src = converter.create_image(640, 480, FourCC.RGBA)
+    with src.map() as m:
+        data = np.frombuffer(m.view(), dtype=np.uint8).copy()
+        # Fill with a gradient pattern
+        data[:] = np.tile(np.arange(256, dtype=np.uint8), len(data) // 256 + 1)[
+            : len(data)
+        ]
+        m.view()[:] = data
+
+    # Create destination via create_image
+    dst = converter.create_image(320, 240, FourCC.RGBA)
+
+    # Convert using both create_image tensors
+    converter.convert(src, dst)
+
+    # Verify destination has data (not zeros)
+    with dst.map() as m:
+        result = np.frombuffer(m.view(), dtype=np.uint8)
+        assert result.any(), "Destination is all zeros after roundtrip convert"


### PR DESCRIPTION
## Summary

Supersedes #16. Adds PBO (Pixel Buffer Object) tensor support so platforms without DMA-buf (e.g., NVIDIA desktop GPUs) get GPU-accelerated image processing instead of falling back to CPU.

- **PBO tensor backend** — GLES 3.0 pixel buffer objects for zero-copy GPU upload/readback via `PboTensor`, `PboOps` trait, and `GlPboOps` GL-thread implementation
- **`create_image()` factory** — probes GPU at init, automatically selects best backend: DMA > PBO > Mem
- **Surfaceless EGL refactor** — no-config EGL contexts with PlatformDevice-first display probing
- **BufferIdentity tracking** — monotonic `AtomicU64` IDs on all tensor types for robust EGLImage cache keying
- **EGLImage LRU cache** — proper least-recently-used eviction with monotonic timestamps, replacing old FIFO (`keys().next()`)
- **Bit-exact int8 shaders** — `highp` precision with `floor(v*255+0.5)` + `mod(q+128,256)/255` bias, replacing `mediump` + `fract()`
- **CPU int8 in-place conversion** — eliminates temporary `TensorImage` allocation via `set_fourcc()` + XOR 0x80
- **eglTerminate in Drop** — EGL display cleanup to avoid leaking connections
- **RGB/int8 format support** — across GL + CPU paths with `RGB_INT8`, `PLANAR_RGB_INT8`
- **Python/C API** — `create_image()` exposed in both bindings with full test coverage
- **gpu-probe** — extracted shared `edgefirst-bench` harness, RGB FBO probe, direct RGB render benchmarks

### Changes from PR #16 review feedback
- Added `eglTerminate` to `GlContext::drop()` (EGL spec ref-counted)
- Replaced FIFO cache eviction with proper LRU
- Fixed int8 shaders to be bit-exact (highp + floor/mod instead of mediump + fract)
- Eliminated temporary allocation in CPU int8 path
- Fixed `FourCC::try_from` mapping `"NV12"` → `NV12` (was incorrectly `RGB`)
- Fixed `PyRotation::degrees_clockwise` using `rem_euclid(360)` (was `90`)
- Added guard against empty EGL device list panic

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass (132 image, 21 tensor, 89 decoder, 14 tracker)
- [x] Python tests — 45 passed, 8 skipped
- [x] Cross-compile `cargo zigbuild --target aarch64-unknown-linux-gnu` — clean
- [x] On-target imx95-evk: 139 passed, 0 failed, 1 ignored
- [x] On-target imx8mpevk-06: 138 passed, 0 failed, 1 ignored (10-thread GPU stress test excluded — pre-existing driver segfault)
- [x] Local NVIDIA desktop: 132 passed, 0 failed, 1 ignored (PBO backend exercised)

Closes #16