### PR TITLE
EDGEAI-1081: Wire Python Decoder(dict) constructor to schema v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Python `Decoder(dict)` constructor now accepts schema v2 metadata.**
+  `PyDecoder::new` previously routed every dict through the legacy
+  `ConfigOutputs` deserialiser, producing the misleading *"invalid type:
+  map, expected tuple struct QuantTuple"* error when given v2 documents
+  produced by `tflite-converter` ≥ v0.3.0. A smart constructor now
+  discriminates on the authoritative `schema_version` field: `>= 2`
+  routes to `DecoderBuilder::with_schema(SchemaV2)`, which supports
+  object-form quantization, per-channel quantization, split logical
+  outputs, and the full v2 type vocabulary. Legacy documents (no
+  `schema_version`, or `schema_version: 1`) continue through the
+  unchanged legacy path. The string constructors
+  (`new_from_json_str` / `new_from_yaml_str`) already went through the
+  v2 path; only the dict constructor was broken. Reference: EDGEAI-1081,
+  `SCHEMA_V2_BUG.md`.
+
+### Changed
+
+- **`ConfigOutput::MaskCoefficients` serde tag renamed to `mask_coefs`
+  with `mask_coefficients` kept as a backward-compatible alias.** The v2
+  spec vocabulary uses `mask_coefs`; the legacy v1 spelling
+  (`mask_coefficients`) continues to parse unchanged so existing models
+  and fixtures are not affected.
+
 ## [0.17.0] - 2026-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `schema_version`, or `schema_version: 1`) continue through the
   unchanged legacy path. The string constructors
   (`new_from_json_str` / `new_from_yaml_str`) already went through the
-  v2 path; only the dict constructor was broken. Reference: EDGEAI-1081,
-  `SCHEMA_V2_BUG.md`.
+  v2 path; only the dict constructor was broken. Reference: EDGEAI-1081.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "pythonize",
  "rayon",
  "rustc_version",
+ "serde_json",
  "uuid",
 ]
 

--- a/crates/decoder/src/decoder/config.rs
+++ b/crates/decoder/src/decoder/config.rs
@@ -53,7 +53,7 @@ pub enum ConfigOutput {
     Scores(configs::Scores),
     #[serde(rename = "boxes")]
     Boxes(configs::Boxes),
-    #[serde(rename = "mask_coefficients")]
+    #[serde(rename = "mask_coefs", alias = "mask_coefficients")]
     MaskCoefficients(configs::MaskCoefficients),
     #[serde(rename = "classes")]
     Classes(configs::Classes),

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -3402,4 +3402,33 @@ outputs:
             assert_eq!(protos_out.shape(), &[1, 160, 160, 32]);
         }
     }
+
+    // =========================================================================
+    // Legacy ConfigOutput serde tag vocabulary
+    // =========================================================================
+
+    mod config_output_serde {
+        use crate::ConfigOutput;
+
+        #[test]
+        fn mask_coefs_is_primary_spelling() {
+            // v2 spec vocabulary uses `mask_coefs`. The legacy ConfigOutput
+            // enum must accept it so that any consumer re-serialising through
+            // the legacy path (or feeding a v2-vocabulary dict into the
+            // legacy deserialiser) stays compatible.
+            let j = r#"{"type": "mask_coefs", "shape": [1, 32, 8400]}"#;
+            let parsed: ConfigOutput = serde_json::from_str(j).unwrap();
+            assert!(matches!(parsed, ConfigOutput::MaskCoefficients(_)));
+        }
+
+        #[test]
+        fn mask_coefficients_alias_still_accepted() {
+            // Legacy v1 spelling — required for backward compatibility with
+            // models already trained and stored before the v2 vocabulary
+            // landed.
+            let j = r#"{"type": "mask_coefficients", "shape": [1, 32, 8400]}"#;
+            let parsed: ConfigOutput = serde_json::from_str(j).unwrap();
+            assert!(matches!(parsed, ConfigOutput::MaskCoefficients(_)));
+        }
+    }
 }

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -30,6 +30,7 @@ numpy = { workspace = true }
 pyo3 = { workspace = true, features = ["extension-module"] }
 rayon = { workspace = true }
 pythonize = { workspace = true }
