### PR TITLE
EDGEAI-759: HailoRT HAL support — schema v2, DFL decode, Scaled masks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,16 +19,13 @@ coverage.xml
 
 env.sh
 
-# Ignore Local Notes
-/AUDIT.md
-/STATUS.md
-/TODO.md
-/ARA2_DECODER.md
-/CODE_REVIEW.md
-/HAILORT_DECODER.md
-/NHWC_PROTOS.md
-/NORMALIZED_BOXES.md
-/STRIDES_BUG.md
+# Ignore Local Notes — local caches of JIRA-style issues/tasks that
+# avoid round-trips to the ticket system. Root-anchored so subcrates
+# are free to ship legitimate files with these prefixes.
+/TODO*.md
+/BUG*.md
+/FIX*.md
+/FEATURE*.md
 
 /SPS/
 /WP1/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`MaskResolution` enum and `resolution` parameter on
+  `ImageProcessor.materialize_masks`.** When set to
+  `MaskResolution.Scaled(width, height)`, HAL upsamples the full
+  proto plane once (correct edge-clamp bilinear) and returns
+  per-detection binary `uint8 {0, 255}` masks at the target
+  resolution — interchangeable with the existing continuous-sigmoid
+  Proto masks via the same `> 127` threshold. Letterbox-aware: when
+  `letterbox` is `Some`, `(width, height)` are interpreted as
+  original-content pixel dims and the inverse letterbox transform is
+  applied during upsample. Resolves the YOLOv8-seg mAP collapse
+  observed on Hailo+HAL when per-tile `ImageProcessor.convert()`
+  upsampling leaks edge activations across tile boundaries; callers
+  currently relying on `decode() + ImageProcessor.convert()` per-tile
+  resize should migrate to
+  `decode_proto() + materialize_masks(MaskResolution.Scaled)`.
+  Reference: EDGEAI-759.
+
+- **HailoRT split-output DFL decode support.** The schema-v2 `boxes`
+  logical output with `encoding: dfl` and per-scale physical children
+  is now accepted end-to-end. At compile time the decoder extracts
+  `reg_max` from the first child (validated uniform across children)
+  and pre-computes per-FPN-level anchor grids with the Ultralytics
+  `+0.5` centre offset; at decode time the per-scale merge runs a
+  numerically stable softmax + weighted-sum + `dist2bbox` per child,
+  collapsing the `4 × reg_max` feature axis to 4 xcycwh pixel-
+  coordinate channels before concat. The merged `(1, 4, total_anchors)`
+  tensor flows through the existing Ultralytics split-decoder
+  unchanged. Reference: `HAILORT_DECODER.md`, EDGEAI-759.
+
+- **DFL primitives module (`edgefirst_decoder::decoder::dfl`).**
+  Pure-function building blocks — `make_anchor_grid`, `dfl_bins`,
+  `softmax_inplace`, `decode_dfl_level` — operating on `&[f32]` so
+  they're trivially unit-testable and SIMD-ready. Seven unit tests
+  mirror validator-side pytest vectors (uniform/concentrated DFL
+  distributions, row-major anchor ordering, large-logit numerical
+  stability).
+
+- **Hailo YOLOv8-seg reference fixture
+  (`testdata/hailo_yolov8seg_edgefirst.json`).** Canonical schema-v2
+  example with three FPN scales (strides 8/16/32), DFL-encoded boxes,
+  sigmoid-pre-applied per-class scores, per-scale mask coefficients,
+  and NHWC protos. Used by end-to-end numerical-parity tests that
+  mirror `scripts/decode_hailo_split.py::test_synthetic` from
+  `edgefirst-validator @ feature/DE-823-hailort`.
+
 - **Schema v2 metadata parser (`edgefirst_decoder::schema`).** New
   data-only module implementing the two-layer logical/physical output
   model from the updated `edgefirst.json` specification. Logical outputs
@@ -45,8 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outputs with physical children, and downconverts the logical-level
   metadata to the legacy dispatch representation. Flat v2 schemas run
   through the existing decode kernels unchanged; schemas with
-  `encoding: dfl` on boxes are rejected with `NotSupported` until the
-  dedicated DFL kernel lands.
+  `encoding: dfl` combined with per-scale children are decoded by the
+  merge path (see the HailoRT DFL entry above). Flat DFL (no
+  children) remains unsupported — the HAL's DFL kernel only runs
+  inside the per-scale merge.
 
 - **Physical → logical merge path at decode time.** `Decoder::decode`
   now executes the compiled `DecodeProgram` when present,
@@ -68,10 +115,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Schema-driven decoding rejects unsupported features early.**
   `NotSupported`/`InvalidConfig` errors flagged at build time for:
