### PR TITLE
EDGEAI-1189: Add HalCameraAdaptorFormatInfo to delegate ABI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1783,11 +1783,11 @@ that cannot determine the shape should set `ndim = 0`.
 
 **`hal_camera_adaptor_format_info`** — describes a camera format adaptor:
 
-| Field             | Type      | Description |
-|-------------------|-----------|-------------|
-| `input_channels`  | `int`     | Number of input channels (e.g., 4 for RGBA) |
-| `output_channels` | `int`     | Number of output channels (e.g., 3 for RGB) |
-| `fourcc`          | `char[8]` | V4L2 FourCC string, NUL-terminated |
+| Field             | Type                       | Description |
+|-------------------|----------------------------|-------------|
+| `input_channels`  | `int`                      | Number of input channels (e.g., 4 for RGBA) |
+| `output_channels` | `int`                      | Number of output channels (e.g., 3 for RGB) |
+| `fourcc`          | `char[HAL_FOURCC_MAX_LEN]` | V4L2 FourCC string, NUL-terminated (ASCII, at most 4 bytes + NUL) |
 
 ### DMA-BUF Functions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1700,13 +1700,19 @@ This work was implemented under **EDGEAI-1107**.
 ### Purpose
 
 The Delegate DMA-BUF Framework defines an ABI contract for querying DMA-BUF
-tensor information from external TFLite delegates (e.g., NXP Neutron NPU).
-The HAL owns the type definitions; function implementations live in delegate
-integrators such as `edgefirst-tflite`.
+tensor information from external TFLite delegates (e.g., NXP Neutron NPU,
+VxDelegate). The HAL owns the type definitions; function implementations
+live in delegate shared libraries.
 
-This enables a fully zero-copy pipeline from camera capture through NPU
-inference by allowing `hal_import_image()` to wrap delegate-owned DMA-BUF
-file descriptors as HAL tensors with full image attributes.
+The API is **query-only by design**: delegates own all DMA-BUF allocations
+internally. Consumers query tensor metadata (fd, shape, dtype) and
+synchronize caches — they never register, allocate, bind, or release
+buffers through this API.
+
+Each delegate ships a self-contained `hal_dmabuf.h` header with all type
+definitions and function declarations. Consumers do **not** need the full
+`edgefirst/hal.h` — they either include the delegate's header or load
+symbols via `dlsym`.
 
 ### Zero-Copy Data Flow
 
@@ -1749,9 +1755,13 @@ anyway.
 ### Type Definitions
 
 **`hal_delegate_t`** — opaque handle for any delegate, defined as `void*`.
-A future revision will formalize this as a proper abstraction. The delegate
-lifetime is managed by the caller; the HAL never creates or destroys
-delegates.
+Implementations receive this as a parameter and cast it internally to their
+concrete delegate type. The delegate lifetime is managed by the caller; the
+HAL never creates or destroys delegates.
+
+> **Important:** Exported function signatures **must** use `hal_delegate_t`
+> (`void*`), not `TfLiteDelegate*` or any other concrete type. This ensures
+> ABI compatibility across different delegate implementations.
 
 **`hal_dmabuf_tensor_info`** — describes a single delegate tensor's DMA-BUF:
 
@@ -1767,60 +1777,142 @@ delegates.
 Fields are ordered to eliminate padding on LP64 (`size_t` fields first,
 then smaller 4-byte fields). Total struct size: 96 bytes on LP64.
 
-### Expected Function Signatures
+All fields are **mandatory**. Implementations must populate `shape`, `ndim`,
+and `dtype` in addition to `fd`, `offset`, and `size`. An implementation
+that cannot determine the shape should set `ndim = 0`.
+
+**`hal_camera_adaptor_format_info`** — describes a camera format adaptor:
+
+| Field             | Type      | Description |
+|-------------------|-----------|-------------|
+| `input_channels`  | `int`     | Number of input channels (e.g., 4 for RGBA) |
+| `output_channels` | `int`     | Number of output channels (e.g., 3 for RGB) |
+| `fourcc`          | `char[8]` | V4L2 FourCC string, NUL-terminated |
+
+### DMA-BUF Functions
 
 These functions are **not implemented in the HAL**. They document the exact
