### PR TITLE
EDGEAI-1146: External buffer rendering for zero-copy DMA-BUF inference

### DIFF
--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -1364,6 +1364,22 @@ size_t hal_tensor_height(const struct hal_tensor *tensor);
 enum hal_fourcc hal_tensor_fourcc(const struct hal_tensor *tensor);
 
 /**
+ * Attach pixel format metadata to a tensor.
+ *
+ * Validates that the tensor's shape is compatible with the format's
+ * layout (packed, planar, or semi-planar). This enables tensors
+ * created via `hal_tensor_from_fd()` to be used as image conversion
+ * destinations.
+ *
+ * @param tensor Tensor handle
+ * @param fourcc Pixel format to attach (HAL_FOURCC_*)
+ * @return 0 on success, -1 on error
+ * @par Errors (errno):
+ * - EINVAL: NULL tensor or shape doesn't match format layout
+ */
+int hal_tensor_set_format(struct hal_tensor *tensor, enum hal_fourcc fourcc);
+
+/**
  * Check if an image tensor uses a planar pixel format.
  *
  * Planar formats store each color channel in a separate plane (e.g., NV12,
@@ -1538,6 +1554,43 @@ struct hal_tensor *hal_image_processor_create_image(struct hal_image_processor *
                                                     size_t height,
                                                     enum hal_fourcc fourcc,
                                                     enum hal_dtype dtype);
+
+/**
+ * Create an image tensor backed by an external DMA-BUF file descriptor.
+ *
+ * The GPU renders directly into this buffer via EGL DMA-BUF import —
+ * no CPU copy is needed after hal_image_processor_convert(). The caller
+ * retains ownership of the underlying buffer; the returned tensor borrows
+ * it via dup(fd).
+ *
+ * @param processor Image processor handle
+ * @param fd DMA-BUF file descriptor (caller retains ownership)
+ * @param width Image width in pixels
+ * @param height Image height in pixels
+ * @param fourcc Pixel format (HAL_FOURCC_*)
+ * @param dtype Data type of tensor elements (HAL_DTYPE_*)
+ * @return New tensor handle on success, NULL on error
+ * @par Errors (errno):
+ * - EINVAL: Invalid argument (NULL processor, zero dimensions, bad fd)
+ * - ENOTSUP: Not supported on this platform
+ * - EIO: fd clone or format validation failed
+ */
+struct hal_tensor *hal_image_processor_create_image_from_fd(struct hal_image_processor *processor,
+                                                            int fd,
+                                                            size_t width,
+                                                            size_t height,
+                                                            enum hal_fourcc fourcc,
+                                                            enum hal_dtype dtype);
+
+/**
+ * Create image from fd stub for non-Linux platforms.
+ */
+struct hal_tensor *hal_image_processor_create_image_from_fd(struct hal_image_processor *processor,
+                                                            int fd,
+                                                            size_t width,
+                                                            size_t height,
+                                                            enum hal_fourcc fourcc,
+                                                            enum hal_dtype dtype);
 
 /**
  * Free an image processor.
@@ -1762,6 +1815,29 @@ int hal_tensor_clone_fd(const struct hal_tensor *tensor);
  * Clone file descriptor stub for non-Unix platforms.
  */
 int hal_tensor_clone_fd(const struct hal_tensor *tensor);