-  DFL-encoded split boxes (DFL kernel pending), per-channel quant on
-  a split child, missing `dshape` on per-scale children, mixed
-  per-scale + channel sub-split decompositions on the same logical
-  output.
+  flat DFL-encoded boxes (no children — the HAL's DFL kernel only
+  runs inside the per-scale merge), heterogeneous `reg_max` across
+  FPN children, per-channel quant on a split child, missing
+  `dshape` on per-scale children, mixed per-scale + channel sub-
+  split decompositions on the same logical output.
 
 - **ARA-2 DVM `padding` dim support.** Schema-v2 metadata emitted by
   the ARA-2 converter declares a trailing `padding: 1` axis on most

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -15,7 +15,7 @@ use crate::{
 use edgefirst_decoder::{DetectBox, Segmentation};
 use edgefirst_image::{
     load_image, save_jpeg, ComputeBackend, Crop, Flip, ImageProcessor, ImageProcessorConfig,
-    ImageProcessorTrait, Rect, Rotation,
+    ImageProcessorTrait, MaskResolution, Rect, Rotation,
 };
 use edgefirst_tensor::{PixelFormat, PixelLayout, TensorDyn, TensorMemory};
 use edgefirst_tracker::TrackInfo;
@@ -995,6 +995,7 @@ pub unsafe extern "C" fn hal_image_processor_materialize_masks(
         &(*detections).boxes,
         &(*proto).inner,
         parse_letterbox(letterbox),
+        MaskResolution::Proto,
     ) {
         Ok(m) => m,
         Err(edgefirst_image::Error::NoConverter) => {

--- a/crates/decoder/src/decoder/dfl.rs
+++ b/crates/decoder/src/decoder/dfl.rs
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! DFL (Distribution Focal Loss) primitives for Hailo-style YOLOv8/v11
+//! split-output decoding. Pure-function module, no tensor-framework
+//! dependencies — operates on `&[f32]` / `Vec<f32>` so it's trivially
+//! unit-testable and can be SIMD-ified later without API churn.
+//!
+//! Reference: `HAILORT_DECODER.md` §"Reference Implementation Tour"
+//! and `edgefirst-validator @ feature/DE-823-hailort`:
+//! `edgefirst/validator/runners/processing/hailo_decode.py`.
+
+/// Build a row-major anchor grid with centres offset by `+0.5`
+/// (Ultralytics convention). Returns `(grid_x, grid_y)` of length
+/// `h * w` each, indexed `[y * w + x]`. Coordinates are in **grid
+/// units**, not pixels — the caller multiplies by stride inside
+/// `dist2bbox`.
+pub(crate) fn make_anchor_grid(h: usize, w: usize) -> (Vec<f32>, Vec<f32>) {
+    let mut gx = Vec::with_capacity(h * w);
+    let mut gy = Vec::with_capacity(h * w);
+    for y in 0..h {
+        for x in 0..w {
+            gx.push(x as f32 + 0.5);
+            gy.push(y as f32 + 0.5);
+        }
+    }
+    (gx, gy)
+}
+
+/// DFL weighted-sum coefficients: `[0.0, 1.0, ..., (reg_max-1) as f32]`.
+pub(crate) fn dfl_bins(reg_max: usize) -> Vec<f32> {
+    (0..reg_max).map(|i| i as f32).collect()
+}
+
+/// Numerically stable softmax in-place: subtracts `max(buf)` before
+/// `exp` to prevent overflow on large logits.
+pub(crate) fn softmax_inplace(buf: &mut [f32]) {
+    if buf.is_empty() {
+        return;
+    }
+    let mut m = buf[0];
+    for &v in buf.iter() {
+        if v > m {
+            m = v;
+        }
+    }
+    let mut sum = 0.0f32;
+    for v in buf.iter_mut() {
+        *v = (*v - m).exp();
+        sum += *v;
+    }
+    let inv = 1.0 / sum;
+    for v in buf.iter_mut() {
+        *v *= inv;
+    }
+}
+
+/// Decode one FPN-level DFL bbox tensor to xcycwh pixel coordinates.
+///
+/// * `bbox` — flattened `(H, W, 4 * reg_max)` f32 buffer, row-major
+///   (NHWC inner layout, as HailoRT returns post-dequant).
+/// * `grid_x`, `grid_y` — precomputed per-anchor grid centres in grid
+///   units (see [`make_anchor_grid`]).
+/// * `stride` — FPN stride in pixels (e.g. 8, 16, 32).
+///
+/// Returns a flattened `(H * W, 4)` buffer `[xc, yc, w, h, xc, yc,
+/// w, h, ...]` in pixel coordinates of the model input.
+pub(crate) fn decode_dfl_level(
+    bbox: &[f32],
+    h: usize,
+    w: usize,
+    reg_max: usize,
+    grid_x: &[f32],
+    grid_y: &[f32],
+    stride: f32,
+) -> Vec<f32> {
+    debug_assert_eq!(bbox.len(), h * w * 4 * reg_max);
+    debug_assert_eq!(grid_x.len(), h * w);
+    debug_assert_eq!(grid_y.len(), h * w);
+
+    let bins = dfl_bins(reg_max);
+    let mut out = Vec::with_capacity(h * w * 4);
+    let mut scratch = vec![0.0f32; reg_max];
+    for anchor in 0..(h * w) {
+        let base = anchor * 4 * reg_max;
+        let mut d = [0.0f32; 4]; // [left, top, right, bottom]
+        for (side, d_side) in d.iter_mut().enumerate() {
+            let slot = &bbox[base + side * reg_max..base + (side + 1) * reg_max];
+            scratch.copy_from_slice(slot);
+            softmax_inplace(&mut scratch);
+            let mut s = 0.0f32;
+            for (i, p) in scratch.iter().enumerate() {
+                s += p * bins[i];
+            }
+            *d_side = s;
+        }
+        let gx = grid_x[anchor];
+        let gy = grid_y[anchor];
+        // Order of operations matters — `(grid + (r - l) / 2) * stride`
+        // matches Ultralytics bit-for-bit; a `grid * stride + ...`
+        // refactoring would differ by float ulps.
+        let xc = (gx + (d[2] - d[0]) * 0.5) * stride;
+        let yc = (gy + (d[3] - d[1]) * 0.5) * stride;
+        let bw = (d[0] + d[2]) * stride;
+        let bh = (d[1] + d[3]) * stride;
+        out.push(xc);
+        out.push(yc);
+        out.push(bw);
+        out.push(bh);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_anchor_grid_centres_match_ultralytics_convention() {
+        let (gx, gy) = make_anchor_grid(2, 2);
+        // Row-major (y-outer, x-inner). Centres: (0.5, 0.5), (1.5, 0.5),
+        // (0.5, 1.5), (1.5, 1.5).
+        assert_eq!(gx, vec![0.5, 1.5, 0.5, 1.5]);
+        assert_eq!(gy, vec![0.5, 0.5, 1.5, 1.5]);
+    }
+
+    #[test]
+    fn dfl_bins_is_arange() {
+        assert_eq!(dfl_bins(4), vec![0.0, 1.0, 2.0, 3.0]);
+        assert_eq!(dfl_bins(16).len(), 16);
+        assert_eq!(dfl_bins(16)[15], 15.0);
+    }
+
+    #[test]
+    fn softmax_stable_against_large_logits() {
+        // Naive `exp(1002)` overflows; stable subtract-max keeps it finite.
+        let mut buf = [1000.0f32, 1001.0, 1002.0];
+        softmax_inplace(&mut buf);
+        let sum: f32 = buf.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6, "sum={sum}");
+        assert!(buf.iter().all(|v| v.is_finite()));
+        assert!(buf[2] > buf[1] && buf[1] > buf[0]);
+    }
+
+    #[test]
+    fn softmax_uniform_is_uniform() {
+        let mut buf = [1.0f32; 8];
+        softmax_inplace(&mut buf);
+        for v in buf {
+            assert!((v - 0.125).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn decode_dfl_level_uniform_distribution() {
+        // All-equal DFL logits → uniform softmax → distance = (reg_max-1)/2
+        // for each side. reg_max=16, stride=8, one cell at grid (0.5, 0.5):
+        //   d_left = d_right = d_top = d_bottom = 7.5
+        //   xc = (0.5 + 0) * 8 = 4.0
+        //   w  = (7.5 + 7.5) * 8 = 120.0
+        let reg_max = 16usize;
+        let bbox = vec![1.0f32; 4 * reg_max];
+        let (gx, gy) = make_anchor_grid(1, 1);
+        let out = decode_dfl_level(&bbox, 1, 1, reg_max, &gx, &gy, 8.0);
+        assert_eq!(out.len(), 4);
+        assert!((out[0] - 4.0).abs() < 1e-4, "xc={}", out[0]);
+        assert!((out[1] - 4.0).abs() < 1e-4, "yc={}", out[1]);
+        assert!((out[2] - 120.0).abs() < 1e-3, "w={}", out[2]);
+        assert!((out[3] - 120.0).abs() < 1e-3, "h={}", out[3]);
+    }
+
+    #[test]
+    fn decode_dfl_level_concentrated_distribution() {
+        // One-hot DFL distribution: logit at bin k huge, others 0
+        // → distance = k. reg_max=16, stride=16, k=5:
+        //   xc = (0.5 + 0) * 16 = 8.0
+        //   w  = (5 + 5) * 16 = 160.0
+        let reg_max = 16usize;
+        let mut bbox = vec![0.0f32; 4 * reg_max];
+        for side in 0..4 {
+            bbox[side * reg_max + 5] = 1000.0;
+        }
+        let (gx, gy) = make_anchor_grid(1, 1);
+        let out = decode_dfl_level(&bbox, 1, 1, reg_max, &gx, &gy, 16.0);
+        assert!((out[0] - 8.0).abs() < 1e-4, "xc={}", out[0]);
+        assert!((out[2] - 160.0).abs() < 1e-3, "w={}", out[2]);
+    }
+
+    #[test]
+    fn decode_dfl_level_multi_cell_orders_row_major() {
+        // 2x2 grid at stride 8, uniform logits → every cell has the same
+        // width (120) and its xc/yc follows (gx+0)*8 / (gy+0)*8.
+        let reg_max = 16usize;
+        let bbox = vec![1.0f32; 2 * 2 * 4 * reg_max];
+        let (gx, gy) = make_anchor_grid(2, 2);
+        let out = decode_dfl_level(&bbox, 2, 2, reg_max, &gx, &gy, 8.0);
+        assert_eq!(out.len(), 4 * 4);
+        // Anchor 0: grid (0.5, 0.5) → xc=4, yc=4
+        assert!((out[0] - 4.0).abs() < 1e-4);
+        assert!((out[1] - 4.0).abs() < 1e-4);
+        // Anchor 1: grid (1.5, 0.5) → xc=12, yc=4
+        assert!((out[4] - 12.0).abs() < 1e-4);
+        assert!((out[5] - 4.0).abs() < 1e-4);
+        // Anchor 2: grid (0.5, 1.5) → xc=4, yc=12
+        assert!((out[8] - 4.0).abs() < 1e-4);
+        assert!((out[9] - 12.0).abs() < 1e-4);
+        // Anchor 3: grid (1.5, 1.5) → xc=12, yc=12
+        assert!((out[12] - 12.0).abs() < 1e-4);
+        assert!((out[13] - 12.0).abs() < 1e-4);
+    }
+}

--- a/crates/decoder/src/decoder/merge.rs
+++ b/crates/decoder/src/decoder/merge.rs
@@ -23,11 +23,6 @@
 //!
 //! # Not yet supported
 //!
-//! - **DFL decoding** — per-scale children with `encoding: dfl` (e.g.
-//!   Hailo YOLOv8 boxes) merge to `(1, reg_max×4, total_anchors)`
-//!   which still carries the DFL distribution. Decoding that to
-//!   `(1, 4, total_anchors)` xcycwh pixel coords requires a per-level
-//!   softmax + weighted sum + dist2bbox kernel. Tracked separately.
 //! - **Per-channel quantization** on split children — the HAL
 //!   currently only consumes per-tensor scalar `(scale, zero_point)`.
 //! - **Activation flags on floats** — when a child carries
@@ -35,9 +30,22 @@
 //!   during merge. For split ARA-2 / Hailo typical usage the NPU
 //!   applies sigmoid on-chip (`activation_applied`), so this is not
 //!   blocking.
+//!
+//! # DFL decoding
+//!
+//! Per-scale children with `encoding: dfl` (Hailo YOLOv8/v11 boxes)
+//! carry `4 × reg_max` channels per anchor. The per-scale merge runs
+//! a numerically stable softmax + weighted-sum + `dist2bbox` inside
+//! [`execute_per_scale`] before spatial concat, collapsing the
+//! feature axis to the 4 xcycwh pixel-coordinate channels the
+//! downstream Ultralytics decoder expects. Per-FPN-level anchor
+//! grids and `dfl_bins` are pre-computed at plan time (see
+//! [`DflConfig`]). Reference: `HAILORT_DECODER.md` §"DFL Decode +
+//! dist2bbox" and [`super::dfl`].
 
 use ndarray::{Array, Array3, ArrayD, ArrayViewD, Axis, IxDyn};
 
+use super::dfl;
 use crate::configs::DimName;
 use crate::schema::{
     self, padding_axes, squeeze_padding_dims, Activation, LogicalOutput, LogicalType, SchemaV2,
@@ -83,6 +91,11 @@ enum LogicalMerge {
         logical_shape: Vec<usize>,
         feature_axis_logical: usize,
         box_axis_logical: usize,
+        /// When `Some`, the feature axis is `4 × reg_max` DFL logits
+        /// and the executor applies per-level DFL decode (softmax,
+        /// weighted sum, `dist2bbox`) before concat, collapsing the
+        /// feature axis to 4 xcycwh pixel-coordinate channels.
+        dfl: Option<DflConfig>,
     },
     /// Children share a common anchor axis and differ along the channel
     /// dimension (e.g. ARA-2 xy + wh). Dequantize each and concat along
@@ -106,6 +119,26 @@ struct PhysicalBinding {
     stride: Option<Stride>,
     #[allow(dead_code)] // applied by the NPU; currently informational
     activation_applied: Option<Activation>,
+}
+
+/// Pre-computed DFL decode state for a logical `boxes` output with
+/// `encoding: dfl` and per-scale children. Produced at plan time so
+/// the per-frame path never allocates anchor grids.
+#[derive(Debug, Clone)]
+pub(crate) struct DflConfig {
+    pub(crate) reg_max: usize,
+    /// One entry per child, in `PerScale::children` order
+    /// (stride-ascending after [`plan_per_scale`]'s sort).
+    grids: Vec<DflChildGrid>,
+}
+
+#[derive(Debug, Clone)]
+struct DflChildGrid {
+    stride: f32,
+    /// Row-major `H*W` anchor-centre x-coordinates in grid units.
+    grid_x: Vec<f32>,
+    /// Row-major `H*W` anchor-centre y-coordinates in grid units.
+    grid_y: Vec<f32>,
 }
 
 impl DecodeProgram {
@@ -144,6 +177,19 @@ impl DecodeProgram {
             .map(|m| execute_merge(m, inputs, &mut used))
             .collect()
     }
+
+    /// Returns the DFL `reg_max` extracted from the first DFL-encoded
+    /// `boxes` logical output in the schema, or `None` when the schema
+    /// has no DFL boxes.
+    #[cfg(test)]
+    pub(crate) fn boxes_reg_max(&self) -> Option<usize> {
+        for m in &self.merges {
+            if let LogicalMerge::PerScale { dfl: Some(d), .. } = m {
+                return Some(d.reg_max);
+            }
+        }
+        None
+    }
 }
 
 fn plan_logical(logical: &LogicalOutput) -> DecoderResult<LogicalMerge> {
@@ -159,14 +205,6 @@ fn plan_logical(logical: &LogicalOutput) -> DecoderResult<LogicalMerge> {
                 .map(schema_quant_to_runtime)
                 .transpose()?,
         });
-    }
-
-    if logical.type_ == LogicalType::Boxes && logical.encoding == Some(schema::BoxEncoding::Dfl) {
-        return Err(DecoderError::NotSupported(format!(
-            "logical `{}` has encoding=dfl with physical children; \
-             DFL decode is not yet implemented in the HAL merge path",
-            logical.name.as_deref().unwrap_or("<anonymous>")
-        )));
     }
 
     let first_has_stride = logical.outputs[0].stride.is_some();
@@ -189,12 +227,108 @@ fn plan_per_scale(logical: &LogicalOutput) -> DecoderResult<LogicalMerge> {
     // absent we cannot merge unambiguously — fall back to heuristics
     // based on common YOLO conventions (batch, features, boxes).
     let (feature_axis_logical, box_axis_logical) = logical_per_scale_axes(logical)?;
+
+    let dfl = if logical.type_ == LogicalType::Boxes
+        && logical.encoding == Some(schema::BoxEncoding::Dfl)
+    {
+        Some(plan_dfl(logical, &children)?)
+    } else {
+        None
+    };
+
     Ok(LogicalMerge::PerScale {
         children,
         logical_shape: logical.shape.clone(),
         feature_axis_logical,
         box_axis_logical,
+        dfl,
     })
+}
+
+/// Compute the DFL `reg_max` and per-child anchor grids at plan time.
+///
+/// `reg_max` is derived from the first child's feature count (`feat /
+/// 4`) and verified to be uniform across all children — the HAL's
+/// schema validator already rejects non-divisible-by-4 feature axes,
+/// but we re-check here so an internal logic bug is caught before
+/// per-frame decode starts reading bogus strides. See
+/// `HAILORT_DECODER.md` §"Open Questions" for the heterogeneous
+/// `reg_max` future work.
+fn plan_dfl(logical: &LogicalOutput, children: &[PhysicalBinding]) -> DecoderResult<DflConfig> {
+    let first_feat = child_feature_count(&children[0])?;
+    if first_feat == 0 || first_feat % 4 != 0 {
+        return Err(DecoderError::InvalidConfig(format!(
+            "DFL logical `{}` first child feature count {first_feat} is not a positive multiple of 4",
+            logical.name.as_deref().unwrap_or("<anonymous>")
+        )));
+    }
+    let reg_max = first_feat / 4;
+    let mut grids = Vec::with_capacity(children.len());
+    for child in children {
+        let feat = child_feature_count(child)?;
+        if feat / 4 != reg_max {
+            return Err(DecoderError::NotSupported(format!(
+                "DFL logical `{}` has heterogeneous reg_max across children \
+                 (child `{}` feature count {feat}, expected {}). \
+                 Per-child reg_max is not yet supported.",
+                logical.name.as_deref().unwrap_or("<anonymous>"),
+                child.name,
+                reg_max * 4,
+            )));
+        }
+        let (h, w) = child_hw(child)?;
+        let stride = child.stride.map(|s| s.x() as f32).ok_or_else(|| {
+            DecoderError::InvalidConfig(format!(
+                "DFL child `{}` has no stride — required for anchor-grid pre-compute",
+                child.name
+            ))
+        })?;
+        let (gx, gy) = dfl::make_anchor_grid(h, w);
+        grids.push(DflChildGrid {
+            stride,
+            grid_x: gx,
+            grid_y: gy,
+        });
+    }
+    Ok(DflConfig { reg_max, grids })
+}
+
+fn child_feature_count(child: &PhysicalBinding) -> DecoderResult<usize> {
+    for (i, (name, _)) in child.dshape.iter().enumerate() {
+        if matches!(
+            name,
+            DimName::NumFeatures
+                | DimName::NumClasses
+                | DimName::NumProtos
+                | DimName::BoxCoords
+                | DimName::NumAnchorsXFeatures
+        ) {
+            return Ok(child.shape[i]);
+        }
+    }
+    Err(DecoderError::InvalidConfig(format!(
+        "per-scale child `{}` dshape {:?} lacks a feature axis",
+        child.name, child.dshape
+    )))
+}
+
+fn child_hw(child: &PhysicalBinding) -> DecoderResult<(usize, usize)> {
+    let mut h = None;
+    let mut w = None;
+    for (i, (name, _)) in child.dshape.iter().enumerate() {
+        match name {
+            DimName::Height => h = Some(child.shape[i]),
+            DimName::Width => w = Some(child.shape[i]),
+            _ => {}
+        }
+    }
+    match (h, w) {
+        (Some(h), Some(w)) => Ok((h, w)),
+        _ => Err(DecoderError::InvalidConfig(format!(
+            "DFL per-scale child `{}` dshape {:?} must name both `height` and `width`",
+            child.name, child.dshape
+        ))),
+    }
 }
 
 fn plan_channel_concat(logical: &LogicalOutput) -> DecoderResult<LogicalMerge> {
@@ -347,12 +481,14 @@ fn execute_merge(
             logical_shape,
             feature_axis_logical,
             box_axis_logical,
+            dfl,
         } => execute_per_scale(
             inputs,
             children,
             logical_shape,
             *feature_axis_logical,
             *box_axis_logical,
+            dfl.as_ref(),
             used,
         ),
     }
@@ -498,6 +634,7 @@ fn execute_per_scale(
     logical_shape: &[usize],
     feature_axis_logical: usize,
     box_axis_logical: usize,
+    dfl_cfg: Option<&DflConfig>,
     used: &mut Vec<usize>,
 ) -> DecoderResult<ArrayD<f32>> {
     if children.is_empty() {
@@ -509,7 +646,7 @@ fn execute_per_scale(
     let mut per_scale_parts: Vec<Array3<f32>> = Vec::with_capacity(children.len());
     let mut feature_count: Option<usize> = None;
     let mut batch: Option<usize> = None;
-    for child in children {
+    for (idx, child) in children.iter().enumerate() {
         let t = find_unused_tensor_by_shape(inputs, &child.shape, used)?;
         let arr = tensor_to_f32(t, child.quant)?;
         let (b, features, part) = child_to_batch_feature_spatial(arr, child)?;
@@ -531,20 +668,85 @@ fn execute_per_scale(
             }
             _ => {}
         }
+        let part = match dfl_cfg {
+            Some(cfg) => dfl_decode_child(part, cfg, idx)?,
+            None => part,
+        };
         per_scale_parts.push(part);
     }
 
     let views: Vec<_> = per_scale_parts.iter().map(|a| a.view()).collect();
     let merged = ndarray::concatenate(Axis(2), &views).map_err(DecoderError::NDArrayShape)?;
 
-    // merged is (batch, features, total_anchors). Reshape to logical shape
-    // by moving features and anchors to their logical positions.
+    // merged is (batch, features, total_anchors) where `features` is 4
+    // for DFL (post-decode) or the raw child feature count otherwise.
+    // Reshape to the logical shape declared in the schema.
     reshape_to_logical(
         merged.into_dyn(),
         logical_shape,
         feature_axis_logical,
         box_axis_logical,
     )
+}
+
+/// Apply per-level DFL decode to one child's `(batch, 4 × reg_max, N)`
+/// tensor, producing a `(batch, 4, N)` tensor of xcycwh pixel
+/// coordinates.
+fn dfl_decode_child(
+    part: Array3<f32>,
+    cfg: &DflConfig,
+    child_idx: usize,
+) -> DecoderResult<Array3<f32>> {
+    let (batch, features, n) = part.dim();
+    let expected_feat = 4 * cfg.reg_max;
+    if features != expected_feat {
+        return Err(DecoderError::InvalidShape(format!(
+            "DFL child {child_idx}: feature count {features} != 4 × reg_max ({expected_feat})"
+        )));
+    }
+    if batch != 1 {
+        return Err(DecoderError::NotSupported(format!(
+            "DFL decode with batch={batch} is not supported (only batch=1 today)"
+        )));
+    }
+    let grid = cfg
+        .grids
+        .get(child_idx)
+        .ok_or_else(|| DecoderError::Internal(format!("DFL grid missing for child {child_idx}")))?;
+    if grid.grid_x.len() != n {
+        return Err(DecoderError::InvalidShape(format!(
+            "DFL child {child_idx}: anchor count {n} != precomputed grid {}",
+            grid.grid_x.len()
+        )));
+    }
+
+    // Transpose (1, F, N) → (1, N, F) and materialise contiguous so
+    // the flat slice is NHWC-inner with features as the innermost
+    // axis — the layout `dfl::decode_dfl_level` expects.
+    let transposed = part.permuted_axes([0, 2, 1]);
+    let contiguous = transposed.as_standard_layout().to_owned();
+    let flat = contiguous
+        .as_slice()
+        .ok_or_else(|| DecoderError::Internal("DFL transposed slice not contiguous".into()))?;
+
+    let decoded = dfl::decode_dfl_level(
+        flat,
+        1,
+        n,
+        cfg.reg_max,
+        &grid.grid_x,
+        &grid.grid_y,
+        grid.stride,
+    );
+    // `decoded` is `N * 4` flat in (anchor, side) order — shape (1, N, 4).
+    // Transpose back to (1, 4, N) for the anchor-axis concat downstream.
+    let decoded_nhwc = Array::from_shape_vec(ndarray::Ix3(1, n, 4), decoded)
+        .map_err(DecoderError::NDArrayShape)?;
+    let out = decoded_nhwc
+        .permuted_axes([0, 2, 1])
+        .as_standard_layout()
+        .to_owned();
+    Ok(out)
 }
 
 /// Permute a physical child's dequantized array to a canonical
@@ -1134,22 +1336,28 @@ mod tests {
     }
 
     #[test]
-    fn rejects_dfl_split() {
+    fn dfl_split_with_per_scale_children_is_accepted_and_exposes_reg_max() {
+        // Schema-level acceptance test: the HAL now consumes DFL boxes
+        // with per-scale children natively (Hailo YOLOv8/v11 split
+        // output convention). The compile step must succeed and
+        // expose the extracted `reg_max` for downstream consumers.
         let schema = SchemaV2 {
             schema_version: 2,
             outputs: vec![LogicalOutput {
                 name: Some("boxes".into()),
                 type_: LogicalType::Boxes,
-                shape: vec![1, 64, 8400],
+                // Post-decode logical shape: 4 xcycwh channels × 6400
+                // anchors (single 80×80 FPN level in this minimal case).
+                shape: vec![1, 4, 6400],
                 dshape: vec![
                     (DimName::Batch, 1),
-                    (DimName::NumFeatures, 64),
-                    (DimName::NumBoxes, 8400),
+                    (DimName::BoxCoords, 4),
+                    (DimName::NumBoxes, 6400),
                 ],
                 decoder: Some(DecoderKind::Ultralytics),
                 encoding: Some(BoxEncoding::Dfl),
                 score_format: None,
-                normalized: Some(true),
+                normalized: Some(false),
                 anchors: None,
                 stride: None,
                 dtype: None,
@@ -1174,8 +1382,326 @@ mod tests {
             }],
             ..Default::default()
         };
-        let err = DecodeProgram::try_from_schema(&schema).unwrap_err();
-        let msg = format!("{err:?}");
-        assert!(msg.contains("DFL"), "got: {msg}");
+        let program = DecodeProgram::try_from_schema(&schema).unwrap().unwrap();
+        assert_eq!(program.boxes_reg_max(), Some(16));
+    }
+
+    #[test]
+    fn per_scale_dfl_merge_produces_4ch_pixel_coordinates() {
+        // Two FPN levels, reg_max=4 (feature axis = 16 per child):
+        //   stride  8 @ 2×2  → 4 anchors
+        //   stride 16 @ 1×1  → 1 anchor
+        // Post-merge shape: (1, 4, 5) xcycwh pixel coords.
+        // Uniform +1.0 logits per slot → uniform softmax → distance =
+        // (reg_max-1)/2 = 1.5 on all four sides for every anchor.
+        //   stride 8,  grid (0.5, 0.5): xc=4,  yc=4,  w=24, h=24
+        //   stride 8,  grid (1.5, 0.5): xc=12, yc=4
+        //   stride 8,  grid (0.5, 1.5): xc=4,  yc=12
+        //   stride 8,  grid (1.5, 1.5): xc=12, yc=12
+        //   stride 16, grid (0.5, 0.5): xc=8,  yc=8,  w=48, h=48
+        let schema = SchemaV2 {
+            schema_version: 2,
+            outputs: vec![LogicalOutput {
+                name: Some("boxes".into()),
+                type_: LogicalType::Boxes,
+                shape: vec![1, 4, 5],
+                dshape: vec![
+                    (DimName::Batch, 1),
+                    (DimName::BoxCoords, 4),
+                    (DimName::NumBoxes, 5),
+                ],
+                decoder: Some(DecoderKind::Ultralytics),
+                encoding: Some(BoxEncoding::Dfl),
+                score_format: None,
+                normalized: Some(false),
+                anchors: None,
+                stride: None,
+                dtype: None,
+                quantization: None,
+                outputs: vec![
+                    PhysicalOutput {
+                        name: "b0".into(),
+                        type_: PhysicalType::Boxes,
+                        shape: vec![1, 2, 2, 16],
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::Height, 2),
+                            (DimName::Width, 2),
+                            (DimName::NumFeatures, 16),
+                        ],
+                        dtype: DType::Float32,
+                        quantization: None,
+                        stride: Some(SchemaStride::Square(8)),
+                        scale_index: Some(0),
+                        activation_applied: None,
+                        activation_required: None,
+                    },
+                    PhysicalOutput {
+                        name: "b1".into(),
+                        type_: PhysicalType::Boxes,
+                        shape: vec![1, 1, 1, 16],
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::Height, 1),
+                            (DimName::Width, 1),
+                            (DimName::NumFeatures, 16),
+                        ],
+                        dtype: DType::Float32,
+                        quantization: None,
+                        stride: Some(SchemaStride::Square(16)),
+                        scale_index: Some(1),
+                        activation_applied: None,
+                        activation_required: None,
+                    },
+                ],
+            }],
+            ..Default::default()
+        };
+        let program = DecodeProgram::try_from_schema(&schema).unwrap().unwrap();
+        let b0 = make_f32_tensor(&[1, 2, 2, 16], &[1.0f32; 2 * 2 * 16]);
+        let b1 = make_f32_tensor(&[1, 1, 1, 16], &[1.0f32; 16]);
+        let inputs: Vec<&TensorDyn> = vec![&b0, &b1];
+        let merged = program.execute(&inputs).unwrap();
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].shape(), &[1, 4, 5]);
+        let arr = &merged[0];
+        // xc across anchors [s8 row-major, s16]:
+        assert!(
+            (arr[[0, 0, 0]] - 4.0).abs() < 1e-3,
+            "xc[0]={}",
+            arr[[0, 0, 0]]
+        );
+        assert!(
+            (arr[[0, 0, 1]] - 12.0).abs() < 1e-3,
+            "xc[1]={}",
+            arr[[0, 0, 1]]
+        );
+        assert!(
+            (arr[[0, 0, 2]] - 4.0).abs() < 1e-3,
+            "xc[2]={}",
+            arr[[0, 0, 2]]
+        );
+        assert!(
+            (arr[[0, 0, 3]] - 12.0).abs() < 1e-3,
+            "xc[3]={}",
+            arr[[0, 0, 3]]
+        );
+        assert!(
+            (arr[[0, 0, 4]] - 8.0).abs() < 1e-3,
+            "xc[4]={}",
+            arr[[0, 0, 4]]
+        );
+        // yc across anchors:
+        assert!((arr[[0, 1, 0]] - 4.0).abs() < 1e-3);
+        assert!((arr[[0, 1, 2]] - 12.0).abs() < 1e-3);
+        assert!((arr[[0, 1, 4]] - 8.0).abs() < 1e-3);
+        // width & height:
+        for a in 0..4 {
+            assert!((arr[[0, 2, a]] - 24.0).abs() < 1e-3);
+            assert!((arr[[0, 3, a]] - 24.0).abs() < 1e-3);
+        }
+        assert!((arr[[0, 2, 4]] - 48.0).abs() < 1e-3);
+        assert!((arr[[0, 3, 4]] - 48.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn dfl_children_declared_out_of_stride_order_are_sorted_ascending() {
+        // Validator-parity: the merged output must place stride-8
+        // anchors before stride-16 anchors regardless of the order
+        // they appear in `edgefirst.json`. Mirrors
+        // `test_make_anchors_flat_orders_stride_ascending` from
+        // `edgefirst-validator @ feature/DE-823-hailort`.
+        let schema = SchemaV2 {
+            schema_version: 2,
+            outputs: vec![LogicalOutput {
+                name: Some("boxes".into()),
+                type_: LogicalType::Boxes,
+                shape: vec![1, 4, 5],
+                dshape: vec![
+                    (DimName::Batch, 1),
+                    (DimName::BoxCoords, 4),
+                    (DimName::NumBoxes, 5),
+                ],
+                decoder: Some(DecoderKind::Ultralytics),
+                encoding: Some(BoxEncoding::Dfl),
+                score_format: None,
+                normalized: Some(false),
+                anchors: None,
+                stride: None,
+                dtype: None,
+                quantization: None,
+                // Intentional descending-stride declaration order:
+                outputs: vec![
+                    PhysicalOutput {
+                        name: "b_big".into(),
+                        type_: PhysicalType::Boxes,
+                        shape: vec![1, 1, 1, 16],
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::Height, 1),
+                            (DimName::Width, 1),
+                            (DimName::NumFeatures, 16),
+                        ],
+                        dtype: DType::Float32,
+                        quantization: None,
+                        stride: Some(SchemaStride::Square(16)),
+                        scale_index: Some(1),
+                        activation_applied: None,
+                        activation_required: None,
+                    },
+                    PhysicalOutput {
+                        name: "b_small".into(),
+                        type_: PhysicalType::Boxes,
+                        shape: vec![1, 2, 2, 16],
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::Height, 2),
+                            (DimName::Width, 2),
+                            (DimName::NumFeatures, 16),
+                        ],
+                        dtype: DType::Float32,
+                        quantization: None,
+                        stride: Some(SchemaStride::Square(8)),
+                        scale_index: Some(0),
+                        activation_applied: None,
+                        activation_required: None,
+                    },
+                ],
+            }],
+            ..Default::default()
+        };
+        let program = DecodeProgram::try_from_schema(&schema).unwrap().unwrap();
+        let big = make_f32_tensor(&[1, 1, 1, 16], &[1.0f32; 16]);
+        let small = make_f32_tensor(&[1, 2, 2, 16], &[1.0f32; 2 * 2 * 16]);
+        // Caller passes inputs in schema declaration order; the plan
+        // sorts children stride-ascending, so after merge the first
+        // four anchors must be stride-8 (w=24) and the last must be
+        // stride-16 (w=48) — not the other way round.
+        let inputs: Vec<&TensorDyn> = vec![&big, &small];
+        let merged = program.execute(&inputs).unwrap();
+        let arr = &merged[0];
+        for a in 0..4 {
+            assert!(
+                (arr[[0, 2, a]] - 24.0).abs() < 1e-3,
+                "anchor {a} w={} (expected 24 stride-8)",
+                arr[[0, 2, a]]
+            );
+        }
+        assert!(
+            (arr[[0, 2, 4]] - 48.0).abs() < 1e-3,
+            "last anchor w={} (expected 48 stride-16)",
+            arr[[0, 2, 4]]
+        );
+    }
+
+    #[test]
+    fn dequantize_affine_reference_values_match_validator() {
+        // Validator-parity: `(q - zp) × scale` with scale=0.130,
+        // zp=70 produces (0 - 70)×0.130 = -9.10, (70 - 70)×0.130 = 0,
+        // (255 - 70)×0.130 = 24.05. Exercised end-to-end through the
+        // `Direct` merge path (non-DFL) so the assertion holds against
+        // the same dequant kernel the DFL path uses.
+        let schema = SchemaV2 {
+            schema_version: 2,
+            outputs: vec![
+                LogicalOutput {
+                    name: Some("scores".into()),
+                    type_: LogicalType::Scores,
+                    shape: vec![1, 1, 3],
+                    dshape: vec![
+                        (DimName::Batch, 1),
+                        (DimName::NumClasses, 1),
+                        (DimName::NumBoxes, 3),
+                    ],
+                    decoder: Some(DecoderKind::Ultralytics),
+                    encoding: None,
+                    score_format: Some(ScoreFormat::PerClass),
+                    normalized: None,
+                    anchors: None,
+                    stride: None,
+                    dtype: Some(DType::Uint8),
+                    quantization: Some(per_tensor_q(0.130, 70, DType::Uint8)),
+                    outputs: vec![],
+                },
+                LogicalOutput {
+                    // Second logical forces a DecodeProgram so the Direct
+                    // branch actually runs (try_from_schema short-circuits
+                    // when nothing needs merging).
+                    name: Some("boxes".into()),
+                    type_: LogicalType::Boxes,
+                    shape: vec![1, 4, 3],
+                    dshape: vec![
+                        (DimName::Batch, 1),
+                        (DimName::BoxCoords, 4),
+                        (DimName::NumBoxes, 3),
+                    ],
+                    decoder: Some(DecoderKind::Ultralytics),
+                    encoding: Some(BoxEncoding::Direct),
+                    score_format: None,
+                    normalized: Some(true),
+                    anchors: None,
+                    stride: None,
+                    dtype: None,
+                    quantization: None,
+                    outputs: vec![
+                        PhysicalOutput {
+                            name: "b0".into(),
+                            type_: PhysicalType::BoxesXy,
+                            shape: vec![1, 2, 3],
+                            dshape: vec![
+                                (DimName::Batch, 1),
+                                (DimName::BoxCoords, 2),
+                                (DimName::NumBoxes, 3),
+                            ],
+                            dtype: DType::Float32,
+                            quantization: None,
+                            stride: None,
+                            scale_index: None,
+                            activation_applied: None,
+                            activation_required: None,
+                        },
+                        PhysicalOutput {
+                            name: "b1".into(),
+                            type_: PhysicalType::BoxesWh,
+                            shape: vec![1, 2, 3],
+                            dshape: vec![
+                                (DimName::Batch, 1),
+                                (DimName::BoxCoords, 2),
+                                (DimName::NumBoxes, 3),
+                            ],
+                            dtype: DType::Float32,
+                            quantization: None,
+                            stride: None,
+                            scale_index: None,
+                            activation_applied: None,
+                            activation_required: None,
+                        },
+                    ],
+                },
+            ],
+            ..Default::default()
+        };
+        let program = DecodeProgram::try_from_schema(&schema).unwrap().unwrap();
+        let scores = make_u8_tensor(&[1, 1, 3], &[0, 70, 255]);
+        let xy = make_f32_tensor(&[1, 2, 3], &[0.0f32; 6]);
+        let wh = make_f32_tensor(&[1, 2, 3], &[0.0f32; 6]);
+        let inputs: Vec<&TensorDyn> = vec![&scores, &xy, &wh];
+        let merged = program.execute(&inputs).unwrap();
+        let scores_out = &merged[0];
+        assert!(
+            (scores_out[[0, 0, 0]] - (-9.10)).abs() < 1e-4,
+            "{}",
+            scores_out[[0, 0, 0]]
+        );
+        assert!(
+            (scores_out[[0, 0, 1]] - 0.00).abs() < 1e-4,
+            "{}",
+            scores_out[[0, 0, 1]]
+        );
+        assert!(
+            (scores_out[[0, 0, 2]] - 24.05).abs() < 1e-3,
+            "{}",
+            scores_out[[0, 0, 2]]
+        );
     }
 }

--- a/crates/decoder/src/decoder/mod.rs
+++ b/crates/decoder/src/decoder/mod.rs
@@ -161,6 +161,7 @@ macro_rules! with_quantized {
 }
 
 mod builder;
+mod dfl;
 mod helpers;
 mod merge;
 mod postprocess;

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -2028,6 +2028,278 @@ outputs:
         assert!(configs::DecoderVersion::Yolo26.is_end_to_end());
     }
 
+    /// Larger-scale variant of the full-stack mask-alignment repro
+    /// that exercises the non-contiguous `protos.to_shape(...)` path
+    /// inside `make_segmentation`. Uses 256-anchor input, 32 protos,
+    /// 160×160 proto grid with each anchor writing a unique integer
+    /// into proto channel K, where K = anchor index modulo 32. Builds
+    /// mask_coefs as a one-hot vector at channel K so the rendered
+    /// mask value uniquely identifies which anchor it came from.
+    /// A mis-indexed mask would lookup the wrong channel → wrong
+    /// rendered value → test failure.
+    #[test]
+    fn yolo_segdet_combined_tensor_large_scale_non_contiguous_crop() {
+        use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
+
+        const NC: usize = 2;
+        const NM: usize = 32;
+        const N: usize = 256;
+        const FEAT: usize = 4 + NC + NM;
+        const PH: usize = 160;
+        const PW: usize = 160;
+
+        let detection_cfg = configs::Detection {
+            decoder: DecoderType::Ultralytics,
+            quantization: Some(QuantTuple(1.0, 0)),
+            shape: vec![1, FEAT, N],
+            dshape: vec![],
+            anchors: None,
+            normalized: Some(true),
+        };
+        let protos_cfg = configs::Protos {
+            decoder: DecoderType::Ultralytics,
+            quantization: Some(QuantTuple(1.0, 0)),
+            shape: vec![1, NM, PH, PW],
+            dshape: vec![],
+        };
+
+        let decoder = DecoderBuilder::default()
+            .with_score_threshold(0.5)
+            .with_iou_threshold(0.99) // disable NMS suppression to keep all survivors identifiable
+            .with_nms(Some(configs::Nms::ClassAgnostic))
+            .add_output(ConfigOutput::Detection(detection_cfg))
+            .add_output(ConfigOutput::Protos(protos_cfg))
+            .build()
+            .expect("YoloSegDet large-scale decoder must build");
+
+        // Detection tensor (1, FEAT, N): 10 anchors pass threshold.
+        // anchor idx 10..20: xywh non-overlapping boxes at different
+        // positions; class 0 score 0.9; mask_coefs = one-hot at index
+        // `k = idx % NM` with value +10 (strong signal). Protos all
+        // zero EXCEPT channel k set to marker value `5.0 + 0.1 * k`
+        // so dot(coefs, protos) = 10 * (5.0 + 0.1*k) for the correct
+        // anchor, and 0 for any mis-indexed lookup. After sigmoid,
+        // correct → ~1 (→ 255 u8); mis-indexed → 0.5 (→ 128 u8).
+        let mut det_data = vec![0.0f32; FEAT * N];
+        let set = |d: &mut [f32], r: usize, c: usize, v: f32| d[r * N + c] = v;
+        let n_targets = 10usize;
+        let target_start = 10usize;
+        for t in 0..n_targets {
+            let anchor = target_start + t;
+            // Non-overlapping bboxes along x-axis: each covers
+            // a narrow vertical strip so they never NMS-suppress.
+            let xc = 0.05 + 0.08 * t as f32;
+            let yc = 0.5;
+            set(&mut det_data, 0, anchor, xc);
+            set(&mut det_data, 1, anchor, yc);
+            set(&mut det_data, 2, anchor, 0.06);
+            set(&mut det_data, 3, anchor, 0.4);
+            set(&mut det_data, 4, anchor, 0.9); // class 0
+            let k = anchor % NM;
+            set(&mut det_data, 4 + NC + k, anchor, 10.0); // one-hot mask coef
+        }
+
+        let det_tensor: TensorDyn = {
+            let t = Tensor::<f32>::new(&[1, FEAT, N], Some(TensorMemory::Mem), None).unwrap();
+            {
+                let mut m = t.map().unwrap();
+                m.as_mut_slice().copy_from_slice(&det_data);
+            }
+            TensorDyn::F32(t)
+        };
+
+        // Protos (1, NM, PH, PW) NCHW. Channel k filled with value
+        // (5.0 + 0.1*k). Channels that appear in `target_start..`
+        // anchor k = anchor % NM mappings are 10..20 → k = 10..20.
+        let mut proto_data = vec![0.0f32; NM * PH * PW];
+        for k in 0..NM {
+            let val = 5.0 + 0.1 * k as f32;
+            for i in 0..(PH * PW) {
+                proto_data[k * PH * PW + i] = val;
+            }
+        }
+        let protos_tensor: TensorDyn = {
+            let t = Tensor::<f32>::new(&[1, NM, PH, PW], Some(TensorMemory::Mem), None).unwrap();
+            {
+                let mut m = t.map().unwrap();
+                m.as_mut_slice().copy_from_slice(&proto_data);
+            }
+            TensorDyn::F32(t)
+        };
+
+        let inputs: Vec<&TensorDyn> = vec![&det_tensor, &protos_tensor];
+        let mut out_boxes: Vec<DetectBox> = Vec::with_capacity(50);
+        let mut out_masks: Vec<crate::Segmentation> = Vec::with_capacity(50);
+        decoder
+            .decode(&inputs, &mut out_boxes, &mut out_masks)
+            .expect("YoloSegDet large-scale decode must succeed");
+        assert_eq!(
+            out_boxes.len(),
+            n_targets,
+            "all {n_targets} targets should survive; got {}",
+            out_boxes.len()
+        );
+
+        // For each output, compute the expected mask mean from the
+        // anchor-k mapping (inferred from bbox centre xc = 0.05+0.08*t
+        // → t = round((xc-0.05)/0.08) → anchor = 10+t → k = anchor%NM).
+        // Sigmoid(10 * (5.0 + 0.1*k)) ≈ 1.0 for k ≥ 0 → mask mean ≈ 255.
+        // If mask coef looks up the wrong channel (not anchor%NM), the
+        // rendered value would be 0 · protos = 0 → sigmoid = 0.5 →
+        // mean ≈ 128, far from 255.
+        for (b, m) in out_boxes.iter().zip(out_masks.iter()) {
+            let cx = (b.bbox.xmin + b.bbox.xmax) * 0.5;
+            let mean: f32 = {
+                let s = &m.segmentation;
+                let total: u32 = s.iter().map(|&v| v as u32).sum();
+                total as f32 / s.len() as f32
+            };
+            assert!(
+                mean > 250.0,
+                "detection centre {cx:.3}: expected ~255 mask mean (correct mask lookup); \
+                 got {mean}. If mean is near 128, the mask coef was sigmoid-of-zero — \
+                 indicating the mask row was looked up at the wrong anchor index."
+            );
+        }
+    }
+
+    /// Full-stack reproducer for HAILORT_BUG.md's mask-vs-detection
+    /// misalignment claim. Exercises the same config the validator
+    /// passes to HAL when running HailoRT → HAL-postproc:
+    ///
+    ///   { type: detection, shape: [1, 116, 8400] }
+    ///   { type: protos,    shape: [1, 32, 160, 160] }   // NCHW
+    ///
+    /// Input tensors encode anchor-identity in both the mask
+    /// coefficients and the proto channel ordering so a mis-indexed
+    /// mask would produce rendered values wildly different from the
+    /// expected pattern. The test builds `Decoder::decode()` through
+    /// the public `TensorDyn` API — same entry point the Python
+    /// bindings call.
+    #[test]
+    fn yolo_segdet_combined_detection_protos_full_stack_mask_alignment() {
+        use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
+
+        const NC: usize = 2;
+        const NM: usize = 2;
+        const N: usize = 5;
+        const FEAT: usize = 4 + NC + NM;
+        const PH: usize = 8;
+        const PW: usize = 8;
+
+        let detection_cfg = configs::Detection {
+            decoder: DecoderType::Ultralytics,
+            quantization: Some(QuantTuple(1.0, 0)),
+            shape: vec![1, FEAT, N],
+            dshape: vec![],
+            anchors: None,
+            normalized: Some(true),
+        };
+        let protos_cfg = configs::Protos {
+            decoder: DecoderType::Ultralytics,
+            quantization: Some(QuantTuple(1.0, 0)),
+            shape: vec![1, NM, PH, PW],
+            dshape: vec![],
+        };
+
+        let decoder = DecoderBuilder::default()
+            .with_score_threshold(0.5)
+            .with_iou_threshold(0.5)
+            .with_nms(Some(configs::Nms::ClassAgnostic))
+            .add_output(ConfigOutput::Detection(detection_cfg))
+            .add_output(ConfigOutput::Protos(protos_cfg))
+            .build()
+            .expect("YoloSegDet detection+protos decoder must build");
+        assert!(
+            matches!(decoder.model_type, ModelType::YoloSegDet { .. }),
+            "expected YoloSegDet model type, got {:?}",
+            decoder.model_type
+        );
+
+        // Build the (1, 8, 5) detection tensor:
+        //   anchor 0: xywh (0.2, 0.2, 0.1, 0.1)  class 0 score 0.95  mask_coefs (+3, +3)
+        //   anchor 1: below threshold (filler)
+        //   anchor 2: xywh (0.8, 0.8, 0.1, 0.1)  class 0 score 0.85  mask_coefs (-3, -3)
+        //   anchor 3: below threshold (filler)
+        //   anchor 4: below threshold (filler)
+        // Two survivors; mask for a0 should sigmoid to ~0.9975 (→ 254
+        // u8), mask for a2 to ~0.0025 (→ 1 u8). ≈250-point gap makes
+        // any misalignment trivially detectable.
+        let mut det_data = vec![0.0f32; FEAT * N];
+        let set = |d: &mut [f32], r: usize, c: usize, v: f32| d[r * N + c] = v;
+        set(&mut det_data, 0, 0, 0.2);
+        set(&mut det_data, 1, 0, 0.2);
+        set(&mut det_data, 2, 0, 0.1);
+        set(&mut det_data, 3, 0, 0.1);
+        set(&mut det_data, 0, 2, 0.8);
+        set(&mut det_data, 1, 2, 0.8);
+        set(&mut det_data, 2, 2, 0.1);
+        set(&mut det_data, 3, 2, 0.1);
+        set(&mut det_data, 4, 0, 0.95); // score
+        set(&mut det_data, 4, 2, 0.85);
+        set(&mut det_data, 6, 0, 3.0);
+        set(&mut det_data, 7, 0, 3.0);
+        set(&mut det_data, 6, 2, -3.0);
+        set(&mut det_data, 7, 2, -3.0);
+
+        let det_tensor: TensorDyn = {
+            let t = Tensor::<f32>::new(&[1, FEAT, N], Some(TensorMemory::Mem), None).unwrap();
+            {
+                let mut m = t.map().unwrap();
+                m.as_mut_slice().copy_from_slice(&det_data);
+            }
+            TensorDyn::F32(t)
+        };
+        // Protos in NCHW (1, 2, 8, 8) all-ones — any proto channel
+        // contributes identically, so the sign of mask_coefs dominates
+        // the rendered mask pixel value.
+        let proto_data = vec![1.0f32; NM * PH * PW];
+        let protos_tensor: TensorDyn = {
+            let t = Tensor::<f32>::new(&[1, NM, PH, PW], Some(TensorMemory::Mem), None).unwrap();
+            {
+                let mut m = t.map().unwrap();
+                m.as_mut_slice().copy_from_slice(&proto_data);
+            }
+            TensorDyn::F32(t)
+        };
+
+        let inputs: Vec<&TensorDyn> = vec![&det_tensor, &protos_tensor];
+        let mut out_boxes: Vec<DetectBox> = Vec::with_capacity(10);
+        let mut out_masks: Vec<crate::Segmentation> = Vec::with_capacity(10);
+        decoder
+            .decode(&inputs, &mut out_boxes, &mut out_masks)
+            .expect("YoloSegDet decode must succeed");
+        assert_eq!(
+            out_boxes.len(),
+            2,
+            "two anchors above 0.5 should survive; got {}",
+            out_boxes.len()
+        );
+        assert_eq!(out_masks.len(), out_boxes.len(), "one mask per box");
+
+        for (b, m) in out_boxes.iter().zip(out_masks.iter()) {
+            let cx = (b.bbox.xmin + b.bbox.xmax) * 0.5;
+            let mean: f32 = {
+                let s = &m.segmentation;
+                let total: u32 = s.iter().map(|&v| v as u32).sum();
+                total as f32 / s.len() as f32
+            };
+            if cx < 0.3 {
+                assert!(
+                    mean > 200.0,
+                    "anchor-0 detection (cx={cx:.2}) should have high mask mean; got {mean}"
+                );
+            } else if cx > 0.7 {
+                assert!(
+                    mean < 50.0,
+                    "anchor-2 detection (cx={cx:.2}) should have low mask mean; got {mean}"
+                );
+            } else {
+                panic!("unexpected detection centre {cx:.2}");
+            }
+        }
+    }
+
     #[test]
     fn test_dshape_dict_format() {
         // Spec produces array-of-single-key-dicts: [{"batch": 1}, {"num_features": 84}]
@@ -2980,6 +3252,154 @@ outputs:
                 matches!(err, DecoderError::NotSupported(_)),
                 "expected NotSupported, got {err:?}"
             );
+        }
+
+        #[test]
+        fn with_schema_real_hailo_yolov8seg_builds_and_reports_dfl_reg_max() {
+            // Schema-level e2e: parse the canonical Hailo YOLOv8-seg
+            // fixture (strides 8/16/32, DFL boxes, sigmoid-applied
+            // scores, mask coefficients per-scale, NHWC protos), build
+            // a decoder, and confirm:
+            //   * a DecodeProgram is attached (split schema)
+            //   * normalized == false (pixel coords per HAILORT spec)
+            //   * the DFL reg_max extracted from the program == 16
+            //     (= 64 feature channels ÷ 4)
+            let json = include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../testdata/hailo_yolov8seg_edgefirst.json"
+            ));
+            let schema = SchemaV2::parse_json(json).unwrap();
+            schema.validate().unwrap();
+            let decoder = DecoderBuilder::new()
+                .with_schema(schema)
+                .with_score_threshold(0.25)
+                .build()
+                .expect("Hailo YOLOv8-seg schema should build");
+            assert!(
+                decoder.decode_program.is_some(),
+                "Hailo schema has per-scale children; DecodeProgram required"
+            );
+            assert_eq!(decoder.normalized_boxes(), Some(false));
+            assert_eq!(
+                decoder.decode_program.as_ref().unwrap().boxes_reg_max(),
+                Some(16),
+                "reg_max must be 16 (64 feature channels ÷ 4)"
+            );
+        }
+
+        /// End-to-end numerical parity with the validator's synthetic
+        /// test (`scripts/decode_hailo_split.py::test_synthetic`):
+        /// feed uniform uint8=128 tensors through the whole pipeline
+        /// and confirm the DFL-decoded first anchor's xc / w match the
+        /// analytic values from HAILORT_DECODER.md §"Test Vectors".
+        ///
+        /// Uniform 128 produces uniform DFL logits (scale-independent
+        /// post-dequant since softmax normalises), so every anchor
+        /// decodes to distance `(reg_max-1)/2 = 7.5` on all four sides.
+        /// For the first stride-8 anchor at grid (0.5, 0.5):
+        ///   xc = (0.5 + 0) * 8 = 4.0
+        ///   w  = (7.5 + 7.5) * 8 = 120.0
+        #[test]
+        fn hailo_yolov8seg_uniform_uint8_128_dfl_decode_parity() {
+            use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
+            let json = include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../testdata/hailo_yolov8seg_edgefirst.json"
+            ));
+            let schema = SchemaV2::parse_json(json).unwrap();
+            let decoder = DecoderBuilder::new()
+                .with_schema(schema)
+                .with_score_threshold(0.25)
+                .with_iou_threshold(0.5)
+                .build()
+                .unwrap();
+
+            fn uniform_u8(shape: &[usize], value: u8) -> TensorDyn {
+                let t = Tensor::<u8>::new(shape, Some(TensorMemory::Mem), None).unwrap();
+                {
+                    let mut m = t.map().unwrap();
+                    for byte in m.as_mut_slice() {
+                        *byte = value;
+                    }
+                }
+                TensorDyn::U8(t)
+            }
+
+            // Shapes in schema order. 128 across the board → uniform
+            // DFL distributions and sigmoid-pre-applied scores of
+            // `128 × (1/255) ≈ 0.502`.
+            let b0 = uniform_u8(&[1, 80, 80, 64], 128);
+            let b1 = uniform_u8(&[1, 40, 40, 64], 128);
+            let b2 = uniform_u8(&[1, 20, 20, 64], 128);
+            let s0 = uniform_u8(&[1, 80, 80, 80], 128);
+            let s1 = uniform_u8(&[1, 40, 40, 80], 128);
+            let s2 = uniform_u8(&[1, 20, 20, 80], 128);
+            let m0 = uniform_u8(&[1, 80, 80, 32], 128);
+            let m1 = uniform_u8(&[1, 40, 40, 32], 128);
+            let m2 = uniform_u8(&[1, 20, 20, 32], 128);
+            let protos = uniform_u8(&[1, 160, 160, 32], 128);
+            let inputs: Vec<&TensorDyn> =
+                vec![&b0, &b1, &b2, &s0, &s1, &s2, &m0, &m1, &m2, &protos];
+
+            // Reach into the decode program directly to verify the
+            // post-DFL merged boxes tensor rather than running the full
+            // NMS — uniform input produces 8400 near-identical
+            // candidates which collapse arbitrarily through NMS.
+            let program = decoder
+                .decode_program
+                .as_ref()
+                .expect("Hailo schema compiles a DecodeProgram");
+            let merged = program.execute(&inputs).unwrap();
+
+            // Schema order: boxes, scores, mask_coefs, protos.
+            let boxes = &merged[0];
+            assert_eq!(
+                boxes.shape(),
+                &[1, 4, 8400],
+                "post-DFL merged boxes must be (1, 4, 8400)"
+            );
+
+            // First anchor = stride-8 grid (0, 0) → xc = 4.0, w = 120.
+            assert!(
+                (boxes[[0, 0, 0]] - 4.0).abs() < 1e-2,
+                "first anchor xc = {}, expected ~4.0",
+                boxes[[0, 0, 0]]
+            );
+            assert!(
+                (boxes[[0, 1, 0]] - 4.0).abs() < 1e-2,
+                "first anchor yc = {}, expected ~4.0",
+                boxes[[0, 1, 0]]
+            );
+            assert!(
+                (boxes[[0, 2, 0]] - 120.0).abs() < 1e-1,
+                "first anchor w = {}, expected ~120.0",
+                boxes[[0, 2, 0]]
+            );
+            assert!(
+                (boxes[[0, 3, 0]] - 120.0).abs() < 1e-1,
+                "first anchor h = {}, expected ~120.0",
+                boxes[[0, 3, 0]]
+            );
+
+            // Scores merged: (1, 80, 8400). Sigmoid-pre-applied with
+            // scale=1/255 and zp=0 ⇒ dequant(128) = 128/255 ≈ 0.5020.
+            let scores = &merged[1];
+            assert_eq!(scores.shape(), &[1, 80, 8400]);
+            let s00 = scores[[0, 0, 0]];
+            assert!(
+                (s00 - 0.5020).abs() < 1e-3,
+                "score[0,0,0] = {s00}, expected ~0.5020"
+            );
+
+            // Mask coefs merged: (1, 32, 8400).
+            let mask_coefs = &merged[2];
+            assert_eq!(mask_coefs.shape(), &[1, 32, 8400]);
+
+            // Protos passthrough: (1, 160, 160, 32) — schema declares
+            // NHWC; HAL does not transpose on merge. Downstream mask
+            // rendering is a separate concern (NHWC_PROTOS.md).
+            let protos_out = &merged[3];
+            assert_eq!(protos_out.shape(), &[1, 160, 160, 32]);
         }
     }
 }

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -694,17 +694,32 @@ impl SchemaV2 {
     /// Returns [`DecoderError::NotSupported`] when the schema uses
     /// features the v1 decoder cannot express at the logical level:
     /// - Per-channel quantization arrays on a logical output.
-    /// - `encoding: dfl` on a flat logical output (no physical
-    ///   children) — the HAL does not yet include a DFL decode kernel.
+    /// - `encoding: dfl` on a **flat** logical output (no physical
+    ///   children). DFL combined with per-scale children is handled by
+    ///   the merge path (see [`crate::decoder::merge::DecodeProgram`])
+    ///   which decodes the distribution before producing the merged
+    ///   post-decode `(1, 4, total_anchors)` tensor the legacy decoder
+    ///   consumes.
     pub fn to_legacy_config_outputs(&self) -> DecoderResult<ConfigOutputs> {
         let mut outputs = Vec::with_capacity(self.outputs.len());
         for logical in &self.outputs {
-            if logical.type_ == LogicalType::Boxes && logical.encoding == Some(BoxEncoding::Dfl) {
+            // Flat DFL (no children) remains unsupported — the HAL has
+            // no path that applies softmax + dist2bbox to a single
+            // `(1, 4·reg_max, anchors)` tensor yet. DFL with per-scale
+            // children is decoded by the merge path, so we let it
+            // through here and rely on the merged logical shape (post-
+            // decode 4 channels) being valid for the legacy dispatch.
+            if logical.type_ == LogicalType::Boxes
+                && logical.encoding == Some(BoxEncoding::Dfl)
+                && logical.outputs.is_empty()
+            {
                 return Err(DecoderError::NotSupported(format!(
-                    "`boxes` output `{}` has `encoding: dfl`; the HAL \
-                     does not yet include a DFL decode kernel. Pre-decode \
-                     to 4 channels in the model graph (as TFLite does) or \
-                     wait for the HAL DFL kernel to land.",
+                    "`boxes` output `{}` has `encoding: dfl` on a flat \
+                     logical (no per-scale children); the HAL's DFL \
+                     decode kernel only runs inside the per-scale merge \
+                     path. Split the boxes output into per-FPN-level \
+                     children (Hailo convention) or pre-decode to 4 \
+                     channels in the model graph (TFLite convention).",
                     logical.name.as_deref().unwrap_or("<anonymous>"),
                 )));
             }

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -2408,4 +2408,115 @@ mod tests {
             result.len()
         );
     }
+
+    /// Regression test for HAILORT_BUG.md — the YoloSegDet path
+    /// (combined `(4 + nc + nm, N)` detection tensor + separate protos)
+    /// must pair each surviving detection with the mask coefficient
+    /// row at the SAME anchor index the box came from. The validator
+    /// sees this path miss the pairing under schema-v2 Hailo inputs
+    /// (mAP collapse from 46.8 → 3.65 while mask IoU stays at 66.9,
+    /// the fingerprint of mask-to-detection misalignment).
+    ///
+    /// Construction: three anchors with distinct mask-coef signatures
+    /// that, after dot(coefs, protos) + sigmoid, produce HIGH vs LOW
+    /// mask pixel values. Two anchors survive (one high, one low); if
+    /// the mask row is looked up at the wrong index, the per-detection
+    /// mean mask value would cross the threshold and we catch it.
+    #[test]
+    fn segdet_combined_tensor_pairs_detection_with_matching_mask_row() {
+        let nc = 2; // num_classes
+        let nm = 2; // num_protos
+        let n = 3; // num_anchors
+        let feat = 4 + nc + nm; // 8
+
+        // Tensor layout: (8, 3) rows=features, cols=anchors.
+        // Row indices:  0..4 = xywh, 4..6 = scores, 6..8 = mask_coefs.
+        //
+        //         anchor 0 | anchor 1 | anchor 2
+        // xc       0.2      | 0.5      | 0.8
+        // yc       0.2      | 0.5      | 0.8
+        // w        0.1      | 0.1      | 0.1
+        // h        0.1      | 0.1      | 0.1
+        // s[0]     0.9      | 0.0      | 0.8   (class 0)
+        // s[1]     0.0      | 0.0      | 0.0   (class 1 — always loses)
+        // m[0]     3.0      | 0.0      | -3.0  (high for a0, low for a2)
+        // m[1]     3.0      | 0.0      | -3.0
+        //
+        // Proto[0] = Proto[1] = all-ones (8x8), so
+        //   mask(a0) = sigmoid(3 + 3) ≈ 0.9975 → 254
+        //   mask(a2) = sigmoid(-3 + -3) ≈ 0.0025 → 1
+        // 250-point gap makes any misalignment trivially detectable.
+        let mut data = vec![0.0f32; feat * n];
+        let set = |d: &mut [f32], r: usize, c: usize, v: f32| d[r * n + c] = v;
+        set(&mut data, 0, 0, 0.2);
+        set(&mut data, 1, 0, 0.2);
+        set(&mut data, 2, 0, 0.1);
+        set(&mut data, 3, 0, 0.1);
+        set(&mut data, 0, 1, 0.5);
+        set(&mut data, 1, 1, 0.5);
+        set(&mut data, 2, 1, 0.1);
+        set(&mut data, 3, 1, 0.1);
+        set(&mut data, 0, 2, 0.8);
+        set(&mut data, 1, 2, 0.8);
+        set(&mut data, 2, 2, 0.1);
+        set(&mut data, 3, 2, 0.1);
+        set(&mut data, 4, 0, 0.9);
+        set(&mut data, 4, 2, 0.8);
+        set(&mut data, 6, 0, 3.0);
+        set(&mut data, 7, 0, 3.0);
+        set(&mut data, 6, 2, -3.0);
+        set(&mut data, 7, 2, -3.0);
+
+        let output = Array2::from_shape_vec((feat, n), data).unwrap();
+        let protos = Array3::<f32>::from_elem((8, 8, nm), 1.0);
+
+        let mut boxes: Vec<DetectBox> = Vec::with_capacity(10);
+        let mut masks: Vec<Segmentation> = Vec::with_capacity(10);
+        decode_yolo_segdet_float(
+            output.view(),
+            protos.view(),
+            0.5,
+            0.5,
+            Some(Nms::ClassAgnostic),
+            &mut boxes,
+            &mut masks,
+        )
+        .unwrap();
+
+        assert_eq!(
+            boxes.len(),
+            2,
+            "two anchors above threshold should survive (a0 score=0.9, a2 score=0.8); got {}",
+            boxes.len()
+        );
+
+        // Build a (anchor_index → mask_mean) mapping from the results.
+        // Anchor 0 has centre (0.2, 0.2), anchor 2 has centre (0.8,
+        // 0.8). The DetectBox bbox is the post-XYWH-to-XYXY conversion
+        // of the original xywh; cropping inside protobox may shrink it,
+        // so match by centre (0.2 vs 0.8) rather than exact bbox.
+        for (b, m) in boxes.iter().zip(masks.iter()) {
+            let cx = (b.bbox.xmin + b.bbox.xmax) * 0.5;
+            let mean = {
+                let s = &m.segmentation;
+                let total: u32 = s.iter().map(|&v| v as u32).sum();
+                total as f32 / s.len() as f32
+            };
+            if cx < 0.3 {
+                // anchor 0 — expect HIGH mask values ≈ 254
+                assert!(
+                    mean > 200.0,
+                    "anchor 0 detection (centre {cx:.2}) should have high-value mask; got mean {mean}"
+                );
+            } else if cx > 0.7 {
+                // anchor 2 — expect LOW mask values ≈ 1
+                assert!(
+                    mean < 50.0,
+                    "anchor 2 detection (centre {cx:.2}) should have low-value mask; got mean {mean}"
+                );
+            } else {
+                panic!("unexpected detection centre {cx:.2}");
+            }
+        }
+    }
 }

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -320,6 +320,279 @@ impl CPUProcessor {
             })
             .collect::<crate::Result<Vec<_>>>()
     }
