### PR TITLE
EDGEAI-1218 Documentation refresh and low-risk code fixes for 0.14.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -642,7 +642,9 @@ See [README.md § Benchmarking](../README.md#benchmarking) for full instructions
 | `tensor_benchmark` | `edgefirst-tensor` | Allocation and map/unmap latency (Heap, SHM, DMA) |
 | `pipeline_benchmark` | `edgefirst-image` | Letterbox pipeline and format conversion |
 | `mask_benchmark` | `edgefirst-image` | Mask rendering paths (GL, CPU, hybrid) |
+| `image_benchmark` | `edgefirst-image` | JPEG loading, convert, and resize operations |
 | `decoder_benchmark` | `edgefirst-decoder` | YOLO post-processing, NMS, dequantization |
+| `opencv_benchmark` | `edgefirst-image` | Cross-library comparison (requires `--features opencv`) |
 
 **Key env vars:** `EDGEFIRST_FORCE_BACKEND={cpu,opengl,g2d}`, `EDGEFIRST_FORCE_TRANSFER=pbo`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # EdgeFirst Hardware Abstraction Layer - Architecture
 
-**Version:** 2.9
-**Last Updated:** March 23, 2026
+**Version:** 3.0
+**Last Updated:** March 2026
 **Status:** Production
 **Audience:** Developers contributing to EdgeFirst HAL or integrating it into applications
 
@@ -343,6 +343,29 @@ The OpenGL processor selects a transfer backend at initialization time:
 
 The `PboOps` trait bridges the tensor crate and the GL thread: `PboTensor` holds a `WeakSender` to the GL thread channel. When the tensor needs to map/unmap/delete the PBO, it sends a message through this channel. The weak sender ensures PBO tensors don't prevent GL thread shutdown.
 
+**GLES 3.1 Context and Compute Shader Path**:
+
+At context creation time, the GL thread attempts to create a GLES 3.1 context
+first. If the driver does not support GLES 3.1, it falls back to GLES 3.0:
+
+```
+Try GLES 3.1  →  success: compute shaders available
+              →  failure: fall back to GLES 3.0 (no compute shaders)
+```
+
+When a GLES 3.1 context is active, an opt-in compute shader path is available for
+HWC→CHW proto tensor repack. Enable it by setting `EDGEFIRST_PROTO_COMPUTE=1`
+before launching the process:
+
+```sh
+EDGEFIRST_PROTO_COMPUTE=1 ./my_app
+```
+
+The compute shader performs the HWC→CHW layout transpose of the proto tensor on
+the GPU using an SSBO, avoiding a CPU-side copy. If compilation fails at runtime,
+the implementation logs a warning and falls back to the CPU repack path
+transparently — no API changes are required.
+
 **Why PBO matters**: On desktop Linux with NVIDIA GPUs, DMA-buf allocation
 succeeds (via `/dev/dma_heap/system`) but the NVIDIA EGL driver cannot import
 those buffers — the `verify_dma_buf_roundtrip()` check catches this at
@@ -447,6 +470,22 @@ changes are required from callers.
   - Mixed data type support (different types per input tensor)
 - **ModelPack** (Au-Zone proprietary format)
   - Detection with anchor-based decoding
+
+**`YoloSegDet2Way` Model Type**:
+
+TFLite INT8 segmentation models exported with 3 separate output tensors use the
+`YoloSegDet2Way` model type. The builder auto-selects this variant when 3 outputs
+are detected matching the expected shapes:
+
+| Tensor | Shape | Content |
+|--------|-------|---------|
+| detection | `[1, nc+4, N]` | Combined boxes and class scores |
+| mask_coeff | `[1, 32, N]` | Per-detection mask coefficients |
+| protos | `[1, H/4, W/4, 32]` | Prototype masks |
+
+This differs from the standard `YoloSegDet` variant (which combines boxes and
+mask coefficients into a single tensor). The builder auto-selects `YoloSegDet2Way`
+when the output count and shapes match the 3-tensor layout.
 
 **YOLO26 End-to-End Support**:
 
@@ -561,6 +600,39 @@ The HAL provides two workflows for consuming these masks:
 |----------|--------|------|---|:---:|:------:|:---:|
 | **Draw** — fused overlay onto image | `processor.draw_masks()` | `draw_proto_masks()` | `hal_image_processor_draw_masks()` | Yes | Yes | No |
 | **Draw pre-decoded** — draw already-decoded masks | `processor.draw_decoded_masks()` | `draw_decoded_masks()` | `hal_image_processor_draw_decoded_masks()` | Yes | Yes | No |
+| **Draw with tracking** — decode, track, and draw in one call | `processor.draw_masks_tracked()` | `draw_masks_tracked()` | `hal_image_processor_draw_masks_tracked()` | Yes | Yes | No |
+
+**`MaskOverlay` Parameters**:
+
+The `draw_decoded_masks` and `draw_proto_masks` methods (and `draw_masks_tracked`)
+accept a `MaskOverlay<'_>` struct controlling compositing behaviour:
+
+```rust
+pub struct MaskOverlay<'a> {
+    pub background: Option<&'a TensorDyn>,  // blit this image into dst before drawing masks
+    pub opacity: f32,                        // scale mask alpha; 1.0 = fully opaque
+}
+```
+
+Use the builder API to construct it:
+
+```rust
+// Default: no background blit, full opacity
+let overlay = MaskOverlay::default();
+
+// With a background frame and reduced opacity
+let overlay = MaskOverlay::new()
+    .with_background(&bg_tensor)
+    .with_opacity(0.7);
+```
+
+`draw_masks_tracked` combines decoding, tracking, and mask rendering in a single
+call, returning `(Vec<DetectBox>, Vec<TrackInfo>)`:
+
+```rust
+let (boxes, tracks) = processor.draw_masks_tracked(
+    &decoder, &mut tracker, timestamp, &outputs, &mut dst, overlay)?;
+```
 
 > **G2D limitation:** The NXP G2D hardware accelerator does not support mask
 > rendering. On platforms where G2D is the primary image processor (e.g.
@@ -726,10 +798,12 @@ The `edgefirst_image` crate depends on `edgefirst_decoder` for the `DetectBox`, 
 | File | Lines | Scope |
 |------|------:|-------|
 | `tensor.rs` | ~1,200 | Tensor create, map, reshape, fd sharing |
-| `image.rs` | ~1,800 | ImageProcessor, convert, draw |
-| `decoder.rs` | ~2,800 | Decoder create, decode detection/segmentation |
+| `image.rs` | ~2,600 | ImageProcessor, convert, draw |
+| `decoder.rs` | ~3,200 | Decoder create, decode detection/segmentation |
 | `tracker.rs` | ~300 | ByteTrack create, update |
 | `error.rs` | ~120 | Error handling utilities |
+| `delegate.rs` | ~200 | Delegate DMA-BUF ABI types and camera adaptor format info |
+| `log.rs` | ~50 | C-side logging configuration |
 
 ### 7. G2D FFI (`g2d-sys`)
 
@@ -759,7 +833,7 @@ use edgefirst_tensor::{PixelFormat, DType, TensorDyn};
 let bytes = std::fs::read("testdata/zidane.jpg")?;
 let input = load_image(&bytes, Some(PixelFormat::Rgb), None)?;
 
-// Create converter (auto-selects best backend: G2D, OpenGL, CPU)
+// Create converter (auto-selects best backend: OpenGL, G2D, CPU)
 let mut converter = ImageProcessor::new()?;
 
 // Create output buffer with optimal GPU memory (DMA > PBO > Mem)
@@ -772,18 +846,21 @@ converter.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default
 ### Pattern 2: Detection Decoding
 
 ```rust
-use edgefirst_hal::decoder::Decoder;
-use std::collections::HashMap;
+use edgefirst_decoder::{Decoder, DetectBox, Segmentation};
+use edgefirst_tensor::TensorDyn;
 
-// Build decoder from configuration dictionary/JSON
-let config: HashMap<String, serde_json::Value> = 
-    serde_json::from_str(&config_json)?;
+// Build decoder from JSON configuration
+let decoder = DecoderBuilder::new()
+    .with_config_json_str(&config_json)?
+    .with_score_threshold(0.5)
+    .with_iou_threshold(0.45)
+    .build()?;
 
-let decoder = Decoder::new(config, 0.5, 0.45)?;  // score_thresh, iou_thresh
-
-// Decode model outputs (supports mixed types per tensor)
-let outputs = vec![boxes_tensor, scores_tensor];
-let (bboxes, scores, classes) = decoder.decode_detection(&outputs)?;
+// Decode model outputs into pre-allocated output vectors
+let mut output_boxes: Vec<DetectBox> = Vec::new();
+let mut output_masks: Vec<Segmentation> = Vec::new();
+let outputs: Vec<&TensorDyn> = vec![&boxes_tensor, &scores_tensor];
+decoder.decode(&outputs, &mut output_boxes, &mut output_masks)?;
 ```
 
 **Python Example**:
@@ -1586,7 +1663,7 @@ Several modules are significantly larger than typical Rust modules:
 | `image/src/gl/processor.rs` | ~4,600 | GPU rendering pipelines (convert, masks, atlas) |
 | `decoder/src/decoder/` (total) | ~7,000 | Config parsing, decode logic, postprocessing, tests |
 | `image/src/lib.rs` | ~5,500 | load_image, save_jpeg, ImageProcessor |
-| `capi/src/decoder.rs` | ~2,800 | C API decoder bindings |
+| `capi/src/decoder.rs` | ~3,200 | C API decoder bindings |
 
 ---
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,8 +1,8 @@
 # EdgeFirst HAL - Benchmarks
 
-**Version:** 2.1
-**Last Updated:** March 23, 2026
-**Status:** Added C API preprocessing benchmark (`bench_preproc`) results for i.MX 95, i.MX 8MP, and x86 desktop; added tensor reuse impact analysis with quantified EGL cache penalties
+**Version:** 2.2
+**Last Updated:** March 27, 2026
+**Status:** Added date stamps to all benchmark sections; added image_benchmark to binary table; noted pending YoloSegDet2Way data; noted pending mask rendering optimization updates
 
 ---
 
@@ -110,6 +110,17 @@ All benchmarks use the `edgefirst-bench` custom harness which:
 
 See [README.md § Benchmarking](README.md#benchmarking) for full instructions on running benchmarks locally, cross-compiling for aarch64, and deploying to target platforms.
 
+### Benchmark Binaries
+
+| Binary | Crate | What It Measures |
+|--------|-------|-----------------|
+| `tensor_benchmark` | `edgefirst-tensor` | Tensor allocation and map/unmap latency across buffer types (Heap, SHM, DMA) |
+| `image_benchmark` | `edgefirst-image` | JPEG loading, format convert, resize operations across buffer backends |
+| `pipeline_benchmark` | `edgefirst-image` | Letterbox pipeline and format conversion (camera→model input) |
+| `mask_benchmark` | `edgefirst-image` | Mask rendering: draw_decoded_masks, draw_proto_masks, hybrid path |
+| `opencv_benchmark` | `edgefirst-image` | OpenCV baseline comparison for same operations |
+| `decoder_benchmark` | `edgefirst-decoder` | YOLO detection/segmentation post-processing, NMS, dequantization |
+
 JSON files are collected in `benchmarks/<platform>/` and processed by `.github/scripts/generate_benchmark_tables.py` to produce the tables in this document.
 
 ---
@@ -205,6 +216,8 @@ JSON files are collected in `benchmarks/<platform>/` and processed by `.github/s
 ## Benchmark Results
 
 ### Buffer Infrastructure
+
+**Data collected:** March 20, 2026
 
 #### Allocation Latency
 
@@ -350,6 +363,8 @@ The most critical benchmark: simulates a real camera-to-model preprocessing pipe
 
 ### Format Conversion (Same Size, No Resize)
 
+**Data collected:** March 20, 2026
+
 **1080p → 1080p:**
 
 | Platform | Compute | Buffer | YUYV→RGBA | YUYV→RGB | NV12→RGBA | RGB→RGBA | RGBA→BGRA | RGBA→GREY |
@@ -367,7 +382,11 @@ The most critical benchmark: simulates a real camera-to-model preprocessing pipe
 
 ### Decoder Post-Processing
 
+**Data collected:** March 20, 2026
+
 All CPU-only (decoder is not GPU-accelerated).
+
+> **Note:** `YoloSegDet2Way` (two-way split segmentation decoder) benchmark data is pending. Results will be added once the decoder is exercised on all target platforms.
 
 **YOLOv8 Detection (84×8400, 80 classes):**
 
@@ -396,6 +415,10 @@ All CPU-only (decoder is not GPU-accelerated).
 | x86-desktop | f32 | 850 us |
 
 ### Mask Rendering
+
+**Data collected:** March 20, 2026
+
+> **Note:** Numbers in this section will be updated after the upcoming release ships the fused dequant+matmul kernel and other mask rendering optimizations. Current figures reflect pre-optimization baselines.
 
 **640×640 RGBA destination, ~2 detections (YOLOv8n-seg):**
 
@@ -635,6 +658,7 @@ The binary requires a DMA-heap device (`/dev/dma_heap/linux,cma` or `/dev/dma_he
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2.2 | 2026-03-27 | Add collection date stamps to all benchmark result sections; add image_benchmark to benchmark binary table; note pending YoloSegDet2Way benchmark data in decoder section; note pending mask rendering optimization updates |
 | 2.1 | 2026-03-23 | Add C API preprocessing benchmark (`bench_preproc`) results for i.MX 95-EVK (Mali), i.MX 8MP EVK-06 (Vivante), and x86 desktop (GTX 1080 PBO); add tensor reuse impact analysis (3.3× penalty on i.MX 95, 1.7× on i.MX 8MP, negligible on PBO); document buffer pool validation |
 | 2.0 | 2026-03-20 | TensorDyn unification: auto-backend priority changed to OpenGL→G2D→CPU; always use two-pass packed RGB (rgb_direct removed); added per-platform forced-backend comparison tables at 720p; added u8/i8 DType benchmark variants; replaced 8BPi with 8BPS_i8 naming |
 | 1.5 | 2026-03-18 | Remove stale Known Issue #3 (EDGEFIRST_FORCE_TRANSFER=pbo now implemented); documentation accuracy updates |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`HalCameraAdaptorFormatInfo`** (EDGEAI-1189) — new struct added to the
+  camera adaptor delegate ABI that describes a camera adaptor's channel
+  mapping and V4L2 FourCC code: `input_channels` (`int`),
+  `output_channels` (`int`), and `fourcc` (`char[8]`, NUL-terminated V4L2
+  FourCC string, at most 4 bytes + NUL). Populated by the delegate's
+  `hal_camera_adaptor_get_format_info()` callback.
+
 - **YOLO-SEG 2-way split decoder** (`ModelType::YoloSegDet2Way`) — supports
   TFLite INT8 segmentation models with 3 outputs: a combined detection tensor
   `[1, nc+4, N]` (boxes + scores), a separate mask-coefficient tensor
   `[1, 32, N]`, and a prototype-mask tensor `[1, H/4, W/4, 32]`.  The
   builder auto-selects this variant when `Detection` + `MaskCoefficients` +
   `Protos` outputs are provided.  Supported in all decode paths (float,
-  quantized, and proto variants).
+  quantized, and proto variants), including all tracked decode paths
+  (`decode_tracked_quantized`, `decode_tracked_float`,
+  `decode_tracked_quantized_proto`, `decode_tracked_float_proto`, and the
+  public `decode_tracked` / `decode_proto_tracked` wrappers).
 
 - **`MaskOverlay` compositing options** for `draw_decoded_masks()` and
   `draw_proto_masks()` — new `overlay` parameter with two controls:
@@ -418,6 +428,15 @@ shows before/after code for each one.
 - **Dual Python wheel builds** (`abi3-py311` and `abi3-py38`). Python 3.11+
   users get zero-copy buffer protocol support; Python 3.8–3.10 users get a
   compatible fallback. Pip automatically selects the best wheel
+
+- **C logging API** (`hal_log_init_file`, `hal_log_init_callback`) —
+  two new C functions for initialising HAL logging from C/C++ callers.
+  `hal_log_init_file(FILE*, HalLogLevel)` writes formatted log lines to a
+  `FILE*` (typically `stderr`).
+  `hal_log_init_callback(HalLogCallback, void*, HalLogLevel)` routes
+  each log record to a user-supplied callback, enabling integration with
+  GStreamer, syslog, or other logging frameworks. Only the first call per
+  process takes effect; subsequent calls return `-1` with `errno = EALREADY`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ graph TB
         CAPI --> Tracker
 
         Image --> Tensor
+        Image --> Decoder
         Image --> G2D["G2D FFI (g2d-sys)<br/>NXP i.MX hardware acceleration"]
     end
 
@@ -547,6 +548,7 @@ let (bboxes, scores, classes) = decoder.decode_detection(&outputs)?;
 ### Multi-Frame Tracking
 
 ```rust
+// Requires: edgefirst-hal = { version = "0.13", features = ["tracker"] }
 use edgefirst_hal::tracker::{ByteTrack, Tracker, DetectionBox};
 
 let mut tracker = ByteTrack::default();
@@ -575,6 +577,21 @@ let fd = tensor.clone_fd()?;
 
 // Process B recreates tensor from fd
 let shared_tensor = Tensor::<u8>::from_fd(fd, &[1920, 1080, 3], None)?;
+```
+
+### Zero-Copy Import of External DMA-BUF
+
+```rust
+use edgefirst_image::{ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
+use edgefirst_tensor::{PixelFormat, DType, PlaneDescriptor};
+
+// Render directly into a DMA-BUF buffer owned by the NPU delegate.
+// No memcpy between HAL output and the delegate's input buffer.
+let mut processor = ImageProcessor::new()?;
+let pd = PlaneDescriptor::new(vx_fd.as_fd())?;  // dups fd — caller keeps ownership
+let mut dst = processor.import_image(pd, None, 640, 640, PixelFormat::Rgb, DType::U8)?;
+processor.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())?;
+// dst's backing memory IS vx_fd — no memcpy needed
 ```
 
 </details>
@@ -615,6 +632,30 @@ decoder = edgefirst_hal.Decoder(config_dict, 0.5, 0.45)
 
 # Decode outputs (accepts List[Tensor]; automatically handles quantization)
 boxes, scores, classes, masks = decoder.decode([output0, output1])
+```
+
+### Tracked Segmentation
+
+```python
+import time
+import edgefirst_hal as ef
+
+converter = ef.ImageProcessor()
+decoder = ef.Decoder(config_dict, 0.5, 0.45)
+tracker = ef.ByteTrack()
+
+dst = converter.create_image(640, 640, ef.PixelFormat.Rgb)
+
+for frame in video_frames:
+    converter.convert(frame, dst)
+    outputs = run_inference(dst)
+
+    # Draw segmentation masks with stable per-track colours.
+    # timestamp must be monotonic nanoseconds for correct track expiry.
+    converter.draw_masks(
+        decoder, outputs, dst,
+        tracker=tracker, timestamp=time.monotonic_ns()
+    )
 ```
 
 </details>
@@ -707,7 +748,7 @@ Consistent error handling throughout:
 
 ## Build System
 
-- **Workspace**: Cargo workspace with 7 crates
+- **Workspace**: Cargo workspace with 9 crates (tensor, image, decoder, tracker, hal, capi, python, bench, gpu-probe)
 - **Build Scripts**: Custom build.rs for PyO3 configuration
 - **Features**: Conditional compilation for hardware features
 - **Profiles**: Release, profiling, and debug profiles
@@ -728,6 +769,21 @@ pip install target/wheels/edgefirst_hal-*.whl
 ```
 
 **Note**: `maturin` is the recommended and standard way to build PyO3 Python extensions. It handles the complex linking requirements between Python and Rust automatically.
+
+## Environment Variables
+
+The HAL respects the following environment variables at runtime:
+
+| Variable | Description |
+|----------|-------------|
+| `EDGEFIRST_TENSOR_FORCE_MEM` | Set to `1` to force heap memory (disables DMA/SHM) |
+| `EDGEFIRST_DISABLE_G2D` | Disable G2D backend |
+| `EDGEFIRST_DISABLE_GL` | Disable OpenGL backend |
+| `EDGEFIRST_DISABLE_CPU` | Disable CPU backend |
+| `EDGEFIRST_FORCE_BACKEND` | Force a single backend: `cpu`, `g2d`, or `opengl`. Disables fallback chain. |
+| `EDGEFIRST_FORCE_TRANSFER` | Force GPU transfer method: `pbo` or `dmabuf` |
+| `EDGEFIRST_OPENGL_RENDERSURFACE` | Set to `1` to enable EGL renderbuffer path for non-dma_heap DMA-BUF buffers (i.MX 95 Neutron NPU) |
+| `EDGEFIRST_PROTO_COMPUTE` | Set to `1` to enable GLES 3.1 compute shader for HWC-to-CHW proto repack |
 
 ## Testing
 
@@ -813,7 +869,7 @@ cargo-zigbuild build --target aarch64-unknown-linux-gnu --release \
 
 ### Deploying to Targets
 
-SSH hostnames are configured in `~/.ssh/config`: `imx8mp-frdm`, `imx95-frdm`, `rpi5-hailo`
+SSH hostnames are configured in `~/.ssh/config`: `imx8mp-frdm`, `imx95-frdm`, `rpi5-hailo`, `jetson-orin-nano`, `maivin`
 
 ```bash
 # Copy benchmark binary to target
@@ -873,8 +929,11 @@ graph TD
     Python --> PyO3
     Python --> Numpy
     
-    Tracker[tracker<br/>standalone]
-    
+    Tracker[tracker<br/>optional]
+
+    Image -.->|tracker feature| Tracker
+    Decoder -.->|tracker feature| Tracker
+
     style EF fill:#fff4e1
     style Python fill:#e1f5ff
     style Tracker fill:#e8f5e9
@@ -944,4 +1003,4 @@ For security vulnerabilities, please see [SECURITY.md](SECURITY.md) or email sup
 
 Apache License 2.0 - see [LICENSE](LICENSE) for details.
 
-Copyright 2025 Au-Zone Technologies
+Copyright 2025-2026 Au-Zone Technologies

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,333 @@
+# EdgeFirst HAL - Testing Guide
+
+**Version:** 1.0
+**Last Updated:** March 2026
+**Status:** Production
+**Audience:** Developers contributing to EdgeFirst HAL or running tests on target hardware
+
+---
+
+## Overview
+
+This guide consolidates all testing information for the EdgeFirst HAL project. Testing spans five categories: Rust unit tests, Python integration tests, C API integration tests, GL hardware-gated tests, and on-target tests. All categories share a single constraint: tests must run single-threaded.
+
+---
+
+## Quick Reference
+
+| Makefile Target  | What It Does                                              |
+|------------------|-----------------------------------------------------------|
+| `make test`      | Run all tests (Rust + Python) with coverage               |
+| `make test-rust` | Run Rust tests only with `cargo-llvm-cov nextest`         |
+| `make test-python` | Run Python tests only with pytest (and slipcover if available) |
+| `make bench`     | Run Rust criterion benchmarks                             |
+| `make build`     | Build with coverage instrumentation (profiling profile)   |
+
+C API tests are built and run separately from `crates/capi/tests/` using their own Makefile.
+
+---
+
+## Required Toolchain
+
+The following tools must be installed before running tests:
+
+| Tool | Required | Purpose |
+|------|----------|---------|
+| `cargo-nextest` | Yes | Fast Rust test runner; used by `make test-rust` |
+| `cargo-llvm-cov` | Yes | Coverage instrumentation; required by `make test-rust` |
+| `maturin` | Yes | Build Python bindings before running Python tests |
+| `psutil` | Optional | Python dependency for some test helpers |
+| `slipcover` | Optional | Python branch coverage; `make test-python` falls back to plain pytest when absent |
+
+Install the mandatory tools:
+
+```bash
+cargo install cargo-nextest
+cargo install cargo-llvm-cov --locked
+pip install maturin
+```
+
+Install `slipcover` into the local virtual environment for coverage reports:
+
+```bash
+source venv/bin/activate
+pip install slipcover
+```
+
+---
+
+## Test Categories
+
+### Rust Unit Tests
+
+Rust tests are co-located with source code in `#[cfg(test)]` modules:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_data_valid_input() {
+        // test implementation
+    }
+}
+```
+
+Tests live in every crate under `crates/`: `tensor`, `image`, `decoder`, `tracker`, `hal`, `capi`, `gpu-probe`. The `edgefirst_hal` Python crate is excluded from most test runs because it requires a live Python interpreter.
+
+### Python Integration Tests
+
+Python tests are located in `tests/` and use pytest:
+
+```
+tests/
+├── test_tensor.py
+├── image/
+│   ├── test_image.py
+│   └── test_image_perf.py
+└── decoder/
+    └── test_decoder.py
+```
+
+Python tests require the bindings to be built with `maturin develop` before running. Some tests use `pytest.mark.skipif` to gate platform-specific paths (e.g., DMA-BUF tests require `sys.platform == "linux"`). Benchmark tests use `pytest.mark.benchmark` with `warmup_iterations=3`.
+
+### C API Integration Tests
+
+C integration tests live in `crates/capi/tests/` and are built by their own Makefile. The test suite covers tensor, image, decoder, and tracker APIs:
+
+| Source File | Coverage Area |
+|-------------|---------------|
+| `test_tensor.c` | Tensor allocation, DMA-BUF, memory types |
+| `test_image.c` | Image loading, format conversion |
+| `test_decoder.c` | YOLO decoder, post-processing |
+| `test_tracker.c` | Object tracking API |
+| `test_neutron_dmabuf.c` | On-target Neutron NPU DMA-BUF regression |
+| `bench_preproc.c` | C preprocessing benchmark |
+
+Build and run:
+
+```bash
+# First build the C library
+cargo build --release -p edgefirst-hal-capi
+
+# Then build and run the C tests
+cd crates/capi/tests
+make test
+
+# Individual test suites
+make test_tensor
+make test_image
+make test_decoder
+make test_tracker
+
+# Memory check
+make valgrind
+```
+
+The Neutron DMA-BUF regression test (`test_neutron_dmabuf`) requires a live TFLite delegate and model; it must be run on target hardware with `NEUTRON_ENABLE_ZERO_COPY=1`.
+
+### GL Hardware-Gated Tests
+
+OpenGL and G2D tests inside `crates/image/src/gl/tests.rs` use `OnceLock<bool>` to probe hardware availability once and skip if the hardware is absent:
+
+```rust
+static GL_AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+fn is_opengl_available() -> bool {
+    *GL_AVAILABLE.get_or_init(|| GLProcessorThreaded::new(None).is_ok())
+}
+```
+
+A test that requires OpenGL calls `is_opengl_available()` at the start and returns early when it returns `false`. This keeps the test suite green on developer machines without GPU hardware, while exercising the full hardware path on target boards and CI runners with GPU access.
+
+The Neutron-scenario tests gate on `/dev/neutron0` as a platform discriminator for i.MX 95 with Mali GPU. This device node indicates that large-offset DMA-BUF EGLImage imports are supported — these fail with `EGL(BadAccess)` on Vivante (i.MX 8MP) even without the NPU driver:
+
+```rust
+fn is_neutron_available() -> bool {
+    *NEUTRON_AVAILABLE.get_or_init(|| std::path::Path::new("/dev/neutron0").exists())
+}
+```
+
+### On-Target Tests
+
+Tests that exercise DMA-heap or G2D acceleration require target hardware. They are automatically skipped on development machines when the required devices are absent.
+
+| Device Node | What It Gates |
+|-------------|---------------|
+| `/dev/dma_heap/linux,cma` or `/dev/dma_heap/system` | DMA-BUF tensor allocation tests |
+| `/dev/galcore` | G2D hardware acceleration tests |
+| `/dev/neutron0` | Neutron NPU DMA-BUF EGLImage tests |
+| `/dev/dri/renderD128` | DRM render node; required for DMA-buf backend |
+
+---
+
+## Single-Threaded Execution
+
+**All tests must run single-threaded.** This is a hard requirement, not a recommendation.
+
+Use `--test-threads=1` with `cargo test` and `-j 1` with `cargo nextest`. The Makefile enforces this automatically via `cargo llvm-cov nextest ... -j 1`.
+
+### Why Single-Threaded
+
+Three independent constraints each independently require single-threaded execution:
+
+1. **EGL display sharing**: When multiple tests run in parallel threads within one process, `eglTerminate` on one thread can tear down a shared EGL display while other threads still reference it. This causes intermittent failures that are difficult to reproduce and platform-dependent.
+
+2. **G2D driver state**: The `galcore` kernel driver maintains per-process state that is not safe to access from concurrent threads creating and destroying G2D contexts.
+
+3. **DMA-heap CMA pool exhaustion**: Concurrent DMA-heap allocations from multiple test threads can exhaust the CMA pool on memory-constrained embedded targets, causing allocation failures that mask the real test failures.
+
+`cargo nextest` already provides per-test process isolation, but `-j 1` is still required to prevent DMA and GPU contention across test processes.
+
+This constraint applies to CI (`test.yml`), the Makefile, and local development. See ARCHITECTURE.md section "Testing with GPU Resources" for the full technical rationale.
+
+---
+
+## Running Tests Locally
+
+### Native Development (x86_64)
+
+```bash
+# 1. Run the full test suite (Rust + Python) with coverage
+make test
+
+# 2. Run Rust tests only
+make test-rust
+
+# 3. Run Python tests only
+make test-python
+
+# 4. Run Rust tests manually with nextest
+cargo nextest run --workspace --exclude edgefirst_hal -j 1
+
+# 5. Run tests for a specific crate
+cargo test -p edgefirst_image -- --test-threads=1
+cargo test -p edgefirst_decoder -- --test-threads=1
+cargo test -p edgefirst_tensor -- --test-threads=1
+```
+
+### Python Test Setup
+
+Python tests require the native bindings to be installed into the virtual environment:
+
+```bash
+# 1. Activate the virtual environment
+source venv/bin/activate
+
+# 2. Build and install the Python bindings in development mode
+maturin develop -m crates/python/Cargo.toml
+
+# 3. Run tests
+python -m pytest tests/
+
+# 4. Run a specific test module
+python -m pytest tests/image/test_image.py
+python -m pytest tests/decoder/test_decoder.py
+
+# 5. Run with coverage (if slipcover is installed)
+python -m slipcover --xml --out target/python-coverage.xml -m pytest tests/
+```
+
+### Disabling Hardware Backends
+
+Use environment variables to isolate tests to specific backends:
+
+| Variable | Effect |
+|----------|--------|
+| `EDGEFIRST_TENSOR_FORCE_MEM=1` | Force heap (`MemTensor`) allocation; skips DMA-heap and shared memory |
+| `EDGEFIRST_FORCE_BACKEND=cpu` | Force CPU-only image processing |
+| `EDGEFIRST_FORCE_BACKEND=opengl` | Force OpenGL backend |
+| `EDGEFIRST_FORCE_BACKEND=g2d` | Force G2D backend |
+| `EDGEFIRST_DISABLE_GL=1` | Disable OpenGL even when hardware is present |
+| `EDGEFIRST_DISABLE_G2D=1` | Disable G2D even when hardware is present |
+
+Example — run tests without any GPU backend:
+
+```bash
+EDGEFIRST_DISABLE_GL=1 EDGEFIRST_DISABLE_G2D=1 cargo test --workspace -- --test-threads=1
+```
+
+---
+
+## Cross-Compilation and On-Target Testing
+
+The project primarily targets ARM64 embedded Linux (NXP i.MX 8M Plus, i.MX 95). Tests that exercise DMA or GPU acceleration must run on physical hardware.
+
+### Step 1: Cross-Compile Tests
+
+Use `cargo-zigbuild` to produce test binaries without running them. Exclude the Python crate because PyO3 requires a target Python installation:
+
+```bash
+cargo-zigbuild test --target aarch64-unknown-linux-gnu --release --no-run \
+    --workspace --exclude edgefirst_hal
+```
+
+Test binaries are written to `target/aarch64-unknown-linux-gnu/release/deps/`.
+
+### Step 2: Copy Binaries to Target
+
+```bash
+# Copy test binaries (the hash suffix varies per build)
+scp target/aarch64-unknown-linux-gnu/release/deps/edgefirst_image-* user@target:/tmp/hal-tests/
+scp target/aarch64-unknown-linux-gnu/release/deps/edgefirst_tensor-* user@target:/tmp/hal-tests/
+scp target/aarch64-unknown-linux-gnu/release/deps/edgefirst_decoder-* user@target:/tmp/hal-tests/
+
+# Also copy test data
+scp -r testdata/ user@target:/tmp/hal-tests/
+```
+
+### Step 3: Run Tests on Target
+
+```bash
+ssh user@target 'cd /tmp/hal-tests && ./edgefirst_image-<hash> --test-threads=1'
+```
+
+The `--test-threads=1` flag is mandatory on target hardware for the same reasons as local development — the CMA pool exhaustion risk is higher on embedded boards with limited memory.
+
+---
+
+## Coverage Thresholds
+
+| Scope | Minimum Threshold |
+|-------|-------------------|
+| Overall workspace | 70% line coverage |
+| Critical paths (tensor ops, decoder, image processing hot paths) | 90% line coverage |
+
+Coverage is collected using `cargo-llvm-cov` for Rust and `slipcover` for Python. Both generate LCOV reports that are merged and reported to SonarCloud.
+
+Coverage reports:
+- Rust: `target/rust-coverage.lcov`
+- Python: `target/python-coverage.xml`
+
+CI enforces coverage gating on pull requests. A failing coverage check blocks the merge.
+
+---
+
+## CI/CD Test Matrix
+
+Tests run across multiple runner types:
+
+| Job | Runner | Architecture | Hardware |
+|-----|--------|--------------|----------|
+| Build & Test (x86_64) | ubuntu-22.04 | x86_64 | No GPU |
+| Build & Test (macOS) | macos-latest | x86_64/arm64 | No GPU |
+| Build (aarch64) | ubuntu-22.04-arm-xlarge | aarch64 | No GPU (compile only) |
+| Test (aarch64) | ubuntu-22.04-arm | aarch64 | No GPU |
+| Hardware Test (imx8mp) | nxp-imx8mp-latest | aarch64 | G2D, DMA-heap |
+
+The hardware runner (`nxp-imx8mp-latest`) is the only environment where G2D and DMA-BUF tests are fully exercised. Hardware-gated tests that return early on the x86 and arm runners are counted as passed (not skipped) because the gate is an explicit probe, not a `#[ignore]` attribute.
+
+---
+
+## Common Failures and Remedies
+
+| Symptom | Likely Cause | Remedy |
+|---------|--------------|--------|
+| Intermittent EGL segfault | Tests running in parallel | Ensure `--test-threads=1` / `-j 1` |
+| `DMA-heap allocation failed` on target | CMA pool exhaustion from parallel tests | Reduce parallelism; use `-j 1` |
+| `cargo-nextest not found` | Tool not installed | `cargo install cargo-nextest` |
+| `cargo-llvm-cov not found` | Tool not installed | `cargo install cargo-llvm-cov --locked` |
+| Python tests fail with `ModuleNotFoundError` | Bindings not built | `maturin develop -m crates/python/Cargo.toml` |
+| C API tests fail with `libedgefirst_hal.so not found` | C library not built | `cargo build --release -p edgefirst-hal-capi` |
+| GL tests all skip | No EGL display available | Expected on headless CI; set `DISPLAY` or use a virtual framebuffer |