+
+/**
+ * Clone the DMA-BUF file descriptor backing a tensor.
+ *
+ * Unlike hal_tensor_clone_fd(), this function returns a clear error if the
+ * tensor is not DMA-backed, rather than a generic I/O error. Use this when
+ * you specifically need a DMA-BUF fd for zero-copy hardware import.
+ *
+ * Creates a new owned file descriptor that the caller must close().
+ *
+ * @param tensor Tensor handle
+ * @return New file descriptor on success, -1 on error
+ * @par Errors (errno):
+ * - EINVAL: NULL tensor
+ * - ENOTSUP: Tensor is not DMA-backed (Mem, Shm, or Pbo)
+ * - EIO: Failed to clone file descriptor
+ */
+int hal_tensor_dmabuf_clone(const struct hal_tensor *tensor);
+
+/**
+ * Clone DMA-BUF fd stub for non-Linux platforms.
+ */
+int hal_tensor_dmabuf_clone(const struct hal_tensor *tensor);
 
 /**
  * Reshape a tensor to a new shape.

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -1571,9 +1571,10 @@ struct hal_tensor *hal_image_processor_create_image(struct hal_image_processor *
  * @param dtype Data type of tensor elements (HAL_DTYPE_*)
  * @return New tensor handle on success, NULL on error
  * @par Errors (errno):
- * - EINVAL: Invalid argument (NULL processor, zero dimensions, bad fd)
+ * - EINVAL: Invalid argument (NULL processor, zero dimensions, bad fd,
+ *   invalid image shape, or not an image)
  * - ENOTSUP: Not supported on this platform
- * - EIO: fd clone or format validation failed
+ * - EIO: Underlying I/O error or unexpected internal failure
  */
 struct hal_tensor *hal_image_processor_create_image_from_fd(struct hal_image_processor *processor,
                                                             int fd,

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -882,7 +882,7 @@ pub unsafe extern "C" fn hal_image_processor_convert_ref(
     let dst_inner = unsafe { &mut (*dst_tensor).inner };
 
     // Validate that the tensor is u8 and attach the requested pixel format.
-    if let TensorDyn::U8(ref mut t) = dst_inner {
+    if let TensorDyn::U8(ref mut t) = *dst_inner {
         if t.set_format(dst_fourcc.to_pixel_format()).is_err() {
             return set_error(libc::EINVAL);
         }

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -1065,9 +1065,10 @@ pub unsafe extern "C" fn hal_image_processor_create_image(
 /// @param dtype Data type of tensor elements (HAL_DTYPE_*)
 /// @return New tensor handle on success, NULL on error
 /// @par Errors (errno):
-/// - EINVAL: Invalid argument (NULL processor, zero dimensions, bad fd)
+/// - EINVAL: Invalid argument (NULL processor, zero dimensions, bad fd,
+///   invalid image shape, or not an image)
 /// - ENOTSUP: Not supported on this platform
-/// - EIO: fd clone or format validation failed
+/// - EIO: Underlying I/O error or unexpected internal failure
 #[no_mangle]
 #[cfg(target_os = "linux")]
 pub unsafe extern "C" fn hal_image_processor_create_image_from_fd(

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -652,6 +652,28 @@ pub unsafe extern "C" fn hal_tensor_fourcc(tensor: *const HalTensor) -> HalFourc
     }
 }
 
+/// Attach pixel format metadata to a tensor.
+///
+/// Validates that the tensor's shape is compatible with the format's
+/// layout (packed, planar, or semi-planar). This enables tensors
+/// created via `hal_tensor_from_fd()` to be used as image conversion
+/// destinations.
+///
+/// @param tensor Tensor handle
+/// @param fourcc Pixel format to attach (HAL_FOURCC_*)
+/// @return 0 on success, -1 on error
+/// @par Errors (errno):
+/// - EINVAL: NULL tensor or shape doesn't match format layout
+#[no_mangle]
+pub unsafe extern "C" fn hal_tensor_set_format(tensor: *mut HalTensor, fourcc: HalFourcc) -> c_int {
+    check_null!(tensor);
+    let fmt = fourcc.to_pixel_format();
+    match unsafe { &mut *tensor }.inner.set_format(fmt) {
+        Ok(()) => 0,
+        Err(_) => set_error(libc::EINVAL),
+    }
+}
+
 /// Check if an image tensor uses a planar pixel format.
 ///
 /// Planar formats store each color channel in a separate plane (e.g., NV12,
@@ -857,27 +879,15 @@ pub unsafe extern "C" fn hal_image_processor_convert_ref(
 ) -> c_int {
     check_null!(processor, src, dst_tensor);
 
-    // Validate that the tensor is u8 before modifying format
-    if !matches!(unsafe { &*dst_tensor }.inner, TensorDyn::U8(_)) {
-        return set_error(libc::EINVAL);
-    }
+    let dst_inner = unsafe { &mut (*dst_tensor).inner };
 
-    // Move the inner TensorDyn out via ptr::read so we can modify the
-    // format on the inner Tensor<u8> and pass it to convert. We wrap the
-    // source in ManuallyDrop to prevent a double-free if convert() panics.
-    let dst_dyn = unsafe { std::ptr::read(&(*dst_tensor).inner) };
-    let mut dst_dyn = std::mem::ManuallyDrop::new(dst_dyn);
-
-    if let TensorDyn::U8(ref mut t) = *dst_dyn {
+    // Validate that the tensor is u8 and attach the requested pixel format.
+    if let TensorDyn::U8(ref mut t) = dst_inner {
         if t.set_format(dst_fourcc.to_pixel_format()).is_err() {
-            unsafe {
-                std::ptr::write(
-                    &mut (*dst_tensor).inner,
-                    std::mem::ManuallyDrop::into_inner(dst_dyn),
-                )
-            };
             return set_error(libc::EINVAL);
         }
+    } else {
+        return set_error(libc::EINVAL);
     }
 
     let crop_config = if crop.is_null() {
@@ -888,19 +898,11 @@ pub unsafe extern "C" fn hal_image_processor_convert_ref(
 
     let result = unsafe { &mut (*processor) }.inner.convert(
         &unsafe { &(*src) }.inner,
-        &mut dst_dyn,
+        dst_inner,
         rotation.into(),
         flip.into(),
         crop_config,
     );
-
-    // Put the tensor back regardless of success/failure
-    unsafe {
-        std::ptr::write(
-            &mut (*dst_tensor).inner,
-            std::mem::ManuallyDrop::into_inner(dst_dyn),
-        )
-    };
 
     try_or_errno!(result, libc::EIO);
     0
@@ -1048,6 +1050,77 @@ pub unsafe extern "C" fn hal_image_processor_create_image(
     Box::into_raw(Box::new(HalTensor { inner: dyn_tensor }))
 }
 
+/// Create an image tensor backed by an external DMA-BUF file descriptor.
+///
+/// The GPU renders directly into this buffer via EGL DMA-BUF import —
+/// no CPU copy is needed after hal_image_processor_convert(). The caller
+/// retains ownership of the underlying buffer; the returned tensor borrows
+/// it via dup(fd).
+///
+/// @param processor Image processor handle
+/// @param fd DMA-BUF file descriptor (caller retains ownership)
+/// @param width Image width in pixels
+/// @param height Image height in pixels
+/// @param fourcc Pixel format (HAL_FOURCC_*)
+/// @param dtype Data type of tensor elements (HAL_DTYPE_*)
+/// @return New tensor handle on success, NULL on error
+/// @par Errors (errno):
+/// - EINVAL: Invalid argument (NULL processor, zero dimensions, bad fd)
+/// - ENOTSUP: Not supported on this platform
+/// - EIO: fd clone or format validation failed
+#[no_mangle]
+#[cfg(target_os = "linux")]
+pub unsafe extern "C" fn hal_image_processor_create_image_from_fd(
+    processor: *mut HalImageProcessor,
+    fd: c_int,
+    width: size_t,
+    height: size_t,
+    fourcc: HalFourcc,
+    dtype: HalDtype,
+) -> *mut HalTensor {
+    if processor.is_null() || width == 0 || height == 0 || fd < 0 {
+        return set_error_null(libc::EINVAL);
+    }
+
+    use std::os::fd::BorrowedFd;
+    let borrowed = unsafe { BorrowedFd::borrow_raw(fd) };
+    let dyn_tensor = match unsafe { &(*processor) }.inner.create_image_from_fd(
+        borrowed,
+        width,
+        height,
+        fourcc.to_pixel_format(),
+        dtype.into(),
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            return set_error_null(match &e {
+                edgefirst_image::Error::InvalidShape(_) | edgefirst_image::Error::NotAnImage => {
+                    libc::EINVAL
+                }
+                edgefirst_image::Error::NotSupported(_)
+                | edgefirst_image::Error::NotImplemented(_) => libc::ENOTSUP,
+                edgefirst_image::Error::Io(io) => io.raw_os_error().unwrap_or(libc::EIO),
+                _ => libc::EIO,
+            });
+        }
+    };
+    Box::into_raw(Box::new(HalTensor { inner: dyn_tensor }))
+}
+
+/// Create image from fd stub for non-Linux platforms.
+#[no_mangle]
+#[cfg(not(target_os = "linux"))]
+pub unsafe extern "C" fn hal_image_processor_create_image_from_fd(
+    _processor: *mut HalImageProcessor,
+    _fd: c_int,
+    _width: size_t,
+    _height: size_t,
+    _fourcc: HalFourcc,
+    _dtype: HalDtype,
+) -> *mut HalTensor {
+    set_error_null(libc::ENOTSUP)
+}
+
 /// Free an image processor.
 ///
 /// @param processor Image processor handle to free (can be NULL, no-op)
@@ -1117,6 +1190,43 @@ mod tests {
         unsafe {
             // NULL image returns Rgb default
             assert_eq!(hal_tensor_fourcc(std::ptr::null()), HalFourcc::Rgb);
+        }
+    }
+
+    #[test]
+    fn test_tensor_set_format() {
+        use crate::tensor::{hal_tensor_free, hal_tensor_new, HalTensorMemory};
+        unsafe {
+            // Create a raw [480, 640, 3] tensor — no format yet
+            let shape: [size_t; 3] = [480, 640, 3];
+            let tensor = hal_tensor_new(
+                HalDtype::U8,
+                shape.as_ptr(),
+                shape.len(),
+                HalTensorMemory::Mem,
+                std::ptr::null(),
+            );
+            assert!(!tensor.is_null());
+
+            // Before set_format: no image metadata
+            assert_eq!(hal_tensor_width(tensor), 0);
+
+            // Set format to RGB
+            let ret = hal_tensor_set_format(tensor, HalFourcc::Rgb);
+            assert_eq!(ret, 0);
+            assert_eq!(hal_tensor_fourcc(tensor), HalFourcc::Rgb);
+            assert_eq!(hal_tensor_width(tensor), 640);
+            assert_eq!(hal_tensor_height(tensor), 480);
+
+            // Wrong format should fail (4-channel format on 3-channel tensor)
+            let ret = hal_tensor_set_format(tensor, HalFourcc::Rgba);
+            assert_eq!(ret, -1);
+
+            // NULL tensor
+            let ret = hal_tensor_set_format(std::ptr::null_mut(), HalFourcc::Rgb);
+            assert_eq!(ret, -1);
+
+            hal_tensor_free(tensor);
         }
     }
 
@@ -1853,6 +1963,113 @@ mod tests {
             hal_tensor_free(src);
             hal_tensor_free(dst);
             hal_image_processor_free(processor);
+        }
+    }
+
+    #[test]
+    fn test_tensor_set_format_planar() {
+        use crate::tensor::{hal_tensor_free, hal_tensor_new, HalTensorMemory};
+        unsafe {
+            // Create a raw [3, 480, 640] tensor — no format yet
+            let shape: [size_t; 3] = [3, 480, 640];
+            let tensor = hal_tensor_new(
+                HalDtype::U8,
+                shape.as_ptr(),
+                shape.len(),
+                HalTensorMemory::Mem,
+                std::ptr::null(),
+            );
+            assert!(!tensor.is_null());
+
+            // Set format to PlanarRgb
+            let ret = hal_tensor_set_format(tensor, HalFourcc::PlanarRgb);
+            assert_eq!(ret, 0);
+            assert_eq!(hal_tensor_fourcc(tensor), HalFourcc::PlanarRgb);
+            assert_eq!(hal_tensor_width(tensor), 640);
+            assert_eq!(hal_tensor_height(tensor), 480);
+
+            hal_tensor_free(tensor);
+        }
+    }
+
+    #[test]
+    fn test_tensor_set_format_nv12() {
+        use crate::tensor::{hal_tensor_free, hal_tensor_new, HalTensorMemory};
+        unsafe {
+            // Create a raw [720, 640] tensor — NV12: 480 * 3/2 = 720
+            let shape: [size_t; 2] = [720, 640];
+            let tensor = hal_tensor_new(
+                HalDtype::U8,
+                shape.as_ptr(),
+                shape.len(),
+                HalTensorMemory::Mem,
+                std::ptr::null(),
+            );
+            assert!(!tensor.is_null());
+
+            // Set format to Nv12
+            let ret = hal_tensor_set_format(tensor, HalFourcc::Nv12);
+            assert_eq!(ret, 0);
+            assert_eq!(hal_tensor_fourcc(tensor), HalFourcc::Nv12);
+            assert_eq!(hal_tensor_width(tensor), 640);
+            assert_eq!(hal_tensor_height(tensor), 480);
+
+            hal_tensor_free(tensor);
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_create_image_from_fd_null_params() {
+        unsafe {
+            // NULL processor should return NULL
+            let result = hal_image_processor_create_image_from_fd(
+                std::ptr::null_mut(),
+                0,
+                640,
+                480,
+                HalFourcc::Rgba,
+                HalDtype::U8,
+            );
+            assert!(result.is_null());
+
+            // fd = -1 should return NULL
+            let processor = hal_image_processor_new();
+            if !processor.is_null() {
+                let result = hal_image_processor_create_image_from_fd(
+                    processor,
+                    -1,
+                    640,
+                    480,
+                    HalFourcc::Rgba,
+                    HalDtype::U8,
+                );
+                assert!(result.is_null());
+
+                // width = 0 should return NULL
+                let result = hal_image_processor_create_image_from_fd(
+                    processor,
+                    0,
+                    0,
+                    480,
+                    HalFourcc::Rgba,
+                    HalDtype::U8,
+                );
+                assert!(result.is_null());
+
+                // height = 0 should return NULL
+                let result = hal_image_processor_create_image_from_fd(
+                    processor,
+                    0,
+                    640,
+                    0,
+                    HalFourcc::Rgba,
+                    HalDtype::U8,
+                );
+                assert!(result.is_null());
+
+                hal_image_processor_free(processor);
+            }
         }
     }
 }

--- a/crates/capi/src/tensor.rs
+++ b/crates/capi/src/tensor.rs
@@ -457,6 +457,7 @@ pub unsafe extern "C" fn hal_tensor_clone_fd(tensor: *const HalTensor) -> c_int 
     check_null!(tensor);
     match unsafe { &*tensor }.inner.clone_fd() {
         Ok(fd) => fd.into_raw_fd(),
+        Err(edgefirst_tensor::Error::NotImplemented(_)) => set_error(libc::ENOTSUP),
         Err(_) => set_error(libc::EIO),
     }
 }
@@ -465,6 +466,38 @@ pub unsafe extern "C" fn hal_tensor_clone_fd(tensor: *const HalTensor) -> c_int 
 #[no_mangle]
 #[cfg(not(unix))]
 pub unsafe extern "C" fn hal_tensor_clone_fd(_tensor: *const HalTensor) -> c_int {
+    set_error(libc::ENOTSUP)
+}
+
+/// Clone the DMA-BUF file descriptor backing a tensor.
+///
+/// Unlike hal_tensor_clone_fd(), this function returns a clear error if the
+/// tensor is not DMA-backed, rather than a generic I/O error. Use this when
+/// you specifically need a DMA-BUF fd for zero-copy hardware import.
+///
+/// Creates a new owned file descriptor that the caller must close().
+///
+/// @param tensor Tensor handle
+/// @return New file descriptor on success, -1 on error
+/// @par Errors (errno):
+/// - EINVAL: NULL tensor
+/// - ENOTSUP: Tensor is not DMA-backed (Mem, Shm, or Pbo)
+/// - EIO: Failed to clone file descriptor
+#[no_mangle]
+#[cfg(target_os = "linux")]
+pub unsafe extern "C" fn hal_tensor_dmabuf_clone(tensor: *const HalTensor) -> c_int {
+    check_null!(tensor);
+    match unsafe { &*tensor }.inner.dmabuf_clone() {
+        Ok(fd) => fd.into_raw_fd(),
+        Err(edgefirst_tensor::Error::NotImplemented(_)) => set_error(libc::ENOTSUP),
+        Err(_) => set_error(libc::EIO),
+    }
+}
+
+/// Clone DMA-BUF fd stub for non-Linux platforms.
+#[no_mangle]
+#[cfg(not(target_os = "linux"))]
+pub unsafe extern "C" fn hal_tensor_dmabuf_clone(_tensor: *const HalTensor) -> c_int {
     set_error(libc::ENOTSUP)
 }
 
@@ -1075,6 +1108,33 @@ mod tests {
 
             // NULL tensor should return -1
             assert_eq!(hal_tensor_clone_fd(std::ptr::null()), -1);
+
+            hal_tensor_free(tensor);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_tensor_dmabuf_clone_mem_tensor() {
+        unsafe {
+            let shape: [size_t; 2] = [4, 4];
+            let tensor = hal_tensor_new(
+                HalDtype::F32,
+                shape.as_ptr(),
+                shape.len(),
+                HalTensorMemory::Mem,
+                std::ptr::null(),
+            );
+            assert!(!tensor.is_null());
+
+            // MEM tensors are not DMA-backed, should return -1 with ENOTSUP
+            let fd = hal_tensor_dmabuf_clone(tensor);
+            assert_eq!(fd, -1);
+            assert_eq!(errno::errno().0, libc::ENOTSUP);
+
+            // NULL tensor should return -1 with EINVAL
+            assert_eq!(hal_tensor_dmabuf_clone(std::ptr::null()), -1);
+            assert_eq!(errno::errno().0, libc::EINVAL);
 
             hal_tensor_free(tensor);
         }

--- a/crates/image/README.md
+++ b/crates/image/README.md
@@ -149,6 +149,37 @@ let mut dst = TensorDyn::from(model_input);
 processor.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::letterbox())?;
 ```
 
+## Zero-Copy External Buffer (Linux)
+
+When integrating with an NPU delegate (e.g. VxDelegate) that owns its own
+DMA-BUF buffers, use `create_image_from_fd()` to render directly into the
+delegate's buffer — eliminating the `memcpy` between HAL's buffer and the
+delegate's buffer:
+
+```rust,ignore
+// UC1: Render into VxDelegate's DMA-BUF — zero copies
+let mut dst = processor.create_image_from_fd(
+    vx_fd.as_fd(),       // borrow — caller keeps ownership
+    640, 640,
+    PixelFormat::Rgb,
+    DType::U8,
+)?;
+processor.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::letterbox())?;
+// dst's backing memory IS vx_fd — no memcpy needed
+```
+
+For the reverse direction (HAL allocates, consumer imports):
+
+```rust,ignore
+let hal_dst = processor.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
+let fd = hal_dst.dmabuf_clone()?;  // Error if not DMA-backed
+vxdelegate.register_buffer(fd)?;
+```
+
+**Performance tip:** When rotating through a pool of DMA-BUFs (e.g. 2-3
+from VxDelegate), create the `TensorDyn` wrappers once at init and reuse
+them across frames. This avoids EGL image cache misses (~100-300us each).
+
 ## Multiplane NV12/NV16
 
 For V4L2 multi-planar DMA-BUF buffers (separate Y and UV file descriptors):

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -884,6 +884,75 @@ impl ImageProcessor {
             Some(edgefirst_tensor::TensorMemory::Mem),
         )?)
     }
+
+    /// Create an image tensor backed by an external DMA-BUF file descriptor.
+    ///
+    /// The GPU renders directly into this buffer via EGL DMA-BUF import —
+    /// no CPU copy is needed after `convert()`. The caller retains ownership
+    /// of the underlying buffer; the returned tensor borrows it via `dup(fd)`.
+    ///
+    /// # Arguments
+    ///
+    /// * `fd` - Borrowed reference to the DMA-BUF file descriptor
+    /// * `width` - Image width in pixels
+    /// * `height` - Image height in pixels
+    /// * `format` - Pixel format of the buffer
+    /// * `dtype` - Element data type (e.g. `DType::U8`)
+    ///
+    /// # Returns
+    ///
+    /// A `TensorDyn` configured as an image with the given format, backed by a
+    /// `dup`'d copy of the caller's file descriptor.
+    ///
+    /// # Platform
+    ///
+    /// Linux only. Returns `Error::NotSupported` on other platforms.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the fd clone fails or the resulting shape is
+    /// invalid for the given format.
+    #[cfg(target_os = "linux")]
+    pub fn create_image_from_fd(
+        &self,
+        fd: std::os::fd::BorrowedFd<'_>,
+        width: usize,
+        height: usize,
+        format: PixelFormat,
+        dtype: DType,
+    ) -> Result<TensorDyn> {
+        let owned = fd.try_clone_to_owned().map_err(Error::Io)?;
+        let shape = match format.layout() {
+            PixelLayout::Packed => vec![height, width, format.channels()],
+            PixelLayout::Planar => vec![format.channels(), height, width],
+            PixelLayout::SemiPlanar => {
+                let total_h = match format {
+                    PixelFormat::Nv12 => {
+                        if !height.is_multiple_of(2) {
+                            return Err(Error::InvalidShape(format!(
+                                "NV12 requires even height, got {height}"
+                            )));
+                        }
+                        height * 3 / 2
+                    }
+                    PixelFormat::Nv16 => height * 2,
+                    _ => {
+                        return Err(Error::InvalidShape(format!(
+                            "unknown semi-planar height multiplier for {format:?}"
+                        )))
+                    }
+                };
+                vec![total_h, width]
+            }
+            _ => {
+                return Err(Error::NotSupported(format!(
+                    "unsupported pixel layout for create_image_from_fd: {:?}",
+                    format.layout()
+                )));
+            }
+        };
+        Ok(TensorDyn::from_fd(owned, &shape, dtype, None)?.with_format(format)?)
+    }
 }
 
 impl ImageProcessorTrait for ImageProcessor {
@@ -5138,5 +5207,35 @@ mod image_tests {
         };
         let result = converter.draw_masks_proto(&mut dst_dyn, &det, &proto_data);
         assert!(result.is_ok(), "CPU fallback path should work: {result:?}");
+    }
+
+    #[test]
+    fn test_set_format_then_cpu_convert() {
+        // Force CPU backend
+        unsafe { std::env::set_var("EDGEFIRST_FORCE_BACKEND", "cpu") };
+        let mut processor = ImageProcessor::new().unwrap();
+        unsafe { std::env::remove_var("EDGEFIRST_FORCE_BACKEND") };
+
+        // Load a source image
+        let image = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../testdata/zidane.jpg"
+        ));
+        let src = load_image(image, Some(PixelFormat::Rgba), None).unwrap();
+
+        // Create a raw tensor, then attach format — simulating the from_fd workflow
+        let mut dst =
+            TensorDyn::new(&[640, 640, 3], DType::U8, Some(TensorMemory::Mem), None).unwrap();
+        dst.set_format(PixelFormat::Rgb).unwrap();
+
+        // Convert should work with the set_format-annotated tensor
+        processor
+            .convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())
+            .unwrap();
+
+        // Verify format survived conversion
+        assert_eq!(dst.format(), Some(PixelFormat::Rgb));
+        assert_eq!(dst.width(), Some(640));
+        assert_eq!(dst.height(), Some(640));
     }
 }

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -5218,10 +5218,14 @@ mod image_tests {
 
     #[test]
     fn test_set_format_then_cpu_convert() {
-        // Force CPU backend
+        // Force CPU backend (save/restore to avoid leaking into other tests)
+        let original = std::env::var("EDGEFIRST_FORCE_BACKEND").ok();
         unsafe { std::env::set_var("EDGEFIRST_FORCE_BACKEND", "cpu") };
         let mut processor = ImageProcessor::new().unwrap();
-        unsafe { std::env::remove_var("EDGEFIRST_FORCE_BACKEND") };
+        match original {
+            Some(s) => unsafe { std::env::set_var("EDGEFIRST_FORCE_BACKEND", s) },
+            None => unsafe { std::env::remove_var("EDGEFIRST_FORCE_BACKEND") },
+        }
 
         // Load a source image
         let image = include_bytes!(concat!(

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -951,7 +951,14 @@ impl ImageProcessor {
                 )));
             }
         };
-        Ok(TensorDyn::from_fd(owned, &shape, dtype, None)?.with_format(format)?)
+        let tensor = TensorDyn::from_fd(owned, &shape, dtype, None)?;
+        if tensor.memory() != TensorMemory::Dma {
+            return Err(Error::NotSupported(format!(
+                "create_image_from_fd requires DMA-backed fd, got {:?}",
+                tensor.memory()
+            )));
+        }
+        Ok(tensor.with_format(format)?)
     }
 }
 

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -83,6 +83,40 @@ dst_i8 = processor.create_image(640, 640, ef.PixelFormat.Rgb, dtype="int8")
 processor.convert(src, dst_i8)
 ```
 
+## Zero-Copy External Buffer (Linux)
+
+When integrating with an NPU delegate that owns DMA-BUF buffers, render
+directly into the delegate's buffer to eliminate a `memcpy`:
+
+```python
+import edgefirst_hal as ef
+
+processor = ef.ImageProcessor()
+src = ef.Tensor.load("frame.jpg", ef.PixelFormat.Rgb)
+
+# Render directly into the delegate's DMA-BUF — zero copies
+dst = processor.create_image_from_fd(vx_fd, 640, 640, ef.PixelFormat.Rgb)
+processor.convert(src, dst)
+
+# Reverse: HAL allocates, consumer imports the fd
+hal_dst = processor.create_image(640, 640, ef.PixelFormat.Rgb)
+fd = hal_dst.dmabuf_clone()  # Raises if not DMA-backed
+delegate.register(fd)
+```
+
+You can also attach format metadata to any raw tensor created via `from_fd()`:
+
+```python
+t = ef.Tensor.from_fd(some_fd, [480, 640, 3])
+t.set_format(ef.PixelFormat.Rgb)
+processor.convert(src, t)
+```
+
+**Performance tip:** When rotating through a pool of DMA-BUFs (e.g. 2-3
+from an NPU delegate), create the `Tensor` wrappers once at init and
+reuse them across frames. This avoids EGL image cache misses (~100-300us
+each on Vivante GPUs).
+
 ## YOLO Decoding
 
 ```python

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -807,6 +807,35 @@ class Tensor:
     def reshape(self, shape: list[int]) -> None: ...
     """Reshape the tensor to the given shape. The total number of elements must remain the same."""
 
+    def set_format(self, format: PixelFormat) -> None:
+        """Attach pixel format metadata to this tensor.
+
+        Validates that the tensor's shape is compatible with the format's
+        layout (packed, planar, or semi-planar). This enables ``from_fd()``
+        tensors to be used as image conversion destinations.
+
+        Args:
+            format: Pixel format to attach.
+
+        Raises:
+            RuntimeError: If the tensor shape doesn't match the format layout.
+        """
+        ...
+
+    if sys.platform == "linux":
+        def dmabuf_clone(self) -> int:
+            """Clone the DMA-BUF file descriptor backing this tensor.
+
+            Returns a new file descriptor that the caller must close.
+
+            Returns:
+                A new file descriptor (int) that the caller must close.
+
+            Raises:
+                RuntimeError: If the tensor is not DMA-backed or fd clone fails.
+            """
+            ...
+
     def map(self) -> TensorMap: ...
     """Returns a mapped view of the tensor data for direct access."""
 
@@ -1202,6 +1231,39 @@ class ImageProcessor:
             A new image ``Tensor`` backed by the optimal memory type.
         """
         ...
+
+    if sys.platform == "linux":
+        def create_image_from_fd(
+            self,
+            fd: int,
+            width: int,
+            height: int,
+            format: PixelFormat,
+            dtype: str = "uint8",
+        ) -> Tensor:
+            """Create an image tensor backed by an external DMA-BUF file descriptor.
+
+            The GPU renders directly into this buffer via EGL DMA-BUF import —
+            no CPU copy is needed after ``convert()``. The caller retains
+            ownership of the underlying buffer; the returned tensor borrows
+            it via ``dup(fd)``.
+
+            Args:
+                fd: DMA-BUF file descriptor (caller retains ownership).
+                width: Image width in pixels.
+                height: Image height in pixels.
+                format: Pixel format of the buffer.
+                dtype: Element data type string (default: ``"uint8"``).
+
+            Returns:
+                A new image ``Tensor`` backed by the external DMA-BUF.
+
+            Raises:
+                RuntimeError: If the file descriptor is invalid, dimensions are zero,
+                    the format layout is unsupported, NV12 height is odd, or the
+                    fd clone syscall fails.
+            """
+            ...
 
     def set_int8_interpolation(self, mode: str) -> None:
         """Sets the interpolation mode for int8 proto textures.

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -1021,6 +1021,36 @@ impl PyImageProcessor {
         Ok(PyTensor(dyn_tensor))
     }
 
+    /// Create an image tensor backed by an external DMA-BUF file descriptor.
+    ///
+    /// The GPU renders directly into this buffer via EGL DMA-BUF import —
+    /// no CPU copy is needed after ``convert()``. The caller retains ownership
+    /// of the underlying buffer; the returned tensor borrows it via ``dup(fd)``.
+    #[cfg(target_os = "linux")]
+    #[pyo3(signature = (fd, width, height, format, dtype = "uint8"))]
+    pub fn create_image_from_fd(
+        &self,
+        fd: std::os::fd::RawFd,
+        width: usize,
+        height: usize,
+        format: PyPixelFormat,
+        dtype: &str,
+    ) -> Result<PyTensor> {
+        use std::os::fd::BorrowedFd;
+        if fd < 0 {
+            return Err(Error::InvalidArg("Invalid file descriptor".to_string()));
+        }
+        let fmt: PixelFormat = format.into();
+        let dt = crate::tensor::parse_dtype(dtype).map_err(|e| Error::InvalidArg(e.to_string()))?;
+        let borrowed = unsafe { BorrowedFd::borrow_raw(fd) };
+        let dyn_tensor = self
+            .0
+            .lock()
+            .map_err(|_| Error::InvalidArg("ImageProcessor lock poisoned".to_string()))?
+            .create_image_from_fd(borrowed, width, height, fmt, dt)?;
+        Ok(PyTensor(dyn_tensor))
+    }
+
     pub fn set_class_colors(&mut self, colors: Vec<[u8; 4]>) -> Result<()> {
         self.0
             .lock()

--- a/crates/python/src/tensor.rs
+++ b/crates/python/src/tensor.rs
@@ -414,6 +414,29 @@ impl PyTensor {
         Ok(self.0.reshape(&shape)?)
     }
 
+    /// Attach pixel format metadata to this tensor.
+    ///
+    /// Validates that the tensor's shape is compatible with the format's
+    /// layout (packed, planar, or semi-planar). This enables
+    /// `from_fd()` tensors to be used as image conversion destinations.
+    fn set_format(&mut self, format: crate::image::PyPixelFormat) -> Result<()> {
+        use edgefirst_hal::tensor::PixelFormat;
+        let fmt: PixelFormat = format.into();
+        Ok(self.0.set_format(fmt)?)
+    }
+
+    /// Clone the DMA-BUF file descriptor backing this tensor.
+    ///
+    /// Returns a new file descriptor that the caller must close.
+    ///
+    /// Raises RuntimeError if the tensor is not DMA-backed or if the
+    /// fd clone syscall fails.
+    #[cfg(target_os = "linux")]
+    fn dmabuf_clone(&self) -> Result<RawFd> {
+        let owned = self.0.dmabuf_clone()?;
+        Ok(owned.into_raw_fd())
+    }
+
     fn map(&self) -> Result<PyTensorMap> {
         Ok(PyTensorMap {
             mapped: Some(map_tensor_dyn(&self.0)?),

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -623,6 +623,21 @@ where
     }
 
     /// Attach format metadata to an existing tensor.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - The pixel format to attach
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` on success, with the format stored as metadata on the tensor.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidShape` if the tensor shape is incompatible with
+    /// the format's layout (packed expects `[H, W, C]`, planar expects
+    /// `[C, H, W]`, semi-planar expects `[H*k, W]` with format-specific
+    /// height constraints).
     pub fn set_format(&mut self, format: PixelFormat) -> Result<()> {
         let shape = self.shape();
         match format.layout() {
@@ -793,6 +808,28 @@ where
         match &self.storage {
             TensorStorage::Dma(d) => Some(d),
             _ => None,
+        }
+    }
+
+    /// Borrow the DMA-BUF file descriptor backing this tensor.
+    ///
+    /// # Returns
+    ///
+    /// A borrowed reference to the DMA-BUF file descriptor, tied to `self`'s
+    /// lifetime.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::NotImplemented` if the tensor is not DMA-backed.
+    #[cfg(target_os = "linux")]
+    pub fn dmabuf(&self) -> Result<std::os::fd::BorrowedFd<'_>> {
+        use std::os::fd::AsFd;
+        match &self.storage {
+            TensorStorage::Dma(dma) => Ok(dma.fd.as_fd()),
+            _ => Err(Error::NotImplemented(format!(
+                "dmabuf requires DMA-backed tensor, got {:?}",
+                self.storage.memory()
+            ))),
         }
     }
 

--- a/crates/tensor/src/tensor_dyn.rs
+++ b/crates/tensor/src/tensor_dyn.rs
@@ -138,10 +138,88 @@ impl TensorDyn {
         dispatch!(self, reshape, shape)
     }
 
+    /// Attach pixel format metadata to this tensor.
+    ///
+    /// Validates that the tensor's shape is compatible with the format's
+    /// layout (packed, planar, or semi-planar).
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - The pixel format to attach
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` on success, with the format stored as metadata on the tensor.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidShape` if the tensor shape doesn't match
+    /// the expected layout for the given format.
+    pub fn set_format(&mut self, format: PixelFormat) -> crate::Result<()> {
+        dispatch!(self, set_format, format)
+    }
+
+    /// Attach pixel format metadata, consuming and returning self.
+    ///
+    /// Enables builder-style chaining.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - The pixel format to attach
+    ///
+    /// # Returns
+    ///
+    /// The tensor with format metadata attached.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::InvalidShape` if the tensor shape doesn't match
+    /// the expected layout for the given format.
+    pub fn with_format(mut self, format: PixelFormat) -> crate::Result<Self> {
+        self.set_format(format)?;
+        Ok(self)
+    }
+
     /// Clone the file descriptor associated with this tensor.
     #[cfg(unix)]
     pub fn clone_fd(&self) -> crate::Result<std::os::fd::OwnedFd> {
         dispatch!(self, clone_fd)
+    }
+
+    /// Clone the DMA-BUF file descriptor backing this tensor (Linux only).
+    ///
+    /// # Returns
+    ///
+    /// An owned duplicate of the DMA-BUF file descriptor.
+    ///
+    /// # Errors
+    ///
+    /// * `Error::NotImplemented` if the tensor is not DMA-backed (Mem/Shm/Pbo)
+    /// * `Error::IoError` if the fd clone syscall fails (e.g., fd limit reached)
+    #[cfg(target_os = "linux")]
+    pub fn dmabuf_clone(&self) -> crate::Result<std::os::fd::OwnedFd> {
+        if self.memory() != TensorMemory::Dma {
+            return Err(crate::Error::NotImplemented(format!(
+                "dmabuf_clone requires DMA-backed tensor, got {:?}",
+                self.memory()
+            )));
+        }
+        self.clone_fd()
+    }
+
+    /// Borrow the DMA-BUF file descriptor backing this tensor (Linux only).
+    ///
+    /// # Returns
+    ///
+    /// A borrowed reference to the DMA-BUF file descriptor, tied to `self`'s
+    /// lifetime.
+    ///
+    /// # Errors
+    ///
+    /// * `Error::NotImplemented` if the tensor is not DMA-backed
+    #[cfg(target_os = "linux")]
+    pub fn dmabuf(&self) -> crate::Result<std::os::fd::BorrowedFd<'_>> {
+        dispatch!(self, dmabuf)
     }
 
     /// Return `true` if this tensor uses separate plane allocations.
@@ -373,5 +451,107 @@ mod tests {
         let dyn_t = TensorDyn::image(640, 480, PixelFormat::Rgb, DType::I8, None).unwrap();
         assert_eq!(dyn_t.dtype(), DType::I8);
         assert_eq!(dyn_t.format(), Some(PixelFormat::Rgb));
+    }
+
+    #[test]
+    fn set_format_packed() {
+        let mut t = TensorDyn::new(&[480, 640, 3], DType::U8, None, None).unwrap();
+        assert_eq!(t.format(), None);
+        t.set_format(PixelFormat::Rgb).unwrap();
+        assert_eq!(t.format(), Some(PixelFormat::Rgb));
+        assert_eq!(t.width(), Some(640));
+        assert_eq!(t.height(), Some(480));
+    }
+
+    #[test]
+    fn set_format_planar() {
+        let mut t = TensorDyn::new(&[3, 480, 640], DType::U8, None, None).unwrap();
+        t.set_format(PixelFormat::PlanarRgb).unwrap();
+        assert_eq!(t.format(), Some(PixelFormat::PlanarRgb));
+        assert_eq!(t.width(), Some(640));
+        assert_eq!(t.height(), Some(480));
+    }
+
+    #[test]
+    fn set_format_rejects_wrong_shape() {
+        let mut t = TensorDyn::new(&[480, 640, 4], DType::U8, None, None).unwrap();
+        assert!(t.set_format(PixelFormat::Rgb).is_err());
+    }
+
+    #[test]
+    fn with_format_builder() {
+        let t = TensorDyn::new(&[480, 640, 4], DType::U8, None, None)
+            .unwrap()
+            .with_format(PixelFormat::Rgba)
+            .unwrap();
+        assert_eq!(t.format(), Some(PixelFormat::Rgba));
+        assert_eq!(t.width(), Some(640));
+        assert_eq!(t.height(), Some(480));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn dmabuf_clone_mem_tensor_fails() {
+        let t = TensorDyn::new(&[480, 640, 3], DType::U8, Some(TensorMemory::Mem), None).unwrap();
+        assert_eq!(t.memory(), TensorMemory::Mem);
+        assert!(t.dmabuf_clone().is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn dmabuf_mem_tensor_fails() {
+        let t = TensorDyn::new(&[480, 640, 3], DType::U8, Some(TensorMemory::Mem), None).unwrap();
+        assert!(t.dmabuf().is_err());
+    }
+
+    #[test]
+    fn set_format_semi_planar_nv12() {
+        // 720 rows = 480 * 3/2 (NV12: height + height/2 for chroma)
+        let mut t = TensorDyn::new(&[720, 640], DType::U8, Some(TensorMemory::Mem), None).unwrap();
+        t.set_format(PixelFormat::Nv12).unwrap();
+        assert_eq!(t.format(), Some(PixelFormat::Nv12));
+        assert_eq!(t.width(), Some(640));
+        assert_eq!(t.height(), Some(480));
+    }
+
+    #[test]
+    fn set_format_semi_planar_nv16() {
+        // 960 rows = 480 * 2 (NV16: height + height for chroma)
+        let mut t = TensorDyn::new(&[960, 640], DType::U8, Some(TensorMemory::Mem), None).unwrap();
+        t.set_format(PixelFormat::Nv16).unwrap();
+        assert_eq!(t.format(), Some(PixelFormat::Nv16));
+        assert_eq!(t.width(), Some(640));
+        assert_eq!(t.height(), Some(480));
+    }
+
+    #[test]
+    fn with_format_rejects_wrong_shape() {
+        let result = TensorDyn::new(&[480, 640, 4], DType::U8, None, None)
+            .unwrap()
+            .with_format(PixelFormat::Rgb);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn set_format_preserved_after_rejection() {
+        let mut t = TensorDyn::new(&[480, 640, 3], DType::U8, None, None).unwrap();
+        t.set_format(PixelFormat::Rgb).unwrap();
+        assert_eq!(t.format(), Some(PixelFormat::Rgb));
+
+        // Rgba requires 4 channels, should fail on a 3-channel tensor
+        assert!(t.set_format(PixelFormat::Rgba).is_err());
+
+        // Original format should be preserved
+        assert_eq!(t.format(), Some(PixelFormat::Rgb));
+    }
+
+    #[test]
+    fn set_format_idempotent() {
+        let mut t = TensorDyn::new(&[480, 640, 3], DType::U8, None, None).unwrap();
+        t.set_format(PixelFormat::Rgb).unwrap();
+        t.set_format(PixelFormat::Rgb).unwrap();
+        assert_eq!(t.format(), Some(PixelFormat::Rgb));
+        assert_eq!(t.width(), Some(640));
+        assert_eq!(t.height(), Some(480));
     }
 }

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -15,6 +15,7 @@ import numpy as np
 from PIL import Image
 import math
 import os
+import sys
 import pytest
 
 
@@ -275,3 +276,11 @@ def test_create_image_roundtrip():
     with dst.map() as m:
         result = np.frombuffer(m.view(), dtype=np.uint8)
         assert result.any(), "Destination is all zeros after roundtrip convert"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="create_image_from_fd is Linux-only")
+def test_create_image_from_fd_negative_fd():
+    """create_image_from_fd raises RuntimeError for invalid fd."""
+    processor = ImageProcessor()
+    with pytest.raises(RuntimeError):
+        processor.create_image_from_fd(-1, 640, 640, PixelFormat.Rgb)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-from edgefirst_hal import Tensor, TensorMemory
+from edgefirst_hal import Tensor, TensorMemory, PixelFormat
 import os
+import sys
 import pytest
 import gc
 
@@ -547,3 +548,28 @@ def test_shm_fd_leak_with_from_fd():
     assert start_fds == end_fds, (
         f"File descriptor leak detected: {start_fds} -> {end_fds}"
     )
+
+
+def test_set_format_packed():
+    """set_format attaches pixel format metadata to a raw tensor."""
+    t = Tensor([480, 640, 3], dtype="uint8", mem=TensorMemory.MEM)
+    assert t.format is None
+    t.set_format(PixelFormat.Rgb)
+    assert t.format == PixelFormat.Rgb
+    assert t.width == 640
+    assert t.height == 480
+
+
+def test_set_format_rejects_wrong_shape():
+    """set_format raises RuntimeError when shape doesn't match format."""
+    t = Tensor([480, 640, 4], dtype="uint8", mem=TensorMemory.MEM)
+    with pytest.raises(RuntimeError):
+        t.set_format(PixelFormat.Rgb)  # expects 3 channels, got 4
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="DMA-BUF is Linux-only")
+def test_dmabuf_clone_mem_raises():
+    """dmabuf_clone raises RuntimeError on non-DMA tensors."""
+    t = Tensor([4, 4], dtype="float32", mem=TensorMemory.MEM)
+    with pytest.raises(RuntimeError):
+        t.dmabuf_clone()


### PR DESCRIPTION
## Summary

- Add `TensorDyn::set_format()`, `with_format()`, `dmabuf_clone()`, `dmabuf()` for external DMA-BUF buffer workflow
- Add `ImageProcessor::create_image_from_fd()` convenience method — combines fd dup + shape computation + format validation
- Add Python bindings (`set_format`, `dmabuf_clone`, `create_image_from_fd`) with `.pyi` stubs
- Add C API bindings (`hal_tensor_set_format`, `hal_tensor_dmabuf_clone`, `hal_image_processor_create_image_from_fd`)
- Fix pre-existing `hal_tensor_clone_fd` errno mapping (`NotImplemented` → `ENOTSUP` instead of `EIO`)
- Fix pre-existing `hal_image_processor_convert_ref` panic UB from `ptr::read`/`ManuallyDrop` — replaced with direct `&mut` references
- 16 new tests across tensor (5), image (1), capi (3), Python (4), plus 3 hardened existing tests
- Documentation: Rust doc comments per standard, README zero-copy sections, `.pyi` docstrings

## Context

During HAL 0.10 migration of YOLOv8 examples, the only remaining avoidable copy was a CPU `memcpy` (~1.6MB per 640×640 RGBA frame) between HAL's internally-allocated DMA-BUF and VxDelegate's DMA-BUF. At 30fps this wastes ~48MB/s of bandwidth on Cortex-A53.

The root cause: `ImageProcessor::create_image()` always allocates its own buffer — there was no API to render into an externally-provided DMA-BUF. 90% of the infrastructure already existed (`TensorDyn::from_fd()`, GL EGLImage render path). The missing piece was `TensorDyn::set_format()` — without it, `from_fd()` tensors have `format: None` and get rejected by the convert pipeline.

## Expected improvement on i.MX8MP

- Current: ~7.1ms convert + ~1.0-1.6ms memcpy = **~8.1-8.7ms**
- External buffer: ~7.1ms convert, no copy = **~7.1ms**
- **~12-18% reduction** in preprocessing latency per frame

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo clippy --workspace --all-targets --features default,opencv -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo test -p edgefirst-tensor --lib` — 64 tests pass (5 new)
- [ ] `cargo test -p edgefirst-image --lib -- --skip test_crop_skip` — 166 tests pass (1 new)
- [ ] `cargo test -p edgefirst-hal-capi --lib` — 92 tests pass (3 new)
- [ ] Python tests pass — 57 tests (4 new)
- [ ] On-target benchmark on i.MX8MP: measure preprocessing latency with and without external buffer