+
+    /// Produce per-detection masks at `(width, height)` pixel resolution by
+    /// upsampling the full proto plane once then cropping per bbox. Each
+    /// `det.bbox` is assumed to be in model-input normalized coordinates
+    /// (the convention used by the decoder output); when `letterbox` is
+    /// `Some`, `(width, height)` are original-content pixel dims and the
+    /// inverse letterbox transform is applied to both the bbox (for the
+    /// crop region and returned `Segmentation` metadata) and each output
+    /// pixel (for proto-plane sampling). Mask values are binary
+    /// `uint8 {0, 255}` after thresholding sigmoid > 0.5.
+    ///
+    /// Used by [`ImageProcessor::materialize_masks`] when the caller selects
+    /// [`MaskResolution::Scaled`](crate::MaskResolution::Scaled).
+    pub fn materialize_scaled_segmentations(
+        &self,
+        detect: &[crate::DetectBox],
+        proto_data: &crate::ProtoData,
+        letterbox: Option<[f32; 4]>,
+        width: u32,
+        height: u32,
+    ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
+        use edgefirst_decoder::ProtoTensor;
+
+        if detect.is_empty() || proto_data.mask_coefficients.is_empty() {
+            return Ok(Vec::new());
+        }
+        if width == 0 || height == 0 {
+            return Err(crate::Error::InvalidShape(
+                "Scaled mask width/height must be positive".into(),
+            ));
+        }
+
+        match &proto_data.protos {
+            ProtoTensor::Float(protos) => scaled_segmentations_float(
+                detect,
+                &proto_data.mask_coefficients,
+                protos,
+                letterbox,
+                width,
+                height,
+            ),
+            ProtoTensor::Quantized {
+                protos,
+                quantization,
+            } => scaled_segmentations_quant_i8(
+                detect,
+                &proto_data.mask_coefficients,
+                protos,
+                *quantization,
+                letterbox,
+                width,
+                height,
+            ),
+        }
+    }
+}
+
+fn scaled_segmentations_float(
+    detect: &[crate::DetectBox],
+    mask_coefficients: &[Vec<f32>],
+    protos: &ndarray::Array3<f32>,
+    letterbox: Option<[f32; 4]>,
+    width: u32,
+    height: u32,
+) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
+    let (proto_h, proto_w, num_protos) = (protos.shape()[0], protos.shape()[1], protos.shape()[2]);
+
+    // letterbox = [lx0, ly0, lx1, ly1] in model-input normalized coords.
+    // Two uses for the same (lx0, lw) pair:
+    //   * Forward (sampling): each output pixel maps to model-input normalized
+    //     via model_norm = lx0 + out_norm * lw, then to proto pixels.
+    //   * Inverse (bbox frame): det.bbox arrives in model-input normalized
+    //     (decoder output); the crop region and returned Segmentation are in
+    //     output-content normalized, obtained via (bbox - lx0) / lw.
+    // When letterbox is None, (lx0=0, lw=1) makes both directions the identity.
+    let (lx0, lw, ly0, lh) = match letterbox {
+        Some([lx0, ly0, lx1, ly1]) => {
+            let lw = (lx1 - lx0).max(f32::EPSILON);
+            let lh = (ly1 - ly0).max(f32::EPSILON);
+            (lx0, lw, ly0, lh)
+        }
+        None => (0.0_f32, 1.0_f32, 0.0_f32, 1.0_f32),
+    };
+
+    let out_w = width as usize;
+    let out_h = height as usize;
+
+    detect
+        .iter()
+        .zip(mask_coefficients.iter())
+        .map(|(det, coeff)| {
+            if coeff.len() != num_protos {
+                return Err(crate::Error::Internal(format!(
+                    "mask coeff length {} != proto channels {num_protos}",
+                    coeff.len()
+                )));
+            }
+
+            // Canonicalise, then inverse-letterbox into output-content
+            // normalized space for bbox crop + Segmentation metadata.
+            // Matches the end-of-pipeline transform in the Proto path
+            // (see `materialize_segmentations`).
+            let bbox = det.bbox.to_canonical();
+            let xmin = ((bbox.xmin - lx0) / lw).clamp(0.0, 1.0);
+            let ymin = ((bbox.ymin - ly0) / lh).clamp(0.0, 1.0);
+            let xmax = ((bbox.xmax - lx0) / lw).clamp(0.0, 1.0);
+            let ymax = ((bbox.ymax - ly0) / lh).clamp(0.0, 1.0);
+
+            let px0 = (xmin * out_w as f32).round() as usize;
+            let py0 = (ymin * out_h as f32).round() as usize;
+            let px1 = ((xmax * out_w as f32).round() as usize).min(out_w);
+            let py1 = ((ymax * out_h as f32).round() as usize).min(out_h);
+            let bbox_w = px1.saturating_sub(px0).max(1);
+            let bbox_h = py1.saturating_sub(py0).max(1);
+
+            let mut tile = ndarray::Array3::<u8>::zeros((bbox_h, bbox_w, 1));
+
+            // Map each output pixel within bbox back to proto-plane
+            // coordinates. Center-of-pixel offset (-0.5) matches torch
+            // align_corners=False, the Ultralytics retina convention.
+            for yi in 0..bbox_h {
+                let py = (py0 + yi) as f32;
+                let model_y_norm = ly0 + (py + 0.5) / out_h as f32 * lh;
+                let sample_y = model_y_norm * proto_h as f32 - 0.5;
+                for xi in 0..bbox_w {
+                    let px = (px0 + xi) as f32;
+                    let model_x_norm = lx0 + (px + 0.5) / out_w as f32 * lw;
+                    let sample_x = model_x_norm * proto_w as f32 - 0.5;
+                    let acc = bilinear_dot(
+                        protos, coeff, num_protos, sample_x, sample_y, proto_w, proto_h,
+                    );
+                    let sigmoid = fast_sigmoid(acc);
+                    tile[[yi, xi, 0]] = if sigmoid > 0.5 { 255 } else { 0 };
+                }
+            }
+
+            Ok(edgefirst_decoder::Segmentation {
+                xmin,
+                ymin,
+                xmax,
+                ymax,
+                segmentation: tile,
+            })
+        })
+        .collect::<crate::Result<Vec<_>>>()
+}
+
+/// Quantized i8 proto variant of [`scaled_segmentations_float`]. Dequantizes
+/// inline during bilinear sample + dot product:
+///   dequant = (i8 - zero_point) * scale
+/// Factoring scale out of the dot product:
+///   sigmoid(scale * Σ coef_k * (i8 - zp))
+/// so we can run a single scale multiply on the accumulator.
+#[allow(clippy::too_many_arguments)]
+fn scaled_segmentations_quant_i8(
+    detect: &[crate::DetectBox],
+    mask_coefficients: &[Vec<f32>],
+    protos: &ndarray::Array3<i8>,
+    quant: edgefirst_decoder::Quantization,
+    letterbox: Option<[f32; 4]>,
+    width: u32,
+    height: u32,
+) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
+    let (proto_h, proto_w, num_protos) = (protos.shape()[0], protos.shape()[1], protos.shape()[2]);
+
+    // See scaled_segmentations_float for the forward / inverse letterbox
+    // convention — det.bbox arrives in model-input normalized; crop region
+    // and Segmentation metadata are output-content normalized via
+    // (bbox - lx0) / lw; the sampling transform goes the other direction.
+    let (lx0, lw, ly0, lh) = match letterbox {
+        Some([lx0, ly0, lx1, ly1]) => {
+            let lw = (lx1 - lx0).max(f32::EPSILON);
+            let lh = (ly1 - ly0).max(f32::EPSILON);
+            (lx0, lw, ly0, lh)
+        }
+        None => (0.0_f32, 1.0_f32, 0.0_f32, 1.0_f32),
+    };
+
+    let out_w = width as usize;
+    let out_h = height as usize;
+    let scale = quant.scale;
+    let zp = quant.zero_point as f32;
+
+    detect
+        .iter()
+        .zip(mask_coefficients.iter())
+        .map(|(det, coeff)| {
+            if coeff.len() != num_protos {
+                return Err(crate::Error::Internal(format!(
+                    "mask coeff length {} != proto channels {num_protos}",
+                    coeff.len()
+                )));
+            }
+
+            let bbox = det.bbox.to_canonical();
+            let xmin = ((bbox.xmin - lx0) / lw).clamp(0.0, 1.0);
+            let ymin = ((bbox.ymin - ly0) / lh).clamp(0.0, 1.0);
+            let xmax = ((bbox.xmax - lx0) / lw).clamp(0.0, 1.0);
+            let ymax = ((bbox.ymax - ly0) / lh).clamp(0.0, 1.0);
+
+            let px0 = (xmin * out_w as f32).round() as usize;
+            let py0 = (ymin * out_h as f32).round() as usize;
+            let px1 = ((xmax * out_w as f32).round() as usize).min(out_w);
+            let py1 = ((ymax * out_h as f32).round() as usize).min(out_h);
+            let bbox_w = px1.saturating_sub(px0).max(1);
+            let bbox_h = py1.saturating_sub(py0).max(1);
+
+            let mut tile = ndarray::Array3::<u8>::zeros((bbox_h, bbox_w, 1));
+
+            for yi in 0..bbox_h {
+                let py = (py0 + yi) as f32;
+                let model_y_norm = ly0 + (py + 0.5) / out_h as f32 * lh;
+                let sample_y = model_y_norm * proto_h as f32 - 0.5;
+                for xi in 0..bbox_w {
+                    let px = (px0 + xi) as f32;
+                    let model_x_norm = lx0 + (px + 0.5) / out_w as f32 * lw;
+                    let sample_x = model_x_norm * proto_w as f32 - 0.5;
+                    let acc = bilinear_dot_quant_i8(
+                        protos, coeff, num_protos, sample_x, sample_y, proto_w, proto_h, zp,
+                    );
+                    let sigmoid = fast_sigmoid(scale * acc);
+                    tile[[yi, xi, 0]] = if sigmoid > 0.5 { 255 } else { 0 };
+                }
+            }
+
+            Ok(edgefirst_decoder::Segmentation {
+                xmin,
+                ymin,
+                xmax,
+                ymax,
+                segmentation: tile,
+            })
+        })
+        .collect::<crate::Result<Vec<_>>>()
+}
+
+/// Bilinear sample + zero-point-subtracting dot product over an i8 proto
+/// tensor. Returns the scaled-but-not-yet-sigmoid accumulator; caller applies
+/// the quantization scale and sigmoid.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn bilinear_dot_quant_i8(
+    protos: &ndarray::Array3<i8>,
+    coeff: &[f32],
+    num_protos: usize,
+    px: f32,
+    py: f32,
+    proto_w: usize,
+    proto_h: usize,
+    zp: f32,
+) -> f32 {
+    let x0 = (px.floor() as isize).clamp(0, proto_w as isize - 1) as usize;
+    let y0 = (py.floor() as isize).clamp(0, proto_h as isize - 1) as usize;
+    let x1 = (x0 + 1).min(proto_w - 1);
+    let y1 = (y0 + 1).min(proto_h - 1);
+
+    let fx = px - px.floor();
+    let fy = py - py.floor();
+    let w00 = (1.0 - fx) * (1.0 - fy);
+    let w10 = fx * (1.0 - fy);
+    let w01 = (1.0 - fx) * fy;
+    let w11 = fx * fy;
+
+    let mut acc = 0.0f32;
+    for p in 0..num_protos {
+        let v00 = protos[[y0, x0, p]] as f32 - zp;
+        let v10 = protos[[y0, x1, p]] as f32 - zp;
+        let v01 = protos[[y1, x0, p]] as f32 - zp;
+        let v11 = protos[[y1, x1, p]] as f32 - zp;
+        let val = w00 * v00 + w10 * v10 + w01 * v01 + w11 * v11;
+        acc += coeff[p] * val;
+    }
+    acc
 }
 
 /// Bilinear interpolation of proto values at `(px, py)` combined with dot