--- a/crates/capi/README.md
+++ b/crates/capi/README.md
@@ -135,6 +135,263 @@ Check `errno` after any failure for the specific error code (e.g. `EINVAL`,
   for DMA tensors)
 - All `_free()` functions accept `NULL` safely (no-op)
 
+## Logging API
+
+HAL logging is off by default. Initialise it once per process before any other
+HAL calls:
+
+```c
+#include <edgefirst/hal.h>
+#include <stdio.h>
+
+// Option 1: write [LEVEL] target: message lines to a FILE*
+hal_log_init_file(stderr, HAL_LOG_LEVEL_DEBUG);
+
+// Option 2: forward each record to a custom callback
+void my_logger(hal_log_level level, const char *target,
+               const char *message, void *userdata) {
+    fprintf(stderr, "[%d] %s: %s\n", level, target, message);
+}
+hal_log_init_callback(my_logger, NULL, HAL_LOG_LEVEL_INFO);
+```
+
+Only the first successful call takes effect; subsequent calls return `-1` with
+`errno = EALREADY`. Available log levels: `HAL_LOG_LEVEL_ERROR`,
+`HAL_LOG_LEVEL_WARN`, `HAL_LOG_LEVEL_INFO`, `HAL_LOG_LEVEL_DEBUG`,
+`HAL_LOG_LEVEL_TRACE`.
+
+## Zero-Copy Buffer Import
+
+`hal_import_image()` wraps an externally-allocated DMA-BUF (e.g. from a V4L2
+camera or video decoder) as a HAL tensor without copying:
+
+```c
+#include <edgefirst/hal.h>
+
+// Create the image processor
+struct hal_image_processor *proc = hal_image_processor_new();
+
+// Single-plane (e.g. RGBA from a camera)
+struct hal_plane_descriptor *pd = hal_plane_descriptor_new(dmabuf_fd);
+hal_plane_descriptor_set_stride(pd, bytesperline); // optional, for padded rows
+struct hal_tensor *src = hal_import_image(
+    proc, pd, NULL, 1920, 1080, HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8);
+// pd is consumed by hal_import_image — do NOT call hal_plane_descriptor_free()
+
+// Multi-plane NV12 (Y + UV planes on separate fds)
+struct hal_plane_descriptor *y_pd  = hal_plane_descriptor_new(y_fd);
+struct hal_plane_descriptor *uv_pd = hal_plane_descriptor_new(uv_fd);
+struct hal_tensor *nv12 = hal_import_image(
+    proc, y_pd, uv_pd, 1920, 1080, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+
+// Use src with hal_image_processor_convert() or hal_image_processor_draw_masks()
+hal_tensor_free(src);
+hal_tensor_free(nv12);
+hal_image_processor_free(proc);
+```
+
+**Lifecycle rules:**
+- `hal_plane_descriptor_new(fd)` dups the fd immediately; the caller keeps the
+  original.
+- `hal_plane_descriptor_set_stride(pd, stride)` and
+  `hal_plane_descriptor_set_offset(pd, offset)` configure the plane before
+  import.
+- `hal_import_image()` **always consumes** both plane descriptors (even on
+  error). Never call `hal_plane_descriptor_free()` on a descriptor passed to
+  `hal_import_image()`.
+- Linux only (`ENOTSUP` on other platforms).
+
+## Object Tracking
+
+ByteTrack multi-object tracking assigns stable UUID identities to detections
+across frames:
+
+```c
+#include <edgefirst/hal.h>
+#include <stdio.h>
+
+// Create a tracker (custom parameters)
+struct hal_bytetrack *tracker = hal_bytetrack_new(
+    0.25f,  // track_update: smoothness threshold
+    0.70f,  // high_thresh:  high-confidence detection threshold
+    0.25f,  // match_thresh: IOU matching threshold
+    30,     // frame_rate:   expected fps
+    60      // track_buffer: frames to hold lost tracks
+);
+// Or use defaults (track_update=0.25, high_thresh=0.7, match_thresh=0.25,
+//                  track_extra_lifespan=500ms)
+// struct hal_bytetrack *tracker = hal_bytetrack_new_default();
+
+// Each frame: update with decoded detections
+uint64_t timestamp_ns = ...; // monotonic nanoseconds
+struct hal_track_info_list *tracks =
+    hal_bytetrack_update(tracker, detect_box_list, timestamp_ns);
+
+size_t n = hal_track_info_list_len(tracks);
+for (size_t i = 0; i < n; i++) {
+    struct hal_track_info info;
+    hal_track_info_list_get(tracks, i, &info);
+
+    char uuid_str[37];
+    hal_uuid_to_string(&info.uuid, uuid_str, sizeof(uuid_str));
+    printf("track %s  box=[%.1f,%.1f,%.1f,%.1f]  count=%d\n",
+           uuid_str,
+           info.location[0], info.location[1],
+           info.location[2], info.location[3],
+           info.count);
+}
+hal_track_info_list_free(tracks);
+
+// Query currently active tracks without updating
+struct hal_track_info_list *active = hal_bytetrack_get_active_tracks(tracker);
+hal_track_info_list_free(active);
+
+hal_bytetrack_free(tracker);
+```
+
+`hal_track_info` fields:
+| Field | Type | Description |
+|-------|------|-------------|
+| `uuid` | `uint8_t[16]` | 128-bit track identity (RFC 4122) |
+| `location` | `float[4]` | Predicted box in XYXY format |
+| `count` | `int32_t` | Number of times this track has been updated |
+| `created` | `uint64_t` | Nanosecond timestamp when track was first created |
+| `last_updated` | `uint64_t` | Nanosecond timestamp of last update |
+
+## Mask Rendering
+
+Draw segmentation masks (and detection boxes) directly onto an output image:
+
+```c
+#include <edgefirst/hal.h>
+
+struct hal_detect_box_list *boxes = NULL;
+
+// Fused decode + render (no tracker)
+int rc = hal_image_processor_draw_masks(
+    processor,
+    decoder,
+    outputs,      // const struct hal_tensor **
+    num_outputs,
+    dst,          // destination image tensor
+    NULL,         // background (NULL = draw over dst)
+    0.6f,         // opacity [0.0, 1.0]
+    &boxes
+);
+
+// Fused decode + render + tracking
+struct hal_track_info_list *tracks = NULL;
+rc = hal_image_processor_draw_masks_tracked(
+    processor,
+    decoder,
+    tracker,
+    timestamp_ns,
+    outputs,
+    num_outputs,
+    dst,
+    NULL,         // background (NULL = draw over dst)
+    0.6f,         // opacity
+    &boxes,
+    &tracks       // may be NULL if track output not needed
+);
+
+hal_detect_box_list_free(boxes);
+hal_track_info_list_free(tracks); // safe no-op if NULL
+```
+
+- `background`: optional source image to composite masks onto before writing to
+  `dst`. Must not alias `dst`.
+- `opacity`: clamped to `[0.0, 1.0]`; `1.0` = fully opaque masks.
+- `out_boxes` is always populated; `out_tracks` in the tracked variant may be
+  `NULL` if track output is not required.
+
+## Tensor Extensions
+
+### Attaching pixel format metadata
+
+Tensors created from a raw DMA-BUF fd (via `hal_tensor_from_fd()`) carry no
+image metadata. Use `hal_tensor_set_format()` to attach a pixel format so they
+can be passed to image-processing functions:
+
+```c
+// Tensor shape [height, width, channels] — created from a DMA-BUF fd
+size_t shape[] = {1080, 1920, 3};
+struct hal_tensor *t = hal_tensor_from_fd(fd, HAL_DTYPE_U8, shape, 3, "rgb");
+hal_tensor_set_format(t, HAL_PIXEL_FORMAT_RGB);
+
+// Now hal_tensor_width(), hal_tensor_height(), hal_tensor_row_stride() work
+size_t w      = hal_tensor_width(t);
+size_t h      = hal_tensor_height(t);
+size_t stride = hal_tensor_row_stride(t); // explicit or computed
+```
+
+`hal_tensor_row_stride()` returns the stride set by
+`hal_plane_descriptor_set_stride()` if one was recorded, otherwise computes
+the minimum packed stride from the format, width, and element size.
+
+### Cloning a DMA-BUF file descriptor
+
+`hal_tensor_dmabuf_clone()` clones the DMA-BUF fd backing a tensor and returns
+a clear `ENOTSUP` error for non-DMA-backed tensors (Mem, Shm), unlike
+`hal_tensor_clone_fd()` which returns a generic I/O error in that case:
+
+```c
+int dmabuf_fd = hal_tensor_dmabuf_clone(tensor);
+if (dmabuf_fd < 0) {
+    if (errno == ENOTSUP)
+        fprintf(stderr, "tensor is not DMA-backed\n");
+    else
+        perror("dmabuf clone failed");
+} else {
+    // use dmabuf_fd for zero-copy hardware import, then:
+    close(dmabuf_fd);
+}
+```
+
+Linux only (`ENOTSUP` on other platforms).
+
+## Delegate DMA-BUF API
+
+The delegate DMA-BUF framework defines the ABI contract that external NPU
+delegates (e.g. NXP Neutron, VxDelegate) use to expose DMA-BUF tensor
+information and camera format negotiation to the HAL.
+
+These are **type definitions owned by the HAL**; the function implementations
+live in the delegate shared libraries. Each delegate ships a
+`hal_dmabuf.h` header that uses these types.
+
+### `HalDmabufTensorInfo`
+
+Describes a single delegate tensor's DMA-BUF allocation:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `size` | `size_t` | Buffer size in bytes |
+| `offset` | `size_t` | Byte offset within the DMA-BUF |
+| `shape` | `size_t[8]` | Tensor dimensions (up to `HAL_DMABUF_MAX_NDIM = 8`) |
+| `ndim` | `size_t` | Number of valid entries in `shape` |
+| `fd` | `int` | DMA-BUF file descriptor — **borrowed, do not close** |
+| `dtype` | `hal_dtype` | Element data type |
+
+The struct must be zero-initialised with `memset(info, 0, info_size)` before
+passing to the delegate's `hal_dmabuf_get_tensor_info()`. The `info_size`
+parameter allows the struct to grow in future versions without breaking ABI.
+Total size: 96 bytes on LP64.
+
+### `HalCameraAdaptorFormatInfo`
+
+Describes the channel mapping and V4L2 FourCC code for a camera format adaptor:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `input_channels` | `int` | Number of input channels (e.g. 4 for RGBA) |
+| `output_channels` | `int` | Number of output channels (e.g. 3 for RGB) |
+| `fourcc` | `char[8]` | NUL-terminated V4L2 FourCC string |
+
+Used by consumers to negotiate upstream formats without requiring
+vendor-specific symbols. Populated by the delegate's
+`hal_camera_adaptor_get_format_info()`.
+
 ## API Reference
 
 The full API is documented with Doxygen comments in

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -62,7 +62,7 @@ typedef void *hal_delegate_t;
 #define HAL_DMABUF_MAX_NDIM 8
 
 /**
- * Maximum length of a FourCC string in [`HalCameraAdaptorFormatInfo`].
+ * Maximum length of a FourCC string in hal_camera_adaptor_format_info.
  */
 #define HAL_FOURCC_MAX_LEN 8
 