+serde_json = { workspace = true }
 uuid = { workspace = true }
 
 [build-dependencies]

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -3,8 +3,8 @@
 
 use crate::tracker::{PyByteTrack, PyTrackInfo};
 use edgefirst_hal::decoder::{
-    configs, configs::Nms, ConfigOutput, Decoder, DecoderBuilder, DetectBox, ProtoData,
-    Segmentation,
+    configs, configs::Nms, schema::SchemaV2, ConfigOutput, ConfigOutputs, Decoder, DecoderBuilder,
+    DetectBox, ProtoData, Segmentation,
 };
 
 /// NMS (Non-Maximum Suppression) mode for filtering overlapping detections.
@@ -497,14 +497,33 @@ impl PyDecoder {
         iou_threshold: f32,
         nms: Option<PyNms>,
     ) -> PyResult<Self> {
-        let config = pythonize::depythonize(&config)?;
         let nms: Option<Nms> = nms.map(|py_nms| py_nms.into());
-        let decoder = DecoderBuilder::default()
+        let builder = DecoderBuilder::default()
             .with_score_threshold(score_threshold)
             .with_iou_threshold(iou_threshold)
-            .with_nms(nms)
-            .with_config(config)
-            .build();
+            .with_nms(nms);
+
+        // EDGEAI-1081: discriminate v2 vs legacy on the authoritative
+        // `schema_version` field. v2 dicts carry object-form quantization
+        // and spec-vocabulary type tags that the legacy `ConfigOutputs`
+        // deserialiser rejects; v1 (or version-less) dicts continue
+        // through the legacy path unchanged.
+        let value: serde_json::Value = pythonize::depythonize(&config)?;
+        let schema_version = value
+            .get("schema_version")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32);
+
+        let decoder = if schema_version.is_some_and(|v| v >= 2) {
+            let schema = SchemaV2::from_json_value(value)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
+            builder.with_schema(schema).build()
+        } else {
+            let legacy: ConfigOutputs = serde_json::from_value(value)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
+            builder.with_config(legacy).build()
+        };
+
         match decoder {
             Ok(decoder) => Ok(Self { decoder }),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}"))),

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -509,10 +509,16 @@ impl PyDecoder {
         // deserialiser rejects; v1 (or version-less) dicts continue
         // through the legacy path unchanged.
         let value: serde_json::Value = pythonize::depythonize(&config)?;
-        let schema_version = value
+        let schema_version: Option<u32> = value
             .get("schema_version")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u32);