@@ -525,4 +798,291 @@ fn fused_dot_sigmoid_f32(
         }
     }
     mask
+}
+
+#[cfg(test)]
+mod scaled_tests {
+    use super::*;
+    use edgefirst_decoder::{BoundingBox, DetectBox, ProtoData, ProtoTensor};
+    use ndarray::Array3;
+
+    fn make_cpu() -> CPUProcessor {
+        CPUProcessor::new()
+    }
+
+    /// A synthetic proto plane where channel 0 is a centred gaussian peaking
+    /// at 10.0 and tailing off to ~0.0 at the edges; other channels zero.
+    /// Mask coefficients (1.0, 0, 0, ...) select only channel 0.
+    fn synthetic_proto_data(proto_h: usize, proto_w: usize, num_protos: usize) -> ProtoData {
+        let mut protos = Array3::<f32>::zeros((proto_h, proto_w, num_protos));
+        let cy = (proto_h as f32 - 1.0) / 2.0;
+        let cx = (proto_w as f32 - 1.0) / 2.0;
+        for y in 0..proto_h {
+            for x in 0..proto_w {
+                let dy = (y as f32 - cy) / cy;
+                let dx = (x as f32 - cx) / cx;
+                protos[[y, x, 0]] = 10.0 * (-(dx * dx + dy * dy)).exp();
+            }
+        }
+        let mut coeffs = vec![0.0_f32; num_protos];
+        coeffs[0] = 1.0;
+        ProtoData {
+            mask_coefficients: vec![coeffs],
+            protos: ProtoTensor::Float(protos),
+        }
+    }
+
+    #[test]
+    fn scaled_central_bbox_produces_foreground_blob() {
+        let cpu = make_cpu();
+        let proto_data = synthetic_proto_data(16, 16, 4);
+
+        // bbox covers the centre 50% of the plane.
+        let detect = vec![DetectBox {
+            bbox: BoundingBox::new(0.25, 0.25, 0.75, 0.75),
+            score: 0.9,
+            label: 0,
+        }];
+
+        let out = cpu
+            .materialize_scaled_segmentations(&detect, &proto_data, None, 64, 64)
+            .expect("scaled mask rendering must succeed");
+
+        assert_eq!(out.len(), 1);
+        let seg = &out[0];
+        assert_eq!(seg.segmentation.shape(), &[32, 32, 1]);
+        let values: Vec<u8> = seg.segmentation.iter().copied().collect();
+        assert!(
+            values.iter().all(|&v| v == 0 || v == 255),
+            "scaled mask must be binary {{0, 255}}, found other values"
+        );
+        let fg_count = values.iter().filter(|&&v| v == 255).count();
+        let fg_frac = fg_count as f32 / values.len() as f32;
+        assert!(
+            fg_frac > 0.80,
+            "expected >80% foreground for centred gaussian, got {fg_frac:.2}"
+        );
+    }
+
+    /// Realistic 160×160 → 640×640 parity vs hand-rolled bilinear + sigmoid
+    /// reference. Tolerate <0.5% pixel mismatch due to fast_sigmoid's ~1.1%
+    /// approximation error near the decision boundary.
+    #[test]
+    fn scaled_realistic_160x160_to_640x640_matches_reference() {
+        let mut rng_seed: u32 = 0xD00D_F00D;
+        let next = |s: &mut u32| -> f32 {
+            *s = s.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (*s as f32) / (u32::MAX as f32) * 2.0 - 1.0
+        };
+
+        let proto_h = 160;
+        let proto_w = 160;
+        let num_protos = 32;
+        let mut protos = Array3::<f32>::zeros((proto_h, proto_w, num_protos));
+        for y in 0..proto_h {
+            for x in 0..proto_w {
+                for k in 0..num_protos {
+                    protos[[y, x, k]] = next(&mut rng_seed) * 3.0;
+                }
+            }
+        }
+        let mut coeffs = vec![0.0_f32; num_protos];
+        for c in &mut coeffs {
+            *c = next(&mut rng_seed);
+        }
+        let proto_data = ProtoData {
+            mask_coefficients: vec![coeffs.clone()],
+            protos: ProtoTensor::Float(protos.clone()),
+        };
+
+        let detect = vec![DetectBox {
+            bbox: BoundingBox::new(0.1, 0.2, 0.6, 0.9),
+            score: 0.9,
+            label: 0,
+        }];
+
+        let cpu = make_cpu();
+        let out = cpu
+            .materialize_scaled_segmentations(&detect, &proto_data, None, 640, 640)
+            .unwrap();
+        assert_eq!(out.len(), 1);
+        let hal_tile = &out[0].segmentation;
+
+        let px0 = (0.1_f32 * 640.0_f32).round() as usize;
+        let py0 = (0.2_f32 * 640.0_f32).round() as usize;
+        let px1 = (0.6_f32 * 640.0_f32).round() as usize;
+        let py1 = (0.9_f32 * 640.0_f32).round() as usize;
+        let bbox_h = py1 - py0;
+        let bbox_w = px1 - px0;
+        assert_eq!(hal_tile.shape(), &[bbox_h, bbox_w, 1]);
+
+        let sx = proto_w as f32 / 640.0_f32;
+        let sy = proto_h as f32 / 640.0_f32;
+        let mut mismatches = 0_usize;
+        for yi in 0..bbox_h {
+            let py = (py0 + yi) as f32;
+            let sy_coord = (py + 0.5) * sy - 0.5;
+            for xi in 0..bbox_w {
+                let px = (px0 + xi) as f32;
+                let sx_coord = (px + 0.5) * sx - 0.5;
+                let x0 = sx_coord.floor().clamp(0.0, proto_w as f32 - 1.0) as usize;
+                let y0 = sy_coord.floor().clamp(0.0, proto_h as f32 - 1.0) as usize;
+                let x1 = (x0 + 1).min(proto_w - 1);
+                let y1 = (y0 + 1).min(proto_h - 1);
+                let fx = sx_coord - sx_coord.floor();
+                let fy = sy_coord - sy_coord.floor();
+                let w00 = (1.0 - fx) * (1.0 - fy);
+                let w10 = fx * (1.0 - fy);
+                let w01 = (1.0 - fx) * fy;
+                let w11 = fx * fy;
+                let mut acc = 0.0_f32;
+                for p in 0..num_protos {
+                    let val = w00 * protos[[y0, x0, p]]
+                        + w10 * protos[[y0, x1, p]]
+                        + w01 * protos[[y1, x0, p]]
+                        + w11 * protos[[y1, x1, p]];
+                    acc += coeffs[p] * val;
+                }
+                let sigmoid = 1.0_f32 / (1.0 + (-acc).exp());
+                let expected: u8 = if sigmoid > 0.5 { 255 } else { 0 };
+                if hal_tile[[yi, xi, 0]] != expected {
+                    mismatches += 1;
+                }
+            }
+        }
+        let total = bbox_h * bbox_w;
+        let mismatch_rate = mismatches as f32 / total as f32;
+        assert!(
+            mismatch_rate < 0.005,
+            "mismatch rate {mismatch_rate:.4} > 0.5% tolerance \
+             ({mismatches}/{total} pixels)"
+        );
+    }
+
+    /// Letterbox path: the inverse letterbox transform must shift the
+    /// bbox sample into the proto plane correctly when (width, height)
+    /// are original-content pixel dims. A centred gaussian on the proto
+    /// plane, aligned with the content region via letterbox, should
+    /// still produce a centred foreground blob in the original-content
+    /// coordinate frame.
+    #[test]
+    fn scaled_letterbox_original_content_coords() {
+        let cpu = make_cpu();
+        let proto_data = synthetic_proto_data(16, 16, 4);
+
+        // Bbox in *model-input* normalized coords — the frame used by the
+        // decoder output and consumed by `materialize_scaled_segmentations`.
+        // Under the letterbox below, this maps to output-content normalized
+        // (0.25, 0.3, 0.75, 0.7) and centres on the proto-plane centre.
+        let detect = vec![DetectBox {
+            bbox: BoundingBox::new(0.25, 0.3875, 0.75, 0.6125),
+            score: 0.9,
+            label: 0,
+        }];
+
+        // Letterbox: content fills full width, centred 56.25% vertically.
+        // Caller requests Scaled(640, 360) in original-content space.
+        let letterbox = Some([0.0_f32, 0.21875, 1.0, 0.78125]);
+        let out = cpu
+            .materialize_scaled_segmentations(&detect, &proto_data, letterbox, 640, 360)
+            .expect("letterbox scaled rendering must succeed");
+
+        assert_eq!(out.len(), 1);
+        let seg = &out[0];
+        let bbox_w = (0.5_f32 * 640.0_f32).round() as usize; // 320
+        let bbox_h = (0.4_f32 * 360.0_f32).round() as usize; // 144
+        assert_eq!(seg.segmentation.shape(), &[bbox_h, bbox_w, 1]);
+        let uniq: std::collections::BTreeSet<u8> = seg.segmentation.iter().copied().collect();
+        assert!(
+            uniq.iter().all(|&v| v == 0 || v == 255),
+            "letterbox scaled mask must be binary {{0, 255}}, got {uniq:?}"
+        );
+
+        // Middle-25%-square of the bbox should be solidly foreground
+        // (the proto gaussian is centred; the bbox is centred on the
+        // original-content frame; letterbox preserves centre alignment).
+        let cy = bbox_h / 2;
+        let cx = bbox_w / 2;
+        let patch_h = bbox_h / 4;
+        let patch_w = bbox_w / 4;
+        let mut fg = 0_usize;
+        let mut total = 0_usize;
+        for y in cy.saturating_sub(patch_h / 2)..=(cy + patch_h / 2).min(bbox_h - 1) {
+            for x in cx.saturating_sub(patch_w / 2)..=(cx + patch_w / 2).min(bbox_w - 1) {
+                if seg.segmentation[[y, x, 0]] == 255 {
+                    fg += 1;
+                }
+                total += 1;
+            }
+        }
+        let fg_frac = fg as f32 / total as f32;
+        assert!(
+            fg_frac > 0.95,
+            "centre of letterboxed bbox should be >95% foreground, got {fg_frac:.2}"
+        );
+    }
+
+    /// Quantized i8 protos must produce the same binary mask as a float
+    /// equivalent, modulo quantization rounding error.
+    #[test]
+    fn scaled_quantized_proto_produces_same_result_as_float() {
+        use edgefirst_decoder::Quantization;
+
+        let proto_h = 32;
+        let proto_w = 32;
+        let num_protos = 8;
+        let mut protos_f32 = Array3::<f32>::zeros((proto_h, proto_w, num_protos));
+        for y in 0..proto_h {
+            for x in 0..proto_w {
+                for k in 0..num_protos {
+                    let v = ((y + x + k * 3) as f32 * 0.05).sin() * 3.0;
+                    protos_f32[[y, x, k]] = v;
+                }
+            }
+        }
+        let scale = 0.1_f32;
+        let zp = 0_i32;
+        let protos_i8 = protos_f32.mapv(|v| (v / scale).round().clamp(-127.0, 127.0) as i8);
+        let coeffs: Vec<f32> = (0..num_protos).map(|k| (k as f32 - 3.5) * 0.3).collect();
+
+        let pd_float = ProtoData {
+            mask_coefficients: vec![coeffs.clone()],
+            protos: ProtoTensor::Float(protos_f32.clone()),
+        };
+        let pd_quant = ProtoData {
+            mask_coefficients: vec![coeffs.clone()],
+            protos: ProtoTensor::Quantized {
+                protos: protos_i8,
+                quantization: Quantization {
+                    scale,
+                    zero_point: zp,
+                },
+            },
+        };
+
+        let detect = vec![DetectBox {
+            bbox: BoundingBox::new(0.1, 0.1, 0.9, 0.9),
+            score: 0.9,
+            label: 0,
+        }];
+
+        let cpu = make_cpu();
+        let out_f = cpu
+            .materialize_scaled_segmentations(&detect, &pd_float, None, 320, 320)
+            .unwrap();
+        let out_q = cpu
+            .materialize_scaled_segmentations(&detect, &pd_quant, None, 320, 320)
+            .unwrap();
+        let mismatches = out_f[0]
+            .segmentation
+            .iter()
+            .zip(out_q[0].segmentation.iter())
+            .filter(|(a, b)| a != b)
+            .count();
+        let total = out_f[0].segmentation.len();
+        assert!(
+            mismatches < total / 200,
+            "quantized and float diverged at {mismatches}/{total} pixels (>0.5%)"
+        );
+    }
 }

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -371,6 +371,42 @@ impl ColorMode {
     }
 }
 
