### PR TITLE
EDGEAI-1189 Add delegate DMA-BUF API type definitions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1695,6 +1695,155 @@ The `edgefirstcameraadaptor` element detects multi-plane buffers
 
 This work was implemented under **EDGEAI-1107**.
 
+## Appendix B: Delegate DMA-BUF Framework
+
+### Purpose
+
+The Delegate DMA-BUF Framework defines an ABI contract for querying DMA-BUF
+tensor information from external TFLite delegates (e.g., NXP Neutron NPU).
+The HAL owns the type definitions; function implementations live in delegate
+integrators such as `edgefirst-tflite`.
+
+This enables a fully zero-copy pipeline from camera capture through NPU
+inference by allowing `hal_import_image()` to wrap delegate-owned DMA-BUF
+file descriptors as HAL tensors with full image attributes.
+
+### Zero-Copy Data Flow
+
+```
+Camera DMA-BUF
+  → hal_import_image(camera_fd, ..., width, height, format, dtype)
+  → HAL Tensor with image attributes (camera source)
+
+NPU input DMA-BUF (fd/shape from hal_dmabuf_get_tensor_info)
+  → hal_import_image(npu_input_fd, ..., model_width, model_height, format, dtype)
+  → HAL Tensor with image attributes (NPU destination)
+
+ImageProcessor::convert(camera_tensor, npu_tensor)
+  → DMA→DMA convert (resize, colorspace, letterbox)
+
+hal_dmabuf_sync_for_device(delegate, input_tensor_index)
+  → flush CPU caches so NPU can read
+
+NPU inference
+
+hal_dmabuf_sync_for_cpu(delegate, output_tensor_index) [optional]
+  → invalidate CPU caches so CPU sees NPU writes
+```
+
+Both camera and NPU input tensors are imported via `hal_import_image()` so
+that `convert()` has the pixel format, dimensions, stride, and plane metadata
+it requires. This is mandatory — `hal_tensor_from_fd()` creates raw tensors
+without image attributes and cannot be used as a `convert()` source or
+destination.
+
+Output DMA-BUF access via `hal_dmabuf_get_tensor_info()` is optional and
+depends on the use case: useful when feeding outputs to GPU (e.g., mask
+rendering via OpenGL), but for CPU-side post-processing (YOLO decode, NMS)
+it is simpler to read tensor data directly since the decode will memcpy
+anyway.
+
+### Type Definitions
+
+**`hal_delegate_t`** — opaque handle for any delegate, defined as `void*`.
+A future revision will formalize this as a proper abstraction. The delegate
+lifetime is managed by the caller; the HAL never creates or destroys
+delegates.
+
+**`hal_dmabuf_tensor_info`** — describes a single delegate tensor's DMA-BUF:
+
+| Field   | Type                          | Description |
+|---------|-------------------------------|-------------|
+| `size`  | `size_t`                      | Buffer size in bytes (may exceed logical tensor size for padded buffers) |
+| `offset`| `size_t`                      | Byte offset within the DMA-BUF (for sub-allocated buffers) |
+| `shape` | `size_t[HAL_DMABUF_MAX_NDIM]` | Tensor dimensions (max 8) |
+| `ndim`  | `size_t`                      | Number of valid entries in `shape` |
+| `fd`    | `int`                         | DMA-BUF file descriptor (**borrowed** — do not close) |
+| `dtype` | `hal_dtype`                   | Element data type |
+
+Fields are ordered to eliminate padding on LP64 (`size_t` fields first,
+then smaller 4-byte fields). Total struct size: 96 bytes on LP64.
+
+### Expected Function Signatures
+
+These functions are **not implemented in the HAL**. They document the exact
+ABI that delegate integrators must export and that consumers probe via
+`dlsym`.
+
+```c
+/* Query whether the delegate supports DMA-BUF tensor access.
+ * Returns 1 if supported, 0 if not supported or on error.
+ * A NULL delegate pointer returns 0. */
+int hal_dmabuf_is_supported(hal_delegate_t delegate);
+
+/* Get DMA-BUF tensor info for a given tensor index.
+ * Returns 0 on success, -1 on error (sets errno).
+ *
+ * info_size enables forward-compatible versioning: pass
+ * sizeof(hal_dmabuf_tensor_info). Implementations zero-initialize
+ * with memset(info, 0, info_size) and only write fields whose
+ * offsetof + sizeof fits within info_size.
+ *
+ * Errno: EINVAL (bad args), ENOTSUP (no DMA-BUF support),
+ *        ERANGE (index out of range), EIO (internal failure) */
+int hal_dmabuf_get_tensor_info(hal_delegate_t delegate,
+                               int tensor_index,
+                               hal_dmabuf_tensor_info *info,
+                               size_t info_size);
+
+/* Flush CPU caches → device can read.
+ * Call after ImageProcessor::convert() into the input tensor,
+ * before invoking NPU inference.
+ * Returns 0 on success, -1 on error (sets errno).
+ * Errno: EINVAL, ERANGE, EIO */
+int hal_dmabuf_sync_for_device(hal_delegate_t delegate, int tensor_index);
+
+/* Invalidate CPU caches → CPU sees device writes.
+ * Call after NPU inference, before reading output tensor data.
+ * Returns 0 on success, -1 on error (sets errno).
+ * Errno: EINVAL, ERANGE, EIO */
+int hal_dmabuf_sync_for_cpu(hal_delegate_t delegate, int tensor_index);
+```
+
+`tensor_index` must be non-negative; negative values return -1 with
+`errno` set to `EINVAL`.
+
+### Integration Pattern
+
+1. `edgefirst-tflite` (or another delegate integrator) implements the four
+   functions above and exports them as public C symbols.
+2. Consumers probe for the symbols at runtime via `dlsym` on the delegate's
+   shared library.
+3. If `hal_dmabuf_is_supported()` returns 1, consumers call
+   `hal_dmabuf_get_tensor_info()` to obtain the DMA-BUF fd and shape for
+   each tensor of interest.
+4. The fd and metadata are passed to `hal_import_image()` to create a
+   HAL tensor with full image attributes for use with
+   `ImageProcessor::convert()`.
+
+### Lifecycle and Ownership
+
+- The **delegate** owns all DMA-BUF allocations. File descriptors returned
+  by `hal_dmabuf_get_tensor_info()` are borrowed — callers must not close
+  them.
+- Sync functions (`sync_for_device`, `sync_for_cpu`) wrap
+  `DMA_BUF_IOCTL_SYNC` and bracket hardware access. They must be called
+  at the correct points in the pipeline (see data flow above).
+- The delegate instance itself is created and destroyed by the caller
+  (e.g., via the TFLite C API). The HAL never manages delegate lifetime.
+
+### Thread Safety
+
+Delegate functions are not required to be thread-safe for concurrent calls
+on the same delegate instance. Callers must serialize access per delegate.
+Different delegate instances may be used concurrently from different threads.
+
+### Tracking
+
+- **Epic:** [EDGEAI-1185](https://au-zone.atlassian.net/browse/EDGEAI-1185) — NXP Neutron DMABUF Zero-Copy Support
+- **Type definitions:** [EDGEAI-1189](https://au-zone.atlassian.net/browse/EDGEAI-1189) — EdgeFirst HAL: formalize hal_dmabuf_* interface
+- **Implementation:** [EDGEAI-1190](https://au-zone.atlassian.net/browse/EDGEAI-1190) — edgefirst-tflite: update probing for hal_dmabuf_* symbols
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1712,11 +1712,13 @@ file descriptors as HAL tensors with full image attributes.
 
 ```
 Camera DMA-BUF
-  → hal_import_image(camera_fd, ..., width, height, format, dtype)
+  → hal_plane_descriptor (wraps camera_fd, stride, offset)
+  → hal_import_image(proc, camera_pd, NULL, width, height, format, dtype)
   → HAL Tensor with image attributes (camera source)
 
 NPU input DMA-BUF (fd/shape from hal_dmabuf_get_tensor_info)
-  → hal_import_image(npu_input_fd, ..., model_width, model_height, format, dtype)
+  → hal_plane_descriptor (wraps npu_input_fd, stride, offset)
+  → hal_import_image(proc, npu_pd, NULL, model_width, model_height, format, dtype)
   → HAL Tensor with image attributes (NPU destination)
 
 ImageProcessor::convert(camera_tensor, npu_tensor)
@@ -1733,9 +1735,10 @@ hal_dmabuf_sync_for_cpu(delegate, output_tensor_index) [optional]
 
 Both camera and NPU input tensors are imported via `hal_import_image()` so
 that `convert()` has the pixel format, dimensions, stride, and plane metadata
-it requires. This is mandatory — `hal_tensor_from_fd()` creates raw tensors
-without image attributes and cannot be used as a `convert()` source or
-destination.
+it requires. `hal_tensor_from_fd()` creates raw tensors without image
+attributes; to use such tensors as a `convert()` source or destination you
+must either import them as images (via `hal_import_image()`) or attach the
+required image metadata (for example with `hal_tensor_set_format()`).
 
 Output DMA-BUF access via `hal_dmabuf_get_tensor_info()` is optional and
 depends on the use case: useful when feeding outputs to GPU (e.g., mask

--- a/crates/capi/cbindgen.toml
+++ b/crates/capi/cbindgen.toml
@@ -45,6 +45,17 @@ extern "C" {
  * - All functions are thread-safe unless documented otherwise
  * - Tensor map operations require external synchronization when used concurrently
  */
+
+/**
+ * @brief Opaque delegate handle.
+ *
+ * Used by the delegate DMA-BUF API (hal_dmabuf_*) to reference an
+ * externally-owned TFLite delegate instance. The delegate lifetime
+ * is managed by the caller; the HAL never creates or destroys delegates.
+ *
+ * A future revision will formalize this as a proper abstraction.
+ */
+typedef void *hal_delegate_t;
 """
 
 trailer = """
@@ -86,6 +97,7 @@ item_types = ["enums", "structs", "unions", "typedefs", "opaque", "functions", "
 "HalTrackInfoList" = "hal_track_info_list"
 "HalTensorMap" = "hal_tensor_map"
 "HalPlaneDescriptor" = "hal_plane_descriptor"
+"HalDmabufTensorInfo" = "hal_dmabuf_tensor_info"
 "HalComputeBackend" = "hal_compute_backend"
 "HalLogLevel" = "hal_log_level"
 "HalLogCallback" = "hal_log_callback"

--- a/crates/capi/cbindgen.toml
+++ b/crates/capi/cbindgen.toml
@@ -71,6 +71,10 @@ sys_includes = ["stddef.h", "stdio.h"]
 no_includes = false
 
 [export]
+# HalDmabufTensorInfo has no exported functions referencing it (the HAL
+# only defines the type; implementations live in edgefirst-tflite), so
+# cbindgen would otherwise skip it. This list is additive — all other
+# types/functions are still emitted normally.
 include = ["HalDmabufTensorInfo"]
 exclude = []
 item_types = ["enums", "structs", "unions", "typedefs", "opaque", "functions", "constants"]

--- a/crates/capi/cbindgen.toml
+++ b/crates/capi/cbindgen.toml
@@ -71,7 +71,7 @@ sys_includes = ["stddef.h", "stdio.h"]
 no_includes = false
 
 [export]
-include = []
+include = ["HalDmabufTensorInfo"]
 exclude = []
 item_types = ["enums", "structs", "unions", "typedefs", "opaque", "functions", "constants"]
 

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -728,13 +728,12 @@ typedef struct hal_track_info {
  * first (8-byte aligned), then smaller `int` and enum fields (4 bytes
  * each) at the end. Total size: 96 bytes on LP64.
  *
- * # Versioning
- *
- * The companion `hal_dmabuf_get_tensor_info()` function accepts an
- * `info_size` parameter so that the struct can grow in future versions
+ * @par Versioning
+ * The companion hal_dmabuf_get_tensor_info() function accepts an
+ * info_size parameter so that the struct can grow in future versions
  * without breaking ABI. Implementations must zero-initialize the
- * struct with `memset(info, 0, info_size)` before populating it, and
- * only write fields whose offset + size fits within `info_size`.
+ * struct with memset(info, 0, info_size) before populating it, and
+ * only write fields whose offset + size fits within info_size.
  */
 typedef struct hal_dmabuf_tensor_info {
   /**
@@ -746,7 +745,7 @@ typedef struct hal_dmabuf_tensor_info {
    */
   size_t offset;
   /**
-   * Tensor dimensions (up to [`HAL_DMABUF_MAX_NDIM`]).
+   * Tensor dimensions (up to HAL_DMABUF_MAX_NDIM).
    *
    * Uses a literal length so cbindgen can emit the array in the C header.
    */

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -718,6 +718,54 @@ typedef struct hal_track_info {
 } hal_track_info;
 
 /**
+ * DMA-BUF tensor information returned by a delegate.
+ *
+ * Describes a single tensor's DMA-BUF allocation, including the file
+ * descriptor, buffer geometry, and element type. The fd is borrowed
+ * from the delegate and must NOT be closed by the caller.
+ *
+ * Fields are ordered to eliminate padding on LP64: all `size_t` fields
+ * first (8-byte aligned), then smaller `int` and enum fields (4 bytes
+ * each) at the end. Total size: 96 bytes on LP64.
+ *
+ * # Versioning
+ *
+ * The companion `hal_dmabuf_get_tensor_info()` function accepts an
+ * `info_size` parameter so that the struct can grow in future versions
+ * without breaking ABI. Implementations must zero-initialize the
+ * struct with `memset(info, 0, info_size)` before populating it, and
+ * only write fields whose offset + size fits within `info_size`.
+ */
+typedef struct hal_dmabuf_tensor_info {
+  /**
+   * Buffer size in bytes.
+   */
+  size_t size;
+  /**
+   * Byte offset within the DMA-BUF.
+   */
+  size_t offset;
+  /**
+   * Tensor dimensions (up to [`HAL_DMABUF_MAX_NDIM`]).
+   *
+   * Uses a literal length so cbindgen can emit the array in the C header.
+   */
+  size_t shape[8];
+  /**
+   * Number of valid entries in `shape`.
+   */
+  size_t ndim;
+  /**
+   * DMA-BUF file descriptor (borrowed — do not close).
+   */
+  int fd;
+  /**
+   * Element data type.
+   */
+  enum hal_dtype dtype;
+} hal_dmabuf_tensor_info;
+
+/**
  * Create new decoder parameters.
  *
  * Returns an opaque handle initialized with safe defaults:

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -33,6 +33,17 @@ extern "C" {
  * - Tensor map operations require external synchronization when used concurrently
  */
 
+/**
+ * @brief Opaque delegate handle.
+ *
+ * Used by the delegate DMA-BUF API (hal_dmabuf_*) to reference an
+ * externally-owned TFLite delegate instance. The delegate lifetime
+ * is managed by the caller; the HAL never creates or destroys delegates.
+ *
+ * A future revision will formalize this as a proper abstraction.
+ */
+typedef void *hal_delegate_t;
+
 
 /* Generated with cbindgen:0.29.2 */
 
@@ -44,6 +55,11 @@ extern "C" {
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
+
+/**
+ * Maximum number of dimensions in a delegate tensor shape.
+ */
+#define HAL_DMABUF_MAX_NDIM 8
 
 /**
  * Output type for model tensor outputs.

--- a/crates/capi/src/delegate.rs
+++ b/crates/capi/src/delegate.rs
@@ -34,7 +34,7 @@ pub const HAL_DMABUF_MAX_NDIM: usize = 8;
 /// struct with memset(info, 0, info_size) before populating it, and
 /// only write fields whose offset + size fits within info_size.
 #[repr(C)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct HalDmabufTensorInfo {
     /// Buffer size in bytes.
     pub size: size_t,
@@ -54,14 +54,11 @@ pub struct HalDmabufTensorInfo {
 
 impl Default for HalDmabufTensorInfo {
     fn default() -> Self {
-        Self {
-            size: 0,
-            offset: 0,
-            shape: [0; HAL_DMABUF_MAX_NDIM],
-            ndim: 0,
-            fd: -1,
-            dtype: HalDtype::U8,
-        }
+        // Safety: HalDmabufTensorInfo is a #[repr(C)] plain-old-data struct
+        // used for FFI, and the C ABI contract explicitly requires callers
+        // to zero-initialize it with memset(info, 0, info_size) before use.
+        // A fully zeroed bit-pattern is therefore a valid "empty" state.
+        unsafe { std::mem::zeroed() }
     }
 }
 

--- a/crates/capi/src/delegate.rs
+++ b/crates/capi/src/delegate.rs
@@ -27,13 +27,12 @@ pub const HAL_DMABUF_MAX_NDIM: usize = 8;
 /// first (8-byte aligned), then smaller `int` and enum fields (4 bytes
 /// each) at the end. Total size: 96 bytes on LP64.
 ///
-/// # Versioning
-///
-/// The companion `hal_dmabuf_get_tensor_info()` function accepts an
-/// `info_size` parameter so that the struct can grow in future versions
+/// @par Versioning
+/// The companion hal_dmabuf_get_tensor_info() function accepts an
+/// info_size parameter so that the struct can grow in future versions
 /// without breaking ABI. Implementations must zero-initialize the
-/// struct with `memset(info, 0, info_size)` before populating it, and
-/// only write fields whose offset + size fits within `info_size`.
+/// struct with memset(info, 0, info_size) before populating it, and
+/// only write fields whose offset + size fits within info_size.
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct HalDmabufTensorInfo {
@@ -41,7 +40,7 @@ pub struct HalDmabufTensorInfo {
     pub size: size_t,
     /// Byte offset within the DMA-BUF.
     pub offset: size_t,
-    /// Tensor dimensions (up to [`HAL_DMABUF_MAX_NDIM`]).
+    /// Tensor dimensions (up to HAL_DMABUF_MAX_NDIM).
     ///
     /// Uses a literal length so cbindgen can emit the array in the C header.
     pub shape: [size_t; 8],

--- a/crates/capi/src/delegate.rs
+++ b/crates/capi/src/delegate.rs
@@ -42,7 +42,9 @@ pub struct HalDmabufTensorInfo {
     /// Byte offset within the DMA-BUF.
     pub offset: size_t,
     /// Tensor dimensions (up to [`HAL_DMABUF_MAX_NDIM`]).
-    pub shape: [size_t; HAL_DMABUF_MAX_NDIM],
+    ///
+    /// Uses a literal length so cbindgen can emit the array in the C header.
+    pub shape: [size_t; 8],
     /// Number of valid entries in `shape`.
     pub ndim: size_t,
     /// DMA-BUF file descriptor (borrowed — do not close).
@@ -66,4 +68,5 @@ impl Default for HalDmabufTensorInfo {
 
 // Compile-time layout assertion: 11 × size_t + 1 × c_int + 1 × HalDtype
 // = 11×8 + 4 + 4 = 96 bytes on LP64 with no internal padding.
+#[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<HalDmabufTensorInfo>() == 96);

--- a/crates/capi/src/delegate.rs
+++ b/crates/capi/src/delegate.rs
@@ -55,12 +55,20 @@ pub struct HalDmabufTensorInfo {
 impl Default for HalDmabufTensorInfo {
     fn default() -> Self {
         // Safety: HalDmabufTensorInfo is a #[repr(C)] plain-old-data struct
-        // used for FFI, and the C ABI contract explicitly requires callers
-        // to zero-initialize it with memset(info, 0, info_size) before use.
-        // A fully zeroed bit-pattern is therefore a valid "empty" state.
+        // used for FFI, and the C ABI contract for hal_dmabuf_get_tensor_info()
+        // requires implementations to zero-initialize `info` with
+        // memset(info, 0, info_size) before populating it. This Default
+        // mirrors that initialization, so a fully zeroed bit-pattern is a
+        // valid "empty" state.
         unsafe { std::mem::zeroed() }
     }
 }
+
+// Ensure the shape array length matches HAL_DMABUF_MAX_NDIM (the literal 8
+// in the struct is required by cbindgen, but must stay in sync with the const).
+const _: () = assert!(
+    std::mem::size_of::<[size_t; 8]>() == std::mem::size_of::<[size_t; HAL_DMABUF_MAX_NDIM]>()
+);
 
 // Compile-time layout assertion: 11 × size_t + 1 × c_int + 1 × HalDtype
 // = 11×8 + 4 + 4 = 96 bytes on LP64 with no internal padding.

--- a/crates/capi/src/delegate.rs
+++ b/crates/capi/src/delegate.rs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Delegate DMA-BUF API — shared type definitions.
+//!
+//! This module defines the ABI contract for querying DMA-BUF tensor
+//! information from external TFLite delegates (e.g., NXP Neutron NPU).
+//! The HAL owns the type definitions; function implementations live in
+//! delegate integrators such as `edgefirst-tflite`.
+//!
+//! See ARCHITECTURE.md "Delegate DMA-BUF Framework" for the full
+//! specification including expected function signatures.
+
+use crate::tensor::HalDtype;
+use libc::{c_int, size_t};
+
+/// Maximum number of dimensions in a delegate tensor shape.
+pub const HAL_DMABUF_MAX_NDIM: usize = 8;
+
+/// DMA-BUF tensor information returned by a delegate.
+///
+/// Describes a single tensor's DMA-BUF allocation, including the file
+/// descriptor, buffer geometry, and element type. The fd is borrowed
+/// from the delegate and must NOT be closed by the caller.
+///
+/// Fields are ordered to eliminate padding on LP64: all `size_t` fields
+/// first (8-byte aligned), then smaller `int` and enum fields (4 bytes
+/// each) at the end. Total size: 96 bytes on LP64.
+///
+/// # Versioning
+///
+/// The companion `hal_dmabuf_get_tensor_info()` function accepts an
+/// `info_size` parameter so that the struct can grow in future versions
+/// without breaking ABI. Implementations must zero-initialize the
+/// struct with `memset(info, 0, info_size)` before populating it, and
+/// only write fields whose offset + size fits within `info_size`.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct HalDmabufTensorInfo {
+    /// Buffer size in bytes.
+    pub size: size_t,
+    /// Byte offset within the DMA-BUF.
+    pub offset: size_t,
+    /// Tensor dimensions (up to [`HAL_DMABUF_MAX_NDIM`]).
+    pub shape: [size_t; HAL_DMABUF_MAX_NDIM],
+    /// Number of valid entries in `shape`.
+    pub ndim: size_t,
+    /// DMA-BUF file descriptor (borrowed — do not close).
+    pub fd: c_int,
+    /// Element data type.
+    pub dtype: HalDtype,
+}
+
+impl Default for HalDmabufTensorInfo {
+    fn default() -> Self {
+        Self {
+            size: 0,
+            offset: 0,
+            shape: [0; HAL_DMABUF_MAX_NDIM],
+            ndim: 0,
+            fd: -1,
+            dtype: HalDtype::U8,
+        }
+    }
+}
+
+// Compile-time layout assertion: 11 × size_t + 1 × c_int + 1 × HalDtype
+// = 11×8 + 4 + 4 = 96 bytes on LP64 with no internal padding.
+const _: () = assert!(std::mem::size_of::<HalDmabufTensorInfo>() == 96);

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 mod decoder;
+mod delegate;
 mod error;
 mod image;
 mod log;
@@ -18,6 +19,7 @@ mod tensor;
 mod tracker;
 
 pub use decoder::*;
+pub use delegate::*;
 pub use error::*;
 pub use image::*;
 pub use log::*;


### PR DESCRIPTION
## Summary

- Add `HalDmabufTensorInfo` struct and `HAL_DMABUF_MAX_NDIM` constant to `crates/capi/src/delegate.rs`
- Add `hal_delegate_t` opaque typedef in cbindgen header preamble
- Document the Delegate DMA-BUF Framework in ARCHITECTURE.md (Appendix B), covering zero-copy data flow, type definitions, expected function signatures, integration pattern, lifecycle/ownership, and thread safety

## Context

Part of [EDGEAI-1185](https://au-zone.atlassian.net/browse/EDGEAI-1185) (NXP Neutron DMABUF Zero-Copy Support). The HAL defines the ABI contract (types and documented function signatures); actual function implementations will be added in `edgefirst-tflite` under [EDGEAI-1190](https://au-zone.atlassian.net/browse/EDGEAI-1190).

Jira: [EDGEAI-1189](https://au-zone.atlassian.net/browse/EDGEAI-1189)

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy -p edgefirst-hal-capi -- -D warnings` passes
- [x] `make format lint` passes
- [x] Compile-time assertion verifies `HalDmabufTensorInfo` is 96 bytes (no padding)
- [ ] Verify cbindgen generates correct `hal_dmabuf_tensor_info` in `hal.h`

[EDGEAI-1185]: https://au-zone.atlassian.net/browse/EDGEAI-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDGEAI-1190]: https://au-zone.atlassian.net/browse/EDGEAI-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDGEAI-1189]: https://au-zone.atlassian.net/browse/EDGEAI-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