-ABI that delegate integrators must export and that consumers probe via
-`dlsym`.
+ABI that delegate shared libraries must export and that consumers probe via
+`dlsym`. All exported symbols must use
+`__attribute__((visibility("default")))`.
 
 ```c
+/* Get the delegate's internal handle.
+ *
+ * When TFLite creates a delegate via TfLiteExternalDelegateCreate(), it
+ * wraps the real delegate in an opaque adapter. This function returns the
+ * inner delegate pointer that the hal_dmabuf_* functions expect.
+ *
+ * Returns the inner delegate handle, or NULL if no delegate has been
+ * created. */
+hal_delegate_t hal_dmabuf_get_instance(void);
+
 /* Query whether the delegate supports DMA-BUF tensor access.
- * Returns 1 if supported, 0 if not supported or on error.
- * A NULL delegate pointer returns 0. */
+ * Returns 1 if supported, 0 otherwise (including NULL delegate or error).
+ * This function does not set errno. */
 int hal_dmabuf_is_supported(hal_delegate_t delegate);
 
 /* Get DMA-BUF tensor info for a given tensor index.
  * Returns 0 on success, -1 on error (sets errno).
  *
  * info_size enables forward-compatible versioning: pass
- * sizeof(hal_dmabuf_tensor_info). Implementations zero-initialize
- * with memset(info, 0, info_size) and only write fields whose
- * offsetof + sizeof fits within info_size.
+ * sizeof(hal_dmabuf_tensor_info). Implementations must:
+ * 1. memset(info, 0, info_size) before populating
+ * 2. Only write fields whose offsetof + sizeof fits within info_size
  *
- * Errno: EINVAL (bad args), ENOTSUP (no DMA-BUF support),
- *        ERANGE (index out of range), EIO (internal failure) */
+ * Errno: EINVAL (NULL info, negative tensor_index, info_size too small),
+ *        ENOTSUP (DMA-BUF not supported),
+ *        ERANGE (tensor_index out of range),
+ *        EIO (DMA-BUF ioctl or internal failure) */
 int hal_dmabuf_get_tensor_info(hal_delegate_t delegate,
                                int tensor_index,
                                hal_dmabuf_tensor_info *info,
                                size_t info_size);
 
 /* Flush CPU caches → device can read.
- * Call after ImageProcessor::convert() into the input tensor,
- * before invoking NPU inference.
+ * Call after writing to an input tensor (e.g., via
+ * ImageProcessor::convert()), before invoking NPU inference.
  * Returns 0 on success, -1 on error (sets errno).
- * Errno: EINVAL, ERANGE, EIO */
+ * Errno: EINVAL (NULL delegate, negative tensor_index),
+ *        ERANGE (tensor_index out of range),
+ *        EIO (DMA-BUF ioctl failure) */
 int hal_dmabuf_sync_for_device(hal_delegate_t delegate, int tensor_index);
 
 /* Invalidate CPU caches → CPU sees device writes.
- * Call after NPU inference, before reading output tensor data.
+ * Call after NPU inference completes, before reading output tensor data.
  * Returns 0 on success, -1 on error (sets errno).
- * Errno: EINVAL, ERANGE, EIO */
+ * Errno: EINVAL (NULL delegate, negative tensor_index),
+ *        ERANGE (tensor_index out of range),
+ *        EIO (DMA-BUF ioctl failure) */
 int hal_dmabuf_sync_for_cpu(hal_delegate_t delegate, int tensor_index);
 ```
 
 `tensor_index` must be non-negative; negative values return -1 with
 `errno` set to `EINVAL`.
 
+### Camera Adaptor Functions
+
+Some delegates support NPU-accelerated format conversion (e.g., RGBA→RGB
+channel slicing, uint8→int8 quantization) that runs as part of the
+inference graph. These functions allow consumers to query format support
+without vendor-specific symbols.
+
+Format conversion is configured **before** graph compilation via delegate
+options (e.g., `DelegateOptions::option("camera_adaptor", "rgba")`), not
+through this query API.
+
+```c
+/* Check if the delegate supports a camera format adaptor.
+ * Returns 1 if the given format is supported, 0 otherwise.
+ * This function does not set errno.
+ *
+ * Delegates without camera adaptor support always return 0. */
+int hal_camera_adaptor_is_supported(hal_delegate_t delegate,
+                                    const char *format);
+
+/* Query camera adaptor format information.
+ * Returns 0 on success, -1 on error (sets errno).
+ *
+ * info_size enables forward-compatible versioning (same pattern as
+ * hal_dmabuf_get_tensor_info).
+ *
+ * Errno: EINVAL (NULL format or info),
+ *        ENOTSUP (format not supported by this delegate) */
+int hal_camera_adaptor_get_format_info(hal_delegate_t delegate,
+                                       const char *format,
+                                       hal_camera_adaptor_format_info *info,
+                                       size_t info_size);
+```
+
+### errno Requirements
+
+Implementations **must** set `errno` before returning -1. The following
+table specifies which errno values apply to each function:
+
+| Function | EINVAL | ENOTSUP | ERANGE | EIO |
+|----------|--------|---------|--------|-----|
+| `hal_dmabuf_get_tensor_info` | NULL info, negative index, info_size too small | DMA-BUF not supported | tensor_index out of range | ioctl or internal failure |
+| `hal_dmabuf_sync_for_device` | NULL delegate, negative index | — | tensor_index out of range | ioctl failure |
+| `hal_dmabuf_sync_for_cpu` | NULL delegate, negative index | — | tensor_index out of range | ioctl failure |
+| `hal_camera_adaptor_get_format_info` | NULL format or info | format not supported | — | — |
+
+Functions that return 1/0 (`hal_dmabuf_is_supported`,
+`hal_camera_adaptor_is_supported`) do **not** set errno.
+
 ### Integration Pattern
 
-1. `edgefirst-tflite` (or another delegate integrator) implements the four
-   functions above and exports them as public C symbols.
+1. The delegate shared library (e.g., `libvx_delegate.so`,
+   `libneutron_delegate.so`) implements the functions above and exports
+   them as public C symbols with default visibility.
 2. Consumers probe for the symbols at runtime via `dlsym` on the delegate's
    shared library.