+            .cloned()
+            .map(serde_json::from_value::<u32>)
+            .transpose()
+            .map_err(|e| {
+                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                    "invalid schema_version: {e}"
+                ))
+            })?;
 
         let decoder = if schema_version.is_some_and(|v| v >= 2) {
             let schema = SchemaV2::from_json_value(value)

--- a/tests/decoder/test_decoder.py
+++ b/tests/decoder/test_decoder.py
@@ -159,6 +159,177 @@ def test_from_dict_yaml():
     assert len(masks) == 0
 
 
+def test_from_dict_v2_minimal():
+    """EDGEAI-1081: Schema v2 dict with object-style quantization must succeed.
+
+    Regression test for the blocker where `Decoder(dict)` routed v2 dicts
+    through the legacy `ConfigOutputs` deserializer, producing the
+    misleading "invalid type: map, expected tuple struct QuantTuple" error
+    because the legacy `QuantTuple(f32, i32)` expects a JSON array while
+    v2 prescribes `{"scale": ..., "zero_point": ..., "dtype": ...}`.
+    """
+    cfg = {
+        "schema_version": 2,
+        "decoder_version": "yolov8",
+        "nms": "class_agnostic",
+        "outputs": [
+            {
+                "name": "boxes",
+                "type": "boxes",
+                "shape": [1, 4, 8400],
+                "dshape": [{"batch": 1}, {"box_coords": 4}, {"num_boxes": 8400}],
+                "dtype": "int8",
+                "quantization": {
+                    "scale": 0.0262,
+                    "zero_point": 0,
+                    "dtype": "int8",
+                },
+                "decoder": "ultralytics",
+                "encoding": "direct",
+                "normalized": True,
+            },
+            {
+                "name": "scores",
+                "type": "scores",
+                "shape": [1, 80, 8400],
+                "dshape": [
+                    {"batch": 1},
+                    {"num_classes": 80},
+                    {"num_boxes": 8400},
+                ],
+                "dtype": "int8",
+                "quantization": {
+                    "scale": 0.00392,
+                    "zero_point": -128,
+                    "dtype": "int8",
+                },
+                "decoder": "ultralytics",
+                "score_format": "per_class",
+            },
+        ],
+    }
+    decoder = edgefirst_hal.Decoder(cfg)
+    assert decoder is not None
+
+
+def test_from_dict_v2_ara2_full_surface():
+    """EDGEAI-1081: Full v2 surface (per-channel quant, split xy/wh, mask_coefs).
+
+    Feeds the canonical ARA-2 fixture through the dict constructor. This
+    exercises the same DecodeProgram compilation path `new_from_json_str`
+    already covers via string, but via dict so the Python binding's smart
+    constructor is the one doing the heavy lifting.
+    """
+    import json
+
+    with open("testdata/ara2_int8_edgefirst.json") as f:
+        cfg = json.load(f)
+
+    decoder = edgefirst_hal.Decoder(cfg, 0.25, 0.5)
+
+    xy = numpy_to_tensor(np.zeros((1, 2, 8400, 1), dtype=np.int8))
+    wh = numpy_to_tensor(np.zeros((1, 2, 8400, 1), dtype=np.int8))
+    scores = numpy_to_tensor(np.zeros((1, 80, 8400, 1), dtype=np.uint8))
+    mask_coefs = numpy_to_tensor(np.zeros((1, 32, 8400, 1), dtype=np.int8))
+    protos = numpy_to_tensor(np.zeros((1, 32, 160, 160), dtype=np.int8))
+
+    boxes, scores_out, classes, masks = decoder.decode(
+        [xy, wh, scores, mask_coefs, protos]
+    )
+    assert len(boxes) == 0
+    assert len(scores_out) == 0
+    assert len(classes) == 0
+    assert len(masks) == 0
+
+
+def test_from_dict_v2_rejects_unsupported_schema_version():
+    """EDGEAI-1081: `schema_version` above MAX_SUPPORTED must be rejected.
+
+    Without version gating the document would silently fall through to the
+    legacy deserialiser and produce a confusing QuantTuple error. The
+    smart constructor must surface a NotSupported-shaped error instead.
+    """
+    cfg = {
+        "schema_version": 99,
+        "outputs": [
+            {"type": "boxes", "shape": [1, 4, 8400], "dtype": "int8"},
+        ],
+    }
+    with pytest.raises(Exception) as exc_info:
+        edgefirst_hal.Decoder(cfg)
+    msg = str(exc_info.value)
+    assert "QuantTuple" not in msg, f"v1 error leaked into v2 path: {msg}"
+    assert "99" in msg or "not supported" in msg.lower() or "NotSupported" in msg
+
+
+def test_from_dict_v2_mask_coefs_type_tag():
+    """EDGEAI-1081: v2 vocabulary 'mask_coefs' is accepted by the dict path.
+
+    The v2 spec defines the mask coefficients type as `mask_coefs`; the
+    legacy enum spelled it `mask_coefficients`. Both must continue to
+    parse — v2 as the primary tag, legacy as an alias.
+    """
+    cfg = {
+        "schema_version": 2,
+        "nms": "class_agnostic",
+        "decoder_version": "yolov8",
+        "outputs": [
+            {
+                "type": "boxes",
+                "shape": [1, 4, 8400],
+                "dshape": [
+                    {"batch": 1},
+                    {"box_coords": 4},
+                    {"num_boxes": 8400},
+                ],
+                "dtype": "int8",
+                "quantization": {"scale": 0.01, "zero_point": 0, "dtype": "int8"},
+                "decoder": "ultralytics",
+                "encoding": "direct",
+            },
+            {
+                "type": "scores",
+                "shape": [1, 80, 8400],
+                "dshape": [
+                    {"batch": 1},
+                    {"num_classes": 80},
+                    {"num_boxes": 8400},
+                ],
+                "dtype": "int8",
+                "quantization": {"scale": 0.01, "zero_point": 0, "dtype": "int8"},
+                "decoder": "ultralytics",
+                "score_format": "per_class",
+            },
+            {
+                "type": "mask_coefs",
+                "shape": [1, 32, 8400],
+                "dshape": [
+                    {"batch": 1},
+                    {"num_protos": 32},
+                    {"num_boxes": 8400},
+                ],
+                "dtype": "int8",
+                "quantization": {"scale": 0.01, "zero_point": 0, "dtype": "int8"},
+                "decoder": "ultralytics",
+            },
+            {
+                "type": "protos",
+                "shape": [1, 160, 160, 32],
+                "dshape": [
+                    {"batch": 1},
+                    {"height": 160},
+                    {"width": 160},
+                    {"num_protos": 32},
+                ],
+                "dtype": "int8",
+                "quantization": {"scale": 0.01, "zero_point": 0, "dtype": "int8"},
+            },
+        ],
+    }
+    decoder = edgefirst_hal.Decoder(cfg)
+    assert decoder is not None
+
+
 def test_nms():
     tf = pytest.importorskip("tensorflow")
 


### PR DESCRIPTION
## Summary

Fixes [EDGEAI-1081](https://au-zone.atlassian.net/browse/EDGEAI-1081) — blocker.

HAL 0.17.0's Python `Decoder(dict)` constructor could not load schema v2 metadata produced by `tflite-converter` ≥ v0.3.0, raising the misleading `invalid type: map, expected tuple struct QuantTuple` error. The Rust core is fully v2-ready (`SchemaV2`, `DecoderBuilder::with_schema`, `DecodeProgram` for split outputs) — only the Python dict constructor was wired to the legacy `ConfigOutputs` deserialiser.

- **Smart constructor** (`crates/python/src/decoder.rs`): `PyDecoder::new` now discriminates on the authoritative `schema_version` field. `>= 2` routes through `SchemaV2::from_json_value` → `with_schema`; legacy documents (no `schema_version`, or `< 2`) continue through `ConfigOutputs` unchanged.
- **`mask_coefs` serde tag** (`crates/decoder/src/decoder/config.rs`): `ConfigOutput::MaskCoefficients` now primary-spells its tag as `mask_coefs` (v2 vocabulary) with `mask_coefficients` kept as a `serde(alias)` for backward compatibility with already-serialised v1 fixtures.
- **CHANGELOG** updated under `[Unreleased]`.

String constructors (`new_from_json_str` / `new_from_yaml_str`) already went through the v2 path via `with_config_json_str`; only the dict constructor was broken. Callers can work around today by `json.dumps(cfg)` + `new_from_json_str`, but the proper fix belongs in the dict path.

## Test plan

- [x] Four new Python regression tests in `tests/decoder/test_decoder.py`:
  - `test_from_dict_v2_minimal` — minimal v2 dict (boxes + scores, object-form quant) succeeds
  - `test_from_dict_v2_ara2_full_surface` — full v2 surface via `testdata/ara2_int8_edgefirst.json` (per-channel quant, `boxes_xy`/`boxes_wh` split, `mask_coefs`, protos) + end-to-end decode smoke test
  - `test_from_dict_v2_rejects_unsupported_schema_version` — `schema_version: 99` surfaces a `NotSupported` error, not a `QuantTuple` red herring
  - `test_from_dict_v2_mask_coefs_type_tag` — v2 `mask_coefs` tag accepted on the dict path
- [x] Two new Rust unit tests in `crates/decoder/src/decoder/tests.rs::decoder_builder_tests::config_output_serde`:
  - `mask_coefs_is_primary_spelling` — v2 tag parses
  - `mask_coefficients_alias_still_accepted` — v1 alias still parses
- [x] All 224 Rust decoder unit tests pass
- [x] All 86 Python tests (decoder + non-image) pass; all 26 Python image tests pass
- [x] `make format lint check` clean
- [x] `make sbom` clean — license policy validated
- [x] Signed-off (DCO)

## Acceptance (from EDGEAI-1081)

Reproduces the failing `ef.Decoder(metadata)` call from `load_metadata.py`. Now succeeds for `tflite-converter` v0.3.0 output on sessions like `coffeecup-yolov8n-segmentation-rgba-640x640-t-266f_quant-u8-i8.tflite`.

[EDGEAI-1081]: https://au-zone.atlassian.net/browse/EDGEAI-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