+/// Controls the resolution and coordinate frame of masks produced by
+/// [`ImageProcessor::materialize_masks`].
+///
+/// - [`Proto`](Self::Proto) returns per-detection tiles at proto-plane
+///   resolution (e.g. 48×32 u8 for a typical COCO bbox on a 160×160 proto
+///   plane). This is the historical behavior of `materialize_masks` and the
+///   fastest path because no upsample runs inside HAL. Mask values are
+///   continuous sigmoid output quantized to `uint8 [0, 255]`.
+/// - [`Scaled`](Self::Scaled) returns per-detection tiles at caller-specified
+///   pixel resolution by upsampling the full proto plane once and cropping by
+///   bbox after sigmoid. The upsample uses bilinear interpolation with
+///   edge-clamp sampling — semantically equivalent to Ultralytics'
+///   `process_masks_retina` reference. When a `letterbox` is also passed to
+///   [`materialize_masks`], the inverse letterbox transform is applied during
+///   the upsample so mask pixels land in original-content coordinates
+///   (drop-in for overlay on the original image). Mask values are binary
+///   `uint8 {0, 255}` after thresholding sigmoid > 0.5 — interchangeable
+///   with `Proto` output via the same `> 127` test.
+///
+/// [`materialize_masks`]: ImageProcessor::materialize_masks
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum MaskResolution {
+    /// Per-detection tile at proto-plane resolution (default).
+    #[default]
+    Proto,
+    /// Per-detection tile at `(width, height)` pixel resolution in the
+    /// coordinate frame determined by the `letterbox` parameter of
+    /// [`ImageProcessor::materialize_masks`].
+    Scaled {
+        /// Target pixel width of the output coordinate frame.
+        width: u32,
+        /// Target pixel height of the output coordinate frame.
+        height: u32,
+    },
+}
+
 /// Options for mask overlay rendering.
 ///
 /// Controls how segmentation masks are composited onto the destination image:
@@ -1603,9 +1639,15 @@ impl ImageProcessor {
         detect: &[DetectBox],
         proto_data: &ProtoData,
         letterbox: Option<[f32; 4]>,
+        resolution: MaskResolution,
     ) -> Result<Vec<Segmentation>> {
         let cpu = self.cpu.as_ref().ok_or(Error::NoConverter)?;
-        cpu.materialize_segmentations(detect, proto_data, letterbox)
+        match resolution {
+            MaskResolution::Proto => cpu.materialize_segmentations(detect, proto_data, letterbox),
+            MaskResolution::Scaled { width, height } => {
+                cpu.materialize_scaled_segmentations(detect, proto_data, letterbox, width, height)
+            }
+        }
     }
 }
 

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -1016,6 +1016,36 @@ class ColorMode(enum.Enum):
     Track: ColorMode
     """Color chosen by track ID (use with object tracking)"""
 
