### PR TITLE
Fix dmabuf plane_offset in G2D and OpenGL destination paths

### DIFF
--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -180,7 +180,11 @@ impl G2DProcessor {
         }
 
         if let Some(crop_rect) = crop.dst_rect {
-            dst_surface.planes[0] += ((crop_rect.top * dst_surface.width as usize + crop_rect.left)
+            // stride is in pixels; multiply by bytes-per-pixel (== channels()
+            // for u8 data) to get the byte offset.  All G2D destination
+            // formats are packed, so channels() == bpp always holds here.
+            dst_surface.planes[0] += ((crop_rect.top * dst_surface.stride as usize
+                + crop_rect.left)
                 * dst_fmt.channels()) as u64;
 
             dst_surface.right = crop_rect.width as i32;
@@ -284,7 +288,12 @@ fn tensor_to_g2d_surface(img: &Tensor<u8>) -> Result<G2DSurface> {
 
     // NV12 is a two-plane format: Y plane followed by interleaved UV plane.
     // planes[0] = Y plane start, planes[1] = UV plane start (Y size = width * height)
+    //
+    // plane_offset is the byte offset within the DMA-BUF where pixel data
+    // starts.  G2D works with raw physical addresses so we must add the
+    // offset ourselves — the hardware has no concept of a per-plane offset.
     let base_addr = phys.address();
+    let luma_offset = img.plane_offset().unwrap_or(0) as u64;
     let planes = if fmt == PixelFormat::Nv12 {
         if img.is_multiplane() {
             // Multiplane: UV in separate DMA-BUF, get its physical address
@@ -293,22 +302,33 @@ fn tensor_to_g2d_surface(img: &Tensor<u8>) -> Result<G2DSurface> {
                 Error::NotImplemented("g2d multiplane chroma must be DMA-backed".to_string())
             })?;
             let uv_phys: G2DPhysical = chroma_dma.fd.as_raw_fd().try_into()?;
-            [base_addr, uv_phys.address(), 0]
+            let chroma_offset = img.chroma().and_then(|c| c.plane_offset()).unwrap_or(0) as u64;
+            [
+                base_addr + luma_offset,
+                uv_phys.address() + chroma_offset,
+                0,
+            ]
         } else {
             let w = img.width().unwrap();
             let h = img.height().unwrap();
             let stride = img.effective_row_stride().unwrap_or(w);
-            let offset = img.plane_offset().unwrap_or(0);
-            let uv_offset = (offset + stride * h) as u64;
-            [base_addr, base_addr + uv_offset, 0]
+            let uv_offset = (luma_offset as usize + stride * h) as u64;
+            [base_addr + luma_offset, base_addr + uv_offset, 0]
         }
     } else {
-        [base_addr, 0, 0]
+        [base_addr + luma_offset, 0, 0]
     };
 
     let w = img.width().unwrap();
     let h = img.height().unwrap();
     let fourcc = pixelfmt_to_fourcc(fmt);
+
+    // G2D stride is in pixels.  effective_row_stride() returns bytes, so
+    // divide by the bytes-per-pixel (channels for u8 data) to convert.
+    let stride_pixels = img
+        .effective_row_stride()
+        .map(|s| s / fmt.channels())
+        .unwrap_or(w);
 
     Ok(G2DSurface {
         planes,
@@ -317,7 +337,7 @@ fn tensor_to_g2d_surface(img: &Tensor<u8>) -> Result<G2DSurface> {
         top: 0,
         right: w as i32,
         bottom: h as i32,
-        stride: w as i32,
+        stride: stride_pixels as i32,
         width: w as i32,
         height: h as i32,
         blendfunc: 0,
@@ -1198,5 +1218,187 @@ mod g2d_tests {
             );
         }
         Ok(())
+    }
+
+    // =========================================================================
+    // tensor_to_g2d_surface offset & stride unit tests
+    //
+    // These tests verify that plane_offset and effective_row_stride are
+    // correctly propagated into the G2DSurface.  They require DMA memory
+    // but do NOT require G2D hardware — only the DMA_BUF_IOCTL_PHYS ioctl.
+    // =========================================================================
+
+    /// Helper: build a DMA-backed Tensor<u8> with an optional plane_offset
+    /// and an optional row stride, then return the G2DSurface.
+    fn surface_for(
+        width: usize,
+        height: usize,
+        fmt: PixelFormat,
+        offset: Option<usize>,
+        row_stride: Option<usize>,
+    ) -> Result<G2DSurface, crate::Error> {
+        use edgefirst_tensor::TensorMemory;
+        let mut t = Tensor::<u8>::image(width, height, fmt, Some(TensorMemory::Dma))?;
+        if let Some(o) = offset {
+            t.set_plane_offset(o);
+        }
+        if let Some(s) = row_stride {
+            t.set_row_stride_unchecked(s);
+        }
+        tensor_to_g2d_surface(&t)
+    }
+
+    #[test]
+    fn g2d_surface_single_plane_no_offset() {
+        if !is_dma_available() {
+            return;
+        }
+        let s = surface_for(640, 480, PixelFormat::Rgba, None, None).unwrap();
+        // planes[0] must be non-zero (valid physical address), no offset
+        assert_ne!(s.planes[0], 0);
+        assert_eq!(s.stride, 640);
+    }
+
+    #[test]
+    fn g2d_surface_single_plane_with_offset() {
+        if !is_dma_available() {
+            return;
+        }
+        use edgefirst_tensor::TensorMemory;
+        let mut t =
+            Tensor::<u8>::image(640, 480, PixelFormat::Rgba, Some(TensorMemory::Dma)).unwrap();
+        let s0 = tensor_to_g2d_surface(&t).unwrap();
+        t.set_plane_offset(4096);
+        let s1 = tensor_to_g2d_surface(&t).unwrap();
+        assert_eq!(s1.planes[0], s0.planes[0] + 4096);
+    }
+
+    #[test]
+    fn g2d_surface_single_plane_zero_offset() {
+        if !is_dma_available() {
+            return;
+        }
+        use edgefirst_tensor::TensorMemory;
+        let mut t =
+            Tensor::<u8>::image(640, 480, PixelFormat::Rgba, Some(TensorMemory::Dma)).unwrap();
+        let s_none = tensor_to_g2d_surface(&t).unwrap();
+        t.set_plane_offset(0);
+        let s_zero = tensor_to_g2d_surface(&t).unwrap();
+        // offset=0 should produce the same address as no offset
+        assert_eq!(s_none.planes[0], s_zero.planes[0]);
+    }
+
+    #[test]
+    fn g2d_surface_stride_rgba() {
+        if !is_dma_available() {
+            return;
+        }
+        // Default stride: width in pixels = 640
+        let s_default = surface_for(640, 480, PixelFormat::Rgba, None, None).unwrap();
+        assert_eq!(s_default.stride, 640);
+
+        // Custom stride: 2816 bytes / 4 channels = 704 pixels
+        let s_custom = surface_for(640, 480, PixelFormat::Rgba, None, Some(2816)).unwrap();
+        assert_eq!(s_custom.stride, 704);
+    }
+
+    #[test]
+    fn g2d_surface_stride_rgb() {
+        if !is_dma_available() {
+            return;
+        }
+        let s_default = surface_for(640, 480, PixelFormat::Rgb, None, None).unwrap();
+        assert_eq!(s_default.stride, 640);
+
+        // Padded: 1980 bytes / 3 channels = 660 pixels
+        let s_custom = surface_for(640, 480, PixelFormat::Rgb, None, Some(1980)).unwrap();
+        assert_eq!(s_custom.stride, 660);
+    }
+
+    #[test]
+    fn g2d_surface_stride_grey() {
+        if !is_dma_available() {
+            return;
+        }
+        // Grey (Y800) may not be supported by all G2D hardware versions
+        let s = match surface_for(640, 480, PixelFormat::Grey, None, Some(1024)) {
+            Ok(s) => s,
+            Err(crate::Error::G2D(..)) => return,
+            Err(e) => panic!("unexpected error: {e:?}"),
+        };
+        // Grey: 1 channel. stride in bytes = stride in pixels
+        assert_eq!(s.stride, 1024);
+    }
+
+    #[test]
+    fn g2d_surface_contiguous_nv12_offset() {
+        if !is_dma_available() {
+            return;
+        }
+        use edgefirst_tensor::TensorMemory;
+        let mut t =
+            Tensor::<u8>::image(640, 480, PixelFormat::Nv12, Some(TensorMemory::Dma)).unwrap();
+        let s0 = tensor_to_g2d_surface(&t).unwrap();
+
+        t.set_plane_offset(8192);
+        let s1 = tensor_to_g2d_surface(&t).unwrap();
+
+        // Luma plane should shift by offset
+        assert_eq!(s1.planes[0], s0.planes[0] + 8192);
+        // UV plane = base + offset + stride * height
+        // Without offset: UV = base + 640 * 480 = base + 307200
+        // With offset 8192: UV = base + 8192 + 640 * 480 = base + 315392
+        assert_eq!(s1.planes[1], s0.planes[1] + 8192);
+    }
+
+    #[test]
+    fn g2d_surface_contiguous_nv12_stride() {
+        if !is_dma_available() {
+            return;
+        }
+        // NV12: 1 byte per pixel for Y. stride 640 bytes = 640 pixels.
+        let s = surface_for(640, 480, PixelFormat::Nv12, None, None).unwrap();
+        assert_eq!(s.stride, 640);
+
+        // Padded stride: 1024 bytes = 1024 pixels (NV12 channels = 1)
+        let s_padded = surface_for(640, 480, PixelFormat::Nv12, None, Some(1024)).unwrap();
+        assert_eq!(s_padded.stride, 1024);
+    }
+
+    #[test]
+    fn g2d_surface_multiplane_nv12_offset() {
+        if !is_dma_available() {
+            return;
+        }
+        use edgefirst_tensor::TensorMemory;
+
+        // Create luma and chroma as separate DMA tensors
+        let mut luma =
+            Tensor::<u8>::new(&[480, 640], Some(TensorMemory::Dma), Some("luma")).unwrap();
+        let mut chroma =
+            Tensor::<u8>::new(&[240, 640], Some(TensorMemory::Dma), Some("chroma")).unwrap();
+
+        // Get baseline physical addresses with no offsets
+        let luma_base = {
+            let dma = luma.as_dma().unwrap();
+            let phys: G2DPhysical = dma.fd.as_raw_fd().try_into().unwrap();
+            phys.address()
+        };
+        let chroma_base = {
+            let dma = chroma.as_dma().unwrap();
+            let phys: G2DPhysical = dma.fd.as_raw_fd().try_into().unwrap();
+            phys.address()
+        };
+
+        // Set offsets and build multiplane tensor
+        luma.set_plane_offset(4096);
+        chroma.set_plane_offset(2048);
+        let combined = Tensor::<u8>::from_planes(luma, chroma, PixelFormat::Nv12).unwrap();
+        let s = tensor_to_g2d_surface(&combined).unwrap();
+
+        // Luma should include its offset
+        assert_eq!(s.planes[0], luma_base + 4096);
+        // Chroma should include its offset
+        assert_eq!(s.planes[1], chroma_base + 2048);
     }
 }

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -325,10 +325,18 @@ fn tensor_to_g2d_surface(img: &Tensor<u8>) -> Result<G2DSurface> {
 
     // G2D stride is in pixels.  effective_row_stride() returns bytes, so
     // divide by the bytes-per-pixel (channels for u8 data) to convert.
-    let stride_pixels = img
-        .effective_row_stride()
-        .map(|s| s / fmt.channels())
-        .unwrap_or(w);
+    let stride_pixels = match img.effective_row_stride() {
+        Some(s) => {
+            let channels = fmt.channels();
+            if s % channels != 0 {
+                return Err(Error::NotImplemented(
+                    "g2d requires row stride to be a multiple of bytes-per-pixel".to_string(),
+                ));
+            }
+            s / channels
+        }
+        None => w,
+    };
 
     Ok(G2DSurface {
         planes,

--- a/crates/image/src/gl/processor.rs
+++ b/crates/image/src/gl/processor.rs
@@ -3956,7 +3956,10 @@ impl GLProcessorST {
         })?;
         let fd = dma.fd.as_raw_fd();
 
-        let pitch = width * bpp;
+        // Use the tensor's stored stride when available (externally allocated
+        // buffers with row padding), otherwise compute the tightly-packed pitch.
+        let pitch = img.effective_row_stride().unwrap_or(width * bpp);
+        let offset = img.plane_offset().unwrap_or(0);
         let egl_img_attr = vec![
             egl_ext::LINUX_DRM_FOURCC as Attrib,
             drm_format as u32 as Attrib,
@@ -3967,7 +3970,7 @@ impl GLProcessorST {
             egl_ext::DMA_BUF_PLANE0_PITCH as Attrib,
             pitch as Attrib,
             egl_ext::DMA_BUF_PLANE0_OFFSET as Attrib,
-            0 as Attrib,
+            offset as Attrib,
             egl_ext::DMA_BUF_PLANE0_FD as Attrib,
             fd as Attrib,
             egl::IMAGE_PRESERVED as Attrib,

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -1599,4 +1599,312 @@ mod gl_tests {
         };
         assert_pixels_match(contig_bytes, multi_bytes, 0);
     }
+
+    // =========================================================================
+    // Destination DMA-BUF plane_offset tests
+    //
+    // These verify that create_egl_image_with_dims correctly passes
+    // plane_offset to EGL, so the GPU renders at the right position within
+    // a shared DMA-BUF (critical for NPU buffers where a single allocation
+    // serves the entire accelerator).
+    // =========================================================================
+
+    /// Regression: destination with explicit offset=0 must produce the same
+    /// output as a destination with no offset set.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn test_opengl_dst_offset_zero_regression() {
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+
+        let src = load_raw_image(
+            1280,
+            720,
+            PixelFormat::Nv12,
+            Some(TensorMemory::Dma),
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../testdata/camera720p.nv12"
+            )),
+        )
+        .unwrap();
+
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+
+        // Destination without offset
+        let dst_no_off = TensorDyn::image(
+            640,
+            480,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Dma),
+        )
+        .unwrap();
+        let src_dyn = src;
+        let mut dst_no_off_dyn = dst_no_off;
+        gl.convert(
+            &src_dyn,
+            &mut dst_no_off_dyn,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        )
+        .unwrap();
+
+        // Destination with explicit offset=0
+        let mut dst_zero =
+            Tensor::<u8>::image(640, 480, PixelFormat::Rgba, Some(TensorMemory::Dma)).unwrap();
+        dst_zero.set_plane_offset(0);
+        let mut dst_zero_dyn = TensorDyn::from(dst_zero);
+        gl.convert(
+            &src_dyn,
+            &mut dst_zero_dyn,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        )
+        .unwrap();
+
+        let a = dst_no_off_dyn.as_u8().unwrap().map().unwrap();
+        let b = dst_zero_dyn.as_u8().unwrap().map().unwrap();
+        assert_pixels_match(a.as_slice(), b.as_slice(), 0);
+    }
+
+    /// Functional: allocate an oversized DMA buffer, import the second half
+    /// as a destination via PlaneDescriptor with offset, convert, and verify
+    /// the GPU wrote at the offset — not at byte 0.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn test_opengl_dst_nonzero_offset() {
+        use edgefirst_tensor::PlaneDescriptor;
+        use std::os::fd::AsFd;
+
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+
+        let width = 640;
+        let height = 480;
+        let image_bytes = width * height * 4; // RGBA
+        let offset = image_bytes; // put image in the second half
+
+        // Allocate a DMA buffer twice the image size and fill with a sentinel
+        let large_buf =
+            Tensor::<u8>::new(&[image_bytes * 2], Some(TensorMemory::Dma), None).unwrap();
+        large_buf.map().unwrap().as_mut_slice().fill(0xAA);
+
+        // Import the second half as an RGBA destination via PlaneDescriptor
+        let fd = large_buf.as_dma().unwrap().fd.as_fd();
+        let plane = PlaneDescriptor::new(fd).unwrap().with_offset(offset);
+        let proc = crate::ImageProcessor::new().unwrap();
+        let mut dst = proc
+            .import_image(plane, None, width, height, PixelFormat::Rgba, DType::U8)
+            .unwrap();
+
+        // Source: NV12 camera frame
+        let src = load_raw_image(
+            1280,
+            720,
+            PixelFormat::Nv12,
+            Some(TensorMemory::Dma),
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../testdata/camera720p.nv12"
+            )),
+        )
+        .unwrap();
+
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let src_dyn = src;
+        gl.convert(
+            &src_dyn,
+            &mut dst,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        )
+        .unwrap();
+
+        // Verify: the first half (before offset) must still be our sentinel
+        let map = large_buf.map().unwrap();
+        let buf = map.as_slice();
+        let untouched = &buf[..offset];
+        assert!(
+            untouched.iter().all(|&b| b == 0xAA),
+            "GPU wrote before the offset boundary — offset not applied"
+        );
+
+        // Verify: the second half (at offset) should contain rendered data,
+        // not all sentinels
+        let rendered = &buf[offset..];
+        assert!(
+            rendered.iter().any(|&b| b != 0xAA),
+            "GPU did not write at the offset position — destination is still sentinel"
+        );
+    }
+
+    /// Destination with offset=0 via PlaneDescriptor import (same path as NPU
+    /// workflow) must produce identical output to a normal DMA allocation.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn test_opengl_dst_imported_offset_zero() {
+        use edgefirst_tensor::PlaneDescriptor;
+        use std::os::fd::AsFd;
+
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+
+        let width = 640;
+        let height = 480;
+
+        let src = load_raw_image(
+            1280,
+            720,
+            PixelFormat::Nv12,
+            Some(TensorMemory::Dma),
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../testdata/camera720p.nv12"
+            )),
+        )
+        .unwrap();
+
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+
+        // Reference: normal DMA destination
+        let dst_ref = TensorDyn::image(
+            width,
+            height,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Dma),
+        )
+        .unwrap();
+        let src_dyn = src;
+        let mut dst_ref_dyn = dst_ref;
+        gl.convert(
+            &src_dyn,
+            &mut dst_ref_dyn,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        )
+        .unwrap();
+
+        // Imported: PlaneDescriptor with offset=0
+        let dst_buf =
+            Tensor::<u8>::image(width, height, PixelFormat::Rgba, Some(TensorMemory::Dma)).unwrap();
+        let fd = dst_buf.as_dma().unwrap().fd.as_fd();
+        let plane = PlaneDescriptor::new(fd).unwrap().with_offset(0);
+        let proc = crate::ImageProcessor::new().unwrap();
+        let mut dst_imported = proc
+            .import_image(plane, None, width, height, PixelFormat::Rgba, DType::U8)
+            .unwrap();
+        gl.convert(
+            &src_dyn,
+            &mut dst_imported,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        )
+        .unwrap();
+
+        let a = dst_ref_dyn.as_u8().unwrap().map().unwrap();
+        let b = dst_buf.map().unwrap();
+        assert_pixels_match(a.as_slice(), b.as_slice(), 1);
+    }
+
+    /// Functional: packed RGB destination with nonzero offset.  This exercises
+    /// `create_egl_image_with_dims` (the two-pass RGB pipeline), which was the
+    /// specific function that had the hardcoded offset=0 bug.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn test_opengl_dst_nonzero_offset_rgb() {
+        use edgefirst_tensor::PlaneDescriptor;
+        use std::os::fd::AsFd;
+
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+
+        let width = 640;
+        let height = 480;
+        let image_bytes = width * height * 3; // RGB
+        let offset = image_bytes; // put image in the second half
+
+        // Allocate a DMA buffer twice the image size and fill with a sentinel
+        let large_buf =
+            Tensor::<u8>::new(&[image_bytes * 2], Some(TensorMemory::Dma), None).unwrap();
+        large_buf.map().unwrap().as_mut_slice().fill(0xAA);
+
+        // Import the second half as an RGB destination via PlaneDescriptor
+        let fd = large_buf.as_dma().unwrap().fd.as_fd();
+        let plane = PlaneDescriptor::new(fd).unwrap().with_offset(offset);
+        let proc = crate::ImageProcessor::new().unwrap();
+        let mut dst = proc
+            .import_image(plane, None, width, height, PixelFormat::Rgb, DType::U8)
+            .unwrap();
+
+        // Source: NV12 camera frame
+        let src = load_raw_image(
+            1280,
+            720,
+            PixelFormat::Nv12,
+            Some(TensorMemory::Dma),
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../testdata/camera720p.nv12"
+            )),
+        )
+        .unwrap();
+
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let src_dyn = src;
+        gl.convert(
+            &src_dyn,
+            &mut dst,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        )
+        .unwrap();
+
+        // Verify: the first half (before offset) must still be our sentinel
+        let map = large_buf.map().unwrap();
+        let buf = map.as_slice();
+        let untouched = &buf[..offset];
+        assert!(
+            untouched.iter().all(|&b| b == 0xAA),
+            "GPU wrote before the offset boundary — RGB offset not applied"
+        );
+
+        // Verify: the second half (at offset) should contain rendered data
+        let rendered = &buf[offset..];
+        assert!(
+            rendered.iter().any(|&b| b != 0xAA),
+            "GPU did not write at the RGB offset position — destination is still sentinel"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **G2D**: `plane_offset` was never added to physical addresses for single-plane formats, and was missing from luma/chroma in multiplane NV12. Also fixes stride (now uses `effective_row_stride` converted to pixels) and crop path (uses stride instead of width for row pitch).
- **OpenGL**: `create_egl_image_with_dims` (packed RGB destination path) hardcoded `DMA_BUF_PLANE0_OFFSET` to 0 and computed pitch from width alone, ignoring `plane_offset()` and `effective_row_stride()` from the tensor.
- These bugs caused incorrect memory access when importing sub-regions of shared DMA-BUF allocations (e.g., Neutron NPU buffers where a single dmabuf serves the entire accelerator).

## Test plan

- [x] `make format lint check` — all pass
- [x] Local tests (561 passed, 0 failed)
- [x] aarch64 cross-compile with `g2d_test_formats,dma_test_formats` features
- [x] imx8mp-frdm on-target: 194 passed, 0 failed, 6 ignored
- [x] imx95-frdm on-target: 194 passed, 0 failed, 6 ignored
- 10 new G2D unit tests (offset propagation for single-plane, contiguous NV12, multiplane NV12; stride for RGBA, RGB, Grey, NV12)
- 4 new OpenGL integration tests (destination offset for RGBA and RGB paths, zero and nonzero offsets with sentinel-pattern verification)