@@ -790,9 +790,9 @@ typedef struct hal_camera_adaptor_format_info {
    */
   int output_channels;
   /**
-   * V4L2 FourCC string, NUL-terminated.
+   * V4L2 FourCC string, NUL-terminated (ASCII, at most 4 bytes + NUL).
    */
-  uint8_t fourcc[8];
+  char fourcc[HAL_FOURCC_MAX_LEN];
 } hal_camera_adaptor_format_info;
 
 /**

--- a/crates/decoder/Cargo.toml
+++ b/crates/decoder/Cargo.toml
@@ -20,7 +20,6 @@ tracker = ["dep:edgefirst-tracker"]
 argminmax = { workspace = true }
 edgefirst-tensor = { workspace = true }
 edgefirst-tracker = { workspace = true, optional = true }
-env_logger = { workspace = true }
 fast-math = { workspace = true }
 log = { workspace = true }
 ndarray = { workspace = true }
@@ -33,6 +32,7 @@ serde_yaml = { workspace = true }
 
 [dev-dependencies]
 edgefirst-bench = { workspace = true }
+env_logger = { workspace = true }
 image = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }

--- a/crates/decoder/README.md
+++ b/crates/decoder/README.md
@@ -151,6 +151,7 @@ The decoder automatically selects the appropriate model type based on the config
 |---------|---------|-------------|
 | `YoloDet` | 1 (detection) | Standard YOLO detection |
 | `YoloSegDet` | 2 (detection + protos) | YOLO detection + segmentation |
+| `YoloSegDet2Way` | 3 (detection + mask_coefs + protos) | YOLO segmentation with 2-way split output |
 | `YoloSplitDet` | 2 (boxes + scores) | Split-output detection |
 | `YoloSplitSegDet` | 4 (boxes + scores + mask_coeff + protos) | Split-output segmentation |
 | `YoloEndToEndDet` | 1 (detection) | End-to-end detection (post-NMS) |
@@ -162,6 +163,106 @@ The decoder automatically selects the appropriate model type based on the config
 | `ModelPackDetSplit` | N (detection layers) | ModelPack split detection |
 | `ModelPackSegDetSplit` | N+1 (detection layers + segmentation) | ModelPack split segmentation |
 | `ModelPackSeg` | 1 (segmentation) | ModelPack semantic segmentation |
+
+### YOLO-SEG 2-Way Split Format
+
+`YoloSegDet2Way` handles TFLite INT8 segmentation models that use a **2-way split** to separate mask coefficients from the combined detection output. Boxes and class scores remain merged — they share similar value ranges so splitting them yields no quantization benefit. Only mask coefficients (unbounded linear projection) need a separate quantization scale.
+
+#### Output Tensor Layout
+
+| Output | Name | Shape | Content |
+|--------|------|-------|---------|
+| `output0` | detection | `[1, nc+4, N]` | Boxes (4 channels) + class scores (nc channels), combined |
+| `output1` | protos | `[1, H/4, W/4, 32]` | Prototype masks (4D NHWC) |
+| `output2` | mask_coefs | `[1, 32, N]` | Mask coefficients per anchor |
+
+Where `N=8400` for 640×640 input (standard YOLO multi-scale anchors: 80×80 + 40×40 + 20×20).
+**COCO example** (nc=80): detection is `[1, 84, 8400]`, mask_coefs is `[1, 32, 8400]`, protos is `[1, 160, 160, 32]`.
+
+#### Output Identification by Shape
+
+The builder classifies the three outputs by shape alone:
+
+- **4D tensor** → protos (only protos are 4D)
+- **3D, feature_dim == 32** → mask_coefs
+- **3D, feature_dim != 32** → detection (nc+4 channels)
+
+The feature dimension is the smaller of the two non-batch dimensions (channels-first: `shape[1]`; channels-last: `shape[2]`).
+
+#### Edge Case: nc=28
+
+When `num_classes + 4 == 32`, the detection and mask_coefs feature dimensions collide, making shape-based classification ambiguous. In this case the split is **not performed** — the model exports 2 outputs (unsplit detection + protos) and is decoded as `YoloSegDet` instead.
+
+#### Auto-Selection
+
+The builder selects `YoloSegDet2Way` automatically when it detects exactly 3 outputs whose shapes match the pattern above (one 4D proto tensor, one 3D tensor with feature_dim=32, one 3D tensor with feature_dim≠32). No extra configuration is required.
+
+#### Backwards Compatibility
+
+Older 4-output models (separate boxes + scores + mask_coefs + protos, i.e., `YoloSplitSegDet`) remain supported. The decoder classifies by shape, not by output count.
+
+## Tracked Decoding
+
+The `tracker` feature adds `decode_tracked` to integrate object tracking directly into the decode step. Each decoded detection box is matched to a persistent track and assigned a stable UUID for the lifetime of the track.
+
+Enable the feature in `Cargo.toml`:
+
+```toml
+edgefirst-decoder = { version = "0.13", features = ["tracker"] }
+```
+
+### Usage
+
+```rust,ignore
+use edgefirst_decoder::{DecoderBuilder, DetectBox, Segmentation, TrackInfo};
+use edgefirst_decoder::Tracker; // re-exported from edgefirst-tracker
+use edgefirst_tracker::ByteTrackBuilder;
+
+let decoder = DecoderBuilder::new()
+    .with_score_threshold(0.25)
+    .with_iou_threshold(0.7)
+    .with_config_json_str(model_config_json)
+    .build()?;
+
+let mut tracker = ByteTrackBuilder::new()
+    .track_high_conf(0.5)
+    .track_update(0.1)
+    .build();
+
+let mut detections: Vec<DetectBox> = Vec::with_capacity(100);
+let mut masks: Vec<Segmentation> = Vec::with_capacity(100);
+let mut tracks: Vec<TrackInfo> = Vec::with_capacity(100);
+
+decoder.decode_tracked(
+    &mut tracker,
+    timestamp,          // u64 frame timestamp
+    &model_outputs,     // &[&TensorDyn]
+    &mut detections,
+    &mut masks,
+    &mut tracks,
+)?;
+
+// detections[i] and tracks[i] correspond to the same object
+for (det, track) in detections.iter().zip(tracks.iter()) {
+    println!(
+        "Track {} class {} score={:.2} at [{:.1}, {:.1}, {:.1}, {:.1}]",
+        track.uuid, det.label, det.score,
+        det.bbox.xmin, det.bbox.ymin, det.bbox.xmax, det.bbox.ymax,
+    );
+}
+```
+
+### TrackInfo Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `uuid` | `Uuid` | Stable unique identifier for the track |
+| `tracked_location` | `[f32; 4]` | Kalman-smoothed location in XYXY format |
+| `count` | `i32` | Number of times the track has been updated |
+| `created` | `u64` | Timestamp when the track was first created |
+| `last_updated` | `u64` | Timestamp of the most recent update |
+
+The `tracked_location` reflects the Kalman-filter prediction and may differ slightly from `det.bbox`, which is the raw decoded box before smoothing.
 
 ## License
 

--- a/crates/decoder/benches/decoder_benchmark.rs
+++ b/crates/decoder/benches/decoder_benchmark.rs
@@ -17,7 +17,7 @@ use edgefirst_decoder::{
 use ndarray::s;
 
 const WARMUP: usize = 10;
-const ITERATIONS: usize = 200;
+const ITERATIONS: usize = 100;
 
 fn bench_yolo_quant(suite: &mut BenchSuite) {
     let score_threshold = 0.25;

--- a/crates/decoder/src/decoder/configs.rs
+++ b/crates/decoder/src/decoder/configs.rs
@@ -363,21 +363,3 @@ pub enum ModelType {
         protos: Protos,
     },
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum DataType {
-    Raw = 0,
-    Int8 = 1,
-    UInt8 = 2,
-    Int16 = 3,
-    UInt16 = 4,
-    Float16 = 5,
-    Int32 = 6,
-    UInt32 = 7,
-    Float32 = 8,
-    Int64 = 9,
-    UInt64 = 10,
-    Float64 = 11,
-    String = 12,
-}

--- a/crates/decoder/src/modelpack.rs
+++ b/crates/decoder/src/modelpack.rs
@@ -153,8 +153,7 @@ pub fn decode_modelpack_split_float<D: AsPrimitive<f32>>(
 ///
 /// # Panics
 /// Panics if shapes don't match the expected dimensions.
-#[doc(hidden)]
-pub fn impl_modelpack_quant<
+pub(crate) fn impl_modelpack_quant<
     B: BBoxTypeTrait,
     BOX: PrimInt + AsPrimitive<f32> + Send + Sync,
     SCORE: PrimInt + AsPrimitive<f32> + Send + Sync,
@@ -170,7 +169,7 @@ pub fn impl_modelpack_quant<
     let (boxes_tensor, quant_boxes) = boxes;
     let (scores_tensor, quant_scores) = scores;
     let boxes = {
-        let score_threshold = quantize_score_threshold(score_threshold, quant_boxes);
+        let score_threshold = quantize_score_threshold(score_threshold, quant_scores);
         postprocess_boxes_quant::<B, _, _>(
             score_threshold,
             boxes_tensor,
@@ -194,8 +193,7 @@ pub fn impl_modelpack_quant<
 ///
 /// # Panics
 /// Panics if shapes don't match the expected dimensions.
-#[doc(hidden)]
-pub fn impl_modelpack_float<
+pub(crate) fn impl_modelpack_float<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Send + Sync,
     SCORE: Float + AsPrimitive<f32> + Send + Sync,
@@ -226,8 +224,7 @@ pub fn impl_modelpack_float<
 ///
 /// # Panics
 /// Panics if shapes don't match the expected dimensions.
-#[doc(hidden)]
-pub fn impl_modelpack_split_quant<B: BBoxTypeTrait, D: AsPrimitive<f32>>(
+pub(crate) fn impl_modelpack_split_quant<B: BBoxTypeTrait, D: AsPrimitive<f32>>(
     outputs: &[ArrayView3<D>],
     configs: &[ModelPackDetectionConfig],
     score_threshold: f32,
@@ -257,8 +254,7 @@ pub fn impl_modelpack_split_quant<B: BBoxTypeTrait, D: AsPrimitive<f32>>(
 ///
 /// # Panics
 /// Panics if shapes don't match the expected dimensions.
-#[doc(hidden)]
-pub fn impl_modelpack_split_float<B: BBoxTypeTrait, D: AsPrimitive<f32>>(
+pub(crate) fn impl_modelpack_split_float<B: BBoxTypeTrait, D: AsPrimitive<f32>>(
     outputs: &[ArrayView3<D>],
     configs: &[ModelPackDetectionConfig],
     score_threshold: f32,
@@ -282,8 +278,7 @@ pub fn impl_modelpack_split_float<B: BBoxTypeTrait, D: AsPrimitive<f32>>(
 /// Post processes ModelPack split detection into detection boxes,
 /// filtering out any boxes below the score threshold. Returns the boxes and
 /// scores tensors. Boxes are in XYWH format.
-#[doc(hidden)]
-pub fn postprocess_modelpack_split_quant<T: AsPrimitive<f32>>(
+pub(crate) fn postprocess_modelpack_split_quant<T: AsPrimitive<f32>>(
     outputs: &[ArrayView3<T>],
     config: &[ModelPackDetectionConfig],
 ) -> (Array2<f32>, Array2<f32>) {
@@ -379,8 +374,7 @@ pub fn postprocess_modelpack_split_quant<T: AsPrimitive<f32>>(
 /// Post processes ModelPack split detection into detection boxes,
 /// filtering out any boxes below the score threshold. Returns the boxes and
 /// scores tensors. Boxes are in XYWH format.
-#[doc(hidden)]
-pub fn postprocess_modelpack_split_float<T: AsPrimitive<f32>>(
+pub(crate) fn postprocess_modelpack_split_float<T: AsPrimitive<f32>>(
     outputs: &[ArrayView3<T>],
     config: &[ModelPackDetectionConfig],
 ) -> (Array2<f32>, Array2<f32>) {

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -586,7 +586,7 @@ pub(crate) fn postprocess_yolo_split_end_to_end_segdet<
 ///
 /// Expected shapes of inputs:
 /// - output: (4 + num_classes, num_boxes)
-pub fn impl_yolo_quant<B: BBoxTypeTrait, T: PrimInt + AsPrimitive<f32> + Send + Sync>(
+pub(crate) fn impl_yolo_quant<B: BBoxTypeTrait, T: PrimInt + AsPrimitive<f32> + Send + Sync>(
     output: (ArrayView2<T>, Quantization),
     score_threshold: f32,
     iou_threshold: f32,
@@ -620,7 +620,7 @@ pub fn impl_yolo_quant<B: BBoxTypeTrait, T: PrimInt + AsPrimitive<f32> + Send + 
 ///
 /// Expected shapes of inputs:
 /// - output: (4 + num_classes, num_boxes)
-pub fn impl_yolo_float<B: BBoxTypeTrait, T: Float + AsPrimitive<f32> + Send + Sync>(
+pub(crate) fn impl_yolo_float<B: BBoxTypeTrait, T: Float + AsPrimitive<f32> + Send + Sync>(
     output: ArrayView2<T>,
     score_threshold: f32,
     iou_threshold: f32,
@@ -649,7 +649,7 @@ pub fn impl_yolo_float<B: BBoxTypeTrait, T: Float + AsPrimitive<f32> + Send + Sy
 ///
 /// # Panics
 /// Panics if shapes don't match the expected dimensions.
-pub fn impl_yolo_split_quant<
+pub(crate) fn impl_yolo_split_quant<
     B: BBoxTypeTrait,
     BOX: PrimInt + AsPrimitive<f32> + Send + Sync,
     SCORE: PrimInt + AsPrimitive<f32> + Send + Sync,
@@ -695,7 +695,7 @@ pub fn impl_yolo_split_quant<
 ///
 /// # Panics
 /// Panics if shapes don't match the expected dimensions.
-pub fn impl_yolo_split_float<
+pub(crate) fn impl_yolo_split_float<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Send + Sync,
     SCORE: Float + AsPrimitive<f32> + Send + Sync,
@@ -730,7 +730,7 @@ pub fn impl_yolo_split_float<
 ///
 /// # Errors
 /// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
-pub fn impl_yolo_segdet_quant<
+pub(crate) fn impl_yolo_segdet_quant<
     B: BBoxTypeTrait,
     BOX: PrimInt + AsPrimitive<i64> + AsPrimitive<i128> + AsPrimitive<f32> + Send + Sync,
     PROTO: PrimInt + AsPrimitive<i64> + AsPrimitive<i128> + AsPrimitive<f32> + Send + Sync,
@@ -777,7 +777,7 @@ where
 ///
 /// # Panics
 /// Panics if shapes don't match the expected dimensions.
-pub fn impl_yolo_segdet_float<
+pub(crate) fn impl_yolo_segdet_float<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Send + Sync,
     PROTO: Float + AsPrimitive<f32> + Send + Sync,
@@ -795,7 +795,7 @@ where
 {
     let num_protos = protos.dim().2;
     let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes, num_protos);
-    let boxes = impl_yolo_segdet_get_boxes::<XYWH, _, _>(
+    let boxes = impl_yolo_segdet_get_boxes::<B, _, _>(
         boxes_tensor,
         scores_tensor,
         score_threshold,
@@ -958,7 +958,7 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
 ///
 /// # Errors
 /// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
-pub fn impl_yolo_split_segdet_quant<
+pub(crate) fn impl_yolo_split_segdet_quant<
     B: BBoxTypeTrait,
     BOX: PrimInt + AsPrimitive<f32> + Send + Sync,
     SCORE: PrimInt + AsPrimitive<f32> + Send + Sync,
@@ -1014,7 +1014,7 @@ where
 ///
 /// # Errors
 /// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
-pub fn impl_yolo_split_segdet_float<
+pub(crate) fn impl_yolo_split_segdet_float<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Send + Sync,
     SCORE: Float + AsPrimitive<f32> + Send + Sync,
@@ -1037,7 +1037,7 @@ where
     let (boxes_tensor, scores_tensor, mask_tensor) =
         postprocess_yolo_split_segdet(boxes_tensor, scores_tensor, mask_tensor);
 
-    let boxes = impl_yolo_segdet_get_boxes::<XYWH, _, _>(
+    let boxes = impl_yolo_segdet_get_boxes::<B, _, _>(
         boxes_tensor,
         scores_tensor,
         score_threshold,
@@ -1102,7 +1102,7 @@ where
 
 /// Proto-extraction variant of `impl_yolo_segdet_float`.
 /// Runs NMS but returns raw `ProtoData` instead of materialized masks.
-pub fn impl_yolo_segdet_float_proto<
+pub(crate) fn impl_yolo_segdet_float_proto<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Send + Sync,
     PROTO: Float + AsPrimitive<f32> + Send + Sync,
@@ -1120,7 +1120,7 @@ where
     let num_protos = protos.dim().2;
     let (boxes_tensor, scores_tensor, mask_tensor) = postprocess_yolo_seg(&boxes, num_protos);
 
-    let boxes = impl_yolo_segdet_get_boxes::<XYWH, _, _>(
+    let boxes = impl_yolo_segdet_get_boxes::<B, _, _>(
         boxes_tensor,
         scores_tensor,
         score_threshold,
@@ -1132,61 +1132,10 @@ where
     extract_proto_data_float(boxes, mask_tensor, protos, output_boxes)
 }
 
-/// Proto-extraction variant of `impl_yolo_split_segdet_quant`.
-/// Runs NMS but returns raw `ProtoData` instead of materialized masks.
-#[allow(clippy::too_many_arguments)]
-pub fn impl_yolo_split_segdet_quant_proto<
-    B: BBoxTypeTrait,
-    BOX: PrimInt + AsPrimitive<f32> + Send + Sync,
-    SCORE: PrimInt + AsPrimitive<f32> + Send + Sync,
-    MASK: PrimInt + AsPrimitive<f32> + Send + Sync,
-    PROTO: PrimInt + AsPrimitive<f32> + AsPrimitive<i8> + Send + Sync,
->(
-    boxes: (ArrayView2<BOX>, Quantization),
-    scores: (ArrayView2<SCORE>, Quantization),
-    mask_coeff: (ArrayView2<MASK>, Quantization),
-    protos: (ArrayView3<PROTO>, Quantization),
-    score_threshold: f32,
-    iou_threshold: f32,
-    nms: Option<Nms>,
-    output_boxes: &mut Vec<DetectBox>,
-) -> ProtoData
-where
-    f32: AsPrimitive<SCORE>,
-{
-    let (boxes_, scores_, mask_coeff_) =
-        postprocess_yolo_split_segdet(boxes.0, scores.0, mask_coeff.0);
-    let boxes = (boxes_, boxes.1);
-    let scores = (scores_, scores.1);
-    let mask_coeff = (mask_coeff_, mask_coeff.1);
-
-    let det_indices = impl_yolo_split_segdet_quant_get_boxes::<B, _, _>(
-        boxes,
-        scores,
-        score_threshold,
-        iou_threshold,
-        nms,
-        output_boxes.capacity(),
-    );
-
-    let (masks, quant_masks) = mask_coeff;
-    let masks = masks.reversed_axes();
-    let (protos_arr, quant_protos) = protos;
-
-    extract_proto_data_quant(
-        det_indices,
-        masks,
-        quant_masks,
-        protos_arr,
-        quant_protos,
-        output_boxes,
-    )
-}
-
 /// Proto-extraction variant of `impl_yolo_split_segdet_float`.
 /// Runs NMS but returns raw `ProtoData` instead of materialized masks.
 #[allow(clippy::too_many_arguments)]
-pub fn impl_yolo_split_segdet_float_proto<
+pub(crate) fn impl_yolo_split_segdet_float_proto<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Send + Sync,
     SCORE: Float + AsPrimitive<f32> + Send + Sync,

--- a/crates/hal/README.md
+++ b/crates/hal/README.md
@@ -57,6 +57,19 @@ processor.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default
 | macOS | Mem | CPU |
 | Other Unix | SHM, Mem | CPU |
 
+## Feature Flags
+
+The following Cargo feature flags are available for `edgefirst-hal`:
+
+- `ndarray` (default) — Enable ndarray integration in the tensor crate. Allows converting tensors to/from `ndarray::Array`.
+- `opengl` (default) — Enable the OpenGL backend for hardware-accelerated image processing on Linux.
+- `tracker` (optional, not default) — Enable multi-object tracking support via ByteTrack. Enables `draw_masks_tracked()` in the image crate and `decode_tracked()` in the decoder crate. Requires explicit opt-in:
+
+  ```toml
+  [dependencies]
+  edgefirst-hal = { version = "...", features = ["tracker"] }
+  ```
+
 ## Python Bindings
 
 This library is also available as a Python package:

--- a/crates/image/README.md
+++ b/crates/image/README.md
@@ -74,6 +74,7 @@ Note: Int8 variants (e.g. packed RGB int8, planar RGB int8) use `DType::I8` with
 
 - `opengl` (default) - Enable OpenGL backend on Linux
 - `decoder` (default) - Enable detection box rendering
+- `tracker` (optional) - Enable multi-object tracking support in `draw_masks_tracked()`. Requires `features = ["tracker"]` in your dependency declaration.
 
 ## Environment Variables
 
@@ -83,10 +84,56 @@ Note: Int8 variants (e.g. packed RGB int8, planar RGB int8) use `DType::I8` with
 - `EDGEFIRST_FORCE_BACKEND` — Force a single backend: `cpu`, `g2d`, or `opengl`. Disables fallback chain.
 - `EDGEFIRST_FORCE_TRANSFER` — Force GPU transfer method: `pbo` or `dmabuf`
 - `EDGEFIRST_TENSOR_FORCE_MEM` — Set to `1` to force heap memory (disables DMA/SHM)
+- `EDGEFIRST_OPENGL_RENDERSURFACE` — Set to `1` to use renderbuffer-backed EGLImages for DMA destinations. Required on i.MX 95 / Mali-G310 with Neutron NPU DMA-BUF destinations. Defaults to `0` (texture path).
+- `EDGEFIRST_PROTO_COMPUTE` — Set to `1` to enable the experimental GLES 3.1 compute shader path for proto repack. Requires GLES 3.1 hardware support.
 
 ## Segmentation Mask Rendering
 
 Three rendering pipelines for YOLO instance segmentation masks:
+
+### MaskOverlay
+
+`MaskOverlay` controls how segmentation masks are composited onto the destination image:
+
+```rust,ignore
+use edgefirst_image::MaskOverlay;
+
+// Default: no background replacement, full opacity
+let overlay = MaskOverlay::default();
+
+// With a background image and 50% transparent masks
+let overlay = MaskOverlay { background: Some(&bg_tensor), opacity: 0.5 };
+```
+
+Fields:
+- `background: Option<&TensorDyn>` — Optional tensor to blit into `dst` before drawing masks. Must match `dst`'s shape. `None` keeps the existing `dst` content.
+- `opacity: f32` — Scales mask alpha in the range `0.0` (invisible) to `1.0` (fully opaque, default).
+
+### draw_masks()
+
+Convenience method that decodes model outputs, runs NMS, and draws segmentation masks in a single call:
+
+```rust,ignore
+let boxes = processor.draw_masks(&decoder, &outputs, &mut frame, MaskOverlay::default())?;
+```
+
+### draw_masks_tracked()
+
+Like `draw_masks()` but integrates a `Tracker` for maintaining object identities across frames. The tracker runs after NMS but before mask extraction. Requires the `tracker` feature flag.
+
+```rust,ignore
+#[cfg(feature = "tracker")]
+let (boxes, tracks) = processor.draw_masks_tracked(
+    &decoder,
+    &mut tracker,
+    timestamp_ns,
+    &outputs,
+    &mut frame,
+    MaskOverlay::default(),
+)?;
+```
+
+Returns `(Vec<DetectBox>, Vec<TrackInfo>)`.
 
 ### Fused GPU Proto Path (`draw_proto_masks`)
 

--- a/crates/image/benches/mask_benchmark.rs
+++ b/crates/image/benches/mask_benchmark.rs
@@ -30,7 +30,7 @@ use edgefirst_tensor::{DType, PixelFormat};
 use ndarray::s;
 
 const WARMUP: usize = 10;
-const ITERATIONS: usize = 200;
+const ITERATIONS: usize = 100;
 
 // Quantization parameters from the YOLOv8 segmentation test model.
 const QUANT_BOXES: Quantization = Quantization {

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -133,6 +133,84 @@ decoder = ef.Decoder(
 boxes, scores, classes = decoder.decode([output_tensor])
 ```
 
+## Object Tracking
+
+`ByteTrack` is a multi-object tracker based on ByteTrack with Kalman filtering.
+It assigns consistent track IDs across frames.
+
+```python
+import edgefirst_hal as ef
+
+tracker = ef.ByteTrack(
+    high_conf=0.7,         # High-confidence detection threshold
+    iou=0.25,              # IoU threshold for association
+    update=0.25,           # Update/low-confidence threshold
+    lifespan_ns=500_000_000,  # Track lifespan without detection (nanoseconds)
+)
+
+# Decode and track in one call (returns boxes, scores, classes, masks, track_infos)
+boxes, scores, classes, masks, tracks = decoder.decode_tracked(
+    tracker, timestamp_ns, [output_tensor]
+)
+# masks is empty for detection-only models
+
+# Or query currently active tracks
+active = tracker.get_active_tracks()
+```
+
+## Segmentation Mask Rendering
+
+### draw_decoded_masks()
+
+Draw pre-decoded masks onto a destination image:
+
+```python
+processor.draw_decoded_masks(
+    dst,
+    bbox,           # numpy array [N, 4]
+    scores,         # numpy array [N]
+    classes,        # numpy array [N]
+    seg=[],         # list of segmentation arrays (optional)
+    background=None,  # optional background tensor to blit before drawing
+    opacity=1.0,    # mask alpha scale (0.0 – 1.0)
+)
+```
+
+### draw_masks()
+
+Decode model outputs and draw segmentation masks in a single call. Masks never
+leave Rust, eliminating the Python round-trip overhead of `decode()` +
+`draw_decoded_masks()`.
+
+Without a tracker, returns `(boxes, scores, classes)`. With a tracker, returns
+`(boxes, scores, classes, track_infos)`.
+
+```python
+import edgefirst_hal as ef
+
+processor = ef.ImageProcessor()
+tracker = ef.ByteTrack()
+
+# Without tracking
+boxes, scores, classes = processor.draw_masks(decoder, outputs, dst)
+
+# With overlay parameters
+boxes, scores, classes = processor.draw_masks(
+    decoder, outputs, dst,
+    background=bg_tensor,  # blit bg_tensor into dst before masks
+    opacity=0.7,           # semi-transparent masks
+)
+
+# With tracking (requires tracker= and timestamp=)
+import time
+ts = time.monotonic_ns()
+boxes, scores, classes, tracks = processor.draw_masks(
+    decoder, outputs, dst,
+    tracker=tracker,
+    timestamp=ts,
+)
+```
+
 ## Platform Support
 
 | Platform | GPU Acceleration | Memory Types |

--- a/crates/tensor/README.md
+++ b/crates/tensor/README.md
@@ -62,6 +62,91 @@ let fd = tensor.clone_fd()?;
 
 - `EDGEFIRST_TENSOR_FORCE_MEM` - Set to `1` or `true` to force heap allocation
 
+## PlaneDescriptor
+
+`PlaneDescriptor` wraps a duplicated file descriptor for use with
+`ImageProcessor::import_image()`. It captures optional stride and offset
+metadata alongside the fd so that the importer gets a complete picture of the
+plane layout without additional out-of-band parameters.
+
+```rust,no_run
+use edgefirst_tensor::PlaneDescriptor;
+use std::os::fd::BorrowedFd;
+
+// SAFETY: replace 42 with a real, valid fd from a DMA-BUF allocation.
+let pd = unsafe { PlaneDescriptor::new(BorrowedFd::borrow_raw(42)) }
+    .expect("failed to duplicate fd — check that the fd is valid")
+    .with_stride(2048)  // optional: row stride in bytes
+    .with_offset(0);    // optional: plane offset in bytes
+```
+
+The fd is duplicated eagerly in `new()` — a bad fd fails immediately rather
+than inside `import_image`. The caller retains ownership of the original fd.
+
+## DMA-BUF fd Accessors
+
+`TensorDyn` exposes two fd accessors for DMA-backed tensors (Linux only):
+
+- `dmabuf(&self) -> Result<BorrowedFd<'_>>` — Borrow the DMA-BUF fd tied to the tensor's lifetime.
+- `dmabuf_clone(&self) -> Result<OwnedFd>` — Duplicate the DMA-BUF fd. Fails with `Error::NotImplemented` if the tensor is not DMA-backed.
+
+```rust,ignore
+// Share the buffer with an external consumer (e.g. NPU delegate)
+let fd = tensor.dmabuf_clone()?;
+delegate.register_buffer(fd)?;
+```
+
+## Pixel Format Metadata
+
+Attach a `PixelFormat` to any tensor for image processing:
+
+- `set_format(format: PixelFormat) -> Result<()>` — Validates shape compatibility and stores the format.
+- `with_format(format: PixelFormat) -> Result<Self>` — Builder-style consuming variant.
+
+```rust,ignore
+let mut t = TensorDyn::new(&[480, 640, 3], DType::U8, None, None)?;
+t.set_format(PixelFormat::Rgb)?;
+```
+
+## Row Stride
+
+For externally allocated buffers with row padding (e.g. V4L2 camera frames):
+
+- `row_stride(&self) -> Option<usize>` — Stored stride, `None` if tightly packed.
+- `effective_row_stride(&self) -> Option<usize>` — Stored stride, or computed from format and width if not set.
+- `set_row_stride(stride: usize) -> Result<()>` — Set stride in bytes. Format must be set first.
+- `with_row_stride(stride: usize) -> Result<Self>` — Builder-style consuming variant.
+
+## Plane Offset
+
+For buffers where image data does not start at byte 0 of the fd:
+
+- `plane_offset(&self) -> Option<usize>` — Offset in bytes, `None` if zero.
+- `set_plane_offset(offset: usize)` — Set byte offset.
+- `with_plane_offset(offset: usize) -> Self` — Builder-style consuming variant.
+
+## BufferIdentity
+
+`BufferIdentity` provides a stable cache key for a tensor's underlying buffer.
+It is created fresh on every allocation or import and carries:
+
+- `id() -> u64` — Monotonically increasing integer. Changes whenever the buffer changes. Suitable as a HashMap key or EGL image cache key.
+- `weak() -> Weak<()>` — Goes dead when the owning tensor (and all clones) are dropped, allowing caches to detect stale entries without holding a strong reference.
+
+`buffer_identity()` is accessible on typed tensors via `TensorTrait`:
+
+```rust,ignore
+use edgefirst_tensor::{Tensor, TensorTrait};
+
+let t = Tensor::<u8>::new(&[1920, 1080, 3], None, None)?;
+let key = t.buffer_identity().id();
+let guard = t.buffer_identity().weak();
+// Later: guard.upgrade().is_none() means the tensor was dropped.
+```
+
+`BufferIdentity` is used internally by the image processing backends as an EGL
+image cache key to avoid redundant GPU texture imports across frames.
+
 ## License
 
 Licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE) for details.

--- a/crates/tensor/benches/tensor_benchmark.rs
+++ b/crates/tensor/benches/tensor_benchmark.rs
@@ -25,7 +25,7 @@ use num_traits::Num;
 use edgefirst_bench::{run_bench, BenchSuite};
 
 const WARMUP: usize = 10;
-const ITERATIONS: usize = 200;
+const ITERATIONS: usize = 100;
 
 /// Size configs: [batch, height, width, channels]
 const SIZES: &[([usize; 4], &str)] = &[

--- a/crates/tracker/README.md
+++ b/crates/tracker/README.md
@@ -12,75 +12,161 @@ This crate provides object tracking algorithms for associating detections across
 
 | Algorithm | Description | Use Case |
 |-----------|-------------|----------|
-| **ByteTrack** | High-performance MOT using byte-level features | Real-time tracking |
+| **ByteTrack** | High-performance MOT with two-pass association and Kalman filtering | Real-time tracking |
 
 ## Features
 
 - **UUID-based track IDs** - Globally unique identifiers for each tracked object
 - **Kalman filtering** - Smooth trajectory prediction and state estimation
-- **Configurable association** - IoU-based matching with tunable thresholds
-- **Track lifecycle** - Automatic creation, update, and deletion of tracks
+- **Two-pass association** - High-confidence detections matched first, low-confidence detections used to recover lost tracks
+- **Configurable thresholds** - Tunable IoU, confidence, and lifespan parameters
+- **Track lifecycle** - Automatic creation, update, and expiry of tracks
 
 ## Quick Start
 
 ```rust,ignore
-use edgefirst_tracker::{Tracker, TrackInfo, DetectionBox};
-use edgefirst_tracker::bytetrack::ByteTracker;
+use edgefirst_tracker::{bytetrack::{ByteTrack, ByteTrackBuilder}, Tracker, TrackInfo};
 
-// Create tracker
-let mut tracker = ByteTracker::new(
-    30,    // max lost frames before track deletion
-    0.5,   // high detection threshold
-    0.1,   // low detection threshold
-    0.8,   // match threshold
-);
+// Build a tracker using the builder pattern
+let mut tracker: ByteTrack<MyDetection> = ByteTrackBuilder::new()
+    .track_high_conf(0.7)        // minimum confidence to create a new track
+    .track_iou(0.25)             // IoU threshold for matching
+    .track_update(0.25)          // Kalman filter update rate
+    .track_extra_lifespan(500_000_000)  // nanoseconds to keep a track alive without a match
+    .build();
 
 // Process detections each frame
-let detections = get_detections_from_model();
-let timestamp = frame_number as u64;
+let detections: Vec<MyDetection> = get_detections_from_model();
+let timestamp: u64 = frame_timestamp_ns;
 
-let tracks = tracker.update(&detections, timestamp);
+let tracks: Vec<Option<TrackInfo>> = tracker.update(&detections, timestamp);
 
 // Each detection gets associated track info (or None if untracked)
 for (det, track) in detections.iter().zip(tracks.iter()) {
     if let Some(info) = track {
         println!("Detection matched to track {}", info.uuid);
-        println!("  Track age: {} frames", info.count);
-        println!("  Predicted location: {:?}", info.tracked_location);
+        println!("  Track age: {} updates", info.count);
+        println!("  Kalman-smoothed location: {:?}", info.tracked_location);
     }
 }
 
-// Get all currently active tracks
-for track in tracker.get_active_tracks() {
-    println!("Active track: {} at {:?}", track.uuid, track.tracked_location);
+// Query all currently active tracks
+for active in tracker.get_active_tracks() {
+    println!(
+        "Active track {} — location {:?}, last raw box: {:?}",
+        active.info.uuid, active.info.tracked_location, active.last_box
+    );
 }
 ```
 
+## Default Parameters
+
+`ByteTrackBuilder::new()` sets the following defaults:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `track_high_conf` | `0.7` | Minimum score to create or match a high-confidence track |
+| `track_iou` | `0.25` | IoU threshold for box association |
+| `track_update` | `0.25` | Kalman filter update rate |
+| `track_extra_lifespan` | `500_000_000` ns | How long a track survives without a matching detection |
+
 ## Track Information
+
+`Tracker::update()` returns `Vec<Option<TrackInfo>>`, one entry per input detection. Detections below the high-confidence threshold that do not match an existing track return `None`.
 
 Each `TrackInfo` contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `uuid` | `Uuid` | Globally unique track identifier |
-| `tracked_location` | `[f32; 4]` | Kalman-filtered bounding box `[x1, y1, x2, y2]` |
-| `count` | `i32` | Number of frames this track has been active |
-| `created` | `u64` | Timestamp when track was created |
-| `last_updated` | `u64` | Timestamp of last detection match |
+| `tracked_location` | `[f32; 4]` | Kalman-filtered bounding box in XYXY format `[xmin, ymin, xmax, ymax]` |
+| `count` | `i32` | Number of times this track has been updated |
+| `created` | `u64` | Timestamp (ns) when the track was first created |
+| `last_updated` | `u64` | Timestamp (ns) of the last detection match |
 
-## Integration
+`Tracker::get_active_tracks()` returns `Vec<ActiveTrackInfo<T>>`, which bundles `TrackInfo` with the raw last matched detection box:
 
-Works with any detection source implementing `DetectionBox`:
+| Field | Type | Description |
+|-------|------|-------------|
+| `info` | `TrackInfo` | Tracking metadata (see above) |
+| `last_box` | `T` | The last raw detection box before Kalman smoothing |
+
+## Implementing DetectionBox
+
+Any type used with `ByteTrack<T>` must implement the `DetectionBox` trait:
 
 ```rust
 use edgefirst_tracker::DetectionBox;
 
+#[derive(Debug, Clone)]
+struct MyDetection {
+    bbox: [f32; 4],
+    confidence: f32,
+    class_id: usize,
+}
+
 impl DetectionBox for MyDetection {
-    fn bbox(&self) -> [f32; 4] { self.coordinates }
+    fn bbox(&self) -> [f32; 4] { self.bbox }         // XYXY format
     fn score(&self) -> f32 { self.confidence }
     fn label(&self) -> usize { self.class_id }
 }
 ```
+
+The `bbox()` method must return coordinates in XYXY format: `[xmin, ymin, xmax, ymax]` as normalized or pixel values consistent with the model output.
+
+## The Tracker Trait
+
+Both `ByteTrack<T>` and any custom tracker must implement:
+
+```rust
+pub trait Tracker<T: DetectionBox> {
+    fn update(&mut self, boxes: &[T], timestamp: u64) -> Vec<Option<TrackInfo>>;
+    fn get_active_tracks(&self) -> Vec<ActiveTrackInfo<T>>;
+}
+```
+
+- `timestamp` is expected in nanoseconds and is used for track expiry calculations.
+- The returned `Vec` from `update` is aligned 1-to-1 with the input `boxes` slice.
+
+## Integration with edgefirst-decoder
+
+When used via `edgefirst-hal` or `edgefirst-decoder`, the `tracker` feature flag must be enabled:
+
+```toml
+[dependencies]
+edgefirst-hal = { version = "0.13", features = ["tracker"] }
+```
+
+Or when depending on the decoder directly:
+
+```toml
+[dependencies]
+edgefirst-decoder = { version = "0.13", features = ["tracker"] }
+```
+
+The decoder exposes `decode_tracked()` which accepts any `Tracker<DetectBox>` implementation:
+
+```rust,ignore
+use edgefirst_tracker::{bytetrack::ByteTrackBuilder, Tracker};
+
+let mut tracker = ByteTrackBuilder::new()
+    .track_high_conf(0.8)
+    .build();
+
+decoder.decode_tracked(
+    &mut tracker,
+    timestamp_ns,
+    &tensor_outputs,
+    &mut output_boxes,
+    &mut output_masks,
+    &mut output_tracks,
+)?;
+```
+
+`decode_tracked()` populates:
+- `output_boxes` — decoded detection boxes
+- `output_masks` — segmentation masks (empty if the model has no mask head)
+- `output_tracks` — `Vec<TrackInfo>` with one entry per matched detection
 
 ## License
 

--- a/tests/profile_decode_render.py
+++ b/tests/profile_decode_render.py
@@ -123,7 +123,9 @@ def main():
         arr = np.ascontiguousarray(arr)
         hal_dtype = dtype_map.get(arr.dtype)
         if hal_dtype is None:
-            raise ValueError(f"Unsupported dtype {arr.dtype}; expected one of {list(dtype_map.keys())}")
+            raise ValueError(
+                f"Unsupported dtype {arr.dtype}; expected one of {list(dtype_map.keys())}"
+            )
         t = Tensor(list(arr.shape), dtype=hal_dtype)
         with t.map() as m:
             np.copyto(np.frombuffer(m, dtype=arr.dtype).reshape(arr.shape), arr)


### PR DESCRIPTION
## Summary

- **Fix ModelPack quantized score threshold bug**: `quantize_score_threshold` was using `quant_boxes` instead of `quant_scores`, causing incorrect score filtering for ModelPack models with separate box/score tensors
- **Remove dead code**: unused `DataType` enum, `env_logger` moved to dev-dependencies
- **Narrow API surface**: 21 internal `impl_*` functions changed from `pub` to `pub(crate)`
- **Standardize benchmarks**: all benchmark iteration counts aligned to 100 (matching BENCHMARKS.md)
- **Create TESTING.md**: standalone testing guide consolidating scattered test documentation
- **Fix all sub-crate READMEs**: tracker README rewritten (was using non-existent types), C API README gained 6 new API sections, decoder/image/tensor/python/hal READMEs updated with v0.11-v0.13 APIs
- **Fix README.md**: crate count, architecture diagrams, env vars, examples, copyright
- **Fix ARCHITECTURE.md v3.0**: backend priority, decode API pattern, C API table, MaskOverlay, GLES 3.1
- **Update BENCHMARKS.md v2.2**: date stamps, image_benchmark, pending notes
- **Fix CHANGELOG.md**: missing entries for HalCameraAdaptorFormatInfo, logging API, tracked 2-way split
- **Fix hal.h**: cbindgen output for camera adaptor ABI (fourcc type/docs)

## Test plan

- [x] `make format lint` clean
- [x] `cargo check --all-features --workspace` clean
- [x] `cargo check --benches --workspace` clean
- [x] `make test` — all Rust + Python tests pass (x86_64)
- [x] On-target tests on imx95-evk — 505 passed, 0 failed, 5 ignored (hardware-gated)
- [ ] CI pipeline passes

JIRA: [EDGEAI-1218](https://au-zone.atlassian.net/browse/EDGEAI-1218)

[EDGEAI-1218]: https://au-zone.atlassian.net/browse/EDGEAI-1218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