+class MaskResolution:
+    """Controls the resolution and coordinate frame of masks produced by
+    :meth:`ImageProcessor.materialize_masks`.
+
+    Construct via classmethods:
+
+    - ``MaskResolution.Proto()`` — per-detection tiles at proto-plane
+      resolution (historical default). Mask values are continuous sigmoid
+      ``uint8 [0, 255]``.
+    - ``MaskResolution.Scaled(width, height)`` — per-detection tiles at
+      caller-specified pixel resolution, produced by upsampling the full
+      proto plane once (correct edge-clamp bilinear) and cropping by bbox
+      after sigmoid. Mask values are binary ``uint8 {0, 255}`` —
+      interchangeable with the continuous sigmoid output via the same
+      ``> 127`` test. If a ``letterbox`` is also passed to
+      ``materialize_masks``, ``(width, height)`` are interpreted as
+      original-content pixel dims and the inverse letterbox transform is
+      applied during the upsample.
+    """
+
+    @classmethod
+    def Proto(cls) -> "MaskResolution":
+        """Per-detection tile at proto-plane resolution (default)."""
+        ...
+
+    @classmethod
+    def Scaled(cls, width: int, height: int) -> "MaskResolution":
+        """Per-detection tile at ``(width, height)`` pixel resolution."""
+        ...
+
 class Flip(enum.Enum):
     NoFlip: Flip
     """No flip"""
@@ -1241,14 +1271,24 @@ class ImageProcessor:
         classes: npt.NDArray[np.uintp],
         proto_data: ProtoData,
         letterbox: Optional[Tuple[float, float, float, float]] = None,
+        resolution: Optional[MaskResolution] = None,
     ) -> List[npt.NDArray[np.uint8]]:
         """Materialize per-instance segmentation masks from prototype data.
 
         Computes ``mask_coeff @ protos`` with sigmoid activation for each
-        detection, producing compact masks at prototype resolution (e.g.,
-        160x160 crops). Mask values are **continuous sigmoid confidence**
-        quantized to uint8 (0 = background, 255 = full confidence), **not**
-        binary thresholded.
+        detection. The ``resolution`` parameter selects the output shape
+        and value encoding:
+
+        - ``MaskResolution.Proto()`` (default when ``resolution`` is
+          ``None``): returns per-detection tiles at proto-plane resolution
+          with **continuous sigmoid** values in ``uint8 [0, 255]``.
+        - ``MaskResolution.Scaled(width, height)``: returns per-detection
+          tiles at ``(width, height)`` pixel resolution with **binary**
+          ``uint8 {0, 255}`` values (sigmoid > 0.5 threshold). The upsample
+          happens on the full proto plane with edge-clamp bilinear
+          sampling — correct by construction, unlike per-tile resize.
+          Drop-in replacement for the continuous output under the caller's
+          ``> 127`` threshold.
 
         The returned masks can be inspected for analytics, IoU computation,
         or export, and also passed to :meth:`draw_decoded_masks` for
@@ -1267,10 +1307,16 @@ class ImageProcessor:
             classes: ``(N,)`` uintp array of class indices.
             proto_data: Prototype data from :meth:`Decoder.decode_proto`.
             letterbox: Optional ``(x0, y0, x1, y1)`` letterbox region in
-                normalized coordinates.
+                normalized model-input coordinates. When set with
+                ``MaskResolution.Scaled``, ``(width, height)`` are
+                interpreted as original-content pixel dims and the inverse
+                letterbox transform is applied during the upsample.
+            resolution: Output resolution and encoding. Defaults to
+                :meth:`MaskResolution.Proto` when ``None``.
 
         Returns:
-            List of ``(H, W, 1)`` uint8 arrays with continuous sigmoid values.
+            List of ``(H, W, 1)`` uint8 arrays. Shape and encoding depend
+            on ``resolution`` — see above.
         """
         ...
 

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -6,7 +6,9 @@ use crate::tensor::PyTensor;
 use crate::tracker::PyTrackInfo;
 use edgefirst_hal::{
     decoder::{BoundingBox, DetectBox, Segmentation},
-    image::{self, Crop, Flip, ImageProcessorConfig, ImageProcessorTrait, Rect, Rotation},
+    image::{
+        self, Crop, Flip, ImageProcessorConfig, ImageProcessorTrait, MaskResolution, Rect, Rotation,
+    },
     tensor::{self as tensor, PixelFormat, TensorDyn, TensorMapTrait, TensorTrait},
 };
 
@@ -1087,10 +1089,19 @@ impl PyImageProcessor {
     /// :param proto_data: prototype data from :meth:`Decoder.decode_proto`
     /// :param letterbox: optional letterbox region ``(x0, y0, x1, y1)`` in
     ///     normalized coordinates, or ``None`` if no letterboxing was applied
-    /// :returns: list of (H, W, 1) uint8 numpy arrays with continuous sigmoid
-    ///     mask values
+    /// :param resolution: optional mask materialization mode. When ``None`` or
+    ///     :class:`MaskResolution.Proto`, returns per-detection tiles at
+    ///     proto-plane resolution with continuous sigmoid mask values. When
+    ///     :class:`MaskResolution.Scaled` ``(width, height)``, HAL upsamples
+    ///     the full proto plane once and returns per-detection tiles at the
+    ///     target resolution with binary mask values encoded as
+    ///     ``uint8 {0, 255}``. The same ``> 127`` threshold works for both.
+    /// :returns: list of ``(H, W, 1)`` uint8 numpy arrays. Contents depend on
+    ///     ``resolution``: continuous sigmoid values for ``Proto``, binary
+    ///     ``{0, 255}`` for ``Scaled``.
     /// :rtype: list[numpy.ndarray]
-    #[pyo3(signature = (bbox, scores, classes, proto_data, letterbox=None))]
+    #[pyo3(signature = (bbox, scores, classes, proto_data, letterbox=None, resolution=None))]
+    #[allow(clippy::too_many_arguments)]
     pub fn materialize_masks<'py>(
         &self,
         bbox: PyReadonlyArray2<f32>,
@@ -1098,15 +1109,16 @@ impl PyImageProcessor {
         classes: PyReadonlyArray1<usize>,
         proto_data: &PyProtoData,
         letterbox: Option<[f32; 4]>,
+        resolution: Option<PyMaskResolution>,
         py: Python<'py>,
     ) -> Result<Vec<Bound<'py, numpy::PyArray3<u8>>>> {
         let detect = numpy_to_detect_boxes(&bbox, &scores, &classes)?;
-
+        let resolution = resolution.map(|r| r.0).unwrap_or(MaskResolution::Proto);
         let l = self
             .0
             .lock()
             .map_err(|_| Error::InvalidArg("ImageProcessor lock poisoned".to_string()))?;
-        let masks = l.materialize_masks(&detect, &proto_data.0, letterbox)?;
+        let masks = l.materialize_masks(&detect, &proto_data.0, letterbox, resolution)?;
         Ok(convert_seg_mask(py, &masks))
     }
 