-3. If `hal_dmabuf_is_supported()` returns 1, consumers call
+3. Consumers call `hal_dmabuf_get_instance()` to obtain the inner delegate
+   handle (needed when the delegate was created via
+   `TfLiteExternalDelegateCreate()`).
+4. If `hal_dmabuf_is_supported()` returns 1, consumers call
    `hal_dmabuf_get_tensor_info()` to obtain the DMA-BUF fd and shape for
    each tensor of interest.
-4. The fd and metadata are passed to `hal_import_image()` to create a
+5. The fd and metadata are passed to `hal_import_image()` to create a
    HAL tensor with full image attributes for use with
    `ImageProcessor::convert()`.
 
@@ -1834,6 +1926,13 @@ int hal_dmabuf_sync_for_cpu(hal_delegate_t delegate, int tensor_index);
   at the correct points in the pipeline (see data flow above).
 - The delegate instance itself is created and destroyed by the caller
   (e.g., via the TFLite C API). The HAL never manages delegate lifetime.
+
+### Symbol Visibility
+
+All exported `hal_dmabuf_*` and `hal_camera_adaptor_*` functions must be
+annotated with `__attribute__((visibility("default")))` to ensure they
+remain visible even when the delegate is compiled with
+`-fvisibility=hidden`.
 
 ### Thread Safety
 

--- a/crates/capi/cbindgen.toml
+++ b/crates/capi/cbindgen.toml
@@ -75,7 +75,7 @@ no_includes = false
 # only defines the type; implementations live in edgefirst-tflite), so
 # cbindgen would otherwise skip it. This list is additive — all other
 # types/functions are still emitted normally.
-include = ["HalDmabufTensorInfo"]
+include = ["HalDmabufTensorInfo", "HalCameraAdaptorFormatInfo"]
 exclude = []
 item_types = ["enums", "structs", "unions", "typedefs", "opaque", "functions", "constants"]
 
@@ -102,6 +102,7 @@ item_types = ["enums", "structs", "unions", "typedefs", "opaque", "functions", "
 "HalTensorMap" = "hal_tensor_map"
 "HalPlaneDescriptor" = "hal_plane_descriptor"
 "HalDmabufTensorInfo" = "hal_dmabuf_tensor_info"
+"HalCameraAdaptorFormatInfo" = "hal_camera_adaptor_format_info"
 "HalComputeBackend" = "hal_compute_backend"
 "HalLogLevel" = "hal_log_level"
 "HalLogCallback" = "hal_log_callback"

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -62,6 +62,11 @@ typedef void *hal_delegate_t;
 #define HAL_DMABUF_MAX_NDIM 8
 
 /**
+ * Maximum length of a FourCC string in [`HalCameraAdaptorFormatInfo`].
+ */
+#define HAL_FOURCC_MAX_LEN 8
+
+/**
  * Output type for model tensor outputs.
  *
  * Identifies the role of a model output tensor in the decoder pipeline.
@@ -763,6 +768,32 @@ typedef struct hal_dmabuf_tensor_info {
    */
   enum hal_dtype dtype;
 } hal_dmabuf_tensor_info;
+
+/**
+ * Camera adaptor format information returned by a delegate.
+ *
+ * Describes a camera format adaptor's channel mapping and V4L2 FourCC
+ * code. Used by consumers to negotiate upstream formats without
+ * vendor-specific symbols.
+ *
+ * @par Versioning
+ * The companion `hal_camera_adaptor_get_format_info()` function accepts
+ * an `info_size` parameter for forward-compatible struct growth.
+ */
+typedef struct hal_camera_adaptor_format_info {
+  /**
+   * Number of input channels (e.g., 4 for RGBA).
+   */
+  int input_channels;
+  /**
+   * Number of output channels (e.g., 3 for RGB).
+   */
+  int output_channels;
+  /**
+   * V4L2 FourCC string, NUL-terminated.
+   */
+  uint8_t fourcc[8];
+} hal_camera_adaptor_format_info;
 
 /**
  * Create new decoder parameters.

--- a/crates/capi/src/delegate.rs
+++ b/crates/capi/src/delegate.rs
@@ -15,7 +15,7 @@
 //! specification including expected function signatures.
 
 use crate::tensor::HalDtype;
-use libc::{c_int, size_t};
+use libc::{c_char, c_int, size_t};
 
 /// Maximum number of dimensions in a delegate tensor shape.
 pub const HAL_DMABUF_MAX_NDIM: usize = 8;
@@ -78,7 +78,7 @@ const _: () = assert!(
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<HalDmabufTensorInfo>() == 96);
 
-/// Maximum length of a FourCC string in [`HalCameraAdaptorFormatInfo`].
+/// Maximum length of a FourCC string in hal_camera_adaptor_format_info.
 pub const HAL_FOURCC_MAX_LEN: usize = 8;
 
 /// Camera adaptor format information returned by a delegate.
@@ -97,9 +97,14 @@ pub struct HalCameraAdaptorFormatInfo {
     pub input_channels: c_int,
     /// Number of output channels (e.g., 3 for RGB).
     pub output_channels: c_int,
-    /// V4L2 FourCC string, NUL-terminated.
-    pub fourcc: [u8; 8],
+    /// V4L2 FourCC string, NUL-terminated (ASCII, at most 4 bytes + NUL).
+    pub fourcc: [c_char; HAL_FOURCC_MAX_LEN],
 }
+
+const _: () = assert!(
+    std::mem::size_of::<[c_char; HAL_FOURCC_MAX_LEN]>() == HAL_FOURCC_MAX_LEN,
+    "HAL_FOURCC_MAX_LEN must equal the fourcc array length"
+);
 
 impl Default for HalCameraAdaptorFormatInfo {
     fn default() -> Self {

--- a/crates/capi/src/delegate.rs
+++ b/crates/capi/src/delegate.rs
@@ -1,12 +1,15 @@
 // SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
 // SPDX-License-Identifier: Apache-2.0
 
-//! Delegate DMA-BUF API — shared type definitions.
+//! Delegate API — shared type definitions.
 //!
 //! This module defines the ABI contract for querying DMA-BUF tensor
-//! information from external TFLite delegates (e.g., NXP Neutron NPU).
+//! information and camera adaptor format support from external TFLite
+//! delegates (e.g., NXP Neutron NPU, VxDelegate).
+//!
 //! The HAL owns the type definitions; function implementations live in
-//! delegate integrators such as `edgefirst-tflite`.
+//! delegate shared libraries. Each delegate ships a self-contained
+//! `hal_dmabuf.h` header with these types.
 //!
 //! See ARCHITECTURE.md "Delegate DMA-BUF Framework" for the full
 //! specification including expected function signatures.
@@ -74,3 +77,33 @@ const _: () = assert!(
 // = 11×8 + 4 + 4 = 96 bytes on LP64 with no internal padding.
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(std::mem::size_of::<HalDmabufTensorInfo>() == 96);
+
+/// Maximum length of a FourCC string in [`HalCameraAdaptorFormatInfo`].
+pub const HAL_FOURCC_MAX_LEN: usize = 8;
+
+/// Camera adaptor format information returned by a delegate.
+///
+/// Describes a camera format adaptor's channel mapping and V4L2 FourCC
+/// code. Used by consumers to negotiate upstream formats without
+/// vendor-specific symbols.
+///
+/// @par Versioning
+/// The companion `hal_camera_adaptor_get_format_info()` function accepts
+/// an `info_size` parameter for forward-compatible struct growth.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HalCameraAdaptorFormatInfo {
+    /// Number of input channels (e.g., 4 for RGBA).
+    pub input_channels: c_int,
+    /// Number of output channels (e.g., 3 for RGB).
+    pub output_channels: c_int,
+    /// V4L2 FourCC string, NUL-terminated.
+    pub fourcc: [u8; 8],
+}
+
+impl Default for HalCameraAdaptorFormatInfo {
+    fn default() -> Self {
+        // SAFETY: All-zero is a valid empty state for this POD struct.
+        unsafe { std::mem::zeroed() }
+    }
+}

--- a/crates/capi/tests/Makefile
+++ b/crates/capi/tests/Makefile
@@ -82,6 +82,9 @@ TEST_TRACKER := $(BUILD_DIR)/test_tracker
 # Benchmark executables
 BENCH_PREPROC := $(BUILD_DIR)/bench_preproc
 
+# On-target Neutron DMA-BUF regression test (requires live delegate + model)
+TEST_NEUTRON_DMABUF := $(BUILD_DIR)/test_neutron_dmabuf
+
 # Default target
 .PHONY: all
 all: $(TEST_ALL)
@@ -123,6 +126,16 @@ $(TEST_TRACKER): $(BUILD_DIR)/test_tracker_standalone.o
 # Benchmark executable (standalone, does not use test_common.h)
 $(BENCH_PREPROC): bench_preproc.c | $(BUILD_DIR) check-lib
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LIBS)
+
+# On-target Neutron DMA-BUF regression test (standalone, requires TFLite + delegate)
+$(TEST_NEUTRON_DMABUF): test_neutron_dmabuf.c | $(BUILD_DIR) check-lib
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LIBS) -ldl
+
+# Build on-target Neutron DMA-BUF test
+.PHONY: test_neutron_dmabuf
+test_neutron_dmabuf: $(TEST_NEUTRON_DMABUF)
+	@echo "Built $(TEST_NEUTRON_DMABUF)"
+	@echo "Run on target: NEUTRON_ENABLE_ZERO_COPY=1 $(TEST_NEUTRON_DMABUF) <model.tflite>"
 
 # Run preprocessing benchmark
 .PHONY: bench

--- a/crates/capi/tests/test_neutron_dmabuf.c
+++ b/crates/capi/tests/test_neutron_dmabuf.c
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+//
+// Standalone test for GPU rendering into Neutron NPU DMA-BUF tensor.
+//
+// Compile on target:
+//   gcc -std=c11 -Wall -Wextra -Wno-comment -o test_neutron_dmabuf \
+//       test_neutron_dmabuf.c -I../include -ledgefirst_hal -ldl -lm
+//
+// Run:
+//   NEUTRON_ENABLE_ZERO_COPY=1 ./test_neutron_dmabuf /path/to/model.imx95.tflite
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+#include <edgefirst/hal.h>
+
+// ── TFLite C API (minimal dlsym-loaded subset) ─────────────────────────
+typedef struct TfLiteModel TfLiteModel;
+typedef struct TfLiteInterpreterOptions TfLiteInterpreterOptions;
+typedef struct TfLiteInterpreter TfLiteInterpreter;
+typedef struct TfLiteDelegate TfLiteDelegate;
+typedef struct TfLiteTensor TfLiteTensor;
+typedef enum { kTfLiteOk = 0, kTfLiteError = 1 } TfLiteStatus;
+
+typedef TfLiteModel *(*ModelCreate_fn)(const char *);
+typedef void (*ModelDelete_fn)(TfLiteModel *);
+typedef TfLiteInterpreterOptions *(*OptionsCreate_fn)(void);
+typedef void (*OptionsDelete_fn)(TfLiteInterpreterOptions *);
+typedef void (*OptionsAddDelegate_fn)(TfLiteInterpreterOptions *, TfLiteDelegate *);
+typedef TfLiteInterpreter *(*InterpreterCreate_fn)(const TfLiteModel *, const TfLiteInterpreterOptions *);
+typedef void (*InterpreterDelete_fn)(TfLiteInterpreter *);
+typedef TfLiteStatus (*AllocateTensors_fn)(TfLiteInterpreter *);
+typedef int (*GetInputCount_fn)(const TfLiteInterpreter *);
+typedef const TfLiteTensor *(*GetInputTensor_fn)(const TfLiteInterpreter *, int);
+typedef int (*TensorNumDims_fn)(const TfLiteTensor *);
+typedef int (*TensorDim_fn)(const TfLiteTensor *, int);
+typedef size_t (*TensorByteSize_fn)(const TfLiteTensor *);
+typedef void *(*ExtDelegateCreate_fn)(const void *);
+typedef void (*ExtDelegateDelete_fn)(void *);
+
+// HAL delegate symbols
+typedef int (*hal_is_supported_fn)(void *);
+typedef void *(*hal_get_instance_fn)(void);
+typedef int (*hal_get_info_fn)(void *, int, hal_dmabuf_tensor_info *, size_t);
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+#define FAIL(fmt, ...) do { fprintf(stderr, "FAIL: " fmt "\n", ##__VA_ARGS__); exit(1); } while (0)
+#define INFO(fmt, ...) fprintf(stderr, "INFO: " fmt "\n", ##__VA_ARGS__)
+
+static void *must_dlsym(void *h, const char *name) {
+    void *s = dlsym(h, name);
+    if (!s) FAIL("dlsym(%s): %s", name, dlerror());
+    return s;
+}
+
+static const char *fmt_name(enum hal_pixel_format f) {
+    switch (f) {
+        case HAL_PIXEL_FORMAT_NV12: return "NV12";
+        case HAL_PIXEL_FORMAT_RGBA: return "RGBA";
+        case HAL_PIXEL_FORMAT_BGRA: return "BGRA";
+        case HAL_PIXEL_FORMAT_RGB: return "RGB";
+        case HAL_PIXEL_FORMAT_GREY: return "GREY";
+        case HAL_PIXEL_FORMAT_PLANAR_RGB: return "PlanarRGB";
+        default: return "?";
+    }
+}
+
+static const char *dtype_name(enum hal_dtype d) {
+    switch (d) {
+        case HAL_DTYPE_U8: return "U8";
+        case HAL_DTYPE_I8: return "I8";
+        default: return "?";
+    }
+}
+
+static const char *backend_name(enum hal_compute_backend b) {
+    switch (b) {
+        case HAL_COMPUTE_BACKEND_AUTO: return "AUTO";
+        case HAL_COMPUTE_BACKEND_OPENGL: return "GL";
+        case HAL_COMPUTE_BACKEND_G2D: return "G2D";
+        case HAL_COMPUTE_BACKEND_CPU: return "CPU";
+        default: return "?";
+    }
+}
+
+// ── Single test: import fd at offset, convert with specified backend ────
+
+static int test_convert(int neutron_fd, size_t offset,
+                        int dst_w, int dst_h,
+                        enum hal_pixel_format src_fmt, int src_w, int src_h,
+                        enum hal_pixel_format dst_fmt, enum hal_dtype dst_dtype,
+                        enum hal_compute_backend backend,
+                        const char *label)
+{
+    fprintf(stderr, "\n  %-50s  ", label);
+
+    struct hal_image_processor *proc = hal_image_processor_new_with_backend(backend);
+    if (!proc) { fprintf(stderr, "SKIP (no %s backend)\n", backend_name(backend)); return 0; }
+
+    // Source: HAL-allocated
+    struct hal_tensor *src = hal_image_processor_create_image(proc,
+        src_w, src_h, src_fmt, HAL_DTYPE_U8);
+    if (!src) {
+        fprintf(stderr, "SKIP (src alloc failed)\n");
+        hal_image_processor_free(proc);
+        return 0;
+    }
+
+    // Destination: Neutron fd
+    struct hal_plane_descriptor *pd = hal_plane_descriptor_new(neutron_fd);
+    if (!pd) { fprintf(stderr, "FAIL (pd_new)\n"); hal_tensor_free(src); hal_image_processor_free(proc); return -1; }
+    if (offset > 0)
+        hal_plane_descriptor_set_offset(pd, offset);
+
+    struct hal_tensor *dst = hal_import_image(proc, pd, NULL,
+        dst_w, dst_h, dst_fmt, dst_dtype);
+    if (!dst) {
+        fprintf(stderr, "FAIL (import errno=%d: %s)\n", errno, strerror(errno));
+        hal_tensor_free(src);
+        hal_image_processor_free(proc);
+        return -1;
+    }
+
+    struct hal_crop crop = hal_crop_new();
+    int rc = hal_image_processor_convert(proc, src, dst,
+        HAL_ROTATION_NONE, HAL_FLIP_NONE, &crop);
+
+    if (rc == 0)
+        fprintf(stderr, "PASS (%s)\n", backend_name(backend));
+    else
+        fprintf(stderr, "FAIL (convert rc=%d)\n", rc);
+
+    hal_tensor_free(dst);
+    hal_tensor_free(src);
+    hal_image_processor_free(proc);
+    return rc;
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "Usage: NEUTRON_ENABLE_ZERO_COPY=1 %s <model.tflite> [delegate.so]\n", argv[0]);
+        return 1;
+    }
+    const char *model_path = argv[1];
+    const char *delegate_path = argc > 2 ? argv[2] : "libneutron_delegate.so";
+
+    hal_log_init_file(stderr, HAL_LOG_LEVEL_WARN);
+
+    // ── Load TFLite + delegate + model ──────────────────────────────────
+    const char *libs[] = { "libtensorflow-lite.so", "libtensorflow-lite.so.2.19.0", NULL };
+    void *tfl = NULL;
+    for (int i = 0; libs[i]; i++) { tfl = dlopen(libs[i], RTLD_LAZY); if (tfl) break; }
+    if (!tfl) FAIL("Cannot load TFLite: %s", dlerror());
+
+    void *dlg_h = dlopen(delegate_path, RTLD_LAZY);
+    if (!dlg_h) FAIL("Cannot load delegate: %s", dlerror());
+
+    ModelCreate_fn ModelCreate = must_dlsym(tfl, "TfLiteModelCreateFromFile");
+    ModelDelete_fn ModelDelete = must_dlsym(tfl, "TfLiteModelDelete");
+    OptionsCreate_fn OptionsCreate = must_dlsym(tfl, "TfLiteInterpreterOptionsCreate");
+    OptionsDelete_fn OptionsDelete = must_dlsym(tfl, "TfLiteInterpreterOptionsDelete");
+    OptionsAddDelegate_fn AddDelegate = must_dlsym(tfl, "TfLiteInterpreterOptionsAddDelegate");
+    InterpreterCreate_fn InterpCreate = must_dlsym(tfl, "TfLiteInterpreterCreate");
+    InterpreterDelete_fn InterpDelete = must_dlsym(tfl, "TfLiteInterpreterDelete");
+    AllocateTensors_fn Alloc = must_dlsym(tfl, "TfLiteInterpreterAllocateTensors");
+    GetInputCount_fn InCount = must_dlsym(tfl, "TfLiteInterpreterGetInputTensorCount");
+    GetInputTensor_fn InTensor = must_dlsym(tfl, "TfLiteInterpreterGetInputTensor");
+    TensorNumDims_fn NDims = must_dlsym(tfl, "TfLiteTensorNumDims");
+    TensorDim_fn Dim = must_dlsym(tfl, "TfLiteTensorDim");
+    TensorByteSize_fn ByteSize = must_dlsym(tfl, "TfLiteTensorByteSize");
+    ExtDelegateCreate_fn ExtCreate = must_dlsym(tfl, "TfLiteExternalDelegateCreate");
+    ExtDelegateDelete_fn ExtDelete = dlsym(tfl, "TfLiteExternalDelegateDelete");
+
+    struct { const char *path; int count; const char **keys; const char **values; } opts =
+        { delegate_path, 0, NULL, NULL };
+    TfLiteDelegate *delegate = (TfLiteDelegate *)ExtCreate(&opts);
+    if (!delegate) FAIL("ExtDelegateCreate failed");
+
+    TfLiteModel *model = ModelCreate(model_path);
+    if (!model) FAIL("ModelCreate(%s) failed", model_path);
+    TfLiteInterpreterOptions *options = OptionsCreate();
+    AddDelegate(options, delegate);
+    TfLiteInterpreter *interp = InterpCreate(model, options);
+    if (!interp) FAIL("InterpreterCreate failed");
+    if (Alloc(interp) != kTfLiteOk) FAIL("AllocateTensors failed");
+
+    int n = InCount(interp);
+    INFO("Model: %s (%d inputs)", model_path, n);
+    for (int i = 0; i < n; i++) {
+        const TfLiteTensor *t = InTensor(interp, i);
+        int nd = NDims(t);
+        fprintf(stderr, "  input[%d]: %zu bytes [", i, ByteSize(t));
+        for (int d = 0; d < nd; d++) fprintf(stderr, "%s%d", d?",":"", Dim(t, d));
+        fprintf(stderr, "]\n");
+    }
+
+    // ── Probe HAL delegate ──────────────────────────────────────────────
+    hal_get_instance_fn get_inst = dlsym(dlg_h, "hal_dmabuf_get_instance");
+    hal_is_supported_fn is_sup = dlsym(dlg_h, "hal_dmabuf_is_supported");
+    hal_get_info_fn get_info = dlsym(dlg_h, "hal_dmabuf_get_tensor_info");
+    if (!get_inst || !is_sup || !get_info) FAIL("HAL delegate symbols not found");
+
+    void *hal_dlg = get_inst();
+    if (!hal_dlg) FAIL("get_instance() returned NULL");
+    if (!is_sup(hal_dlg)) FAIL("is_supported()=0 — set NEUTRON_ENABLE_ZERO_COPY=1");
+
+    hal_dmabuf_tensor_info info = {};
+    if (get_info(hal_dlg, 0, &info, sizeof(info)) != 0)
+        FAIL("get_tensor_info(0) failed");
+    INFO("Neutron input: fd=%d offset=%zu size=%zu\n", info.fd, info.offset, info.size);
+
+    int pass = 0, fail = 0, skip = 0;
+
+    // ══════════════════════════════════════════════════════════════════
+    // SECTION 1: Neutron fd WITH offset — U8 formats only (no I8 post-proc)
+    // ══════════════════════════════════════════════════════════════════
+    fprintf(stderr, "═══ SECTION 1: Neutron fd=%d offset=%zu — U8 formats ═══\n", info.fd, info.offset);
+
+    struct { enum hal_pixel_format sfmt; int sw; int sh;
+             enum hal_pixel_format dfmt; enum hal_dtype ddt; int dw; int dh;
+             enum hal_compute_backend be; const char *label; } sec1[] = {
+        // AUTO backend (fallback chain)
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_AUTO, "NV12→RGBA U8 AUTO" },
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_RGB,  HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_AUTO, "NV12→RGB U8 AUTO" },
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_BGRA, HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_AUTO, "NV12→BGRA U8 AUTO" },
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_GREY, HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_AUTO, "NV12→GREY U8 AUTO" },
+        // Force GL
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_OPENGL, "NV12→RGBA U8 GL-only" },
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_RGB,  HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_OPENGL, "NV12→RGB U8 GL-only" },
+        // Force G2D
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_G2D, "NV12→RGBA U8 G2D-only" },
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_RGB,  HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_G2D, "NV12→RGB U8 G2D-only" },
+        // Different src formats
+        { HAL_PIXEL_FORMAT_RGBA, 640, 640,   HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_AUTO, "RGBA→RGBA U8 (passthrough)" },
+        { HAL_PIXEL_FORMAT_RGBA, 640, 640,   HAL_PIXEL_FORMAT_RGB,  HAL_DTYPE_U8, 640, 640, HAL_COMPUTE_BACKEND_AUTO, "RGBA→RGB U8" },
+        // Smaller destination
+        { HAL_PIXEL_FORMAT_NV12, 1920, 1080, HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, 320, 320, HAL_COMPUTE_BACKEND_AUTO, "NV12→RGBA U8 320x320" },
+    };
+    for (int i = 0; i < (int)(sizeof(sec1)/sizeof(sec1[0])); i++) {
+        int rc = test_convert(info.fd, info.offset,
+            sec1[i].dw, sec1[i].dh, sec1[i].sfmt, sec1[i].sw, sec1[i].sh,
+            sec1[i].dfmt, sec1[i].ddt, sec1[i].be, sec1[i].label);
+        if (rc == 0) pass++; else if (rc < 0) fail++; else skip++;
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // SECTION 2: Neutron fd WITH offset — I8 formats (tests int8 path)
+    // ══════════════════════════════════════════════════════════════════
+    fprintf(stderr, "\n═══ SECTION 2: Neutron fd=%d offset=%zu — I8 formats ═══\n", info.fd, info.offset);
+
+    struct { enum hal_pixel_format dfmt; enum hal_compute_backend be; const char *label; } sec2[] = {
+        { HAL_PIXEL_FORMAT_RGB,  HAL_COMPUTE_BACKEND_AUTO,   "NV12→RGB I8 AUTO" },
+        { HAL_PIXEL_FORMAT_RGBA, HAL_COMPUTE_BACKEND_AUTO,   "NV12→RGBA I8 AUTO" },
+        { HAL_PIXEL_FORMAT_RGB,  HAL_COMPUTE_BACKEND_OPENGL, "NV12→RGB I8 GL-only" },
+        { HAL_PIXEL_FORMAT_RGB,  HAL_COMPUTE_BACKEND_G2D,    "NV12→RGB I8 G2D-only" },
+        { HAL_PIXEL_FORMAT_RGBA, HAL_COMPUTE_BACKEND_G2D,    "NV12→RGBA I8 G2D-only" },
+    };
+    for (int i = 0; i < (int)(sizeof(sec2)/sizeof(sec2[0])); i++) {
+        int rc = test_convert(info.fd, info.offset,
+            640, 640, HAL_PIXEL_FORMAT_NV12, 1920, 1080,
+            sec2[i].dfmt, HAL_DTYPE_I8, sec2[i].be, sec2[i].label);
+        if (rc == 0) pass++; else if (rc < 0) fail++; else skip++;
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // SECTION 3: Neutron fd WITHOUT offset (offset=0)
+    // ══════════════════════════════════════════════════════════════════
+    fprintf(stderr, "\n═══ SECTION 3: Neutron fd=%d offset=0 ═══\n", info.fd);
+
+    struct { enum hal_pixel_format dfmt; enum hal_dtype ddt;
+             enum hal_compute_backend be; const char *label; } sec3[] = {
+        { HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, HAL_COMPUTE_BACKEND_AUTO,   "NV12→RGBA U8 offset=0 AUTO" },
+        { HAL_PIXEL_FORMAT_RGB,  HAL_DTYPE_U8, HAL_COMPUTE_BACKEND_AUTO,   "NV12→RGB U8 offset=0 AUTO" },
+        { HAL_PIXEL_FORMAT_RGB,  HAL_DTYPE_I8, HAL_COMPUTE_BACKEND_AUTO,   "NV12→RGB I8 offset=0 AUTO" },
+        { HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, HAL_COMPUTE_BACKEND_OPENGL, "NV12→RGBA U8 offset=0 GL-only" },
+        { HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, HAL_COMPUTE_BACKEND_G2D,    "NV12→RGBA U8 offset=0 G2D-only" },
+    };
+    for (int i = 0; i < (int)(sizeof(sec3)/sizeof(sec3[0])); i++) {
+        int rc = test_convert(info.fd, 0,
+            640, 640, HAL_PIXEL_FORMAT_NV12, 1920, 1080,
+            sec3[i].dfmt, sec3[i].ddt, sec3[i].be, sec3[i].label);
+        if (rc == 0) pass++; else if (rc < 0) fail++; else skip++;
+    }
+
+    // ══════════════════════════════════════════════════════════════════
+    // SECTION 4: HAL-allocated reference (dma_heap, no Neutron fd)
+    // ══════════════════════════════════════════════════════════════════
+    fprintf(stderr, "\n═══ SECTION 4: HAL-allocated dma_heap reference ═══\n");
+
+    struct { enum hal_pixel_format dfmt; enum hal_dtype ddt;
+             enum hal_compute_backend be; const char *label; } sec4[] = {
+        { HAL_PIXEL_FORMAT_RGB,  HAL_DTYPE_I8, HAL_COMPUTE_BACKEND_AUTO,   "NV12→RGB I8 (dma_heap) AUTO" },
+        { HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, HAL_COMPUTE_BACKEND_AUTO,   "NV12→RGBA U8 (dma_heap) AUTO" },
+        { HAL_PIXEL_FORMAT_RGB,  HAL_DTYPE_U8, HAL_COMPUTE_BACKEND_OPENGL, "NV12→RGB U8 (dma_heap) GL-only" },
+        { HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, HAL_COMPUTE_BACKEND_G2D,    "NV12→RGBA U8 (dma_heap) G2D-only" },
+    };
+    for (int i = 0; i < (int)(sizeof(sec4)/sizeof(sec4[0])); i++) {
+        fprintf(stderr, "\n  %-50s  ", sec4[i].label);
+        struct hal_image_processor *p = hal_image_processor_new_with_backend(sec4[i].be);
+        if (!p) { fprintf(stderr, "SKIP (no %s)\n", backend_name(sec4[i].be)); skip++; continue; }
+        struct hal_tensor *s = hal_image_processor_create_image(p, 1920, 1080, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+        struct hal_tensor *d = hal_image_processor_create_image(p, 640, 640, sec4[i].dfmt, sec4[i].ddt);
+        if (!s || !d) { fprintf(stderr, "SKIP (alloc)\n"); skip++; }
+        else {
+            struct hal_crop c = hal_crop_new();
+            int rc = hal_image_processor_convert(p, s, d, HAL_ROTATION_NONE, HAL_FLIP_NONE, &c);
+            if (rc == 0) { fprintf(stderr, "PASS (%s)\n", backend_name(sec4[i].be)); pass++; }
+            else { fprintf(stderr, "FAIL (rc=%d)\n", rc); fail++; }
+        }
+        if (d) hal_tensor_free(d);
+        if (s) hal_tensor_free(s);
+        hal_image_processor_free(p);
+    }
+
+    // ── Summary ─────────────────────────────────────────────────────────
+    fprintf(stderr, "\n══════════════════════════════════════════════════\n");
+    fprintf(stderr, "SUMMARY: %d passed, %d failed, %d skipped\n", pass, fail, skip);
+    fprintf(stderr, "══════════════════════════════════════════════════\n");
+
+    InterpDelete(interp); OptionsDelete(options); ModelDelete(model);
+    if (ExtDelete) ExtDelete(delegate);
+    return fail > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Adds `hal_camera_adaptor_format_info` struct to the C ABI and Rust delegate module, exposing input/output channel counts and V4L2 FourCC for camera format adaptors
- Defines `hal_camera_adaptor_is_supported()` and `hal_camera_adaptor_get_format_info()` ABI contracts (query-only, loaded via `dlsym`)
- Adds `HAL_FOURCC_MAX_LEN` constant and cbindgen exports for the new type
- Expands ARCHITECTURE.md with the camera adaptor section, errno requirements table, symbol visibility rules, and `hal_dmabuf_get_instance()` contract

Linked JIRA: [EDGEAI-1189](https://au-zone.atlassian.net/browse/EDGEAI-1189)

## Test plan

- [ ] Cross-compile for `aarch64-unknown-linux-gnu` with `cargo-zigbuild` — no errors
- [ ] `make format lint` passes
- [ ] `make sbom` passes (license compliance clean)
- [ ] Verify generated `hal.h` contains `hal_camera_adaptor_format_info` struct and `HAL_FOURCC_MAX_LEN` via cbindgen
- [ ] On-target: confirm delegate implementing the new symbols loads correctly via `dlsym`

[EDGEAI-1189]: https://au-zone.atlassian.net/browse/EDGEAI-1189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