@@ -1431,6 +1443,54 @@ impl From<PyColorMode> for image::ColorMode {
             PyColorMode::Class => image::ColorMode::Class,
             PyColorMode::Instance => image::ColorMode::Instance,
             PyColorMode::Track => image::ColorMode::Track,
+        }
+    }
+}
+
+/// Controls the resolution and coordinate frame of masks produced by
+/// :meth:`ImageProcessor.materialize_masks`.
+///
+/// Construct via classmethods:
+///
+/// - ``MaskResolution.Proto()`` — per-detection tiles at proto-plane
+///   resolution (historical default). Mask values are continuous sigmoid
+///   ``uint8 [0, 255]``.
+/// - ``MaskResolution.Scaled(width, height)`` — per-detection tiles at
+///   caller-specified pixel resolution, produced by upsampling the full
+///   proto plane once (correct edge-clamp bilinear) and cropping by bbox
+///   after sigmoid. Mask values are binary ``uint8 {0, 255}`` —
+///   interchangeable with the continuous sigmoid output via the same
+///   ``> 127`` test. If a ``letterbox`` is also passed to
+///   ``materialize_masks``, ``(width, height)`` are interpreted as
+///   original-content pixel dims and the inverse letterbox transform is
+///   applied during the upsample.
+#[pyclass(name = "MaskResolution")]
+#[derive(Debug, Clone, Copy)]
+pub struct PyMaskResolution(pub(crate) MaskResolution);
+
+#[pymethods]
+impl PyMaskResolution {
+    /// Per-detection tile at proto-plane resolution (default).
+    #[classmethod]
+    #[allow(non_snake_case)]
+    fn Proto(_cls: &Bound<'_, pyo3::types::PyType>) -> Self {
+        Self(MaskResolution::Proto)
+    }
+
+    /// Per-detection tile at ``(width, height)`` pixel resolution.
+    #[classmethod]
+    #[allow(non_snake_case)]
+    #[pyo3(signature = (width, height))]
+    fn Scaled(_cls: &Bound<'_, pyo3::types::PyType>, width: u32, height: u32) -> Self {
+        Self(MaskResolution::Scaled { width, height })
+    }
+
+    fn __repr__(&self) -> String {
+        match self.0 {
+            MaskResolution::Proto => "MaskResolution.Proto()".into(),
+            MaskResolution::Scaled { width, height } => {
+                format!("MaskResolution.Scaled(width={width}, height={height})")
+            }
         }
     }
 }

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -49,6 +49,7 @@ pub mod edgefirst_hal {
         m.add_class::<image::PyRotation>()?;
         m.add_class::<image::PyFlip>()?;
         m.add_class::<image::PyColorMode>()?;
+        m.add_class::<image::PyMaskResolution>()?;
         m.add_class::<image::PyImageProcessor>()?;
         m.add_class::<image::PyEglDisplayKind>()?;
         m.add_function(wrap_pyfunction!(image::align_width_for_gpu_pitch, m)?)?;

--- a/testdata/hailo_yolov8seg_edgefirst.json
+++ b/testdata/hailo_yolov8seg_edgefirst.json
@@ -1,0 +1,283 @@
+{
+  "schema_version": 2,
+  "decoder_version": "yolov8",
+  "name": "yolov8n-seg-hailo-reference",
+  "description": "Hailo-8/8L YOLOv8-seg schema v2 reference fixture (strides 8/16/32, DFL boxes, sigmoid-applied scores, NHWC protos). Mirrors HAILORT_DECODER.md §198-250.",
+  "author": "AuZone Technologies Inc",
+  "dataset": {
+    "name": "coco",
+    "id": "ds-hailo-ref",
+    "classes": [
+      "person", "bicycle", "car", "motorcycle", "airplane",
+      "bus", "train", "truck", "boat", "traffic light",
+      "fire hydrant", "stop sign", "parking meter", "bench", "bird",
+      "cat", "dog", "horse", "sheep", "cow",
+      "elephant", "bear", "zebra", "giraffe", "backpack",
+      "umbrella", "handbag", "tie", "suitcase", "frisbee",
+      "skis", "snowboard", "sports ball", "kite", "baseball bat",
+      "baseball glove", "skateboard", "surfboard", "tennis racket", "bottle",
+      "wine glass", "cup", "fork", "knife", "spoon",
+      "bowl", "banana", "apple", "sandwich", "orange",
+      "broccoli", "carrot", "hot dog", "pizza", "donut",
+      "cake", "chair", "couch", "potted plant", "bed",
+      "dining table", "toilet", "tv", "laptop", "mouse",
+      "remote", "keyboard", "cell phone", "microwave", "oven",
+      "toaster", "sink", "refrigerator", "book", "clock",
+      "vase", "scissors", "teddy bear", "hair drier", "toothbrush"
+    ]
+  },
+  "input": {
+    "shape": [1, 3, 640, 640],
+    "cameraadaptor": "rgb",
+    "input_channels": 3,
+    "output_channels": 3
+  },
+  "model": {
+    "name": "yolov8n-seg-hailo-reference",
+    "version": "8.4.9+edgefirst-1.7.0",
+    "task": "segmentation",
+    "size": "nano",
+    "detection": false,
+    "segmentation": true,
+    "anchors": null,
+    "end2end": false
+  },
+  "nms": "class_agnostic",
+  "outputs": [
+    {
+      "name": "boxes",
+      "type": "boxes",
+      "shape": [1, 4, 8400],
+      "dshape": [
+        {"batch": 1},
+        {"box_coords": 4},
+        {"num_boxes": 8400}
+      ],
+      "encoding": "dfl",
+      "decoder": "ultralytics",
+      "normalized": false,
+      "outputs": [
+        {
+          "name": "boxes_stride_8",
+          "type": "boxes",
+          "stride": 8,
+          "scale_index": 0,
+          "shape": [1, 80, 80, 64],
+          "dshape": [
+            {"batch": 1},
+            {"height": 80},
+            {"width": 80},
+            {"num_features": 64}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.13012499,
+            "zero_point": 70,
+            "dtype": "uint8"
+          }
+        },
+        {
+          "name": "boxes_stride_16",
+          "type": "boxes",
+          "stride": 16,
+          "scale_index": 1,
+          "shape": [1, 40, 40, 64],
+          "dshape": [
+            {"batch": 1},
+            {"height": 40},
+            {"width": 40},
+            {"num_features": 64}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.11984375,
+            "zero_point": 60,
+            "dtype": "uint8"
+          }
+        },
+        {
+          "name": "boxes_stride_32",
+          "type": "boxes",
+          "stride": 32,
+          "scale_index": 2,
+          "shape": [1, 20, 20, 64],
+          "dshape": [
+            {"batch": 1},
+            {"height": 20},
+            {"width": 20},
+            {"num_features": 64}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.10931250,
+            "zero_point": 50,
+            "dtype": "uint8"
+          }
+        }
+      ]
+    },
+    {
+      "name": "scores",
+      "type": "scores",
+      "shape": [1, 80, 8400],
+      "dshape": [
+        {"batch": 1},
+        {"num_classes": 80},
+        {"num_boxes": 8400}
+      ],
+      "decoder": "ultralytics",
+      "score_format": "per_class",
+      "outputs": [
+        {
+          "name": "scores_stride_8",
+          "type": "scores",
+          "stride": 8,
+          "scale_index": 0,
+          "shape": [1, 80, 80, 80],
+          "dshape": [
+            {"batch": 1},
+            {"height": 80},
+            {"width": 80},
+            {"num_classes": 80}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.00392157,
+            "zero_point": 0,
+            "dtype": "uint8"
+          },
+          "activation_applied": "sigmoid"
+        },
+        {
+          "name": "scores_stride_16",
+          "type": "scores",
+          "stride": 16,
+          "scale_index": 1,
+          "shape": [1, 40, 40, 80],
+          "dshape": [
+            {"batch": 1},
+            {"height": 40},
+            {"width": 40},
+            {"num_classes": 80}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.00392157,
+            "zero_point": 0,
+            "dtype": "uint8"
+          },
+          "activation_applied": "sigmoid"
+        },
+        {
+          "name": "scores_stride_32",
+          "type": "scores",
+          "stride": 32,
+          "scale_index": 2,
+          "shape": [1, 20, 20, 80],
+          "dshape": [
+            {"batch": 1},
+            {"height": 20},
+            {"width": 20},
+            {"num_classes": 80}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.00392157,
+            "zero_point": 0,
+            "dtype": "uint8"
+          },
+          "activation_applied": "sigmoid"
+        }
+      ]
+    },
+    {
+      "name": "mask_coefs",
+      "type": "mask_coefs",
+      "shape": [1, 32, 8400],
+      "dshape": [
+        {"batch": 1},
+        {"num_protos": 32},
+        {"num_boxes": 8400}
+      ],
+      "decoder": "ultralytics",
+      "outputs": [
+        {
+          "name": "mask_coefs_stride_8",
+          "type": "mask_coefs",
+          "stride": 8,
+          "scale_index": 0,
+          "shape": [1, 80, 80, 32],
+          "dshape": [
+            {"batch": 1},
+            {"height": 80},
+            {"width": 80},
+            {"num_protos": 32}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.02547,
+            "zero_point": 32,
+            "dtype": "uint8"
+          }
+        },
+        {
+          "name": "mask_coefs_stride_16",
+          "type": "mask_coefs",
+          "stride": 16,
+          "scale_index": 1,
+          "shape": [1, 40, 40, 32],
+          "dshape": [
+            {"batch": 1},
+            {"height": 40},
+            {"width": 40},
+            {"num_protos": 32}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.02547,
+            "zero_point": 32,
+            "dtype": "uint8"
+          }
+        },
+        {
+          "name": "mask_coefs_stride_32",
+          "type": "mask_coefs",
+          "stride": 32,
+          "scale_index": 2,
+          "shape": [1, 20, 20, 32],
+          "dshape": [
+            {"batch": 1},
+            {"height": 20},
+            {"width": 20},
+            {"num_protos": 32}
+          ],
+          "dtype": "uint8",
+          "quantization": {
+            "scale": 0.02547,
+            "zero_point": 32,
+            "dtype": "uint8"
+          }
+        }
+      ]
+    },
+    {
+      "name": "protos",
+      "type": "protos",
+      "shape": [1, 160, 160, 32],
+      "dshape": [
+        {"batch": 1},
+        {"height": 160},
+        {"width": 160},
+        {"num_protos": 32}
+      ],
+      "dtype": "uint8",
+      "quantization": {
+        "scale": 0.03084,
+        "zero_point": 10,
+        "dtype": "uint8"
+      },
+      "stride": 4,
+      "decoder": "ultralytics"
+    }
+  ]
+}

--- a/tests/decoder/test_hailort_bug_repro.py
+++ b/tests/decoder/test_hailort_bug_repro.py
@@ -1,0 +1,571 @@
+"""Python-level reproducer for HAILORT_BUG.md.
+
+Mirrors the exact tensor-passing pattern that
+`edgefirst-validator`'s `process_yolo_hal` uses on the Hailo path:
+
+  1. Build per-FPN-scale parts shaped `(H*W, 4 + nc + nm)` and
+     `np.concatenate(axis=0)` into `(total_anchors, 4 + nc + nm)`
+     C-contiguous.
+  2. Apply `.T[np.newaxis]` to get a **non-contiguous view** of shape
+     `(1, 4 + nc + nm, total_anchors)` — the same memory layout the
+     validator's `_prepare_raw_outputs` returns.
+  3. Apply the in-place `x[:, [0, 2]] /= width` normalization in the
+     same 3-dim-fancy-index style `check_normalized_boxes` uses.
+  4. Instantiate `edgefirst_hal.Tensor(shape, dtype).from_numpy(view)`
+     and pass to `decoder.decode(...)` exactly as the validator does.
+  5. Check each surviving detection's mask was rendered from the
+     mask_coef row at its own anchor index.
+
+Encodes an obvious high/low signal in mask_coefs + protos so any
+mask-to-detection index swap would flip the rendered mean by
+~250 u8 values.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import edgefirst_hal
+
+
+def _build_combined_detection_tensor(
+    per_scale_parts, normalize_boxes, model_input=(640, 640)
+):
+    """Replicate `_prepare_raw_outputs` tail + `check_normalized_boxes`.
+
+    * `per_scale_parts`: list of `(H*W, 4 + nc + nm)` float32 arrays.
+    * `normalize_boxes`: when True, divide xc/yc/w/h by model input size
+      (validator does this for pixel-space boxes from Hailo DFL decode).
+    """
+    width, height = model_input
+    detection = np.concatenate(per_scale_parts, axis=0)  # (A, F)
+    detection = detection.T[np.newaxis]  # (1, F, A) view
+    if normalize_boxes:
+        # This is exactly what `check_normalized_boxes` does on a
+        # (1, 4, A) slice when the boundary fraction is < 0.80.
+        detection[:, [0, 2]] /= width
+        detection[:, [1, 3]] /= height
+    return detection
+
+
+def test_hailort_validator_pattern_preserves_mask_detection_pairing():
+    """Full Python-stack replay of the validator's pattern.
+
+    Three FPN levels (strides 8/16/32) at 640×640, reg_max post-decode
+    so boxes are already xcycwh (we build xywh directly). Ten anchors
+    carry unique mask_coef one-hot signatures; protos are per-channel
+    distinct so a correctly-paired mask sigmoid-saturates (→ 255) and
+    any mis-indexed lookup renders as sigmoid(0) ≈ 0.5 (→ 128).
+    """
+    nc = 80
+    nm = 32
+    feat = 4 + nc + nm  # 116
+    width = height = 640
+    # Cheap grids — we don't need every anchor, just enough to put 10
+    # above threshold in three different FPN blocks.
+    fpn = [(80, 80, 8), (40, 40, 16), (20, 20, 32)]
+
+    # Build per-FPN-scale chunks. Most anchors are zero; ten specific
+    # anchors get a valid detection + one-hot mask_coef at channel K.
+    parts = []
+    # Target anchors: (part_idx, local_row, k)
+    targets = []
+    target_count = 10
+    for idx in range(target_count):
+        part_idx = idx % 3
+        h, w, stride = fpn[part_idx]
+        n_anchors = h * w
+        local_row = (idx * 237) % n_anchors
+        k = idx  # one-hot channel equals anchor index in [0, NM=32)
+        targets.append((part_idx, local_row, k, stride))
+
+    for p, (h, w, stride) in enumerate(fpn):
+        n_anchors = h * w
+        chunk = np.zeros((n_anchors, feat), dtype=np.float32)
+        # Fill each target anchor
+        for part_idx, local_row, k, s in targets:
+            if part_idx != p:
+                continue
+            # Place a non-overlapping box centred at a grid-derived
+            # position in pixel coords. Width/height small (~20px) so
+            # NMS doesn't suppress across targets.
+            row = local_row // w
+            col = local_row % w
+            xc = (col + 0.5) * stride
+            yc = (row + 0.5) * stride
+            chunk[local_row, 0] = xc
+            chunk[local_row, 1] = yc
+            chunk[local_row, 2] = 20.0  # width 20 px
+            chunk[local_row, 3] = 20.0  # height 20 px
+            chunk[local_row, 4] = 0.95  # class 0 score (pre-sigmoided)
+            # One-hot mask_coefs at channel k, value +10 (strong)
+            chunk[local_row, 4 + nc + k] = 10.0
+        parts.append(chunk)
+
+    detection = _build_combined_detection_tensor(
+        parts, normalize_boxes=True, model_input=(width, height)
+    )
+    assert detection.shape == (1, feat, 80 * 80 + 40 * 40 + 20 * 20)
+    # Sanity: the view is NOT C-contiguous — that's the validator's
+    # pattern and the one we specifically want to test.
+    assert not detection.flags["C_CONTIGUOUS"], (
+        "test setup bug: combined detection tensor must be "
+        ".T[np.newaxis] non-contig to replicate validator"
+    )
+
+    # Protos NCHW (1, 32, 160, 160). Channel k all-`5.0 + 0.1*k`.
+    protos = np.zeros((1, nm, 160, 160), dtype=np.float32)
+    for k in range(nm):
+        protos[0, k] = 5.0 + 0.1 * k
+
+    # Construct decoder via the dict API (validator's `init_decoder`
+    # path at runners/core.py:164).
+    hal_metadata = {
+        "decoder_version": "yolov8",
+        "nms": "class_agnostic",
+        "outputs": [
+            {
+                "type": "detection",
+                "decoder": "ultralytics",
+                "shape": [1, feat, detection.shape[2]],
+                "score_format": "per_class",
+                "quantization": [1.0, 0],
+            },
+            {
+                "type": "protos",
+                "decoder": "ultralytics",
+                "shape": [1, nm, 160, 160],
+                "quantization": [1.0, 0],
+            },
+        ],
+    }
+    decoder = edgefirst_hal.Decoder(
+        hal_metadata,
+        score_threshold=0.5,
+        iou_threshold=0.5,
+        nms=edgefirst_hal.Nms.ClassAgnostic,
+    )
+
+    # Pass tensors via from_numpy exactly like validator's
+    # process_yolo_hal at runners/core.py:795-804.
+    det_tensor = edgefirst_hal.Tensor(list(detection.shape), dtype="float32")
+    det_tensor.from_numpy(detection)
+    proto_tensor = edgefirst_hal.Tensor(list(protos.shape), dtype="float32")
+    proto_tensor.from_numpy(protos)
+
+    boxes, scores, classes, masks = decoder.decode(
+        [det_tensor, proto_tensor], max_boxes=100
+    )
+    assert len(boxes) == target_count, (
+        f"expected {target_count} detections, got {len(boxes)}"
+    )
+    assert len(masks) == target_count
+
+    # For each surviving detection, verify its rendered mask was
+    # looked up at the CORRECT anchor index. Correct pairings render
+    # to ≈255; any misalignment would render to sigmoid(0) ≈ 128.
+    for i, (b, m) in enumerate(zip(boxes, masks)):
+        mean = float(np.mean(m))
+        assert mean > 240.0, (
+            f"detection {i} box={b} mean mask value {mean} indicates "
+            f"mask-coef row was looked up at the WRONG anchor index "
+            f"(expected ~255 for correct one-hot → per-channel-unique "
+            f"proto lookup; got {mean} which suggests "
+            f"sigmoid(0)≈128 from a zeroed mask_coefs row, "
+            f"i.e. mask-detection misalignment)"
+        )
+
+
+def test_hailort_validator_pattern_with_tensor_cache_across_frames():
+    """Replicate `_TENSOR_CACHE` reuse across multiple frames.
+
+    The validator's `process_yolo_hal` re-uses the same `Tensor`
+    across iterations via the module-level `_TENSOR_CACHE` dict,
+    calling `tensor.from_numpy(output)` each frame. If `from_numpy`
+    leaks stale data or fails to fully overwrite the buffer when
+    the source view is non-contiguous, the decode would pair each
+    frame's detections against some mix of stale + current
+    mask_coefs — manifesting as incorrect mask rendering.
+    """
+    nc = 80
+    nm = 32
+    feat = 4 + nc + nm
+    width = height = 640
+    fpn = [(80, 80, 8), (40, 40, 16), (20, 20, 32)]
+    total_anchors = sum(h * w for h, w, _ in fpn)
+
+    hal_metadata = {
+        "decoder_version": "yolov8",
+        "nms": "class_agnostic",
+        "outputs": [
+            {
+                "type": "detection",
+                "decoder": "ultralytics",
+                "shape": [1, feat, total_anchors],
+                "score_format": "per_class",
+                "quantization": [1.0, 0],
+            },
+            {
+                "type": "protos",
+                "decoder": "ultralytics",
+                "shape": [1, nm, 160, 160],
+                "quantization": [1.0, 0],
+            },
+        ],
+    }
+    decoder = edgefirst_hal.Decoder(
+        hal_metadata,
+        score_threshold=0.5,
+        iou_threshold=0.5,
+        nms=edgefirst_hal.Nms.ClassAgnostic,
+    )
+    # Cache-style reuse: allocate once, from_numpy each frame.
+    det_tensor = edgefirst_hal.Tensor([1, feat, total_anchors], dtype="float32")
+    proto_tensor = edgefirst_hal.Tensor([1, nm, 160, 160], dtype="float32")
+
+    protos = np.zeros((1, nm, 160, 160), dtype=np.float32)
+    for k in range(nm):
+        protos[0, k] = 5.0 + 0.1 * k
+    proto_tensor.from_numpy(protos)
+
+    # Iterate 5 frames, each with DIFFERENT target anchors. If a stale
+    # buffer leaks, a later frame's detection would pick up an earlier
+    # frame's mask_coefs → mismatched mask mean vs expected.
+    rng_sequence = [0xAAAA, 0xBBBB, 0xCCCC, 0xDDDD, 0xEEEE]
+    # Pre-compute the decoded centre for every anchor so we can enforce a
+    # spatial separation when sampling. Without this, two stride-8 neighbours
+    # could both be picked, their 20-px boxes overlap above IoU 0.5, and NMS
+    # would suppress one — making the stale-buffer assertion flaky for
+    # reasons unrelated to what this test is probing.
+    anchor_centres = []
+    offset = 0
+    for h, w, stride in fpn:
+        for local_row in range(h * w):
+            row, col = divmod(local_row, w)
+            xc = (col + 0.5) * stride
+            yc = (row + 0.5) * stride
+            anchor_centres.append((offset + local_row, xc, yc))
+        offset += h * w
+
+    for frame_idx, seed in enumerate(rng_sequence):
+        rng = np.random.default_rng(seed)
+        # Pick 10 spatially separated anchors (centres ≥ 20 px apart in both
+        # axes — i.e. non-overlapping box footprints) + random one-hot k.
+        order = rng.permutation(len(anchor_centres))
+        targets = []
+        selected_centres = []
+        for candidate_idx in order:
+            idx, xc, yc = anchor_centres[int(candidate_idx)]
+            if any(
+                abs(xc - pxc) < 20.0 and abs(yc - pyc) < 20.0
+                for pxc, pyc in selected_centres
+            ):
+                continue
+            k = int(rng.integers(0, nm))
+            targets.append((idx, k))
+            selected_centres.append((xc, yc))
+            if len(targets) == 10:
+                break
+        assert len(targets) == 10, (
+            f"frame {frame_idx}: failed to sample 10 well-separated anchors"
+        )
+
+        # Build per-scale parts.
+        parts = []
+        offset = 0
+        for p, (h, w, stride) in enumerate(fpn):
+            n_anchors = h * w
+            chunk = np.zeros((n_anchors, feat), dtype=np.float32)
+            for tgt_idx, k in targets:
+                if not (offset <= tgt_idx < offset + n_anchors):
+                    continue
+                local_row = tgt_idx - offset
+                row = local_row // w
+                col = local_row % w
+                chunk[local_row, 0] = (col + 0.5) * stride
+                chunk[local_row, 1] = (row + 0.5) * stride
+                chunk[local_row, 2] = 20.0
+                chunk[local_row, 3] = 20.0
+                chunk[local_row, 4] = 0.95
+                chunk[local_row, 4 + nc + k] = 10.0
+            parts.append(chunk)
+            offset += n_anchors
+
+        detection = _build_combined_detection_tensor(
+            parts, normalize_boxes=True, model_input=(width, height)
+        )
+        det_tensor.from_numpy(detection)
+        boxes, scores, classes, masks = decoder.decode(
+            [det_tensor, proto_tensor], max_boxes=100
+        )
+        assert len(boxes) == 10, (
+            f"frame {frame_idx}: expected 10 detections, got {len(boxes)}"
+        )
+        for i, (b, m) in enumerate(zip(boxes, masks)):
+            mean = float(np.mean(m))
+            assert mean > 240.0, (
+                f"frame {frame_idx} detection {i}: mean mask value "
+                f"{mean} < 240 → likely stale-buffer leak in "
+                f"Tensor.from_numpy cross-frame reuse"
+            )
+
+
+def _numpy_reference_mask(mask_coefs, protos, bbox_norm, width, height):
+    """NumPy reference for HAL's YoloSegDet mask rendering.
+
+    * `mask_coefs`: shape `(nm,)` — anchor's mask_coefs row.
+    * `protos`: shape `(nm, H_p, W_p)` NCHW — mask prototypes.
+    * `bbox_norm`: `(x1, y1, x2, y2)` normalised to [0, 1].
+
+    Returns the ROI-cropped mask as uint8 `(h_roi, w_roi)`.
+    """
+    H_p, W_p = protos.shape[1], protos.shape[2]
+    x1 = int(max(0, bbox_norm[0] * W_p))
+    y1 = int(max(0, bbox_norm[1] * H_p))
+    x2 = int(np.ceil(bbox_norm[2] * W_p))
+    y2 = int(np.ceil(bbox_norm[3] * H_p))
+    x2 = max(x2, x1 + 1)
+    y2 = max(y2, y1 + 1)
+    # protos NHWC after HAL's internal protos_to_hwc: (H, W, nm)
+    protos_hwc = protos.transpose(1, 2, 0)
+    cropped = protos_hwc[y1:y2, x1:x2, :]  # (h, w, nm)
+    mask_f = cropped @ mask_coefs  # (h, w)
+    return (1.0 / (1.0 + np.exp(-mask_f)) * 255).round().astype(np.uint8)
+
+
+def test_hailort_validator_pattern_dense_realistic_mask_coefs_match_numpy_reference():
+    """Compare HAL's rendered masks against a NumPy reference using
+    realistic dense mask_coefs (not one-hot). Mirrors the actual
+    YOLOv8-seg runtime data distribution.
+
+    If HAL's mask rendering is correctly paired with each detection,
+    the per-pixel mask values should match the reference within
+    rounding tolerance (± 2 u8).
+    """
+    nc = 80
+    nm = 32
+    feat = 4 + nc + nm
+    width = height = 640
+    fpn = [(80, 80, 8), (40, 40, 16), (20, 20, 32)]
+    total_anchors = sum(h * w for h, w, _ in fpn)
+
+    rng = np.random.default_rng(0x5E6D)
+
+    # Place 12 non-overlapping detections at random anchors, each
+    # with dense Gaussian-like mask_coefs and realistic protos.
+    targets = []
+    used = set()
+    while len(targets) < 12:
+        a = int(rng.integers(0, total_anchors))
+        if a in used:
+            continue
+        used.add(a)
+        targets.append(a)
+
+    # Dense protos: 32 proto channels each containing a smooth
+    # gradient pattern (realistic of segmentation proto outputs).
+    protos = np.zeros((1, nm, 160, 160), dtype=np.float32)
+    yy, xx = np.meshgrid(
+        np.linspace(-1, 1, 160), np.linspace(-1, 1, 160), indexing="ij"
+    )
+    for k in range(nm):
+        phase = k * 0.3
+        protos[0, k] = np.sin(3 * xx + phase) * np.cos(2 * yy - phase)
+
+    parts = []
+    offset = 0
+    anchor_mask_coefs = {}  # anchor_idx → (nm,) mask_coefs
+    anchor_bbox_pix = {}  # anchor_idx → (x1, y1, x2, y2) in pixels
+    for p, (h, w, stride) in enumerate(fpn):
+        n_anchors = h * w
+        chunk = np.zeros((n_anchors, feat), dtype=np.float32)
+        for tgt in targets:
+            if not (offset <= tgt < offset + n_anchors):
+                continue
+            local_row = tgt - offset
+            row = local_row // w
+            col = local_row % w
+            xc_px = (col + 0.5) * stride
+            yc_px = (row + 0.5) * stride
+            w_px = 80.0
+            h_px = 80.0
+            chunk[local_row, 0] = xc_px
+            chunk[local_row, 1] = yc_px
+            chunk[local_row, 2] = w_px
+            chunk[local_row, 3] = h_px
+            chunk[local_row, 4] = 0.9
+            # Dense realistic mask_coefs.
+            coefs = rng.standard_normal(nm).astype(np.float32) * 0.5
+            chunk[local_row, 4 + nc : 4 + nc + nm] = coefs
+            anchor_mask_coefs[tgt] = coefs
+            anchor_bbox_pix[tgt] = (
+                xc_px - w_px / 2,
+                yc_px - h_px / 2,
+                xc_px + w_px / 2,
+                yc_px + h_px / 2,
+            )
+        parts.append(chunk)
+        offset += n_anchors
+
+    detection = _build_combined_detection_tensor(
+        parts, normalize_boxes=True, model_input=(width, height)
+    )
+
+    hal_metadata = {
+        "decoder_version": "yolov8",
+        "nms": "class_agnostic",
+        "outputs": [
+            {
+                "type": "detection",
+                "decoder": "ultralytics",
+                "shape": [1, feat, total_anchors],
+                "score_format": "per_class",
+                "quantization": [1.0, 0],
+            },
+            {
+                "type": "protos",
+                "decoder": "ultralytics",
+                "shape": [1, nm, 160, 160],
+                "quantization": [1.0, 0],
+            },
+        ],
+    }
+    decoder = edgefirst_hal.Decoder(
+        hal_metadata,
+        score_threshold=0.5,
+        iou_threshold=0.5,
+        nms=edgefirst_hal.Nms.ClassAgnostic,
+    )
+    det_tensor = edgefirst_hal.Tensor(list(detection.shape), dtype="float32")
+    det_tensor.from_numpy(detection)
+    proto_tensor = edgefirst_hal.Tensor(list(protos.shape), dtype="float32")
+    proto_tensor.from_numpy(protos)
+    boxes, scores, classes, masks = decoder.decode(
+        [det_tensor, proto_tensor], max_boxes=100
+    )
+    assert len(boxes) == len(targets)
+
+    # For each HAL detection, find the matching anchor from the
+    # original setup (by bbox centre proximity in normalised coords),
+    # then compare HAL's rendered mask to a NumPy reference that uses
+    # that anchor's mask_coefs directly.
+    matched = 0
+    for b, m in zip(boxes, masks):
+        cx = (b[0] + b[2]) * 0.5
+        cy = (b[1] + b[3]) * 0.5
+        # Find the target anchor whose normalised bbox centre is
+        # closest to this HAL detection's centre.
+        best_tgt = None
+        best_d2 = 1e9
+        for tgt, (x1p, y1p, x2p, y2p) in anchor_bbox_pix.items():
+            ncx = (x1p + x2p) / (2 * width)
+            ncy = (y1p + y2p) / (2 * height)
+            d2 = (ncx - cx) ** 2 + (ncy - cy) ** 2
+            if d2 < best_d2:
+                best_d2 = d2
+                best_tgt = tgt
+        assert best_d2 < 1e-3, (
+            f"HAL detection centre ({cx:.3f}, {cy:.3f}) has no "
+            f"nearby target anchor; best d²={best_d2}"
+        )
+        ref = _numpy_reference_mask(
+            anchor_mask_coefs[best_tgt],
+            protos[0],
+            (b[0], b[1], b[2], b[3]),
+            width,
+            height,
+        )
+        hal_mask = m.squeeze()  # (h, w, 1) → (h, w)
+        assert hal_mask.shape == ref.shape, (
+            f"shape mismatch: HAL={hal_mask.shape}, ref={ref.shape}"
+        )
+        # Allow ± 2 u8 for rounding differences.
+        diff = np.abs(hal_mask.astype(np.int32) - ref.astype(np.int32))
+        max_diff = int(diff.max())
+        assert max_diff <= 2, (
+            f"detection at ({cx:.3f}, {cy:.3f}) mask diverges from "
+            f"NumPy reference by up to {max_diff} u8 — HAL used the "
+            f"WRONG mask_coefs row (indicating mask-detection "
+            f"misalignment per HAILORT_BUG.md hypothesis)"
+        )
+        matched += 1
+    assert matched == len(targets)
+
+
+def test_hailort_validator_pattern_contiguous_control():
+    """Control: same data but passed as a C-contiguous copy.
+
+    If the non-contig test fails and this one passes, the bug is in
+    `Tensor.from_numpy`'s non-contiguous copy path. If both pass, the
+    HAL decoder is not mis-pairing masks under validator-style input.
+    """
+    nc = 80
+    nm = 32
+    feat = 4 + nc + nm
+    fpn = [(80, 80, 8), (40, 40, 16), (20, 20, 32)]
+    parts = []
+    targets = []
+    for idx in range(10):
+        part_idx = idx % 3
+        h, w, stride = fpn[part_idx]
+        local_row = (idx * 237) % (h * w)
+        targets.append((part_idx, local_row, idx, stride))
+    for p, (h, w, stride) in enumerate(fpn):
+        chunk = np.zeros((h * w, feat), dtype=np.float32)
+        for part_idx, local_row, k, s in targets:
+            if part_idx != p:
+                continue
+            row = local_row // w
+            col = local_row % w
+            chunk[local_row, 0] = (col + 0.5) * stride
+            chunk[local_row, 1] = (row + 0.5) * stride
+            chunk[local_row, 2] = 20.0
+            chunk[local_row, 3] = 20.0
+            chunk[local_row, 4] = 0.95
+            chunk[local_row, 4 + nc + k] = 10.0
+        parts.append(chunk)
+
+    detection_view = _build_combined_detection_tensor(parts, normalize_boxes=True)
+    # Force a fresh C-contig copy.
+    detection = np.ascontiguousarray(detection_view)
+    assert detection.flags["C_CONTIGUOUS"]
+
+    protos = np.zeros((1, nm, 160, 160), dtype=np.float32)
+    for k in range(nm):
+        protos[0, k] = 5.0 + 0.1 * k
+
+    hal_metadata = {
+        "decoder_version": "yolov8",
+        "nms": "class_agnostic",
+        "outputs": [
+            {
+                "type": "detection",
+                "decoder": "ultralytics",
+                "shape": [1, feat, detection.shape[2]],
+                "score_format": "per_class",
+                "quantization": [1.0, 0],
+            },
+            {
+                "type": "protos",
+                "decoder": "ultralytics",
+                "shape": [1, nm, 160, 160],
+                "quantization": [1.0, 0],
+            },
+        ],
+    }
+    decoder = edgefirst_hal.Decoder(
+        hal_metadata,
+        score_threshold=0.5,
+        iou_threshold=0.5,
+        nms=edgefirst_hal.Nms.ClassAgnostic,
+    )
+    det_tensor = edgefirst_hal.Tensor(list(detection.shape), dtype="float32")
+    det_tensor.from_numpy(detection)
+    proto_tensor = edgefirst_hal.Tensor(list(protos.shape), dtype="float32")
+    proto_tensor.from_numpy(protos)
+    boxes, scores, classes, masks = decoder.decode(
+        [det_tensor, proto_tensor], max_boxes=100
+    )
+    assert len(boxes) == 10
+    for i, (b, m) in enumerate(zip(boxes, masks)):
+        mean = float(np.mean(m))
+        assert mean > 240.0, f"C-contig control FAILED detection {i}: mean={mean}"

--- a/tests/decoder/test_scaled_masks.py
+++ b/tests/decoder/test_scaled_masks.py
@@ -1,0 +1,337 @@
+"""End-to-end tests for ImageProcessor.materialize_masks(MaskResolution.Scaled).
+
+Replays the exact tensor-passing pattern the EdgeFirst validator uses in
+``runners/core.py::process_yolo_hal`` but substitutes the new Scaled path
+for the per-tile ``ImageProcessor.convert()`` loop that exhibits the
+wraparound bug described in HAILORT_BUG.md.
+
+Verifies:
+
+1. Scaled masks are binary ``uint8 {0, 255}`` (not continuous sigmoid).
+2. Binary encoding is drop-in interchangeable with Proto continuous
+   masks via the same ``> 127`` threshold.
+3. Scaled output bbox-crop dimensions match the detection bbox mapped to
+   the target ``(width, height)``.
+4. Scaled masks match a NumPy ``sigmoid(coefs @ protos_upsampled) > 0.5``
+   retina-style reference within the fast_sigmoid approximation
+   tolerance (<0.5% pixel mismatch) when the bbox and protos are
+   well-conditioned.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import edgefirst_hal
+
+W, H = 640, 640
+PROTO_H, PROTO_W = 160, 160
+NC, NM = 80, 32
+
+
+def _hal_metadata():
+    return {
+        "decoder_version": "yolov8",
+        "nms": "class_agnostic",
+        "outputs": [
+            {
+                "type": "detection",
+                "decoder": "ultralytics",
+                "shape": [1, 4 + NC + NM, 8400],
+                "score_format": "per_class",
+                "quantization": [1.0, 0],
+            },
+            {
+                "type": "protos",
+                "decoder": "ultralytics",
+                "shape": [1, NM, PROTO_H, PROTO_W],
+                "quantization": [1.0, 0],
+            },
+        ],
+    }
+
+
+def _to_tensor(arr: np.ndarray) -> edgefirst_hal.Tensor:
+    t = edgefirst_hal.Tensor(list(arr.shape), dtype=arr.dtype.name)
+    t.from_numpy(arr)
+    return t
+
+
+def _build_validator_pattern_tensors(rng, placements):
+    """Replicate `_prepare_raw_outputs` + `check_normalized_boxes` tail.
+
+    Returns `(combined_view, protos_nchw)` where `combined_view` is a
+    non-contiguous `(1, 4+NC+NM, 8400)` view produced by `.T[np.newaxis]`
+    on a C-contiguous `(8400, 4+NC+NM)` base, with pixel-space xywh
+    divided by W/H exactly as the validator does pre-decode.
+    """
+    total_anchors = 8400
+    det = np.zeros((total_anchors, 4 + NC + NM), dtype=np.float32)
+    for i, (x0, y0, x1, y1) in enumerate(placements):
+        det[i, 0] = (x0 + x1) / 2 * W  # xc pixel
+        det[i, 1] = (y0 + y1) / 2 * H  # yc pixel
+        det[i, 2] = (x1 - x0) * W  # w pixel
+        det[i, 3] = (y1 - y0) * H  # h pixel
+        det[i, 4 + (i % NC)] = 0.9  # class score (sigmoid-applied)
+        det[i, 4 + NC + (i % NM)] = 4.0  # mask coef one-hot at (i % NM)
+
+    combined = det.T[np.newaxis]  # (1, 4+NC+NM, 8400) non-contig view
+    # Validator does this in-place on a copy before decode.
+    combined = combined.copy()
+    combined[:, [0, 2]] /= W
+    combined[:, [1, 3]] /= H
+
+    protos = (rng.standard_normal((1, NM, PROTO_H, PROTO_W)) * 2.0).astype(np.float32)
+    return combined, protos
+
+
+def _numpy_reference_retina(protos_nchw, coefs, bbox_xyxy_norm, target_w, target_h):
+    """NumPy reference for ``MaskResolution.Scaled`` (letterbox=None).
+
+    Upsamples the full proto plane to `(target_h, target_w)` with the
+    same center-of-pixel bilinear convention the HAL path uses, computes
+    `sigmoid(coefs @ upsampled) > 0.5` as a binary mask, then bbox-crops.
+    """
+    protos_hwc = protos_nchw[0].transpose(1, 2, 0)  # (H_p, W_p, NM)
+    sx = PROTO_W / target_w
+    sy = PROTO_H / target_h
+    logits = np.zeros((target_h, target_w), dtype=np.float32)
+    for yi in range(target_h):
+        sy_coord = (yi + 0.5) * sy - 0.5
+        y_f = int(np.floor(sy_coord))
+        yw = sy_coord - y_f
+        y_a = max(0, min(y_f, PROTO_H - 1))
+        y_b = max(0, min(y_f + 1, PROTO_H - 1))
+        for xi in range(target_w):
+            sx_coord = (xi + 0.5) * sx - 0.5
+            x_f = int(np.floor(sx_coord))
+            xw = sx_coord - x_f
+            x_a = max(0, min(x_f, PROTO_W - 1))
+            x_b = max(0, min(x_f + 1, PROTO_W - 1))
+            val = (
+                (1 - xw) * (1 - yw) * protos_hwc[y_a, x_a]
+                + xw * (1 - yw) * protos_hwc[y_a, x_b]
+                + (1 - xw) * yw * protos_hwc[y_b, x_a]
+                + xw * yw * protos_hwc[y_b, x_b]
+            )
+            logits[yi, xi] = float(np.dot(val, coefs))
+    mask_full = (1.0 / (1.0 + np.exp(-logits)) > 0.5).astype(np.uint8) * 255
+
+    x0, y0, x1, y1 = bbox_xyxy_norm
+    px0 = int(round(x0 * target_w))
+    py0 = int(round(y0 * target_h))
+    px1 = int(round(x1 * target_w))
+    py1 = int(round(y1 * target_h))
+    return mask_full[py0:py1, px0:px1]
+
+
+def _make_decoder():
+    return edgefirst_hal.Decoder(
+        _hal_metadata(),
+        score_threshold=0.5,
+        iou_threshold=0.5,
+        nms=edgefirst_hal.Nms.ClassAgnostic,
+    )
+
+
+def test_scaled_output_is_binary_0_or_255():
+    """Scaled masks are strictly ``uint8 {0, 255}``, never a continuous value."""
+    rng = np.random.default_rng(42)
+    placements = [(0.10, 0.15, 0.35, 0.55), (0.40, 0.10, 0.65, 0.65)]
+    combined, protos = _build_validator_pattern_tensors(rng, placements)
+
+    decoder = _make_decoder()
+    ip = edgefirst_hal.ImageProcessor()
+
+    boxes, scores, classes, proto_data = decoder.decode_proto(
+        [_to_tensor(combined), _to_tensor(protos)], max_boxes=300
+    )
+    assert proto_data is not None
+    assert len(boxes) >= 1
+
+    masks = ip.materialize_masks(
+        boxes,
+        scores,
+        classes,
+        proto_data,
+        letterbox=None,
+        resolution=edgefirst_hal.MaskResolution.Scaled(W, H),
+    )
+    assert len(masks) == len(boxes)
+
+    for i, m in enumerate(masks):
+        assert m.dtype == np.uint8, f"detection {i} mask dtype={m.dtype}"
+        uniq = set(np.unique(m).tolist())
+        assert uniq.issubset({0, 255}), (
+            f"Scaled mask must be binary {{0, 255}}, got unique values {uniq} "
+            f"for detection {i}"
+        )
+
+
+def test_scaled_bbox_crop_dims_match_target_resolution():
+    """Scaled output tile dims equal the detection bbox mapped to ``(W, H)``."""
+    rng = np.random.default_rng(7)
+    placements = [(0.10, 0.15, 0.35, 0.55)]
+    combined, protos = _build_validator_pattern_tensors(rng, placements)
+    decoder = _make_decoder()
+    ip = edgefirst_hal.ImageProcessor()
+    boxes, scores, classes, proto_data = decoder.decode_proto(
+        [_to_tensor(combined), _to_tensor(protos)], max_boxes=300
+    )
+
+    masks = ip.materialize_masks(
+        boxes,
+        scores,
+        classes,
+        proto_data,
+        resolution=edgefirst_hal.MaskResolution.Scaled(W, H),
+    )
+    for b, m in zip(boxes, masks):
+        expected_w = int(round((b[2] - b[0]) * W))
+        expected_h = int(round((b[3] - b[1]) * H))
+        assert m.shape == (expected_h, expected_w, 1), (
+            f"expected ({expected_h}, {expected_w}, 1) got {m.shape} "
+            f"for bbox {b.tolist()}"
+        )
+
+
+def test_scaled_binary_threshold_matches_greater_than_127():
+    """Binary ``{0, 255}`` output is drop-in under the caller's ``> 127`` test.
+
+    Validator code already does ``(mask > 127).astype(...)`` on continuous
+    sigmoid masks. For Scaled masks this must be identical to ``mask == 255``.
+    """
+    rng = np.random.default_rng(123)
+    placements = [(0.20, 0.25, 0.55, 0.70)]
+    combined, protos = _build_validator_pattern_tensors(rng, placements)
+    decoder = _make_decoder()
+    ip = edgefirst_hal.ImageProcessor()
+    boxes, scores, classes, proto_data = decoder.decode_proto(
+        [_to_tensor(combined), _to_tensor(protos)], max_boxes=300
+    )
+
+    masks = ip.materialize_masks(
+        boxes,
+        scores,
+        classes,
+        proto_data,
+        resolution=edgefirst_hal.MaskResolution.Scaled(W, H),
+    )
+    assert len(masks) >= 1
+    m = masks[0][..., 0]
+    assert np.array_equal(m > 127, m == 255)
+
+
+def test_scaled_matches_numpy_retina_reference():
+    """Scaled masks match a NumPy retina-style reference to within ``fast_sigmoid``
+    approximation tolerance (<1% pixel mismatch per detection).
+
+    Uses a small 96×96 target and 32×32 proto plane so the NumPy reference
+    runs in seconds rather than minutes.
+    """
+    rng = np.random.default_rng(1729)
+    # Override the full-size constants to keep the reference loop tractable.
+    target_w, target_h = 96, 96
+    proto_h, proto_w, nm, nc = 32, 32, 8, 4
+    total_anchors = 8400
+
+    # Build a single-detection fixture with coefficients 1.0 on channel 0.
+    det = np.zeros((total_anchors, 4 + nc + nm), dtype=np.float32)
+    bbox = (0.20, 0.25, 0.70, 0.80)
+    det[0, 0] = (bbox[0] + bbox[2]) / 2 * target_w
+    det[0, 1] = (bbox[1] + bbox[3]) / 2 * target_h
+    det[0, 2] = (bbox[2] - bbox[0]) * target_w
+    det[0, 3] = (bbox[3] - bbox[1]) * target_h
+    det[0, 4] = 0.9
+    det[0, 4 + nc] = 1.0  # mask coef on proto channel 0
+    combined = det.T[np.newaxis].copy()
+    combined[:, [0, 2]] /= target_w
+    combined[:, [1, 3]] /= target_h
+
+    protos = (rng.standard_normal((1, nm, proto_h, proto_w)) * 3.0).astype(np.float32)
+
+    hal_metadata = {
+        "decoder_version": "yolov8",
+        "nms": "class_agnostic",
+        "outputs": [
+            {
+                "type": "detection",
+                "decoder": "ultralytics",
+                "shape": [1, 4 + nc + nm, total_anchors],
+                "score_format": "per_class",
+                "quantization": [1.0, 0],
+            },
+            {
+                "type": "protos",
+                "decoder": "ultralytics",
+                "shape": [1, nm, proto_h, proto_w],
+                "quantization": [1.0, 0],
+            },
+        ],
+    }
+    decoder = edgefirst_hal.Decoder(
+        hal_metadata,
+        score_threshold=0.5,
+        iou_threshold=0.5,
+        nms=edgefirst_hal.Nms.ClassAgnostic,
+    )
+    ip = edgefirst_hal.ImageProcessor()
+    boxes, scores, classes, proto_data = decoder.decode_proto(
+        [_to_tensor(combined), _to_tensor(protos)], max_boxes=10
+    )
+    assert len(boxes) == 1
+
+    hal_masks = ip.materialize_masks(
+        boxes,
+        scores,
+        classes,
+        proto_data,
+        resolution=edgefirst_hal.MaskResolution.Scaled(target_w, target_h),
+    )
+    hal_tile = hal_masks[0][..., 0]
+
+    coefs = np.zeros(nm, dtype=np.float32)
+    coefs[0] = 1.0
+    # Use the HAL-returned bbox (post-snap) so proto-pixel rounding matches.
+    bbox_hal = tuple(float(v) for v in boxes[0])
+    # Local reference (uses the scaled-down proto dims above).
+    protos_hwc = protos[0].transpose(1, 2, 0)
+    sx = proto_w / target_w
+    sy = proto_h / target_h
+    logits = np.zeros((target_h, target_w), dtype=np.float32)
+    for yi in range(target_h):
+        sy_coord = (yi + 0.5) * sy - 0.5
+        y_f = int(np.floor(sy_coord))
+        yw = sy_coord - y_f
+        y_a = max(0, min(y_f, proto_h - 1))
+        y_b = max(0, min(y_f + 1, proto_h - 1))
+        for xi in range(target_w):
+            sx_coord = (xi + 0.5) * sx - 0.5
+            x_f = int(np.floor(sx_coord))
+            xw = sx_coord - x_f
+            x_a = max(0, min(x_f, proto_w - 1))
+            x_b = max(0, min(x_f + 1, proto_w - 1))
+            val = (
+                (1 - xw) * (1 - yw) * protos_hwc[y_a, x_a]
+                + xw * (1 - yw) * protos_hwc[y_a, x_b]
+                + (1 - xw) * yw * protos_hwc[y_b, x_a]
+                + xw * yw * protos_hwc[y_b, x_b]
+            )
+            logits[yi, xi] = float(np.dot(val, coefs))
+    mask_full = (1.0 / (1.0 + np.exp(-logits)) > 0.5).astype(np.uint8) * 255
+    px0 = int(round(bbox_hal[0] * target_w))
+    py0 = int(round(bbox_hal[1] * target_h))
+    px1 = int(round(bbox_hal[2] * target_w))
+    py1 = int(round(bbox_hal[3] * target_h))
+    ref_tile = mask_full[py0:py1, px0:px1]
+
+    assert hal_tile.shape == ref_tile.shape, (
+        f"HAL tile shape {hal_tile.shape} differs from reference {ref_tile.shape}"
+    )
+    mismatches = int(np.sum(hal_tile != ref_tile))
+    total = int(hal_tile.size)
+    rate = mismatches / total
+    assert rate < 0.01, (
+        f"HAL vs NumPy retina reference diverged at {mismatches}/{total} "
+        f"pixels ({rate:.4f} > 1% tolerance)"
+    )


### PR DESCRIPTION
## Summary

Adds end-to-end HAL support for HailoRT-compiled YOLOv8 / YOLOv8-seg models
via the updated schema-v2 metadata format, and restores YOLOv8-seg
segmentation mAP on the Hailo+HAL path by replacing the per-detection
`ImageProcessor.convert()` upsample loop with a single full-plane mask
upsample (`MaskResolution::Scaled`).

Full user-facing notes live in `CHANGELOG.md [Unreleased]`.

### Decoder
- Schema v2 parser (two-layer logical / physical output model) with a
  parse-time v1 compatibility shim; per-channel quantization; explicit
  `DType` / `Activation` / `BoxEncoding` / `ScoreFormat` enums.
- DFL primitives module (`decoder::dfl`) — `make_anchor_grid`, `dfl_bins`,
  `softmax_inplace`, `decode_dfl_level`, SIMD-ready, seven unit tests.
- DFL-aware per-scale merge: softmax + weighted-sum + `dist2bbox` per
  child, collapsing `4×reg_max` → 4 xcycwh channels.
- `DecoderBuilder::with_schema` compiling `SchemaV2` into a `DecodeProgram`.
  Merge strategies: `ChannelConcat` (ARA-2 `boxes_xy`/`boxes_wh`) and
  `PerScale` (FPN, stride-sorted).
- ARA-2 DVM `padding` dim support — verified against real `model.dvm`
  metadata from INT8 and INT16 builds.
- `MAX_NMS_CANDIDATES` = 30 000 pre-NMS top-K cap (Ultralytics-aligned).
- Auto-detect v2 in `with_config_json_str` / `with_config_yaml_str`.

### Image / segmentation
- `MaskResolution` enum and `resolution` parameter on
  `ImageProcessor.materialize_masks`. `Scaled(width, height)` upsamples
  the full proto plane once with edge-clamp bilinear sampling and returns
  per-detection binary `uint8 {0, 255}` masks at target resolution.
  Letterbox-aware.
- Fixes YOLOv8-seg seg-mAP@0.5 collapse on Hailo+HAL (46.8 → 3.7 under
  the old per-tile `convert()` loop) caused by edge-wrap on small tiles.

### Fixed
- `Tensor.from_numpy` panic on pitch-aligned destinations (STRIDES_BUG):
  row-by-row copy into padded buffers; only raises on genuine shape /
  dtype mismatch.

### Added
- `Tensor.row_stride` Python property reporting actual row pitch in bytes.

## Test plan

- [x] Rust: full `edgefirst_decoder` suite (DFL primitives, schema v2
      parsing, merge programs, Hailo YOLOv8-seg fixture end-to-end parity)
- [x] Rust: full `edgefirst_image` suite (masks, draw paths, tensor
      from_numpy pitch handling)
- [x] Python: `tests/decoder/test_scaled_masks.py` parity vs NumPy
      retina reference (4/4 pass, <1% pixel mismatch per detection)
- [x] Python: `tests/decoder/test_hailort_bug_repro.py` regression guards
- [x] On-target validated: imx8mpevk-06 (Vivante GC7000UL),
      imx95-evk (Mali-G310), rpi5-hailo (V3D/Mesa),
      orin-nano (NVIDIA Tegra Orin)
- [x] End-to-end: validator YOLOv8-seg on rpi5-hailo — seg-mAP@0.5 ≈ 46
      (was 3.65), Mask IoU ≈ 76 (was 66.93)

## Reference
- Ticket: EDGEAI-759
- CHANGELOG entry: `[Unreleased]`
- Related validator branch: `edgefirst-validator @ feature/DE-823-hailort`