### PR TITLE
HAL output stage: batched-GEMM + NEON kernels + DMA-BUF stride/format fixes

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,8 +1,8 @@
 # EdgeFirst HAL - Benchmarks
 
-**Version:** 3.0
-**Last Updated:** March 30, 2026
-**Status:** v0.15.0 release — added jetson-orin-nano platform; refreshed all benchmarks across 5 platforms; added materialize_masks API and hybrid path comparison; per-texture EGL binding optimization
+**Version:** 3.1
+**Last Updated:** April 23, 2026
+**Status:** `materialize_masks` batched-GEMM path: scaled 640×640 wins 1.7–45× at N=2–100, proto wins 1.0–2.7× at N≥32 across imx8mp-frdm, imx95-frdm, rpi5-hailo, x86-desktop
 
 ---
 
@@ -379,6 +379,72 @@ The hybrid path decodes masks on CPU (`materialize_segmentations`) then overlays
 | jetson-orin-nano | 440 us | 1.6 ms |
 | x86-desktop | 381 us | 903 us |
 
+### materialize_masks Batched-GEMM Optimisation
+
+`ImageProcessor::materialize_masks` previously ran a per-detection scalar
+kernel (per-pixel bilinear sample + K-wide dot + sigmoid). The validation
+workload — COCO-style with `max_det=100` at low score thresholds — degraded
+linearly with the detection count, dominating the HAL output stage.
+
+The new path:
+
+- **Single batched GEMM** at proto resolution: `coeffs (N, K) · protos.T (K, H·W)`
+  via `ndarray::linalg::general_mat_mul` (backed by `matrixmultiply` —
+  pure-Rust SIMD, no new deps). Runs once per frame regardless of N.
+- **Rayon-parallel per-detection finalisation**: each worker reads its row
+  of the logits buffer, applies `fast_sigmoid` (Proto resolution) or
+  `fast_sigmoid` + bilinear upsample (Scaled resolution), and emits the
+  final `Segmentation`.
+- **Pooled scratch**: `MaskScratch` on `CPUProcessor` reuses the
+  dequantised-protos and logits buffers across calls — validation loops
+  amortise allocations over all frames.
+- **Fused fallback** retained for small N where the batched up-front cost
+  outweighs the per-detection savings:
+  - `MaskResolution::Proto`: batched at `N >= 16`
+  - `MaskResolution::Scaled`: batched at `N >= 2`
+
+Measured A/B in `mask_benchmark` (`materialize_masks/{proto_res,scaled_640x640}`)
+with the env-gated `EDGEFIRST_LEGACY_MATERIALIZE=1` toggle.
+
+**MaskResolution::Proto (median, ms; legacy → batched):**
+
+| Platform | N=8 | N=16 | N=32 | N=64 | N=100 |
+|----------|-----|------|------|------|-------|
+| imx8mp-frdm  (4× A53)   | 5.9→5.9   (1.00×) | 11.7→13.2 (0.89×) | 23.3→17.7 (1.32×) | 46.6→27.4 (1.70×) | 72.7→38.8 (1.87×) |
+| imx95-frdm   (6× A55)   | 6.0→5.9   (1.02×) | 11.8→11.5 (1.03×) | 23.5→16.3 (1.44×) | 46.9→25.7 (1.83×) | 73.2→36.8 (1.99×) |
+| rpi5-hailo   (4× A76)   | 1.5→1.9   (0.79×) | 3.0→2.7   (1.11×) | 6.0→4.0   (1.50×) | 11.9→6.7  (1.78×) | 18.6→9.7  (1.92×) |
+| x86-desktop  (20-core)  | 0.56→0.59 (0.95×) | 1.1→1.1   (1.00×) | 2.3→1.9   (1.21×) | 4.5→1.8   (2.50×) | 7.0→2.6   (2.69×) |
+
+**MaskResolution::Scaled 640×640 (median, ms; legacy → batched):**
+
+| Platform | N=2 | N=8 | N=16 | N=32 | N=64 | N=100 |
+|----------|-----|-----|------|------|------|-------|
+| imx8mp-frdm  (4× A53)   | 29.8→18.0 (1.66×) | 115.5→22.1 (5.23×)  | 229.7→33.1 (6.94×)  | 458.0→55.8 (8.21×)  | 914.6→101.5 (9.01×)  | **1400→153** (**9.13×**)  |
+| imx95-frdm   (6× A55)   | 29.8→17.3 (1.72×) | 115.5→18.2 (6.35×)  | 229.7→27.9 (8.23×)  | 458.2→43.6 (10.51×) | 915.0→77.0  (11.88×) | **1400→114** (**12.28×**) |
+| rpi5-hailo   (4× A76)   | 9.7→3.8   (2.55×) | 37.6→5.2   (7.23×)  | 74.8→8.1   (9.23×)  | 149.2→14.7 (10.15×) | 298.0→27.3 (10.92×) | **466→42**   (**10.95×**) |
+| x86-desktop  (20-core)  | 9.6→3.5   (2.74×) | 37.2→2.2   (16.91×) | 74.0→2.5   (29.60×) | 147.9→4.0  (36.98×) | 295.0→6.9  (42.75×) | **461→10**   (**44.74×**) |
+
+**Notes:**
+
+- The Proto path gains less than the Scaled path because its per-detection
+  ROI kernel only touches `bbox_area × K` pixels — small at any N. The
+  batched path always pays a full-plane `H × W × K` dequant + GEMM, so it
+  only wins once aggregate ROI work exceeds that fixed cost.
+- The Scaled path gains massively because the legacy kernel did
+  `bbox_area × K × 4` ops per detection at output resolution (the ×4 from
+  bilinear). The batched path does the heavy K-wide dot at proto resolution
+  (160×160 = 25,600 vs 640×640 = 409,600 sample points → 16× fewer
+  dot-product ops) and reduces the per-detection work to a cheap
+  `bbox_area` bilinear upsample on the flat logit plane.
+- The Proto regression at N=8 on rpi5-hailo (0.79×) and N=16 on
+  imx8mp-frdm (0.89×) sit just above each platform's crossover. The
+  threshold of 16 is a conservative cross-platform compromise; A76 and x86
+  benefit from a lower threshold, A53 prefers a higher one. Tunable via
+  the `BATCHED_GEMM_MIN_N_PROTO` constant.
+- The Scaled path is a clear win on every tested platform from N=2
+  upward, scaling cleanly to ~9–45× at N=100 depending on cache hierarchy
+  and SIMD width.
+
 ---
 
 ## C API Preprocessing Benchmark (`bench_preproc`)
@@ -582,6 +648,7 @@ The binary requires a DMA-heap device (`/dev/dma_heap/linux,cma` or `/dev/dma_he
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3.1 | 2026-04-23 | `materialize_masks` batched-GEMM path: single GEMM at proto resolution + rayon-parallel per-detection finalisation + pooled `MaskScratch` buffers. Scaled 640×640 wins 1.7–45× across N=2–100; Proto wins 1.0–2.7× at N≥32. Cross-platform A/B measured on imx8mp-frdm, imx95-frdm, rpi5-hailo, x86-desktop |
 | 3.0 | 2026-03-30 | v0.15.0 release: add jetson-orin-nano platform; refresh all benchmarks across 5 platforms; per-texture EGL binding optimization eliminates redundant EGLImageTargetTexture2DOES calls; add materialize_masks API with three-stage pipeline benchmarks; hybrid path 1.4–14.2× faster than fused GPU on all platforms |
 | 2.2 | 2026-03-27 | Add collection date stamps to all benchmark result sections; add image_benchmark to benchmark binary table; note pending YoloSegDet2Way benchmark data in decoder section; note pending mask rendering optimization updates |
 | 2.1 | 2026-03-23 | Add C API preprocessing benchmark (`bench_preproc`) results for i.MX 95-EVK (Mali), i.MX 8MP EVK-06 (Vivante), and x86 desktop (GTX 1080 PBO); add tensor reuse impact analysis (3.3× penalty on i.MX 95, 1.7× on i.MX 8MP, negligible on PBO); document buffer pool validation |

--- a/crates/decoder/src/decoder/merge.rs
+++ b/crates/decoder/src/decoder/merge.rs
@@ -150,14 +150,25 @@ impl DecodeProgram {
     /// legacy decode path directly. Returns an error if the schema
     /// uses unsupported features (per-channel quantization, missing
     /// dshape, DFL encoding on split boxes).
+    ///
+    /// Typeless logical outputs are skipped: they're carried in the
+    /// schema as user-managed / auxiliary tensors and do not participate
+    /// in decoder dispatch. The returned program emits one merged
+    /// tensor per *typed* logical output in schema order — this keeps
+    /// it aligned with [`SchemaV2::to_legacy_config_outputs`], which
+    /// applies the same filter.
     pub fn try_from_schema(schema: &SchemaV2) -> DecoderResult<Option<Self>> {
-        let needs_merge = schema.outputs.iter().any(|l| !l.outputs.is_empty());
+        let needs_merge = schema
+            .outputs
+            .iter()
+            .any(|l| l.type_.is_some() && !l.outputs.is_empty());
         if !needs_merge {
             return Ok(None);
         }
         let merges = schema
             .outputs
             .iter()
+            .filter(|l| l.type_.is_some())
             .map(plan_logical)
             .collect::<DecoderResult<Vec<_>>>()?;
         Ok(Some(Self { merges }))
@@ -971,6 +982,95 @@ mod tests {
         }
     }
 
+    /// Typeless logical outputs are filtered from the DecodeProgram,
+    /// keeping it aligned with `to_legacy_config_outputs` (which applies
+    /// the same filter). Without this, `decode()` would pass N merged
+    /// tensors to a decode path expecting N-k — corrupting downstream
+    /// decoding when a user adds a custom output alongside a decoded
+    /// YOLO model.
+    #[test]
+    fn typeless_logical_not_included_in_decode_program() {
+        let schema = SchemaV2 {
+            schema_version: 2,
+            outputs: vec![
+                // User-managed: no type, flat.
+                LogicalOutput {
+                    name: Some("user_custom".into()),
+                    type_: None,
+                    shape: vec![1, 32],
+                    dshape: vec![],
+                    decoder: None,
+                    encoding: None,
+                    score_format: None,
+                    normalized: None,
+                    anchors: None,
+                    stride: None,
+                    dtype: None,
+                    quantization: None,
+                    outputs: vec![],
+                },
+                // Typed boxes with a single merged child (triggers program).
+                LogicalOutput {
+                    name: Some("boxes".into()),
+                    type_: Some(LogicalType::Boxes),
+                    shape: vec![1, 4, 3],
+                    dshape: vec![
+                        (DimName::Batch, 1),
+                        (DimName::BoxCoords, 4),
+                        (DimName::NumBoxes, 3),
+                    ],
+                    decoder: Some(DecoderKind::Ultralytics),
+                    encoding: Some(BoxEncoding::Direct),
+                    score_format: None,
+                    normalized: Some(true),
+                    anchors: None,
+                    stride: None,
+                    dtype: None,
+                    quantization: None,
+                    outputs: vec![PhysicalOutput {
+                        name: "boxes_raw".into(),
+                        type_: Some(PhysicalType::Boxes),
+                        shape: vec![1, 4, 3],
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::BoxCoords, 4),
+                            (DimName::NumBoxes, 3),
+                        ],
+                        dtype: DType::Float32,
+                        quantization: None,
+                        stride: None,
+                        scale_index: None,
+                        activation_applied: None,
+                        activation_required: None,
+                    }],
+                },
+            ],
+            ..Default::default()
+        };
+
+        let program = DecodeProgram::try_from_schema(&schema)
+            .unwrap()
+            .expect("typed boxes has children → program must be Some");
+
+        // Legacy config filters typeless outputs; the program must
+        // apply the identical filter so positional alignment holds.
+        let legacy = schema.to_legacy_config_outputs().unwrap();
+        assert_eq!(legacy.outputs.len(), 1);
+
+        // Program emits one merged tensor (for the typed `boxes`), not
+        // two (which would include the user_custom placeholder).
+        let boxes_tensor = make_f32_tensor(&[1, 4, 3], &[1.0; 12]);
+        let inputs: Vec<&TensorDyn> = vec![&boxes_tensor];
+        let merged = program.execute(&inputs).unwrap();
+        assert_eq!(
+            merged.len(),
+            1,
+            "decode program must emit one tensor per typed logical, not \
+             per schema-order logical (would otherwise misalign with \
+             legacy ConfigOutputs passed to decode_float)"
+        );
+    }
+
     #[test]
     fn flat_schema_has_no_decode_program() {
         // Logical outputs with no children => no merge needed.
@@ -1024,7 +1124,7 @@ mod tests {
             outputs: vec![
                 PhysicalOutput {
                     name: "xy".into(),
-                    type_: PhysicalType::BoxesXy,
+                    type_: Some(PhysicalType::BoxesXy),
                     shape: vec![1, 2, 3],
                     dshape: vec![
                         (DimName::Batch, 1),
@@ -1040,7 +1140,7 @@ mod tests {
                 },
                 PhysicalOutput {
                     name: "wh".into(),
-                    type_: PhysicalType::BoxesWh,
+                    type_: Some(PhysicalType::BoxesWh),
                     shape: vec![1, 2, 3],
                     dshape: vec![
                         (DimName::Batch, 1),
@@ -1072,7 +1172,7 @@ mod tests {
             outputs: vec![
                 PhysicalOutput {
                     name: "xy".into(),
-                    type_: PhysicalType::BoxesXy,
+                    type_: Some(PhysicalType::BoxesXy),
                     shape: vec![1, 1, 3],
                     dshape: vec![
                         (DimName::Batch, 1),
@@ -1088,7 +1188,7 @@ mod tests {
                 },
                 PhysicalOutput {
                     name: "wh".into(),
-                    type_: PhysicalType::BoxesWh,
+                    type_: Some(PhysicalType::BoxesWh),
                     shape: vec![1, 2, 3],
                     dshape: vec![
                         (DimName::Batch, 1),
@@ -1155,7 +1255,7 @@ mod tests {
                 outputs: vec![
                     PhysicalOutput {
                         name: "b0".into(),
-                        type_: PhysicalType::Boxes,
+                        type_: Some(PhysicalType::Boxes),
                         // NHWC [1, 2, 2, 4]: 4 anchors at stride 8
                         shape: vec![1, 2, 2, 4],
                         dshape: vec![
@@ -1173,7 +1273,7 @@ mod tests {
                     },
                     PhysicalOutput {
                         name: "b1".into(),
-                        type_: PhysicalType::Boxes,
+                        type_: Some(PhysicalType::Boxes),
                         // NHWC [1, 1, 1, 4]: 1 anchor at stride 16
                         shape: vec![1, 1, 1, 4],
                         dshape: vec![
@@ -1276,7 +1376,7 @@ mod tests {
                     outputs: vec![
                         PhysicalOutput {
                             name: "s0".into(),
-                            type_: PhysicalType::Scores,
+                            type_: Some(PhysicalType::Scores),
                             shape: vec![1, 1, 3],
                             dshape: vec![
                                 (DimName::Batch, 1),
@@ -1292,7 +1392,7 @@ mod tests {
                         },
                         PhysicalOutput {
                             name: "s1".into(),
-                            type_: PhysicalType::Scores,
+                            type_: Some(PhysicalType::Scores),
                             shape: vec![1, 1, 3],
                             dshape: vec![
                                 (DimName::Batch, 1),
@@ -1364,7 +1464,7 @@ mod tests {
                 quantization: None,
                 outputs: vec![PhysicalOutput {
                     name: "b0".into(),
-                    type_: PhysicalType::Boxes,
+                    type_: Some(PhysicalType::Boxes),
                     shape: vec![1, 80, 80, 64],
                     dshape: vec![
                         (DimName::Batch, 1),
@@ -1421,7 +1521,7 @@ mod tests {
                 outputs: vec![
                     PhysicalOutput {
                         name: "b0".into(),
-                        type_: PhysicalType::Boxes,
+                        type_: Some(PhysicalType::Boxes),
                         shape: vec![1, 2, 2, 16],
                         dshape: vec![
                             (DimName::Batch, 1),
@@ -1438,7 +1538,7 @@ mod tests {
                     },
                     PhysicalOutput {
                         name: "b1".into(),
-                        type_: PhysicalType::Boxes,
+                        type_: Some(PhysicalType::Boxes),
                         shape: vec![1, 1, 1, 16],
                         dshape: vec![
                             (DimName::Batch, 1),
@@ -1534,7 +1634,7 @@ mod tests {
                 outputs: vec![
                     PhysicalOutput {
                         name: "b_big".into(),
-                        type_: PhysicalType::Boxes,
+                        type_: Some(PhysicalType::Boxes),
                         shape: vec![1, 1, 1, 16],
                         dshape: vec![
                             (DimName::Batch, 1),
@@ -1551,7 +1651,7 @@ mod tests {
                     },
                     PhysicalOutput {
                         name: "b_small".into(),
-                        type_: PhysicalType::Boxes,
+                        type_: Some(PhysicalType::Boxes),
                         shape: vec![1, 2, 2, 16],
                         dshape: vec![
                             (DimName::Batch, 1),
@@ -1646,7 +1746,7 @@ mod tests {
                     outputs: vec![
                         PhysicalOutput {
                             name: "b0".into(),
-                            type_: PhysicalType::BoxesXy,
+                            type_: Some(PhysicalType::BoxesXy),
                             shape: vec![1, 2, 3],
                             dshape: vec![
                                 (DimName::Batch, 1),
@@ -1662,7 +1762,7 @@ mod tests {
                         },
                         PhysicalOutput {
                             name: "b1".into(),
-                            type_: PhysicalType::BoxesWh,
+                            type_: Some(PhysicalType::BoxesWh),
                             shape: vec![1, 2, 3],
                             dshape: vec![
                                 (DimName::Batch, 1),

--- a/crates/decoder/src/decoder/merge.rs
+++ b/crates/decoder/src/decoder/merge.rs
@@ -228,7 +228,7 @@ fn plan_per_scale(logical: &LogicalOutput) -> DecoderResult<LogicalMerge> {
     // based on common YOLO conventions (batch, features, boxes).
     let (feature_axis_logical, box_axis_logical) = logical_per_scale_axes(logical)?;
 
-    let dfl = if logical.type_ == LogicalType::Boxes
+    let dfl = if logical.type_ == Some(LogicalType::Boxes)
         && logical.encoding == Some(schema::BoxEncoding::Dfl)
     {
         Some(plan_dfl(logical, &children)?)
@@ -978,7 +978,7 @@ mod tests {
             schema_version: 2,
             outputs: vec![LogicalOutput {
                 name: Some("boxes".into()),
-                type_: LogicalType::Boxes,
+                type_: Some(LogicalType::Boxes),
                 shape: vec![1, 4, 8400],
                 dshape: vec![
                     (DimName::Batch, 1),
@@ -1006,7 +1006,7 @@ mod tests {
         // ARA-2 style: boxes_xy + boxes_wh → [1, 4, 3]
         let boxes_logical = LogicalOutput {
             name: Some("boxes".into()),
-            type_: LogicalType::Boxes,
+            type_: Some(LogicalType::Boxes),
             shape: vec![1, 4, 3],
             dshape: vec![
                 (DimName::Batch, 1),
@@ -1137,7 +1137,7 @@ mod tests {
             schema_version: 2,
             outputs: vec![LogicalOutput {
                 name: Some("boxes".into()),
-                type_: LogicalType::Boxes,
+                type_: Some(LogicalType::Boxes),
                 shape: vec![1, 4, 5],
                 dshape: vec![
                     (DimName::Batch, 1),
@@ -1238,7 +1238,7 @@ mod tests {
             outputs: vec![
                 LogicalOutput {
                     name: Some("boxes".into()),
-                    type_: LogicalType::Boxes,
+                    type_: Some(LogicalType::Boxes),
                     shape: vec![1, 4, 3],
                     dshape: vec![
                         (DimName::Batch, 1),
@@ -1258,7 +1258,7 @@ mod tests {
                 // Force at least one split to enable DecodeProgram
                 LogicalOutput {
                     name: Some("scores".into()),
-                    type_: LogicalType::Scores,
+                    type_: Some(LogicalType::Scores),
                     shape: vec![1, 2, 3],
                     dshape: vec![
                         (DimName::Batch, 1),
@@ -1345,7 +1345,7 @@ mod tests {
             schema_version: 2,
             outputs: vec![LogicalOutput {
                 name: Some("boxes".into()),
-                type_: LogicalType::Boxes,
+                type_: Some(LogicalType::Boxes),
                 // Post-decode logical shape: 4 xcycwh channels × 6400
                 // anchors (single 80×80 FPN level in this minimal case).
                 shape: vec![1, 4, 6400],
@@ -1403,7 +1403,7 @@ mod tests {
             schema_version: 2,
             outputs: vec![LogicalOutput {
                 name: Some("boxes".into()),
-                type_: LogicalType::Boxes,
+                type_: Some(LogicalType::Boxes),
                 shape: vec![1, 4, 5],
                 dshape: vec![
                     (DimName::Batch, 1),
@@ -1515,7 +1515,7 @@ mod tests {
             schema_version: 2,
             outputs: vec![LogicalOutput {
                 name: Some("boxes".into()),
-                type_: LogicalType::Boxes,
+                type_: Some(LogicalType::Boxes),
                 shape: vec![1, 4, 5],
                 dshape: vec![
                     (DimName::Batch, 1),
@@ -1606,7 +1606,7 @@ mod tests {
             outputs: vec![
                 LogicalOutput {
                     name: Some("scores".into()),
-                    type_: LogicalType::Scores,
+                    type_: Some(LogicalType::Scores),
                     shape: vec![1, 1, 3],
                     dshape: vec![
                         (DimName::Batch, 1),
@@ -1628,7 +1628,7 @@ mod tests {
                     // branch actually runs (try_from_schema short-circuits
                     // when nothing needs merging).
                     name: Some("boxes".into()),
-                    type_: LogicalType::Boxes,
+                    type_: Some(LogicalType::Boxes),
                     shape: vec![1, 4, 3],
                     dshape: vec![
                         (DimName::Batch, 1),

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -140,11 +140,7 @@ pub struct LogicalOutput {
     /// [`SchemaV2::to_legacy_config_outputs`] for how typeless outputs are
     /// filtered out of the legacy config, and the module docs for when to
     /// use this vs. a recognised [`LogicalType`] variant.
-    #[serde(
-        rename = "type",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub type_: Option<LogicalType>,
 
     /// Reconstructed logical shape (what the fallback dequant+merge path
@@ -233,11 +229,7 @@ pub struct PhysicalOutput {
     /// during merging, but is not used to disambiguate against typed
     /// siblings. Useful when a converter emits extra per-scale tensors
     /// the HAL has no semantic for but the user manages downstream.
-    #[serde(
-        rename = "type",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub type_: Option<PhysicalType>,
 
     /// Physical tensor shape.
@@ -1765,10 +1757,7 @@ mod tests {
         let schema: SchemaV2 = serde_json::from_str(j).unwrap();
         assert_eq!(schema.outputs.len(), 2);
         assert_eq!(schema.outputs[0].type_, None);
-        assert_eq!(
-            schema.outputs[0].name.as_deref(),
-            Some("extra_telemetry")
-        );
+        assert_eq!(schema.outputs[0].name.as_deref(), Some("extra_telemetry"));
         assert_eq!(schema.outputs[1].type_, Some(LogicalType::Boxes));
 
         // Typeless output must not serialize a `type` field.

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -228,9 +228,17 @@ pub struct PhysicalOutput {
     pub name: String,
 
     /// Semantic type. Matches the parent's type or declares a sub-split
-    /// such as `boxes_xy` or `boxes_wh`.
-    #[serde(rename = "type")]
-    pub type_: PhysicalType,
+    /// such as `boxes_xy` or `boxes_wh`. `None` marks the child as
+    /// type-opaque: it still binds to a physical tensor by `name`/`shape`
+    /// during merging, but is not used to disambiguate against typed
+    /// siblings. Useful when a converter emits extra per-scale tensors
+    /// the HAL has no semantic for but the user manages downstream.
+    #[serde(
+        rename = "type",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub type_: Option<PhysicalType>,
 
     /// Physical tensor shape.
     pub shape: Vec<usize>,
@@ -813,9 +821,17 @@ fn validate_logical(logical: &LogicalOutput) -> DecoderResult<()> {
     // Uniqueness of physical child shapes *within the same type* — two
     // children with distinct types (e.g. ARA-2 `boxes_xy` + `boxes_wh`)
     // may legitimately share shape, since type disambiguates the binding.
+    //
+    // Typeless children are excluded from this check: shape uniqueness
+    // only matters when we need to bind a tensor by type+shape, and
+    // typeless children are treated as opaque passthrough — name-based
+    // binding still disambiguates them from each other.
     for (i, a) in logical.outputs.iter().enumerate() {
         for b in &logical.outputs[i + 1..] {
-            if a.shape == b.shape && a.type_ == b.type_ {
+            let (Some(ta), Some(tb)) = (a.type_, b.type_) else {
+                continue;
+            };
+            if a.shape == b.shape && ta == tb {
                 return Err(DecoderError::InvalidConfig(format!(
                     "physical children `{}` and `{}` share shape {:?} and \
                      type; tensor binding cannot be resolved",
@@ -1377,7 +1393,7 @@ mod tests {
         assert_eq!(lo.outputs.len(), 1);
         let child = &lo.outputs[0];
         assert_eq!(child.name, "boxes_0");
-        assert_eq!(child.type_, PhysicalType::Boxes);
+        assert_eq!(child.type_, Some(PhysicalType::Boxes));
         assert_eq!(child.stride, Some(Stride::Square(8)));
         assert_eq!(child.scale_index, Some(0));
         assert_eq!(child.dtype, DType::Uint8);
@@ -1410,8 +1426,8 @@ mod tests {
         let lo: LogicalOutput = serde_json::from_str(j).unwrap();
         assert_eq!(lo.encoding, Some(BoxEncoding::Direct));
         assert_eq!(lo.outputs.len(), 2);
-        assert_eq!(lo.outputs[0].type_, PhysicalType::BoxesXy);
-        assert_eq!(lo.outputs[1].type_, PhysicalType::BoxesWh);
+        assert_eq!(lo.outputs[0].type_, Some(PhysicalType::BoxesXy));
+        assert_eq!(lo.outputs[1].type_, Some(PhysicalType::BoxesWh));
         assert!(lo.outputs[0].stride.is_none());
         assert!(lo.outputs[1].stride.is_none());
     }
@@ -1856,6 +1872,69 @@ mod tests {
         assert!(legacy.outputs.is_empty());
     }
 
+    /// Physical children may also omit `type`. The schema parses, the
+    /// output round-trips without a synthetic `type` field, and the
+    /// uniqueness check doesn't flag a typeless child sharing shape
+    /// with a typed sibling (the type disambiguator is absent, but we
+    /// don't bind typeless children by type anyway).
+    #[test]
+    fn typeless_physical_child_parses_and_skips_uniqueness() {
+        let j = r#"{
+            "name": "boxes",
+            "type": "boxes",
+            "shape": [1, 8400, 4],
+            "outputs": [
+                {
+                    "name": "boxes_xy",
+                    "type": "boxes_xy",
+                    "shape": [1, 8400, 2],
+                    "dtype": "float32"
+                },
+                {
+                    "name": "aux_user_managed",
+                    "shape": [1, 8400, 2],
+                    "dtype": "float32"
+                }
+            ]
+        }"#;
+        let lo: LogicalOutput = serde_json::from_str(j).unwrap();
+        assert_eq!(lo.outputs.len(), 2);
+        assert_eq!(lo.outputs[0].type_, Some(PhysicalType::BoxesXy));
+        assert_eq!(lo.outputs[1].type_, None);
+
+        // Wrap in a minimal schema so we can call validate().
+        // BoxesXy and the typeless child share shape `[1, 8400, 2]`;
+        // the uniqueness check must not treat this as a conflict.
+        let schema = SchemaV2 {
+            schema_version: 2,
+            input: None,
+            outputs: vec![lo],
+            nms: None,
+            decoder_version: None,
+        };
+        schema.validate().expect(
+            "typed + typeless children with equal shape must not trigger \
+             uniqueness error",
+        );
+
+        // Serialization skips `type` on the typeless child.
+        let s = serde_json::to_string(&schema).unwrap();
+        assert!(
+            s.contains("\"aux_user_managed\""),
+            "typeless child must survive round-trip: {s}"
+        );
+        // Locate the typeless child's JSON object and confirm no `type` key.
+        let aux_obj = s
+            .split("\"aux_user_managed\"")
+            .nth(1)
+            .and_then(|s| s.split('}').next())
+            .unwrap_or("");
+        assert!(
+            !aux_obj.contains("\"type\""),
+            "typeless child must not serialize `type`, got: {aux_obj}"
+        );
+    }
+
     #[test]
     fn from_v1_modelpack_anchor_detection_maps_encoding() {
         let v1 = ConfigOutputs {
@@ -2060,8 +2139,8 @@ mod tests {
         assert_eq!(boxes.normalized, Some(true));
         assert_eq!(boxes.shape, vec![1, 4, 8400, 1]); // 4D with padding
         assert_eq!(boxes.outputs.len(), 2);
-        assert_eq!(boxes.outputs[0].type_, PhysicalType::BoxesXy);
-        assert_eq!(boxes.outputs[1].type_, PhysicalType::BoxesWh);
+        assert_eq!(boxes.outputs[0].type_, Some(PhysicalType::BoxesXy));
+        assert_eq!(boxes.outputs[1].type_, Some(PhysicalType::BoxesWh));
         // xy quant: scale 0.004177791997790337, zp -122, int8
         let q_xy = boxes.outputs[0].quantization.as_ref().unwrap();
         assert_eq!(q_xy.dtype, Some(DType::Int8));

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -134,9 +134,18 @@ pub struct LogicalOutput {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
-    /// Semantic type.
-    #[serde(rename = "type")]
-    pub type_: LogicalType,
+    /// Semantic type. `None` marks the output as "additional" — carried in
+    /// the schema for completeness (e.g. diagnostic or auxiliary tensors)
+    /// but not participating in decoder dispatch. See
+    /// [`SchemaV2::to_legacy_config_outputs`] for how typeless outputs are
+    /// filtered out of the legacy config, and the module docs for when to
+    /// use this vs. a recognised [`LogicalType`] variant.
+    #[serde(
+        rename = "type",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub type_: Option<LogicalType>,
 
     /// Reconstructed logical shape (what the fallback dequant+merge path
     /// produces).
@@ -703,13 +712,21 @@ impl SchemaV2 {
     pub fn to_legacy_config_outputs(&self) -> DecoderResult<ConfigOutputs> {
         let mut outputs = Vec::with_capacity(self.outputs.len());
         for logical in &self.outputs {
+            // Typeless logical outputs are carried for round-tripping
+            // but are not required for decoding. Skip them — the decoder
+            // builder will surface its own "missing required output"
+            // error if a decode-critical role (e.g. `boxes`) is absent,
+            // which is more actionable than a serde "missing type" error.
+            if logical.type_.is_none() {
+                continue;
+            }
             // Flat DFL (no children) remains unsupported — the HAL has
             // no path that applies softmax + dist2bbox to a single
             // `(1, 4·reg_max, anchors)` tensor yet. DFL with per-scale
             // children is decoded by the merge path, so we let it
             // through here and rely on the merged logical shape (post-
             // decode 4 channels) being valid for the legacy dispatch.
-            if logical.type_ == LogicalType::Boxes
+            if logical.type_ == Some(LogicalType::Boxes)
                 && logical.encoding == Some(BoxEncoding::Dfl)
                 && logical.outputs.is_empty()
             {
@@ -825,7 +842,7 @@ fn validate_logical(logical: &LogicalOutput) -> DecoderResult<()> {
 
     // DFL boxes: every child's feature axis must be divisible by 4
     // (otherwise `reg_max` is not an integer).
-    if logical.type_ == LogicalType::Boxes && logical.encoding == Some(BoxEncoding::Dfl) {
+    if logical.type_ == Some(LogicalType::Boxes) && logical.encoding == Some(BoxEncoding::Dfl) {
         for child in &logical.outputs {
             if let Some(feat) = last_feature_axis(child) {
                 if feat % 4 != 0 {
@@ -888,7 +905,7 @@ fn logical_from_v1(v1: &ConfigOutput) -> DecoderResult<LogicalOutput> {
             };
             Ok(LogicalOutput {
                 name: None,
-                type_: LogicalType::Detection,
+                type_: Some(LogicalType::Detection),
                 shape: d.shape.clone(),
                 dshape: d.dshape.clone(),
                 decoder: Some(DecoderKind::from_v1(d.decoder)),
@@ -904,7 +921,7 @@ fn logical_from_v1(v1: &ConfigOutput) -> DecoderResult<LogicalOutput> {
         }
         ConfigOutput::Boxes(b) => Ok(LogicalOutput {
             name: None,
-            type_: LogicalType::Boxes,
+            type_: Some(LogicalType::Boxes),
             shape: b.shape.clone(),
             dshape: b.dshape.clone(),
             decoder: Some(DecoderKind::from_v1(b.decoder)),
@@ -922,7 +939,7 @@ fn logical_from_v1(v1: &ConfigOutput) -> DecoderResult<LogicalOutput> {
         }),
         ConfigOutput::Scores(s) => Ok(LogicalOutput {
             name: None,
-            type_: LogicalType::Scores,
+            type_: Some(LogicalType::Scores),
             shape: s.shape.clone(),
             dshape: s.dshape.clone(),
             decoder: Some(DecoderKind::from_v1(s.decoder)),
@@ -940,7 +957,7 @@ fn logical_from_v1(v1: &ConfigOutput) -> DecoderResult<LogicalOutput> {
         }),
         ConfigOutput::Protos(p) => Ok(LogicalOutput {
             name: None,
-            type_: LogicalType::Protos,
+            type_: Some(LogicalType::Protos),
             shape: p.shape.clone(),
             dshape: p.dshape.clone(),
             // protos are consumed directly; decoder field is informational.
@@ -956,7 +973,7 @@ fn logical_from_v1(v1: &ConfigOutput) -> DecoderResult<LogicalOutput> {
         }),
         ConfigOutput::MaskCoefficients(m) => Ok(LogicalOutput {
             name: None,
-            type_: LogicalType::MaskCoefs,
+            type_: Some(LogicalType::MaskCoefs),
             shape: m.shape.clone(),
             dshape: m.dshape.clone(),
             decoder: Some(DecoderKind::from_v1(m.decoder)),
@@ -971,7 +988,7 @@ fn logical_from_v1(v1: &ConfigOutput) -> DecoderResult<LogicalOutput> {
         }),
         ConfigOutput::Segmentation(seg) => Ok(LogicalOutput {
             name: None,
-            type_: LogicalType::Segmentation,
+            type_: Some(LogicalType::Segmentation),
             shape: seg.shape.clone(),
             dshape: seg.dshape.clone(),
             decoder: Some(DecoderKind::from_v1(seg.decoder)),
@@ -986,7 +1003,7 @@ fn logical_from_v1(v1: &ConfigOutput) -> DecoderResult<LogicalOutput> {
         }),
         ConfigOutput::Mask(m) => Ok(LogicalOutput {
             name: None,
-            type_: LogicalType::Masks,
+            type_: Some(LogicalType::Masks),
             shape: m.shape.clone(),
             dshape: m.dshape.clone(),
             decoder: Some(DecoderKind::from_v1(m.decoder)),
@@ -1001,7 +1018,7 @@ fn logical_from_v1(v1: &ConfigOutput) -> DecoderResult<LogicalOutput> {
         }),
         ConfigOutput::Classes(c) => Ok(LogicalOutput {
             name: None,
-            type_: LogicalType::Classes,
+            type_: Some(LogicalType::Classes),
             shape: c.shape.clone(),
             dshape: c.dshape.clone(),
             decoder: Some(DecoderKind::from_v1(c.decoder)),
@@ -1150,7 +1167,18 @@ fn logical_to_legacy_config_output(logical: &LogicalOutput) -> DecoderResult<Con
     // axis (ARA-2).
     let (shape, dshape) = squeeze_padding_dims(logical.shape.clone(), logical.dshape.clone());
 
-    Ok(match logical.type_ {
+    let ty = logical.type_.ok_or_else(|| {
+        // Defense-in-depth: `to_legacy_config_outputs` already filters
+        // typeless outputs, so reaching here means a new caller added a
+        // bypass. Surface it as an internal error rather than panicking.
+        DecoderError::InvalidConfig(format!(
+            "logical output `{}` has no type; typeless outputs should be \
+             filtered before legacy conversion",
+            logical.name.as_deref().unwrap_or("<anonymous>")
+        ))
+    })?;
+
+    Ok(match ty {
         LogicalType::Boxes => ConfigOutput::Boxes(configs::Boxes {
             decoder,
             quantization,
@@ -1213,7 +1241,7 @@ fn logical_to_legacy_config_output(logical: &LogicalOutput) -> DecoderResult<Con
             return Err(DecoderError::NotSupported(format!(
                 "logical type {:?} has no legacy v1 equivalent; use the \
                  native v2 decoder path",
-                logical.type_
+                ty
             )));
         }
     })
@@ -1319,7 +1347,7 @@ mod tests {
           "normalized": true
         }"#;
         let lo: LogicalOutput = serde_json::from_str(j).unwrap();
-        assert_eq!(lo.type_, LogicalType::Boxes);
+        assert_eq!(lo.type_, Some(LogicalType::Boxes));
         assert_eq!(lo.encoding, Some(BoxEncoding::Dfl));
         assert_eq!(lo.normalized, Some(true));
         assert!(!lo.is_split());
@@ -1431,7 +1459,7 @@ mod tests {
         let s: SchemaV2 = serde_json::from_str(j).unwrap();
         assert_eq!(s.decoder_version, Some(DecoderVersion::Yolo26));
         assert!(s.decoder_version.unwrap().is_end_to_end());
-        assert_eq!(s.outputs[0].type_, LogicalType::Detections);
+        assert_eq!(s.outputs[0].type_, Some(LogicalType::Detections));
         assert_eq!(s.outputs[0].normalized, Some(false));
         assert!(s.nms.is_none());
     }
@@ -1476,7 +1504,7 @@ mod tests {
           }]
         }"#;
         let lo: LogicalOutput = serde_json::from_str(j).unwrap();
-        assert_eq!(lo.type_, LogicalType::Objectness);
+        assert_eq!(lo.type_, Some(LogicalType::Objectness));
         assert_eq!(lo.outputs[0].activation_applied, Some(Activation::Sigmoid));
     }
 
@@ -1492,7 +1520,7 @@ mod tests {
           "stride": 4
         }"#;
         let lo: LogicalOutput = serde_json::from_str(j).unwrap();
-        assert_eq!(lo.type_, LogicalType::Protos);
+        assert_eq!(lo.type_, Some(LogicalType::Protos));
         assert!(lo.decoder.is_none());
         assert_eq!(lo.stride, Some(Stride::Square(4)));
     }
@@ -1555,7 +1583,7 @@ mod tests {
             }),
             outputs: vec![LogicalOutput {
                 name: Some("boxes".into()),
-                type_: LogicalType::Boxes,
+                type_: Some(LogicalType::Boxes),
                 shape: vec![1, 4, 8400],
                 dshape: vec![],
                 decoder: Some(DecoderKind::Ultralytics),
@@ -1589,7 +1617,7 @@ mod tests {
         assert_eq!(schema.outputs.len(), 2);
         // First output: Detection [1, 116, 8400]
         let det = &schema.outputs[0];
-        assert_eq!(det.type_, LogicalType::Detection);
+        assert_eq!(det.type_, Some(LogicalType::Detection));
         assert_eq!(det.shape, vec![1, 116, 8400]);
         assert_eq!(det.decoder, Some(DecoderKind::Ultralytics));
         assert_eq!(det.encoding, Some(BoxEncoding::Direct));
@@ -1599,7 +1627,7 @@ mod tests {
         assert_eq!(q.zero_point, Some(vec![31]));
         // Second output: Protos [1, 160, 160, 32]
         let protos = &schema.outputs[1];
-        assert_eq!(protos.type_, LogicalType::Protos);
+        assert_eq!(protos.type_, Some(LogicalType::Protos));
         assert_eq!(protos.shape, vec![1, 160, 160, 32]);
     }
 
@@ -1614,7 +1642,7 @@ mod tests {
         assert_eq!(schema.outputs.len(), 2);
         // Both are ModelPack anchor detection with anchors
         for out in &schema.outputs {
-            assert_eq!(out.type_, LogicalType::Detection);
+            assert_eq!(out.type_, Some(LogicalType::Detection));
             assert_eq!(out.decoder, Some(DecoderKind::ModelPack));
             assert_eq!(out.encoding, Some(BoxEncoding::Anchor));
             assert_eq!(out.anchors.as_ref().map(|a| a.len()), Some(3));
@@ -1637,7 +1665,7 @@ mod tests {
         }"#;
         let schema = SchemaV2::parse_json(j).unwrap();
         assert_eq!(schema.schema_version, 2);
-        assert_eq!(schema.outputs[0].type_, LogicalType::Boxes);
+        assert_eq!(schema.outputs[0].type_, Some(LogicalType::Boxes));
     }
 
     #[test]
@@ -1667,8 +1695,8 @@ mod tests {
         let schema = SchemaV2::parse_json(j).expect("v1 legacy parse");
         assert_eq!(schema.schema_version, 2); // converted
         assert_eq!(schema.outputs.len(), 2);
-        assert_eq!(schema.outputs[0].type_, LogicalType::Boxes);
-        assert_eq!(schema.outputs[1].type_, LogicalType::Scores);
+        assert_eq!(schema.outputs[0].type_, Some(LogicalType::Boxes));
+        assert_eq!(schema.outputs[1].type_, Some(LogicalType::Scores));
         // default score_format assumed on v1→v2
         assert_eq!(schema.outputs[1].score_format, Some(ScoreFormat::PerClass));
     }
@@ -1694,6 +1722,138 @@ mod tests {
         assert_eq!(q.scale, vec![0.01]);
         assert_eq!(q.zero_point, Some(vec![5]));
         assert_eq!(q.dtype, None); // v1 did not carry dtype
+    }
+
+    /// Outputs declared without a `type` field must parse successfully
+    /// and round-trip to JSON without introducing a synthetic type.
+    /// The metadata v2 spec lists `type` as required on both logical
+    /// and physical levels, but the HAL tolerates typeless logical
+    /// outputs as "additional" (auxiliary / diagnostic) tensors that
+    /// do not participate in decoder dispatch.
+    #[test]
+    fn typeless_logical_output_parses_and_roundtrips() {
+        let j = r#"{
+            "schema_version": 2,
+            "outputs": [
+                {
+                    "name": "extra_telemetry",
+                    "shape": [1, 16]
+                },
+                {
+                    "name": "boxes",
+                    "type": "boxes",
+                    "shape": [1, 4, 8400]
+                }
+            ]
+        }"#;
+        let schema: SchemaV2 = serde_json::from_str(j).unwrap();
+        assert_eq!(schema.outputs.len(), 2);
+        assert_eq!(schema.outputs[0].type_, None);
+        assert_eq!(
+            schema.outputs[0].name.as_deref(),
+            Some("extra_telemetry")
+        );
+        assert_eq!(schema.outputs[1].type_, Some(LogicalType::Boxes));
+
+        // Typeless output must not serialize a `type` field.
+        let round = serde_json::to_string(&schema).unwrap();
+        let first_obj = round
+            .split("\"outputs\":[")
+            .nth(1)
+            .and_then(|s| s.split("}").next())
+            .expect("outputs array");
+        assert!(
+            !first_obj.contains("\"type\""),
+            "typeless output must not serialize a `type` field, got: {first_obj}"
+        );
+    }
+
+    /// Typeless logical outputs are filtered out of the legacy
+    /// ConfigOutputs — they carry no decoder role and the legacy
+    /// builder can't represent them. A schema with typeless extras
+    /// plus a recognised `boxes` role must lower to a legacy config
+    /// containing only the `boxes` entry.
+    #[test]
+    fn typeless_outputs_filtered_from_legacy_config() {
+        let schema = SchemaV2 {
+            schema_version: 2,
+            input: None,
+            outputs: vec![
+                LogicalOutput {
+                    name: Some("diagnostic_histogram".into()),
+                    type_: None,
+                    shape: vec![1, 256],
+                    dshape: vec![],
+                    decoder: None,
+                    encoding: None,
+                    score_format: None,
+                    normalized: None,
+                    anchors: None,
+                    stride: None,
+                    dtype: None,
+                    quantization: None,
+                    outputs: vec![],
+                },
+                LogicalOutput {
+                    name: Some("boxes".into()),
+                    type_: Some(LogicalType::Boxes),
+                    shape: vec![1, 4, 8400],
+                    dshape: vec![],
+                    decoder: Some(DecoderKind::Ultralytics),
+                    encoding: Some(BoxEncoding::Direct),
+                    score_format: None,
+                    normalized: Some(true),
+                    anchors: None,
+                    stride: None,
+                    dtype: None,
+                    quantization: None,
+                    outputs: vec![],
+                },
+            ],
+            nms: None,
+            decoder_version: None,
+        };
+        let legacy = schema.to_legacy_config_outputs().unwrap();
+        assert_eq!(
+            legacy.outputs.len(),
+            1,
+            "typeless output must be filtered from legacy config"
+        );
+        assert!(
+            matches!(legacy.outputs[0], ConfigOutput::Boxes(_)),
+            "only the typed `boxes` output should survive lowering"
+        );
+    }
+
+    /// A schema that contains no typed outputs (all typeless) lowers
+    /// to an empty legacy config. The decoder builder then surfaces
+    /// its own "No outputs found in config" error — meaningful,
+    /// decoder-centric, not a serde-level "missing field type".
+    #[test]
+    fn all_typeless_schema_produces_empty_legacy_config() {
+        let schema = SchemaV2 {
+            schema_version: 2,
+            input: None,
+            outputs: vec![LogicalOutput {
+                name: Some("aux".into()),
+                type_: None,
+                shape: vec![1, 8],
+                dshape: vec![],
+                decoder: None,
+                encoding: None,
+                score_format: None,
+                normalized: None,
+                anchors: None,
+                stride: None,
+                dtype: None,
+                quantization: None,
+                outputs: vec![],
+            }],
+            nms: None,
+            decoder_version: None,
+        };
+        let legacy = schema.to_legacy_config_outputs().unwrap();
+        assert!(legacy.outputs.is_empty());
     }
 
     #[test]
@@ -1895,7 +2055,7 @@ mod tests {
         // Four logical outputs: boxes (split xy/wh), scores, mask_coefs, protos.
         assert_eq!(schema.outputs.len(), 4);
         let boxes = &schema.outputs[0];
-        assert_eq!(boxes.type_, LogicalType::Boxes);
+        assert_eq!(boxes.type_, Some(LogicalType::Boxes));
         assert_eq!(boxes.encoding, Some(BoxEncoding::Direct));
         assert_eq!(boxes.normalized, Some(true));
         assert_eq!(boxes.shape, vec![1, 4, 8400, 1]); // 4D with padding
@@ -1909,16 +2069,16 @@ mod tests {
         assert_eq!(q_xy.zero_point_at(0), -122);
 
         let scores = &schema.outputs[1];
-        assert_eq!(scores.type_, LogicalType::Scores);
+        assert_eq!(scores.type_, Some(LogicalType::Scores));
         assert_eq!(scores.score_format, Some(ScoreFormat::PerClass));
         assert_eq!(scores.shape, vec![1, 80, 8400, 1]);
 
         let mask_coefs = &schema.outputs[2];
-        assert_eq!(mask_coefs.type_, LogicalType::MaskCoefs);
+        assert_eq!(mask_coefs.type_, Some(LogicalType::MaskCoefs));
         assert_eq!(mask_coefs.shape, vec![1, 32, 8400, 1]);
 
         let protos = &schema.outputs[3];
-        assert_eq!(protos.type_, LogicalType::Protos);
+        assert_eq!(protos.type_, Some(LogicalType::Protos));
         assert_eq!(protos.shape, vec![1, 32, 160, 160]);
 
         // Schema-level validation passes.

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -1097,6 +1097,12 @@ pub(crate) fn squeeze_padding_dims(
     shape: Vec<usize>,
     dshape: Vec<(DimName, usize)>,
 ) -> (Vec<usize>, Vec<(DimName, usize)>) {
+    // dshape is `#[serde(default)]`; a logical output without named dims
+    // arrives here with an empty dshape. `zip` would stop at the shorter
+    // iterator and silently truncate shape to `[]`, so short-circuit.
+    if dshape.is_empty() {
+        return (shape, dshape);
+    }
     let keep: Vec<bool> = dshape
         .iter()
         .map(|(n, _)| !matches!(n, DimName::Padding))
@@ -1958,5 +1964,46 @@ outputs:
         let schema = SchemaV2::parse_yaml(yaml).unwrap();
         assert_eq!(schema.schema_version, 2);
         assert_eq!(schema.outputs[0].score_format, Some(ScoreFormat::PerClass));
+    }
+
+    // ─── squeeze_padding_dims / to_legacy_config_outputs regressions ────
+
+    #[test]
+    fn squeeze_padding_dims_preserves_shape_when_dshape_absent() {
+        // Empty dshape must pass shape through untouched. The previous
+        // `zip` implementation silently truncated to `[]`, which made
+        // every v2 logical output without named dims arrive at the legacy
+        // verifier with `shape: []` and fail rank checks.
+        let (shape, dshape) = squeeze_padding_dims(vec![1, 4, 8400], vec![]);
+        assert_eq!(shape, vec![1, 4, 8400]);
+        assert!(dshape.is_empty());
+    }
+
+    #[test]
+    fn to_legacy_preserves_shape_for_v2_split_boxes_without_dshape() {
+        // Regression: `Decoder({...v2 split boxes, shape:[1,4,8400], no dshape...})`
+        // used to fail with `Invalid Yolo Split Boxes shape []` because
+        // `squeeze_padding_dims` truncated shape when dshape was empty.
+        let j = r#"{
+          "schema_version": 2,
+          "outputs": [
+            {"name":"boxes","type":"boxes","shape":[1,4,8400],
+             "dtype":"float32","decoder":"ultralytics","encoding":"direct"},
+            {"name":"scores","type":"scores","shape":[1,80,8400],
+             "dtype":"float32","decoder":"ultralytics","score_format":"per_class"}
+          ]
+        }"#;
+        let schema = SchemaV2::parse_json(j).unwrap();
+        let legacy = schema.to_legacy_config_outputs().expect("lowers cleanly");
+        let boxes = match &legacy.outputs[0] {
+            crate::ConfigOutput::Boxes(b) => b,
+            other => panic!("expected Boxes, got {other:?}"),
+        };
+        assert_eq!(boxes.shape, vec![1, 4, 8400]);
+        let scores = match &legacy.outputs[1] {
+            crate::ConfigOutput::Scores(s) => s,
+            other => panic!("expected Scores, got {other:?}"),
+        };
+        assert_eq!(scores.shape, vec![1, 80, 8400]);
     }
 }

--- a/crates/image/benches/mask_benchmark.rs
+++ b/crates/image/benches/mask_benchmark.rs
@@ -549,8 +549,9 @@ fn run_diagnostic(proc: &mut ImageProcessor) {
 
 /// Sweep `materialize_masks` cost across realistic detection counts on the
 /// actual `CPUProcessor` API (not the bench-local helper). The batched-GEMM
-/// path activates at `N >= 3`; sizes 8/16/32/64/100 bracket typical COCO
-/// validation loads (pycocotools `max_det=100`).
+/// path activates at `N >= 16` for proto resolution and `N >= 2` for scaled
+/// resolution; sizes 8/16/32/64/100 bracket typical COCO validation loads
+/// (pycocotools `max_det=100`).
 fn bench_materialize_masks_sweep(suite: &mut BenchSuite) {
     use edgefirst_image::CPUProcessor;
 

--- a/crates/image/benches/mask_benchmark.rs
+++ b/crates/image/benches/mask_benchmark.rs
@@ -569,7 +569,11 @@ fn bench_materialize_masks_sweep(suite: &mut BenchSuite) {
 
     // Perturb the base bboxes slightly so they don't all overlap identically
     // (avoids hitting a degenerate cache-hot case).
-    fn replicated_dataset(n: usize, base_detect: &[DetectBox], base_proto: &ProtoData) -> (Vec<DetectBox>, ProtoData) {
+    fn replicated_dataset(
+        n: usize,
+        base_detect: &[DetectBox],
+        base_proto: &ProtoData,
+    ) -> (Vec<DetectBox>, ProtoData) {
         let mut out_detect = Vec::with_capacity(n);
         let mut out_coeffs = Vec::with_capacity(n);
         for i in 0..n {

--- a/crates/image/benches/mask_benchmark.rs
+++ b/crates/image/benches/mask_benchmark.rs
@@ -547,6 +547,95 @@ fn run_diagnostic(proc: &mut ImageProcessor) {
     println!();
 }
 
+/// Sweep `materialize_masks` cost across realistic detection counts on the
+/// actual `CPUProcessor` API (not the bench-local helper). The batched-GEMM
+/// path activates at `N >= 3`; sizes 8/16/32/64/100 bracket typical COCO
+/// validation loads (pycocotools `max_det=100`).
+fn bench_materialize_masks_sweep(suite: &mut BenchSuite) {
+    use edgefirst_image::CPUProcessor;
+
+    println!("\n== materialize_masks: N-sweep (CPUProcessor API) ==\n");
+    println!("  Exercises the real materialize_masks path; sizes span the");
+    println!("  validation workload that dominates HAL output time.\n");
+
+    // Get 2 real detections with NMS applied, then replicate them to fill
+    // the desired N. Each replicated detection gets its own coefficient
+    // vector (cloned) so the GEMM path sees N independent mask planes.
+    let (base_detect, base_proto) = decode_proto_data();
+    if base_detect.is_empty() {
+        println!("  [skipped: no detections from fixture]\n");
+        return;
+    }
+
+    // Perturb the base bboxes slightly so they don't all overlap identically
+    // (avoids hitting a degenerate cache-hot case).
+    fn replicated_dataset(n: usize, base_detect: &[DetectBox], base_proto: &ProtoData) -> (Vec<DetectBox>, ProtoData) {
+        let mut out_detect = Vec::with_capacity(n);
+        let mut out_coeffs = Vec::with_capacity(n);
+        for i in 0..n {
+            let src = &base_detect[i % base_detect.len()];
+            let src_coeff = &base_proto.mask_coefficients[i % base_proto.mask_coefficients.len()];
+            let t = (i as f32 / n as f32) * 0.3;
+            let bbox = src.bbox;
+            out_detect.push(DetectBox {
+                bbox: edgefirst_decoder::BoundingBox::new(
+                    (bbox.xmin + t * 0.1).clamp(0.0, 0.9),
+                    (bbox.ymin + t * 0.1).clamp(0.0, 0.9),
+                    (bbox.xmax - t * 0.1).max(bbox.xmin + 0.05),
+                    (bbox.ymax - t * 0.1).max(bbox.ymin + 0.05),
+                ),
+                score: src.score,
+                label: src.label,
+            });
+            out_coeffs.push(src_coeff.clone());
+        }
+        // Clone the proto tensor so the inner loop doesn't race.
+        let protos = match &base_proto.protos {
+            edgefirst_decoder::ProtoTensor::Float(a) => {
+                edgefirst_decoder::ProtoTensor::Float(a.clone())
+            }
+            edgefirst_decoder::ProtoTensor::Quantized {
+                protos,
+                quantization,
+            } => edgefirst_decoder::ProtoTensor::Quantized {
+                protos: protos.clone(),
+                quantization: *quantization,
+            },
+        };
+        (
+            out_detect,
+            ProtoData {
+                mask_coefficients: out_coeffs,
+                protos,
+            },
+        )
+    }
+
+    for &n in &[1usize, 2, 3, 8, 16, 32, 64, 100] {
+        let (detect, proto_data) = replicated_dataset(n, &base_detect, &base_proto);
+
+        let mut cpu = CPUProcessor::new();
+        let name = format!("materialize_masks/proto_res/N={n}");
+        let result = run_bench(&name, WARMUP, ITERATIONS, || {
+            let _ = cpu
+                .materialize_segmentations(&detect, &proto_data, None)
+                .unwrap();
+        });
+        result.print_summary();
+        suite.record(&result);
+
+        let mut cpu_scaled = CPUProcessor::new();
+        let name_scaled = format!("materialize_masks/scaled_640x640/N={n}");
+        let result = run_bench(&name_scaled, WARMUP, ITERATIONS, || {
+            let _ = cpu_scaled
+                .materialize_scaled_segmentations(&detect, &proto_data, None, 640, 640)
+                .unwrap();
+        });
+        result.print_summary();
+        suite.record(&result);
+    }
+}
+
 fn main() {
     env_logger::init();
     let mut suite = BenchSuite::from_args();
@@ -569,6 +658,7 @@ fn main() {
     bench_draw_proto_masks(&mut proc, &mut suite);
     bench_draw_proto_masks_forced_opengl(&mut suite);
     bench_hybrid_materialize_and_draw(&mut proc, &mut suite);
+    bench_materialize_masks_sweep(&mut suite);
 
     suite.finish();
     println!("\nDone.");

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -471,6 +471,14 @@ impl CPUProcessor {
         if detect.is_empty() || proto_data.mask_coefficients.is_empty() {
             return Ok(Vec::new());
         }
+        if detect.len() != proto_data.mask_coefficients.len() {
+            return Err(crate::Error::InvalidShape(format!(
+                "materialize_segmentations: detect.len() ({}) must match \
+                 mask_coefficients.len() ({})",
+                detect.len(),
+                proto_data.mask_coefficients.len()
+            )));
+        }
         let min_n = if legacy_materialize_forced() {
             usize::MAX
         } else {
@@ -507,6 +515,14 @@ impl CPUProcessor {
 
         if detect.is_empty() || proto_data.mask_coefficients.is_empty() {
             return Ok(Vec::new());
+        }
+        if detect.len() != proto_data.mask_coefficients.len() {
+            return Err(crate::Error::InvalidShape(format!(
+                "materialize_scaled_segmentations: detect.len() ({}) must match \
+                 mask_coefficients.len() ({})",
+                detect.len(),
+                proto_data.mask_coefficients.len()
+            )));
         }
         if width == 0 || height == 0 {
             return Err(crate::Error::InvalidShape(

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -4,7 +4,146 @@
 use super::CPUProcessor;
 use crate::Result;
 use edgefirst_decoder::{DetectBox, Segmentation};
-use ndarray::Axis;
+use ndarray::{linalg::general_mat_mul, Array3, Axis};
+use rayon::prelude::*;
+
+/// Reusable scratch buffers for the batched `materialize_masks` path.
+///
+/// Held on [`CPUProcessor`] so repeated calls (e.g. COCO validation) reuse
+/// the dequantised-protos and logits allocations. All buffers grow with
+/// `resize` (which reuses capacity) rather than being reallocated.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MaskScratch {
+    /// Dequantised protos flattened to `(H*W, K)` row-major.
+    dequant: Vec<f32>,
+    /// Detection mask coefficients packed to `(N, K)` row-major for GEMM.
+    coeffs: Vec<f32>,
+    /// GEMM output `(N, H*W)` row-major — one logit plane per detection.
+    logits: Vec<f32>,
+}
+
+impl MaskScratch {
+    /// Compute per-detection logit planes `(N, H*W)` at proto resolution via
+    /// a single GEMM. Returns a view into the internal buffer so per-detection
+    /// post-processing can read it without copying.
+    ///
+    /// Shape contract:
+    /// - `coeffs`: slice of `N` coefficient vectors, each length `K`.
+    /// - `protos`: `(H, W, K)` float or `(H, W, K)` i8 + quantization.
+    /// - Returns `(N, H*W)` f32 logits (pre-sigmoid).
+    fn compute_logits(
+        &mut self,
+        coeffs: &[Vec<f32>],
+        protos: &edgefirst_decoder::ProtoTensor,
+        proto_h: usize,
+        proto_w: usize,
+        num_protos: usize,
+    ) -> Result<()> {
+        use edgefirst_decoder::ProtoTensor;
+
+        let n = coeffs.len();
+        let hw = proto_h * proto_w;
+
+        // Pack coefficients into contiguous (N, K). Reject early if any
+        // detection has the wrong coefficient count — cheaper to check here
+        // than per-pixel later.
+        self.coeffs.clear();
+        self.coeffs.reserve(n * num_protos);
+        for coeff in coeffs {
+            if coeff.len() != num_protos {
+                return Err(crate::Error::Internal(format!(
+                    "mask coeff length {} != proto channels {num_protos}",
+                    coeff.len()
+                )));
+            }
+            self.coeffs.extend_from_slice(coeff);
+        }
+
+        // Dequantise protos into (H*W, K) row-major. For Float protos we
+        // still copy to guarantee a contiguous (H*W, K) layout regardless of
+        // the source tensor's stride (ndarray protos may arrive with a
+        // non-standard layout from the decoder's tensor_bridge).
+        self.dequant.clear();
+        self.dequant.resize(hw * num_protos, 0.0);
+        match protos {
+            ProtoTensor::Float(arr) => {
+                let src = arr.view();
+                let dst = &mut self.dequant;
+                // (H, W, K) → (H*W, K) row-major
+                for y in 0..proto_h {
+                    for x in 0..proto_w {
+                        let row = (y * proto_w + x) * num_protos;
+                        for k in 0..num_protos {
+                            dst[row + k] = src[[y, x, k]];
+                        }
+                    }
+                }
+            }
+            ProtoTensor::Quantized {
+                protos,
+                quantization,
+            } => {
+                let scale = quantization.scale;
+                let zp = quantization.zero_point as f32;
+                let src = protos.view();
+                let dst = &mut self.dequant;
+                for y in 0..proto_h {
+                    for x in 0..proto_w {
+                        let row = (y * proto_w + x) * num_protos;
+                        for k in 0..num_protos {
+                            dst[row + k] = (src[[y, x, k]] as f32 - zp) * scale;
+                        }
+                    }
+                }
+            }
+        }
+
+        // GEMM: logits (N, HW) = coeffs (N, K) · dequant.T (K, HW)
+        // We build views over the scratch buffers — no extra allocation.
+        self.logits.clear();
+        self.logits.resize(n * hw, 0.0);
+        let a = ndarray::ArrayView2::from_shape((n, num_protos), &self.coeffs)
+            .expect("coeffs buffer matches (N, K)");
+        let b = ndarray::ArrayView2::from_shape((hw, num_protos), &self.dequant)
+            .expect("dequant buffer matches (HW, K)");
+        let mut c = ndarray::ArrayViewMut2::from_shape((n, hw), &mut self.logits)
+            .expect("logits buffer matches (N, HW)");
+        // `b.t()` is a view — no copy — giving us (K, HW).
+        general_mat_mul(1.0, &a, &b.t(), 0.0, &mut c);
+
+        Ok(())
+    }
+
+    /// Read-only view of the last computed logits as `(N, H*W)`.
+    fn logits(&self, n: usize, hw: usize) -> &[f32] {
+        debug_assert_eq!(self.logits.len(), n * hw);
+        &self.logits[..n * hw]
+    }
+}
+
+/// For `MaskResolution::Proto`, the per-detection ROI kernel only touches
+/// the bbox's worth of proto pixels. The batched path dequantises and
+/// GEMMs over the *entire* proto plane regardless of bbox size, so it
+/// only wins once the per-detection work exceeds the up-front full-plane
+/// cost. Measured crossover: `N ~= 16` on Cortex-A55, `N ~= 12` on x86.
+/// Picked conservatively at 16 to avoid regressions on embedded targets
+/// at the cost of a small miss at the crossover on desktop.
+const BATCHED_GEMM_MIN_N_PROTO: usize = 16;
+
+/// For `MaskResolution::Scaled`, the per-detection work is an
+/// `out_w × out_h × K` bilinear+dot+sigmoid loop (multi-ms per detection
+/// at 640×640), so the GEMM amortises cleanly across detections. At
+/// `N=1` on Cortex-A55 the batched full-plane dequant+GEMM slightly
+/// overshoots the single-detection scalar work, so the threshold is 2.
+const BATCHED_GEMM_MIN_N_SCALED: usize = 2;
+
+/// Development/benchmarking toggle: force `materialize_masks` to always use
+/// the legacy per-detection fused kernels, bypassing the batched-GEMM path.
+/// Set `EDGEFIRST_LEGACY_MATERIALIZE=1` to enable. Intended for A/B
+/// profiling only — production callers should never set it.
+fn legacy_materialize_forced() -> bool {
+    std::env::var_os("EDGEFIRST_LEGACY_MATERIALIZE").is_some()
+}
 
 impl CPUProcessor {
     #[allow(clippy::too_many_arguments)]
@@ -217,108 +356,38 @@ impl CPUProcessor {
     /// Benchmarks show this hybrid path (CPU decode + GL overlay) is faster
     /// than the fused GPU `draw_proto_masks` on all tested platforms.
     ///
-    /// Optimized: fused dequantization + dot product avoids a 3.1MB f32
-    /// allocation for the full proto tensor. Uses fast sigmoid approximation.
+    /// Optimized path:
+    /// - `N >= BATCHED_GEMM_MIN_N`: one `(N, K) × (K, H*W)` GEMM via
+    ///   `ndarray`'s `matrixmultiply` backend (SIMD-vectorised) shared across
+    ///   all detections; per-detection tile assembly is rayon-parallel using
+    ///   `MaskScratch` buffers pooled on `CPUProcessor`.
+    /// - `N < BATCHED_GEMM_MIN_N`: per-detection fused dequant+dot+sigmoid
+    ///   (the original path) — avoids the 3.1MB dequant allocation when the
+    ///   GEMM savings can't amortise it.
     pub fn materialize_segmentations(
-        &self,
+        &mut self,
         detect: &[crate::DetectBox],
         proto_data: &crate::ProtoData,
         letterbox: Option<[f32; 4]>,
     ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
-        use edgefirst_decoder::ProtoTensor;
-
         if detect.is_empty() || proto_data.mask_coefficients.is_empty() {
             return Ok(Vec::new());
         }
-
-        // Extract proto tensor metadata for the fused kernel.
-        let (proto_h, proto_w, num_protos) = match &proto_data.protos {
-            ProtoTensor::Quantized { protos, .. } => {
-                (protos.shape()[0], protos.shape()[1], protos.shape()[2])
-            }
-            ProtoTensor::Float(arr) => (arr.shape()[0], arr.shape()[1], arr.shape()[2]),
+        let min_n = if legacy_materialize_forced() {
+            usize::MAX
+        } else {
+            BATCHED_GEMM_MIN_N_PROTO
         };
-
-        // Precompute inverse letterbox scale for output-coord conversion.
-        let (lx0, inv_lw, ly0, inv_lh) = match letterbox {
-            Some([lx0, ly0, lx1, ly1]) => {
-                let lw = lx1 - lx0;
-                let lh = ly1 - ly0;
-                (
-                    lx0,
-                    if lw > 0.0 { 1.0 / lw } else { 1.0 },
-                    ly0,
-                    if lh > 0.0 { 1.0 / lh } else { 1.0 },
-                )
-            }
-            None => (0.0_f32, 1.0_f32, 0.0_f32, 1.0_f32),
-        };
-
-        detect
-            .iter()
-            .zip(proto_data.mask_coefficients.iter())
-            .map(|(det, coeff)| {
-                // Canonicalise bbox (swap min/max if inverted) then clamp to [0,1].
-                // Without canonicalisation a degenerate box (ymax < ymin) causes a
-                // near-zero ROI height after saturating_sub, making the mask invisible.
-                let bbox = det.bbox.to_canonical();
-                let xmin = bbox.xmin.clamp(0.0, 1.0);
-                let ymin = bbox.ymin.clamp(0.0, 1.0);
-                let xmax = bbox.xmax.clamp(0.0, 1.0);
-                let ymax = bbox.ymax.clamp(0.0, 1.0);
-
-                // Map to proto-space pixel coordinates (clamp to valid range)
-                let x0 = ((xmin * proto_w as f32) as usize).min(proto_w.saturating_sub(1));
-                let y0 = ((ymin * proto_h as f32) as usize).min(proto_h.saturating_sub(1));
-                let x1 = ((xmax * proto_w as f32).ceil() as usize).min(proto_w);
-                let y1 = ((ymax * proto_h as f32).ceil() as usize).min(proto_h);
-
-                let roi_w = x1.saturating_sub(x0).max(1);
-                let roi_h = y1.saturating_sub(y0).max(1);
-
-                if coeff.len() != num_protos {
-                    return Err(crate::Error::Internal(format!(
-                        "mask coeff length {} != proto channels {num_protos}",
-                        coeff.len()
-                    )));
-                }
-
-                // Fused dequant + dot product + sigmoid, directly producing u8 mask.
-                // Avoids allocating a full f32 proto tensor and the to_shape copy.
-                let mask = match &proto_data.protos {
-                    ProtoTensor::Quantized {
-                        protos,
-                        quantization,
-                    } => {
-                        let scale = quantization.scale;
-                        let zp = quantization.zero_point as f32;
-                        fused_dequant_dot_sigmoid_i8(
-                            protos, coeff, scale, zp, y0, x0, roi_h, roi_w, num_protos,
-                        )
-                    }
-                    ProtoTensor::Float(protos) => {
-                        fused_dot_sigmoid_f32(protos, coeff, y0, x0, roi_h, roi_w, num_protos)
-                    }
-                };
-
-                // Convert proto-space normalised coords to output-image-normalised
-                // coords by applying the inverse letterbox transform.  When no
-                // letterbox was used (lx0=0, inv_lw=1, ly0=0, inv_lh=1) this is a
-                // no-op and the coords are identical to the proto-normalised values.
-                let seg_xmin = ((x0 as f32 / proto_w as f32) - lx0) * inv_lw;
-                let seg_ymin = ((y0 as f32 / proto_h as f32) - ly0) * inv_lh;
-                let seg_xmax = ((x1 as f32 / proto_w as f32) - lx0) * inv_lw;
-                let seg_ymax = ((y1 as f32 / proto_h as f32) - ly0) * inv_lh;
-
-                Ok(edgefirst_decoder::Segmentation {
-                    xmin: seg_xmin.clamp(0.0, 1.0),
-                    ymin: seg_ymin.clamp(0.0, 1.0),
-                    xmax: seg_xmax.clamp(0.0, 1.0),
-                    ymax: seg_ymax.clamp(0.0, 1.0),
-                    segmentation: mask,
-                })
-            })
-            .collect::<crate::Result<Vec<_>>>()
+        if detect.len() < min_n {
+            materialize_segmentations_fused(detect, proto_data, letterbox)
+        } else {
+            materialize_segmentations_batched(
+                &mut self.mask_scratch,
+                detect,
+                proto_data,
+                letterbox,
+            )
+        }
     }
 
     /// Produce per-detection masks at `(width, height)` pixel resolution by
@@ -334,7 +403,7 @@ impl CPUProcessor {
     /// Used by [`ImageProcessor::materialize_masks`] when the caller selects
     /// [`MaskResolution::Scaled`](crate::MaskResolution::Scaled).
     pub fn materialize_scaled_segmentations(
-        &self,
+        &mut self,
         detect: &[crate::DetectBox],
         proto_data: &crate::ProtoData,
         letterbox: Option<[f32; 4]>,
@@ -350,6 +419,17 @@ impl CPUProcessor {
             return Err(crate::Error::InvalidShape(
                 "Scaled mask width/height must be positive".into(),
             ));
+        }
+
+        if !legacy_materialize_forced() && detect.len() >= BATCHED_GEMM_MIN_N_SCALED {
+            return scaled_segmentations_batched(
+                &mut self.mask_scratch,
+                detect,
+                proto_data,
+                letterbox,
+                width,
+                height,
+            );
         }
 
         match &proto_data.protos {
@@ -375,6 +455,300 @@ impl CPUProcessor {
             ),
         }
     }
+}
+
+// =========================================================================
+// Batched-GEMM paths (shared dequant + single matmul + rayon per-detection)
+// =========================================================================
+
+fn proto_shape(protos: &edgefirst_decoder::ProtoTensor) -> (usize, usize, usize) {
+    use edgefirst_decoder::ProtoTensor;
+    match protos {
+        ProtoTensor::Quantized { protos, .. } => {
+            (protos.shape()[0], protos.shape()[1], protos.shape()[2])
+        }
+        ProtoTensor::Float(arr) => (arr.shape()[0], arr.shape()[1], arr.shape()[2]),
+    }
+}
+
+/// Small-N fused path: exactly the pre-batched implementation, retained for
+/// the `N < BATCHED_GEMM_MIN_N` case where the up-front dequant cost would
+/// dominate the per-detection work.
+fn materialize_segmentations_fused(
+    detect: &[crate::DetectBox],
+    proto_data: &crate::ProtoData,
+    letterbox: Option<[f32; 4]>,
+) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
+    use edgefirst_decoder::ProtoTensor;
+
+    let (proto_h, proto_w, num_protos) = proto_shape(&proto_data.protos);
+    let (lx0, inv_lw, ly0, inv_lh) = inv_letterbox(letterbox);
+
+    detect
+        .iter()
+        .zip(proto_data.mask_coefficients.iter())
+        .map(|(det, coeff)| {
+            let (x0, y0, x1, y1) = bbox_to_proto_roi(det, proto_w, proto_h);
+            let roi_w = x1.saturating_sub(x0).max(1);
+            let roi_h = y1.saturating_sub(y0).max(1);
+
+            if coeff.len() != num_protos {
+                return Err(crate::Error::Internal(format!(
+                    "mask coeff length {} != proto channels {num_protos}",
+                    coeff.len()
+                )));
+            }
+
+            let mask = match &proto_data.protos {
+                ProtoTensor::Quantized {
+                    protos,
+                    quantization,
+                } => fused_dequant_dot_sigmoid_i8(
+                    protos,
+                    coeff,
+                    quantization.scale,
+                    quantization.zero_point as f32,
+                    y0,
+                    x0,
+                    roi_h,
+                    roi_w,
+                    num_protos,
+                ),
+                ProtoTensor::Float(protos) => {
+                    fused_dot_sigmoid_f32(protos, coeff, y0, x0, roi_h, roi_w, num_protos)
+                }
+            };
+
+            Ok(proto_roi_to_segmentation(
+                mask, x0, y0, x1, y1, proto_w, proto_h, lx0, inv_lw, ly0, inv_lh,
+            ))
+        })
+        .collect::<crate::Result<Vec<_>>>()
+}
+
+/// Batched path for `MaskResolution::Proto`: one GEMM, then rayon-parallel
+/// ROI crop + sigmoid+quantize per detection.
+fn materialize_segmentations_batched(
+    scratch: &mut MaskScratch,
+    detect: &[crate::DetectBox],
+    proto_data: &crate::ProtoData,
+    letterbox: Option<[f32; 4]>,
+) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
+    let (proto_h, proto_w, num_protos) = proto_shape(&proto_data.protos);
+    let hw = proto_h * proto_w;
+    let n = detect.len();
+
+    // One GEMM across all detections.
+    scratch.compute_logits(
+        &proto_data.mask_coefficients,
+        &proto_data.protos,
+        proto_h,
+        proto_w,
+        num_protos,
+    )?;
+
+    // Precompute inverse letterbox transform (shared across workers).
+    let (lx0, inv_lw, ly0, inv_lh) = inv_letterbox(letterbox);
+
+    // Shared read-only view of the logits buffer across rayon workers.
+    let logits: &[f32] = scratch.logits(n, hw);
+
+    detect
+        .par_iter()
+        .enumerate()
+        .map(|(i, det)| {
+            let (x0, y0, x1, y1) = bbox_to_proto_roi(det, proto_w, proto_h);
+            let roi_w = x1.saturating_sub(x0).max(1);
+            let roi_h = y1.saturating_sub(y0).max(1);
+            let row = &logits[i * hw..(i + 1) * hw];
+
+            let mut mask = Array3::<u8>::zeros((roi_h, roi_w, 1));
+            for yi in 0..roi_h {
+                let src_row_start = (y0 + yi) * proto_w + x0;
+                let src_row = &row[src_row_start..src_row_start + roi_w];
+                for (xi, &logit) in src_row.iter().enumerate() {
+                    let s = fast_sigmoid(logit);
+                    mask[[yi, xi, 0]] = (s * 255.0 + 0.5) as u8;
+                }
+            }
+
+            Ok(proto_roi_to_segmentation(
+                mask, x0, y0, x1, y1, proto_w, proto_h, lx0, inv_lw, ly0, inv_lh,
+            ))
+        })
+        .collect::<crate::Result<Vec<_>>>()
+}
+
+/// Batched path for `MaskResolution::Scaled`: GEMM at proto resolution, then
+/// per-detection bilinear-upsample the (pre-sigmoid) logits into the bbox
+/// tile at output resolution, threshold, and emit binary {0, 255} mask.
+fn scaled_segmentations_batched(
+    scratch: &mut MaskScratch,
+    detect: &[crate::DetectBox],
+    proto_data: &crate::ProtoData,
+    letterbox: Option<[f32; 4]>,
+    width: u32,
+    height: u32,
+) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
+    let (proto_h, proto_w, num_protos) = proto_shape(&proto_data.protos);
+    let hw = proto_h * proto_w;
+    let n = detect.len();
+
+    scratch.compute_logits(
+        &proto_data.mask_coefficients,
+        &proto_data.protos,
+        proto_h,
+        proto_w,
+        num_protos,
+    )?;
+
+    // letterbox semantics match `scaled_segmentations_float` / `_quant_i8`.
+    let (lx0, lw, ly0, lh) = match letterbox {
+        Some([lx0, ly0, lx1, ly1]) => {
+            let lw = (lx1 - lx0).max(f32::EPSILON);
+            let lh = (ly1 - ly0).max(f32::EPSILON);
+            (lx0, lw, ly0, lh)
+        }
+        None => (0.0_f32, 1.0_f32, 0.0_f32, 1.0_f32),
+    };
+    let out_w = width as usize;
+    let out_h = height as usize;
+
+    let logits: &[f32] = scratch.logits(n, hw);
+
+    detect
+        .par_iter()
+        .enumerate()
+        .map(|(i, det)| {
+            let bbox = det.bbox.to_canonical();
+            let xmin = ((bbox.xmin - lx0) / lw).clamp(0.0, 1.0);
+            let ymin = ((bbox.ymin - ly0) / lh).clamp(0.0, 1.0);
+            let xmax = ((bbox.xmax - lx0) / lw).clamp(0.0, 1.0);
+            let ymax = ((bbox.ymax - ly0) / lh).clamp(0.0, 1.0);
+
+            let px0 = (xmin * out_w as f32).round() as usize;
+            let py0 = (ymin * out_h as f32).round() as usize;
+            let px1 = ((xmax * out_w as f32).round() as usize).min(out_w);
+            let py1 = ((ymax * out_h as f32).round() as usize).min(out_h);
+            let bbox_w = px1.saturating_sub(px0).max(1);
+            let bbox_h = py1.saturating_sub(py0).max(1);
+
+            let mut tile = Array3::<u8>::zeros((bbox_h, bbox_w, 1));
+            let row = &logits[i * hw..(i + 1) * hw];
+
+            // Bilinear sample the logit plane at output resolution, then
+            // sigmoid + threshold. Output pixel → model-input normalized →
+            // proto-plane texel (same math as `scaled_segmentations_float`).
+            for yi in 0..bbox_h {
+                let py = (py0 + yi) as f32;
+                let model_y_norm = ly0 + (py + 0.5) / out_h as f32 * lh;
+                let sample_y = model_y_norm * proto_h as f32 - 0.5;
+                for xi in 0..bbox_w {
+                    let px = (px0 + xi) as f32;
+                    let model_x_norm = lx0 + (px + 0.5) / out_w as f32 * lw;
+                    let sample_x = model_x_norm * proto_w as f32 - 0.5;
+                    let acc = bilinear_sample_plane(row, sample_x, sample_y, proto_w, proto_h);
+                    let sigmoid = fast_sigmoid(acc);
+                    tile[[yi, xi, 0]] = if sigmoid > 0.5 { 255 } else { 0 };
+                }
+            }
+
+            Ok(edgefirst_decoder::Segmentation {
+                xmin,
+                ymin,
+                xmax,
+                ymax,
+                segmentation: tile,
+            })
+        })
+        .collect::<crate::Result<Vec<_>>>()
+}
+
+/// Inverse letterbox factors for mapping from model-input normalized
+/// coordinates to output-content normalized coordinates. `None` → identity.
+fn inv_letterbox(letterbox: Option<[f32; 4]>) -> (f32, f32, f32, f32) {
+    match letterbox {
+        Some([lx0, ly0, lx1, ly1]) => {
+            let lw = lx1 - lx0;
+            let lh = ly1 - ly0;
+            (
+                lx0,
+                if lw > 0.0 { 1.0 / lw } else { 1.0 },
+                ly0,
+                if lh > 0.0 { 1.0 / lh } else { 1.0 },
+            )
+        }
+        None => (0.0_f32, 1.0_f32, 0.0_f32, 1.0_f32),
+    }
+}
+
+/// Canonicalise `det.bbox`, clamp to `[0, 1]`, and map into proto-pixel
+/// coordinates. Returns `(x0, y0, x1, y1)` with `x1/y1` inclusive of the
+/// ceil'd max so `x1 - x0` gives the ROI width.
+fn bbox_to_proto_roi(
+    det: &crate::DetectBox,
+    proto_w: usize,
+    proto_h: usize,
+) -> (usize, usize, usize, usize) {
+    let bbox = det.bbox.to_canonical();
+    let xmin = bbox.xmin.clamp(0.0, 1.0);
+    let ymin = bbox.ymin.clamp(0.0, 1.0);
+    let xmax = bbox.xmax.clamp(0.0, 1.0);
+    let ymax = bbox.ymax.clamp(0.0, 1.0);
+    let x0 = ((xmin * proto_w as f32) as usize).min(proto_w.saturating_sub(1));
+    let y0 = ((ymin * proto_h as f32) as usize).min(proto_h.saturating_sub(1));
+    let x1 = ((xmax * proto_w as f32).ceil() as usize).min(proto_w);
+    let y1 = ((ymax * proto_h as f32).ceil() as usize).min(proto_h);
+    (x0, y0, x1, y1)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn proto_roi_to_segmentation(
+    mask: ndarray::Array3<u8>,
+    x0: usize,
+    y0: usize,
+    x1: usize,
+    y1: usize,
+    proto_w: usize,
+    proto_h: usize,
+    lx0: f32,
+    inv_lw: f32,
+    ly0: f32,
+    inv_lh: f32,
+) -> edgefirst_decoder::Segmentation {
+    let seg_xmin = ((x0 as f32 / proto_w as f32) - lx0) * inv_lw;
+    let seg_ymin = ((y0 as f32 / proto_h as f32) - ly0) * inv_lh;
+    let seg_xmax = ((x1 as f32 / proto_w as f32) - lx0) * inv_lw;
+    let seg_ymax = ((y1 as f32 / proto_h as f32) - ly0) * inv_lh;
+    edgefirst_decoder::Segmentation {
+        xmin: seg_xmin.clamp(0.0, 1.0),
+        ymin: seg_ymin.clamp(0.0, 1.0),
+        xmax: seg_xmax.clamp(0.0, 1.0),
+        ymax: seg_ymax.clamp(0.0, 1.0),
+        segmentation: mask,
+    }
+}
+
+/// Bilinear sample a flat `(H * W)` plane at subpixel `(px, py)`. Out-of-bounds
+/// samples clamp to the plane's edge — matches `bilinear_dot_quant_i8`'s
+/// implicit boundary handling.
+#[inline]
+fn bilinear_sample_plane(plane: &[f32], px: f32, py: f32, w: usize, h: usize) -> f32 {
+    let x0 = (px.floor() as isize).clamp(0, w as isize - 1) as usize;
+    let y0 = (py.floor() as isize).clamp(0, h as isize - 1) as usize;
+    let x1 = (x0 + 1).min(w - 1);
+    let y1 = (y0 + 1).min(h - 1);
+    let fx = px - px.floor();
+    let fy = py - py.floor();
+    let w00 = (1.0 - fx) * (1.0 - fy);
+    let w10 = fx * (1.0 - fy);
+    let w01 = (1.0 - fx) * fy;
+    let w11 = fx * fy;
+    let v00 = plane[y0 * w + x0];
+    let v10 = plane[y0 * w + x1];
+    let v01 = plane[y1 * w + x0];
+    let v11 = plane[y1 * w + x1];
+    w00 * v00 + w10 * v10 + w01 * v01 + w11 * v11
 }
 
 fn scaled_segmentations_float(
@@ -834,7 +1208,7 @@ mod scaled_tests {
 
     #[test]
     fn scaled_central_bbox_produces_foreground_blob() {
-        let cpu = make_cpu();
+        let mut cpu = make_cpu();
         let proto_data = synthetic_proto_data(16, 16, 4);
 
         // bbox covers the centre 50% of the plane.
@@ -901,7 +1275,7 @@ mod scaled_tests {
             label: 0,
         }];
 
-        let cpu = make_cpu();
+        let mut cpu = make_cpu();
         let out = cpu
             .materialize_scaled_segmentations(&detect, &proto_data, None, 640, 640)
             .unwrap();
@@ -967,7 +1341,7 @@ mod scaled_tests {
     /// coordinate frame.
     #[test]
     fn scaled_letterbox_original_content_coords() {
-        let cpu = make_cpu();
+        let mut cpu = make_cpu();
         let proto_data = synthetic_proto_data(16, 16, 4);
 
         // Bbox in *model-input* normalized coords — the frame used by the
@@ -1066,7 +1440,7 @@ mod scaled_tests {
             label: 0,
         }];
 
-        let cpu = make_cpu();
+        let mut cpu = make_cpu();
         let out_f = cpu
             .materialize_scaled_segmentations(&detect, &pd_float, None, 320, 320)
             .unwrap();
@@ -1084,5 +1458,159 @@ mod scaled_tests {
             mismatches < total / 200,
             "quantized and float diverged at {mismatches}/{total} pixels (>0.5%)"
         );
+    }
+
+    // ─── Batched-GEMM path regression tests ───────────────────────────────
+
+    /// Build a `ProtoData` + detection list large enough to trigger the
+    /// batched GEMM path (`N >= BATCHED_GEMM_MIN_N`) with realistic 160×160
+    /// proto dims and 32 channels. Deterministic via seeded LCG so output
+    /// is reproducible across runs.
+    fn realistic_proto_data(n: usize) -> (Vec<DetectBox>, ProtoData) {
+        let mut rng_seed: u32 = 0xABCD_0001;
+        let mut next = || -> f32 {
+            rng_seed = rng_seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (rng_seed as f32) / (u32::MAX as f32) * 2.0 - 1.0
+        };
+        let proto_h = 160;
+        let proto_w = 160;
+        let num_protos = 32;
+        let mut protos = Array3::<f32>::zeros((proto_h, proto_w, num_protos));
+        for y in 0..proto_h {
+            for x in 0..proto_w {
+                for k in 0..num_protos {
+                    protos[[y, x, k]] = next() * 3.0;
+                }
+            }
+        }
+        let mask_coefficients: Vec<Vec<f32>> = (0..n)
+            .map(|_| (0..num_protos).map(|_| next()).collect())
+            .collect();
+        let detect: Vec<DetectBox> = (0..n)
+            .map(|i| {
+                let t = i as f32 / n as f32;
+                DetectBox {
+                    bbox: BoundingBox::new(0.1 + 0.6 * t, 0.15, 0.3 + 0.6 * t, 0.85),
+                    score: 0.9,
+                    label: 0,
+                }
+            })
+            .collect();
+        let proto_data = ProtoData {
+            mask_coefficients,
+            protos: ProtoTensor::Float(protos),
+        };
+        (detect, proto_data)
+    }
+
+    /// `MaskResolution::Proto` batched path must match the fused path to
+    /// within the tolerance of `fast_sigmoid`'s ~1.1% approximation error.
+    /// Both paths share the same kernel math, so any larger divergence
+    /// means the batched GEMM or ROI-crop mapping is wrong.
+    #[test]
+    fn batched_proto_matches_fused_reference_at_n_equals_5() {
+        // Use N=16+ so the batched-GEMM path (threshold 16) actually fires.
+        let (detect, proto_data) = realistic_proto_data(16);
+        debug_assert!(detect.len() >= BATCHED_GEMM_MIN_N_PROTO);
+
+        // Batched path via the public entry point.
+        let mut cpu = make_cpu();
+        let out_batched = cpu
+            .materialize_segmentations(&detect, &proto_data, None)
+            .unwrap();
+
+        // Fused reference path via the small-N helper (bypasses the
+        // BATCHED_GEMM_MIN_N dispatch in the public method).
+        let out_fused = materialize_segmentations_fused(&detect, &proto_data, None).unwrap();
+
+        assert_eq!(out_batched.len(), out_fused.len());
+        for (b, f) in out_batched.iter().zip(out_fused.iter()) {
+            assert_eq!(b.segmentation.shape(), f.segmentation.shape());
+            // Count pixels differing by more than the u8-quant tolerance
+            // (fast_sigmoid error ~1.1% ⇒ ~3 u8 units at the decision band).
+            let mut mismatches = 0usize;
+            for (a, c) in b.segmentation.iter().zip(f.segmentation.iter()) {
+                if (*a as i32 - *c as i32).abs() > 3 {
+                    mismatches += 1;
+                }
+            }
+            let total = b.segmentation.len();
+            assert!(
+                mismatches < total / 100,
+                "batched vs fused diverged at {mismatches}/{total} pixels (>1%)"
+            );
+        }
+    }
+
+    /// `MaskResolution::Scaled` batched path must match the per-detection
+    /// non-batched path within the binary-threshold tolerance.
+    #[test]
+    fn batched_scaled_matches_unbatched_reference_at_n_equals_5() {
+        // Use N=16+ so the batched-GEMM path (threshold 16) actually fires.
+        let (detect, proto_data) = realistic_proto_data(16);
+        debug_assert!(detect.len() >= BATCHED_GEMM_MIN_N_PROTO);
+
+        let mut cpu = make_cpu();
+        let out_batched = cpu
+            .materialize_scaled_segmentations(&detect, &proto_data, None, 320, 320)
+            .unwrap();
+
+        // Reference: call the per-detection helper directly. ProtoData is
+        // Float so `scaled_segmentations_float` is the right reference.
+        let protos = match &proto_data.protos {
+            ProtoTensor::Float(p) => p,
+            _ => unreachable!("test fixture uses Float protos"),
+        };
+        let out_ref = scaled_segmentations_float(
+            &detect,
+            &proto_data.mask_coefficients,
+            protos,
+            None,
+            320,
+            320,
+        )
+        .unwrap();
+
+        assert_eq!(out_batched.len(), out_ref.len());
+        for (b, r) in out_batched.iter().zip(out_ref.iter()) {
+            assert_eq!(b.segmentation.shape(), r.segmentation.shape());
+            let mut mismatches = 0usize;
+            for (a, c) in b.segmentation.iter().zip(r.segmentation.iter()) {
+                if *a != *c {
+                    mismatches += 1;
+                }
+            }
+            let total = b.segmentation.len();
+            // Binary masks — tolerate up to 2% boundary pixel differences
+            // due to sigmoid approximation at the decision band.
+            assert!(
+                mismatches < total / 50,
+                "batched vs ref scaled diverged at {mismatches}/{total} pixels (>2%)"
+            );
+        }
+    }
+
+    /// MaskScratch buffers must be reused (capacity ≥ previous call) rather
+    /// than reallocated each call. Regression guard for the pooling
+    /// contract that validation loops depend on.
+    #[test]
+    fn mask_scratch_reuses_buffers_across_calls() {
+        // N must be >= BATCHED_GEMM_MIN_N_PROTO so the batched path fires
+        // and populates the scratch buffers.
+        let (detect, proto_data) = realistic_proto_data(BATCHED_GEMM_MIN_N_PROTO);
+        let mut cpu = make_cpu();
+        cpu.materialize_segmentations(&detect, &proto_data, None)
+            .unwrap();
+        let cap_dequant = cpu.mask_scratch.dequant.capacity();
+        let cap_coeffs = cpu.mask_scratch.coeffs.capacity();
+        let cap_logits = cpu.mask_scratch.logits.capacity();
+        assert!(cap_dequant > 0 && cap_coeffs > 0 && cap_logits > 0);
+
+        // Second call with identical shape must reuse capacity.
+        cpu.materialize_segmentations(&detect, &proto_data, None)
+            .unwrap();
+        assert_eq!(cpu.mask_scratch.dequant.capacity(), cap_dequant);
+        assert_eq!(cpu.mask_scratch.coeffs.capacity(), cap_coeffs);
+        assert_eq!(cpu.mask_scratch.logits.capacity(), cap_logits);
     }
 }

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -63,12 +63,20 @@ impl MaskScratch {
         // still copy to guarantee a contiguous (H*W, K) layout regardless of
         // the source tensor's stride (ndarray protos may arrive with a
         // non-standard layout from the decoder's tensor_bridge).
-        self.dequant.clear();
-        self.dequant.resize(hw * num_protos, 0.0);
+        //
+        // Only grow the buffer when needed — the dequant and GEMM loops
+        // below overwrite every element in `0..required`, so we can reuse
+        // whatever stale data is past `0..required` from previous calls
+        // and skip the per-frame memset that otherwise costs ~0.5% on
+        // i.MX 95 validation runs.
+        let dequant_required = hw * num_protos;
+        if self.dequant.len() < dequant_required {
+            self.dequant.resize(dequant_required, 0.0);
+        }
         match protos {
             ProtoTensor::Float(arr) => {
                 let src = arr.view();
-                let dst = &mut self.dequant;
+                let dst = &mut self.dequant[..dequant_required];
                 // (H, W, K) → (H*W, K) row-major
                 for y in 0..proto_h {
                     for x in 0..proto_w {
@@ -86,7 +94,7 @@ impl MaskScratch {
                 let scale = quantization.scale;
                 let zp = quantization.zero_point as f32;
                 let src = protos.view();
-                let dst = &mut self.dequant;
+                let dst = &mut self.dequant[..dequant_required];
                 for y in 0..proto_h {
                     for x in 0..proto_w {
                         let row = (y * proto_w + x) * num_protos;
@@ -100,14 +108,20 @@ impl MaskScratch {
 
         // GEMM: logits (N, HW) = coeffs (N, K) · dequant.T (K, HW)
         // We build views over the scratch buffers — no extra allocation.
-        self.logits.clear();
-        self.logits.resize(n * hw, 0.0);
+        // Same grow-only discipline: GEMM with beta=0.0 writes every
+        // element in `0..logits_required`; anything past that is stale
+        // but ignored by `logits()`.
+        let logits_required = n * hw;
+        if self.logits.len() < logits_required {
+            self.logits.resize(logits_required, 0.0);
+        }
         let a = ndarray::ArrayView2::from_shape((n, num_protos), &self.coeffs)
             .expect("coeffs buffer matches (N, K)");
-        let b = ndarray::ArrayView2::from_shape((hw, num_protos), &self.dequant)
+        let b = ndarray::ArrayView2::from_shape((hw, num_protos), &self.dequant[..dequant_required])
             .expect("dequant buffer matches (HW, K)");
-        let mut c = ndarray::ArrayViewMut2::from_shape((n, hw), &mut self.logits)
-            .expect("logits buffer matches (N, HW)");
+        let mut c =
+            ndarray::ArrayViewMut2::from_shape((n, hw), &mut self.logits[..logits_required])
+                .expect("logits buffer matches (N, HW)");
         // `b.t()` is a view — no copy — giving us (K, HW).
         general_mat_mul(1.0, &a, &b.t(), 0.0, &mut c);
 
@@ -115,8 +129,12 @@ impl MaskScratch {
     }
 
     /// Read-only view of the last computed logits as `(N, H*W)`.
+    ///
+    /// The buffer may be larger than `n * hw` because we grow the Vec
+    /// only when required and leave stale trailing data to avoid a
+    /// per-frame memset — callers only read the first `n * hw` entries.
     fn logits(&self, n: usize, hw: usize) -> &[f32] {
-        debug_assert_eq!(self.logits.len(), n * hw);
+        debug_assert!(self.logits.len() >= n * hw);
         &self.logits[..n * hw]
     }
 }
@@ -648,8 +666,11 @@ fn scaled_segmentations_batched(
                     let model_x_norm = lx0 + (px + 0.5) / out_w as f32 * lw;
                     let sample_x = model_x_norm * proto_w as f32 - 0.5;
                     let acc = bilinear_sample_plane(row, sample_x, sample_y, proto_w, proto_h);
-                    let sigmoid = fast_sigmoid(acc);
-                    tile[[yi, xi, 0]] = if sigmoid > 0.5 { 255 } else { 0 };
+                    // Scaled masks threshold at sigmoid > 0.5, which is
+                    // monotonically equivalent to `acc > 0` — skip the
+                    // fast_sigmoid call entirely (was ~15-20% of total
+                    // runtime on i.MX 95 from the fdiv in 1/(1+exp(-x))).
+                    tile[[yi, xi, 0]] = if acc > 0.0 { 255 } else { 0 };
                 }
             }
 
@@ -825,8 +846,8 @@ fn scaled_segmentations_float(
                     let acc = bilinear_dot(
                         protos, coeff, num_protos, sample_x, sample_y, proto_w, proto_h,
                     );
-                    let sigmoid = fast_sigmoid(acc);
-                    tile[[yi, xi, 0]] = if sigmoid > 0.5 { 255 } else { 0 };
+                    // sigmoid(x) > 0.5  ⟺  x > 0 (sigmoid is monotonic).
+                    tile[[yi, xi, 0]] = if acc > 0.0 { 255 } else { 0 };
                 }
             }
 
@@ -874,7 +895,9 @@ fn scaled_segmentations_quant_i8(
 
     let out_w = width as usize;
     let out_h = height as usize;
-    let scale = quant.scale;
+    // `scale` is no longer needed: the scaled-mask threshold collapses to
+    // `acc > 0` regardless of the positive scale factor (see below).
+    let _ = quant.scale;
     let zp = quant.zero_point as f32;
 
     detect
@@ -914,8 +937,9 @@ fn scaled_segmentations_quant_i8(
                     let acc = bilinear_dot_quant_i8(
                         protos, coeff, num_protos, sample_x, sample_y, proto_w, proto_h, zp,
                     );
-                    let sigmoid = fast_sigmoid(scale * acc);
-                    tile[[yi, xi, 0]] = if sigmoid > 0.5 { 255 } else { 0 };
+                    // sigmoid(scale * acc) > 0.5  ⟺  scale * acc > 0  ⟺  acc > 0
+                    // (quantization scale is always positive).
+                    tile[[yi, xi, 0]] = if acc > 0.0 { 255 } else { 0 };
                 }
             }
 

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -126,8 +126,9 @@ impl MaskScratch {
         }
         let a = ndarray::ArrayView2::from_shape((n, num_protos), &self.coeffs)
             .expect("coeffs buffer matches (N, K)");
-        let b = ndarray::ArrayView2::from_shape((hw, num_protos), &self.dequant[..dequant_required])
-            .expect("dequant buffer matches (HW, K)");
+        let b =
+            ndarray::ArrayView2::from_shape((hw, num_protos), &self.dequant[..dequant_required])
+                .expect("dequant buffer matches (HW, K)");
         let mut c =
             ndarray::ArrayViewMut2::from_shape((n, hw), &mut self.logits[..logits_required])
                 .expect("logits buffer matches (N, HW)");
@@ -479,12 +480,7 @@ impl CPUProcessor {
         if detect.len() < min_n {
             materialize_segmentations_fused(detect, proto_data, letterbox)
         } else {
-            materialize_segmentations_batched(
-                &mut self.mask_scratch,
-                detect,
-                proto_data,
-                letterbox,
-            )
+            materialize_segmentations_batched(&mut self.mask_scratch, detect, proto_data, letterbox)
         }
     }
 
@@ -751,7 +747,8 @@ fn scaled_segmentations_batched(
                 lw,
                 ly0,
                 lh,
-                tile.as_slice_mut().expect("Array3<u8>::zeros is contiguous"),
+                tile.as_slice_mut()
+                    .expect("Array3<u8>::zeros is contiguous"),
             );
 
             Ok(edgefirst_decoder::Segmentation {
@@ -793,8 +790,8 @@ fn fill_scaled_tile(
     {
         unsafe {
             fill_scaled_tile_neon(
-                plane, proto_w, proto_h, px0, py0, bbox_w, bbox_h, out_w, out_h, lx0, lw, ly0,
-                lh, tile,
+                plane, proto_w, proto_h, px0, py0, bbox_w, bbox_h, out_w, out_h, lx0, lw, ly0, lh,
+                tile,
             )
         };
         return;
@@ -977,10 +974,7 @@ unsafe fn fill_scaled_tile_neon(
             let v_u8 = vqmovn_u16(vcombine_u16(v_u16, vdup_n_u16(0)));
             // Store the low 4 lanes as one 32-bit write.
             let out = vget_lane_u32::<0>(vreinterpret_u32_u8(v_u8));
-            core::ptr::write_unaligned(
-                tile.as_mut_ptr().add(tile_row_off + xi) as *mut u32,
-                out,
-            );
+            core::ptr::write_unaligned(tile.as_mut_ptr().add(tile_row_off + xi) as *mut u32, out);
             xi += 4;
         }
 

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -73,16 +73,22 @@ impl MaskScratch {
         if self.dequant.len() < dequant_required {
             self.dequant.resize(dequant_required, 0.0);
         }
+        let dst = &mut self.dequant[..dequant_required];
         match protos {
             ProtoTensor::Float(arr) => {
-                let src = arr.view();
-                let dst = &mut self.dequant[..dequant_required];
-                // (H, W, K) → (H*W, K) row-major
-                for y in 0..proto_h {
-                    for x in 0..proto_w {
-                        let row = (y * proto_w + x) * num_protos;
-                        for k in 0..num_protos {
-                            dst[row + k] = src[[y, x, k]];
+                // Fast path: standard-layout (H, W, K) with K innermost is
+                // already contiguous row-major and matches our dst layout
+                // byte-for-byte — avoid the per-element indexing overhead.
+                if let Some(src_slice) = arr.as_slice() {
+                    dst.copy_from_slice(src_slice);
+                } else {
+                    let src = arr.view();
+                    for y in 0..proto_h {
+                        for x in 0..proto_w {
+                            let row = (y * proto_w + x) * num_protos;
+                            for k in 0..num_protos {
+                                dst[row + k] = src[[y, x, k]];
+                            }
                         }
                     }
                 }
@@ -93,13 +99,16 @@ impl MaskScratch {
             } => {
                 let scale = quantization.scale;
                 let zp = quantization.zero_point as f32;
-                let src = protos.view();
-                let dst = &mut self.dequant[..dequant_required];
-                for y in 0..proto_h {
-                    for x in 0..proto_w {
-                        let row = (y * proto_w + x) * num_protos;
-                        for k in 0..num_protos {
-                            dst[row + k] = (src[[y, x, k]] as f32 - zp) * scale;
+                if let Some(src_slice) = protos.as_slice() {
+                    dequant_i8_to_f32(src_slice, dst, zp, scale);
+                } else {
+                    let src = protos.view();
+                    for y in 0..proto_h {
+                        for x in 0..proto_w {
+                            let row = (y * proto_w + x) * num_protos;
+                            for k in 0..num_protos {
+                                dst[row + k] = (src[[y, x, k]] as f32 - zp) * scale;
+                            }
                         }
                     }
                 }
@@ -161,6 +170,77 @@ const BATCHED_GEMM_MIN_N_SCALED: usize = 2;
 /// profiling only — production callers should never set it.
 fn legacy_materialize_forced() -> bool {
     std::env::var_os("EDGEFIRST_LEGACY_MATERIALIZE").is_some()
+}
+
+/// Dequantise a contiguous i8 slice into a contiguous f32 slice of the same
+/// length: `dst[i] = (src[i] as f32 - zp) * scale`.
+///
+/// On aarch64 this dispatches to the NEON path below (16 elements per
+/// iteration via a cascade of `sxtl`, `scvtf`, `fsub`, `fmul`); on other
+/// architectures the compiler typically auto-vectorises the scalar
+/// fallback well enough that this function is not the bottleneck.
+#[inline]
+fn dequant_i8_to_f32(src: &[i8], dst: &mut [f32], zp: f32, scale: f32) {
+    debug_assert_eq!(src.len(), dst.len());
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        // Safe: target_arch=aarch64 guarantees NEON is available (unlike
+        // armv7 where NEON is optional). The SIMD path itself only uses
+        // intrinsics that are in the base aarch64 NEON ISA.
+        unsafe { dequant_i8_to_f32_neon(src, dst, zp, scale) };
+        return;
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        for (s, d) in src.iter().zip(dst.iter_mut()) {
+            *d = (*s as f32 - zp) * scale;
+        }
+    }
+}
+
+/// NEON cascade: 16 i8 → 16 f32 per iteration.
+///
+///   sxtl   i8 → i16   (16→8 halves × 2)
+///   sxtl   i16 → i32  (8→4 quarters × 4)
+///   scvtf  i32 → f32  (× 4)
+///   fsub   -= zp
+///   fmul   *= scale
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn dequant_i8_to_f32_neon(src: &[i8], dst: &mut [f32], zp: f32, scale: f32) {
+    use core::arch::aarch64::*;
+
+    let zp_v = vdupq_n_f32(zp);
+    let scale_v = vdupq_n_f32(scale);
+
+    let n = src.len();
+    let chunks = n / 16;
+    let mut i = 0;
+    for _ in 0..chunks {
+        let v_i8 = vld1q_s8(src.as_ptr().add(i));
+        let v_i16_lo = vmovl_s8(vget_low_s8(v_i8));
+        let v_i16_hi = vmovl_s8(vget_high_s8(v_i8));
+        let v_i32_0 = vmovl_s16(vget_low_s16(v_i16_lo));
+        let v_i32_1 = vmovl_s16(vget_high_s16(v_i16_lo));
+        let v_i32_2 = vmovl_s16(vget_low_s16(v_i16_hi));
+        let v_i32_3 = vmovl_s16(vget_high_s16(v_i16_hi));
+        let v_f0 = vmulq_f32(vsubq_f32(vcvtq_f32_s32(v_i32_0), zp_v), scale_v);
+        let v_f1 = vmulq_f32(vsubq_f32(vcvtq_f32_s32(v_i32_1), zp_v), scale_v);
+        let v_f2 = vmulq_f32(vsubq_f32(vcvtq_f32_s32(v_i32_2), zp_v), scale_v);
+        let v_f3 = vmulq_f32(vsubq_f32(vcvtq_f32_s32(v_i32_3), zp_v), scale_v);
+        vst1q_f32(dst.as_mut_ptr().add(i), v_f0);
+        vst1q_f32(dst.as_mut_ptr().add(i + 4), v_f1);
+        vst1q_f32(dst.as_mut_ptr().add(i + 8), v_f2);
+        vst1q_f32(dst.as_mut_ptr().add(i + 12), v_f3);
+        i += 16;
+    }
+    // Scalar tail for n % 16 remainder.
+    while i < n {
+        *dst.get_unchecked_mut(i) = (*src.get_unchecked(i) as f32 - zp) * scale;
+        i += 1;
+    }
 }
 
 impl CPUProcessor {
@@ -655,24 +735,24 @@ fn scaled_segmentations_batched(
             let row = &logits[i * hw..(i + 1) * hw];
 
             // Bilinear sample the logit plane at output resolution, then
-            // sigmoid + threshold. Output pixel → model-input normalized →
-            // proto-plane texel (same math as `scaled_segmentations_float`).
-            for yi in 0..bbox_h {
-                let py = (py0 + yi) as f32;
-                let model_y_norm = ly0 + (py + 0.5) / out_h as f32 * lh;
-                let sample_y = model_y_norm * proto_h as f32 - 0.5;
-                for xi in 0..bbox_w {
-                    let px = (px0 + xi) as f32;
-                    let model_x_norm = lx0 + (px + 0.5) / out_w as f32 * lw;
-                    let sample_x = model_x_norm * proto_w as f32 - 0.5;
-                    let acc = bilinear_sample_plane(row, sample_x, sample_y, proto_w, proto_h);
-                    // Scaled masks threshold at sigmoid > 0.5, which is
-                    // monotonically equivalent to `acc > 0` — skip the
-                    // fast_sigmoid call entirely (was ~15-20% of total
-                    // runtime on i.MX 95 from the fdiv in 1/(1+exp(-x))).
-                    tile[[yi, xi, 0]] = if acc > 0.0 { 255 } else { 0 };
-                }
-            }
+            // threshold at `acc > 0`. Dispatches to a NEON-vectorised
+            // inner kernel on aarch64; scalar fallback elsewhere.
+            fill_scaled_tile(
+                row,
+                proto_w,
+                proto_h,
+                px0,
+                py0,
+                bbox_w,
+                bbox_h,
+                out_w,
+                out_h,
+                lx0,
+                lw,
+                ly0,
+                lh,
+                tile.as_slice_mut().expect("Array3<u8>::zeros is contiguous"),
+            );
 
             Ok(edgefirst_decoder::Segmentation {
                 xmin,
@@ -683,6 +763,237 @@ fn scaled_segmentations_batched(
             })
         })
         .collect::<crate::Result<Vec<_>>>()
+}
+
+/// Fill a `bbox_h × bbox_w` u8 tile by bilinear-sampling a flat logit plane
+/// and thresholding at `acc > 0` (scaled-mask convention).
+///
+/// `tile` is a contiguous `bbox_h * bbox_w` slice in row-major order.
+#[allow(clippy::too_many_arguments)]
+fn fill_scaled_tile(
+    plane: &[f32],
+    proto_w: usize,
+    proto_h: usize,
+    px0: usize,
+    py0: usize,
+    bbox_w: usize,
+    bbox_h: usize,
+    out_w: usize,
+    out_h: usize,
+    lx0: f32,
+    lw: f32,
+    ly0: f32,
+    lh: f32,
+    tile: &mut [u8],
+) {
+    debug_assert_eq!(tile.len(), bbox_h * bbox_w);
+    debug_assert_eq!(plane.len(), proto_h * proto_w);
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        unsafe {
+            fill_scaled_tile_neon(
+                plane, proto_w, proto_h, px0, py0, bbox_w, bbox_h, out_w, out_h, lx0, lw, ly0,
+                lh, tile,
+            )
+        };
+        return;
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let proto_wf = proto_w as f32;
+        let proto_hf = proto_h as f32;
+        let out_wf = out_w as f32;
+        let out_hf = out_h as f32;
+        for yi in 0..bbox_h {
+            let py = (py0 + yi) as f32;
+            let model_y_norm = ly0 + (py + 0.5) / out_hf * lh;
+            let sample_y = model_y_norm * proto_hf - 0.5;
+            for xi in 0..bbox_w {
+                let px = (px0 + xi) as f32;
+                let model_x_norm = lx0 + (px + 0.5) / out_wf * lw;
+                let sample_x = model_x_norm * proto_wf - 0.5;
+                let acc = bilinear_sample_plane(plane, sample_x, sample_y, proto_w, proto_h);
+                tile[yi * bbox_w + xi] = if acc > 0.0 { 255 } else { 0 };
+            }
+        }
+    }
+}
+
+/// NEON-vectorised `fill_scaled_tile`.
+///
+/// Strategy: process 4 output pixels per iteration along the `xi` axis.
+/// The `y`-related state (sample_y, y0, y1, fy) is scalar — shared across
+/// all 4 xi in a row. The 4-wide inner loop vectorises the px→sample_x
+/// chain, bilinear-weight computation, corner fetch (via 4× scalar loads
+/// assembled into a NEON register), bilinear accumulation, and the
+/// `acc > 0 → {0, 255}` compare-and-pack.
+///
+/// Gather is the single non-vectorisable op: pre-SVE NEON has no native
+/// gather, so each of the 4 corners (v00, v10, v01, v11) costs 4 scalar
+/// loads that the CPU issues into the load pipe. Still a net win because
+/// the arithmetic (roughly 2/3 of the original scalar work) goes 4-wide.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn fill_scaled_tile_neon(
+    plane: &[f32],
+    proto_w: usize,
+    proto_h: usize,
+    px0: usize,
+    py0: usize,
+    bbox_w: usize,
+    bbox_h: usize,
+    out_w: usize,
+    out_h: usize,
+    lx0: f32,
+    lw: f32,
+    ly0: f32,
+    lh: f32,
+    tile: &mut [u8],
+) {
+    use core::arch::aarch64::*;
+
+    // Precompute scalar constants reused across the whole tile.
+    let proto_wf = proto_w as f32;
+    let proto_hf = proto_h as f32;
+    let inv_out_w = 1.0_f32 / out_w as f32;
+    let inv_out_h = 1.0_f32 / out_h as f32;
+    let proto_w_max_i32 = (proto_w as i32) - 1;
+    let proto_h_max_i32 = (proto_h as i32) - 1;
+
+    // x-offset lane pattern for the 4-wide SIMD sweep: xi + [0, 1, 2, 3]
+    let lane_offsets = [0.0_f32, 1.0, 2.0, 3.0];
+    let v_lane_offsets = vld1q_f32(lane_offsets.as_ptr());
+
+    // Broadcast constants.
+    let v_lx0 = vdupq_n_f32(lx0);
+    let v_lw_over_outw = vdupq_n_f32(lw * inv_out_w);
+    let v_proto_wf = vdupq_n_f32(proto_wf);
+    let v_half = vdupq_n_f32(0.5);
+    let v_neg_half = vdupq_n_f32(-0.5);
+    let v_one = vdupq_n_f32(1.0);
+    let v_zero = vdupq_n_f32(0.0);
+    let v_proto_w_max = vdupq_n_s32(proto_w_max_i32);
+    let v_zero_i32 = vdupq_n_s32(0);
+    let v_mask_byte = vdupq_n_u32(0xFF);
+
+    let plane_ptr = plane.as_ptr();
+
+    for yi in 0..bbox_h {
+        // Scalar y state shared across all xi in this row.
+        let py = (py0 + yi) as f32;
+        let model_y_norm = ly0 + (py + 0.5) * inv_out_h * lh;
+        let sample_y = model_y_norm * proto_hf - 0.5;
+        let y0_i32 = sample_y.floor() as i32;
+        let y0 = y0_i32.clamp(0, proto_h_max_i32) as usize;
+        let y1 = (y0 + 1).min(proto_h.saturating_sub(1));
+        let fy = sample_y - sample_y.floor();
+        let one_minus_fy = 1.0 - fy;
+        let v_fy = vdupq_n_f32(fy);
+        let v_one_minus_fy = vdupq_n_f32(one_minus_fy);
+        let y0_row = y0 * proto_w;
+        let y1_row = y1 * proto_w;
+        let tile_row_off = yi * bbox_w;
+
+        let mut xi = 0;
+        // Main SIMD loop: 4 output pixels per iteration.
+        while xi + 4 <= bbox_w {
+            // px = px0 + xi + [0, 1, 2, 3]
+            let v_xi_base = vdupq_n_f32((px0 + xi) as f32);
+            let v_px = vaddq_f32(v_xi_base, v_lane_offsets);
+            // model_x = lx0 + (px + 0.5) * (lw / out_w)
+            let v_model_x = vfmaq_f32(v_lx0, vaddq_f32(v_px, v_half), v_lw_over_outw);
+            // sample_x = model_x * proto_w - 0.5
+            let v_sample_x = vfmaq_f32(v_neg_half, v_model_x, v_proto_wf);
+            // floor(sample_x) → int32, clamp to [0, proto_w-1]; also keep float floor for fx
+            let v_floor = vrndmq_f32(v_sample_x); // round toward -inf
+            let v_fx = vsubq_f32(v_sample_x, v_floor);
+            let v_x0_raw = vcvtq_s32_f32(v_floor);
+            let v_x0 = vminq_s32(vmaxq_s32(v_x0_raw, v_zero_i32), v_proto_w_max);
+            let v_x1 = vminq_s32(vaddq_s32(v_x0, vdupq_n_s32(1)), v_proto_w_max);
+            // Weights: w00 = (1-fx)(1-fy), w10 = fx(1-fy), w01 = (1-fx)fy, w11 = fx*fy
+            let v_one_minus_fx = vsubq_f32(v_one, v_fx);
+            let v_w00 = vmulq_f32(v_one_minus_fx, v_one_minus_fy);
+            let v_w10 = vmulq_f32(v_fx, v_one_minus_fy);
+            let v_w01 = vmulq_f32(v_one_minus_fx, v_fy);
+            let v_w11 = vmulq_f32(v_fx, v_fy);
+
+            // Extract the 4 x0 / x1 indices as usize for the gather.
+            // Using vgetq_lane_s32 keeps the values in GP regs for the
+            // address math below.
+            let x0_0 = vgetq_lane_s32(v_x0, 0) as usize;
+            let x0_1 = vgetq_lane_s32(v_x0, 1) as usize;
+            let x0_2 = vgetq_lane_s32(v_x0, 2) as usize;
+            let x0_3 = vgetq_lane_s32(v_x0, 3) as usize;
+            let x1_0 = vgetq_lane_s32(v_x1, 0) as usize;
+            let x1_1 = vgetq_lane_s32(v_x1, 1) as usize;
+            let x1_2 = vgetq_lane_s32(v_x1, 2) as usize;
+            let x1_3 = vgetq_lane_s32(v_x1, 3) as usize;
+
+            // Gather the 4 corners — no native NEON gather; scalar loads
+            // land in regular f32 regs then get packed into a NEON vector.
+            let v00_arr = [
+                *plane_ptr.add(y0_row + x0_0),
+                *plane_ptr.add(y0_row + x0_1),
+                *plane_ptr.add(y0_row + x0_2),
+                *plane_ptr.add(y0_row + x0_3),
+            ];
+            let v10_arr = [
+                *plane_ptr.add(y0_row + x1_0),
+                *plane_ptr.add(y0_row + x1_1),
+                *plane_ptr.add(y0_row + x1_2),
+                *plane_ptr.add(y0_row + x1_3),
+            ];
+            let v01_arr = [
+                *plane_ptr.add(y1_row + x0_0),
+                *plane_ptr.add(y1_row + x0_1),
+                *plane_ptr.add(y1_row + x0_2),
+                *plane_ptr.add(y1_row + x0_3),
+            ];
+            let v11_arr = [
+                *plane_ptr.add(y1_row + x1_0),
+                *plane_ptr.add(y1_row + x1_1),
+                *plane_ptr.add(y1_row + x1_2),
+                *plane_ptr.add(y1_row + x1_3),
+            ];
+            let v_v00 = vld1q_f32(v00_arr.as_ptr());
+            let v_v10 = vld1q_f32(v10_arr.as_ptr());
+            let v_v01 = vld1q_f32(v01_arr.as_ptr());
+            let v_v11 = vld1q_f32(v11_arr.as_ptr());
+
+            // acc = w00*v00 + w10*v10 + w01*v01 + w11*v11 (FMA chain)
+            let mut v_acc = vmulq_f32(v_w00, v_v00);
+            v_acc = vfmaq_f32(v_acc, v_w10, v_v10);
+            v_acc = vfmaq_f32(v_acc, v_w01, v_v01);
+            v_acc = vfmaq_f32(v_acc, v_w11, v_v11);
+
+            // Threshold: (acc > 0) → 0xFFFFFFFF, else 0; mask with 0xFF, pack.
+            let v_gt = vcgtq_f32(v_acc, v_zero); // u32x4 of 0 or -1
+            let v_bytes_u32 = vandq_u32(v_gt, v_mask_byte);
+            // Narrow u32x4 → u16x4, zero-combine → u16x8, narrow → u8x8, keep low 4 bytes.
+            let v_u16 = vqmovn_u32(v_bytes_u32);
+            let v_u8 = vqmovn_u16(vcombine_u16(v_u16, vdup_n_u16(0)));
+            // Store the low 4 lanes as one 32-bit write.
+            let out = vget_lane_u32::<0>(vreinterpret_u32_u8(v_u8));
+            core::ptr::write_unaligned(
+                tile.as_mut_ptr().add(tile_row_off + xi) as *mut u32,
+                out,
+            );
+            xi += 4;
+        }
+
+        // Scalar tail for bbox_w % 4.
+        while xi < bbox_w {
+            let px = (px0 + xi) as f32;
+            let model_x_norm = lx0 + (px + 0.5) * inv_out_w * lw;
+            let sample_x = model_x_norm * proto_wf - 0.5;
+            let acc = bilinear_sample_plane(plane, sample_x, sample_y, proto_w, proto_h);
+            *tile.get_unchecked_mut(tile_row_off + xi) = if acc > 0.0 { 255 } else { 0 };
+            xi += 1;
+        }
+    }
 }
 
 /// Inverse letterbox factors for mapping from model-input normalized

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -455,11 +455,11 @@ impl CPUProcessor {
     /// than the fused GPU `draw_proto_masks` on all tested platforms.
     ///
     /// Optimized path:
-    /// - `N >= BATCHED_GEMM_MIN_N`: one `(N, K) × (K, H*W)` GEMM via
+    /// - `N >= BATCHED_GEMM_MIN_N_PROTO`: one `(N, K) × (K, H*W)` GEMM via
     ///   `ndarray`'s `matrixmultiply` backend (SIMD-vectorised) shared across
     ///   all detections; per-detection tile assembly is rayon-parallel using
     ///   `MaskScratch` buffers pooled on `CPUProcessor`.
-    /// - `N < BATCHED_GEMM_MIN_N`: per-detection fused dequant+dot+sigmoid
+    /// - `N < BATCHED_GEMM_MIN_N_PROTO`: per-detection fused dequant+dot+sigmoid
     ///   (the original path) — avoids the 3.1MB dequant allocation when the
     ///   GEMM savings can't amortise it.
     pub fn materialize_segmentations(
@@ -1835,8 +1835,8 @@ mod scaled_tests {
     /// Both paths share the same kernel math, so any larger divergence
     /// means the batched GEMM or ROI-crop mapping is wrong.
     #[test]
-    fn batched_proto_matches_fused_reference_at_n_equals_5() {
-        // Use N=16+ so the batched-GEMM path (threshold 16) actually fires.
+    fn batched_proto_matches_fused_reference_at_n_equals_16() {
+        // N=16 == BATCHED_GEMM_MIN_N_PROTO, so the batched-GEMM path fires.
         let (detect, proto_data) = realistic_proto_data(16);
         debug_assert!(detect.len() >= BATCHED_GEMM_MIN_N_PROTO);
 
@@ -1872,10 +1872,11 @@ mod scaled_tests {
     /// `MaskResolution::Scaled` batched path must match the per-detection
     /// non-batched path within the binary-threshold tolerance.
     #[test]
-    fn batched_scaled_matches_unbatched_reference_at_n_equals_5() {
-        // Use N=16+ so the batched-GEMM path (threshold 16) actually fires.
+    fn batched_scaled_matches_unbatched_reference_at_n_equals_16() {
+        // N=16 > BATCHED_GEMM_MIN_N_SCALED (2), so the batched path fires.
+        // Kept at 16 so both scaled and proto regressions share one fixture.
         let (detect, proto_data) = realistic_proto_data(16);
-        debug_assert!(detect.len() >= BATCHED_GEMM_MIN_N_PROTO);
+        debug_assert!(detect.len() >= BATCHED_GEMM_MIN_N_SCALED);
 
         let mut cpu = make_cpu();
         let out_batched = cpu

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -581,8 +581,8 @@ fn proto_shape(protos: &edgefirst_decoder::ProtoTensor) -> (usize, usize, usize)
 }
 
 /// Small-N fused path: exactly the pre-batched implementation, retained for
-/// the `N < BATCHED_GEMM_MIN_N` case where the up-front dequant cost would
-/// dominate the per-detection work.
+/// the `N < BATCHED_GEMM_MIN_N_PROTO` case where the up-front dequant cost
+/// would dominate the per-detection work.
 fn materialize_segmentations_fused(
     detect: &[crate::DetectBox],
     proto_data: &crate::ProtoData,
@@ -1806,7 +1806,7 @@ mod scaled_tests {
     // ─── Batched-GEMM path regression tests ───────────────────────────────
 
     /// Build a `ProtoData` + detection list large enough to trigger the
-    /// batched GEMM path (`N >= BATCHED_GEMM_MIN_N`) with realistic 160×160
+    /// batched GEMM path (`N >= BATCHED_GEMM_MIN_N_PROTO`) with realistic 160×160
     /// proto dims and 32 channels. Deterministic via seeded LCG so output
     /// is reproducible across runs.
     fn realistic_proto_data(n: usize) -> (Vec<DetectBox>, ProtoData) {
@@ -1863,7 +1863,7 @@ mod scaled_tests {
             .unwrap();
 
         // Fused reference path via the small-N helper (bypasses the
-        // BATCHED_GEMM_MIN_N dispatch in the public method).
+        // BATCHED_GEMM_MIN_N_PROTO dispatch in the public method).
         let out_fused = materialize_segmentations_fused(&detect, &proto_data, None).unwrap();
 
         assert_eq!(out_batched.len(), out_fused.len());

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -190,7 +190,6 @@ fn dequant_i8_to_f32(src: &[i8], dst: &mut [f32], zp: f32, scale: f32) {
         // armv7 where NEON is optional). The SIMD path itself only uses
         // intrinsics that are in the base aarch64 NEON ISA.
         unsafe { dequant_i8_to_f32_neon(src, dst, zp, scale) };
-        return;
     }
 
     #[cfg(not(target_arch = "aarch64"))]
@@ -794,7 +793,6 @@ fn fill_scaled_tile(
                 tile,
             )
         };
-        return;
     }
 
     #[cfg(not(target_arch = "aarch64"))]

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -21,6 +21,10 @@ pub struct CPUProcessor {
     resizer: fast_image_resize::Resizer,
     options: fast_image_resize::ResizeOptions,
     colors: [[u8; 4]; 20],
+    /// Reusable scratch buffers for `materialize_masks` batched-GEMM path.
+    /// Grown with `reserve` across calls so validation loops amortise the
+    /// dequant-protos + logits allocations over all frames.
+    pub(crate) mask_scratch: masks::MaskScratch,
 }
 
 unsafe impl Send for CPUProcessor {}
@@ -135,6 +139,7 @@ impl CPUProcessor {
             resizer,
             options,
             colors: crate::DEFAULT_COLORS_U8,
+            mask_scratch: masks::MaskScratch::default(),
         }
     }
 
@@ -149,6 +154,7 @@ impl CPUProcessor {
             resizer,
             options,
             colors: crate::DEFAULT_COLORS_U8,
+            mask_scratch: masks::MaskScratch::default(),
         }
     }
 

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -1757,7 +1757,7 @@ mod cpu_tests {
 
     #[test]
     fn test_materialize_empty_detections() {
-        let cpu = CPUProcessor::new();
+        let mut cpu = CPUProcessor::new();
         let proto_data = make_proto_data(8, 8, 4, vec![vec![1.0; 4]]);
         let result = cpu.materialize_segmentations(&[], &proto_data, None);
         assert!(result.is_ok());
@@ -1766,7 +1766,7 @@ mod cpu_tests {
 
     #[test]
     fn test_materialize_empty_proto_data() {
-        let cpu = CPUProcessor::new();
+        let mut cpu = CPUProcessor::new();
         let proto_data = make_proto_data(8, 8, 4, vec![]);
         let det = [make_detect_box(0.1, 0.1, 0.5, 0.5)];
         let result = cpu.materialize_segmentations(&det, &proto_data, None);
@@ -1776,7 +1776,7 @@ mod cpu_tests {
 
     #[test]
     fn test_materialize_single_detection() {
-        let cpu = CPUProcessor::new();
+        let mut cpu = CPUProcessor::new();
         let proto_data = make_proto_data(8, 8, 4, vec![vec![0.5; 4]]);
         let det = [make_detect_box(0.1, 0.1, 0.5, 0.5)];
         let result = cpu.materialize_segmentations(&det, &proto_data, None);
@@ -1791,7 +1791,7 @@ mod cpu_tests {
 
     #[test]
     fn test_materialize_bbox_edge_one() {
-        let cpu = CPUProcessor::new();
+        let mut cpu = CPUProcessor::new();
         let proto_data = make_proto_data(8, 8, 4, vec![vec![0.5; 4]]);
         let det = [make_detect_box(0.5, 0.5, 1.0, 1.0)];
         let result = cpu.materialize_segmentations(&det, &proto_data, None);
@@ -1805,7 +1805,7 @@ mod cpu_tests {
 
     #[test]
     fn test_materialize_bbox_negative_clamp() {
-        let cpu = CPUProcessor::new();
+        let mut cpu = CPUProcessor::new();
         let proto_data = make_proto_data(8, 8, 4, vec![vec![0.5; 4]]);
         let det = [make_detect_box(-0.5, -0.5, 0.5, 0.5)];
         let result = cpu.materialize_segmentations(&det, &proto_data, None);
@@ -1822,7 +1822,7 @@ mod cpu_tests {
 
     #[test]
     fn test_materialize_invalid_coeff_shape() {
-        let cpu = CPUProcessor::new();
+        let mut cpu = CPUProcessor::new();
         // Proto has 4 channels but coefficients have 6 elements — mismatch
         let proto_data = make_proto_data(8, 8, 4, vec![vec![0.5; 6]]);
         let det = [make_detect_box(0.1, 0.1, 0.5, 0.5)];
@@ -1840,7 +1840,7 @@ mod cpu_tests {
 
     #[test]
     fn test_materialize_multiple_detections() {
-        let cpu = CPUProcessor::new();
+        let mut cpu = CPUProcessor::new();
         let proto_data = make_proto_data(8, 8, 4, vec![vec![0.5; 4], vec![0.3; 4], vec![0.1; 4]]);
         let det = [
             make_detect_box(0.0, 0.0, 0.5, 0.5),
@@ -1854,7 +1854,7 @@ mod cpu_tests {
 
     #[test]
     fn test_materialize_zero_area_bbox() {
-        let cpu = CPUProcessor::new();
+        let mut cpu = CPUProcessor::new();
         let proto_data = make_proto_data(8, 8, 4, vec![vec![0.5; 4]]);
         // xmin == xmax → zero-width bbox
         let det = [make_detect_box(0.5, 0.1, 0.5, 0.5)];

--- a/crates/image/src/gl/dma_import.rs
+++ b/crates/image/src/gl/dma_import.rs
@@ -85,7 +85,27 @@ impl DmaImportAttrs {
                 }
             }
         } else {
-            if !src_w.is_multiple_of(4) {
+            // For 3-bpp (Rgb) and 1-bpp (Grey) packed formats the natural
+            // row pitch is `width * bpp`, which is only 4-byte aligned
+            // when `width % 4 == 0`. EGL DMA-BUF import via
+            // `eglCreateImage` requires word-aligned row reads on every
+            // tested platform (Mali G310, Vivante GC7000UL, V3D, Tegra),
+            // so we keep the blanket width%4 check for those.
+            //
+            // 4-bpp packed formats (Rgba, Bgra) have a row pitch of
+            // `width * 4` which is trivially 4-byte aligned at any width.
+            // The DRM fourcc spec (ABGR8888 / ARGB8888) imposes no
+            // pixel-alignment requirement on top of pitch alignment, and
+            // these drivers accept arbitrary widths as long as the
+            // 64-byte pitch padding (handled by `padded_dma_pitch_for`)
+            // is applied. Letting these through unlocks the zero-copy
+            // EGL path for dataset-loader widths like 375 / 427 / 443 —
+            // empirically verified on imx8mp-frdm, imx95-frdm,
+            // rpi5-hailo, and orin-nano. If a driver fails the import,
+            // `egl_create_image_with_fallback` downgrades to the CPU
+            // texture upload path with a one-shot slow-path warning.
+            let needs_width_mod_4 = !matches!(src_fmt, PixelFormat::Rgba | PixelFormat::Bgra);
+            if needs_width_mod_4 && !src_w.is_multiple_of(4) {
                 return Err(Error::NotSupported(format!(
                     "EGLImage requires width divisible by 4 for {src_fmt}, got {src_w}"
                 )));
@@ -839,5 +859,118 @@ mod tests {
             stride * height,
             width * height,
         );
+    }
+
+    // ─── Width-alignment pre-check (from_tensor) regression tests ───────
+
+    /// RGBA at a non-4-aligned width (e.g. 375, 427, 443) must pass the
+    /// `DmaImportAttrs::from_tensor` pre-check — RGBA's natural pitch is
+    /// `width × 4` which is always 4-byte aligned at any width, and the
+    /// DRM fourcc ABGR8888 spec imposes no pixel-alignment requirement.
+    ///
+    /// This unlocks the zero-copy EGL path for dataset-loader widths that
+    /// previously fell back to CPU texture upload.
+    #[cfg(feature = "dma_test_formats")]
+    #[test]
+    fn test_from_tensor_accepts_non_4_aligned_rgba() {
+        if !is_dma_available() {
+            eprintln!("SKIPPED: test_from_tensor_accepts_non_4_aligned_rgba — DMA not available");
+            return;
+        }
+        use crate::{align_pitch_bytes_to_gpu_alignment, primary_plane_bpp};
+        for &w in &[375usize, 427, 443] {
+            let bpp = primary_plane_bpp(PixelFormat::Rgba, 1).unwrap();
+            let aligned = align_pitch_bytes_to_gpu_alignment(w * bpp).unwrap();
+            let t = match Tensor::<u8>::image_with_stride(
+                w,
+                64,
+                PixelFormat::Rgba,
+                aligned,
+                Some(edgefirst_tensor::TensorMemory::Dma),
+            ) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("SKIPPED: image_with_stride failed at width {w}: {e}");
+                    return;
+                }
+            };
+            let attrs = DmaImportAttrs::from_tensor(&t, PixelFormat::Rgba).unwrap_or_else(|e| {
+                panic!(
+                    "RGBA width {w} must pass the pre-check; got {e}. \
+                     Width%4 is not required for 4-bpp packed formats."
+                )
+            });
+            assert_eq!(attrs.width, w);
+            assert_eq!(attrs.plane0_pitch, aligned);
+        }
+    }
+
+    /// BGRA must also accept non-4-aligned widths (same reasoning as RGBA —
+    /// 4-bpp packed, pitch always 4-byte aligned).
+    #[cfg(feature = "dma_test_formats")]
+    #[test]
+    fn test_from_tensor_accepts_non_4_aligned_bgra() {
+        if !is_dma_available() {
+            eprintln!("SKIPPED: test_from_tensor_accepts_non_4_aligned_bgra — DMA not available");
+            return;
+        }
+        use crate::{align_pitch_bytes_to_gpu_alignment, primary_plane_bpp};
+        let bpp = primary_plane_bpp(PixelFormat::Bgra, 1).unwrap();
+        let aligned = align_pitch_bytes_to_gpu_alignment(375 * bpp).unwrap();
+        let t = match Tensor::<u8>::image_with_stride(
+            375,
+            64,
+            PixelFormat::Bgra,
+            aligned,
+            Some(edgefirst_tensor::TensorMemory::Dma),
+        ) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("SKIPPED: image_with_stride failed: {e}");
+                return;
+            }
+        };
+        DmaImportAttrs::from_tensor(&t, PixelFormat::Bgra)
+            .expect("BGRA width 375 must pass the pre-check");
+    }
+
+    /// 3-bpp (Rgb) still requires width%4 — its natural pitch is
+    /// `width × 3`, which is 4-byte aligned only when `width % 4 == 0`.
+    #[test]
+    fn test_from_tensor_rejects_non_4_aligned_rgb() {
+        // We need a tensor with width=375 to hit the pre-check. Mem-backed
+        // works for this — from_tensor only reads width/height/memory
+        // metadata and the pre-check fires before the DMA fd lookup.
+        let t = Tensor::<u8>::image(
+            375,
+            64,
+            PixelFormat::Rgb,
+            Some(edgefirst_tensor::TensorMemory::Mem),
+        )
+        .unwrap();
+        let err = DmaImportAttrs::from_tensor(&t, PixelFormat::Rgb)
+            .expect_err("RGB width 375 must still be rejected");
+        match err {
+            crate::Error::NotSupported(msg) => {
+                assert!(msg.contains("divisible by 4"), "got: {msg}");
+            }
+            other => panic!("expected NotSupported, got {other:?}"),
+        }
+    }
+
+    /// 1-bpp (Grey) likewise still requires width%4 — natural pitch is
+    /// `width × 1`, which is 4-byte aligned only when `width % 4 == 0`.
+    #[test]
+    fn test_from_tensor_rejects_non_4_aligned_grey() {
+        let t = Tensor::<u8>::image(
+            375,
+            64,
+            PixelFormat::Grey,
+            Some(edgefirst_tensor::TensorMemory::Mem),
+        )
+        .unwrap();
+        let err = DmaImportAttrs::from_tensor(&t, PixelFormat::Grey)
+            .expect_err("Grey width 375 must still be rejected");
+        assert!(matches!(err, crate::Error::NotSupported(_)));
     }
 }

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -1880,7 +1880,7 @@ mod gl_tests {
         assert!(!output_boxes.is_empty(), "No detections from model");
 
         // Materialize masks on CPU for the hybrid path
-        let cpu_proc = crate::CPUProcessor::new();
+        let mut cpu_proc = crate::CPUProcessor::new();
         let segmentation = cpu_proc
             .materialize_segmentations(&output_boxes, &proto_data, None)
             .unwrap();

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -2381,65 +2381,143 @@ fn load_jpeg(
 }
 
 /// Load a PNG image from raw bytes and return a [`TensorDyn`].
+///
+/// Supports the same destination formats as the CPU backend's format
+/// converter (`Rgb`, `Rgba`, `Bgra`, `Grey`, etc.). Earlier revisions only
+/// accepted `Rgb`/`Rgba`; greyscale PNGs decoded to `Grey` now work through
+/// the same pitch-aware DMA path as JPEG. LumaA PNGs are normalised to
+/// `Grey` inline (alpha stripped) before going through the shared CPU
+/// converter.
 fn load_png(
     image: &[u8],
     format: Option<PixelFormat>,
     memory: Option<TensorMemory>,
 ) -> Result<TensorDyn> {
-    let fmt = format.unwrap_or(PixelFormat::Rgb);
-    let alpha = match fmt {
-        PixelFormat::Rgb => false,
-        PixelFormat::Rgba => true,
-        _ => {
-            return Err(Error::NotImplemented(
-                "Unsupported image format".to_string(),
-            ));
-        }
-    };
+    let dest_fmt = format.unwrap_or(PixelFormat::Rgb);
 
+    // Decode with add_alpha=false — any alpha upgrade/strip happens via
+    // the CPU converter downstream so we share one code path with
+    // load_jpeg instead of duplicating promotion logic here.
     let options = DecoderOptions::default()
-        .png_set_add_alpha_channel(alpha)
+        .png_set_add_alpha_channel(false)
         .png_set_decode_animated(false);
     let mut decoder = PngDecoder::new_with_options(image, options);
     decoder.decode_headers()?;
+
     let (width, height, rotation, flip) = {
-        let image_info = decoder.get_info().ok_or(Error::Internal(
-            "PNG did not return decoded image info".to_string(),
-        ))?;
-        let (rotation, flip) = image_info
+        let info = decoder
+            .get_info()
+            .ok_or_else(|| Error::Internal("PNG did not return decoded image info".to_string()))?;
+        let (rot, flip) = info
             .exif
             .as_ref()
             .map(|x| read_exif_orientation(x))
             .unwrap_or((Rotation::None, Flip::None));
-        (image_info.width, image_info.height, rotation, flip)
+        (info.width, info.height, rot, flip)
     };
 
-    if (rotation, flip) == (Rotation::None, Flip::None) {
-        // Same pitch-padding treatment as load_jpeg — see comment there.
-        #[cfg(target_os = "linux")]
-        if let Some(aligned_pitch) = padded_dma_pitch_for(fmt, width, &memory) {
-            let staging = Tensor::<u8>::image(width, height, fmt, Some(TensorMemory::Mem))?;
-            decoder.decode_into(&mut staging.map()?)?;
-            let mut dma = Tensor::<u8>::image_with_stride(
-                width,
-                height,
-                fmt,
-                aligned_pitch,
-                Some(TensorMemory::Dma),
-            )?;
-            copy_packed_to_padded_dma(&staging, &mut dma)?;
-            return Ok(TensorDyn::from(dma));
+    // Map the decoder's native colorspace onto a PixelFormat that the CPU
+    // converter understands. LumaA has no direct PixelFormat variant so we
+    // decode as LumaA and then strip alpha inline to get Grey.
+    let decoder_cs = decoder
+        .get_colorspace()
+        .ok_or_else(|| Error::Internal("PNG decoder did not return colorspace".to_string()))?;
+    let (decoded_fmt, strip_luma_alpha) = match decoder_cs {
+        ColorSpace::Luma => (PixelFormat::Grey, false),
+        ColorSpace::LumaA => (PixelFormat::Grey, true),
+        ColorSpace::RGB => (PixelFormat::Rgb, false),
+        ColorSpace::RGBA => (PixelFormat::Rgba, false),
+        other => {
+            return Err(Error::NotSupported(format!(
+                "PNG decoder produced unsupported colorspace {other:?}"
+            )));
         }
+    };
 
-        let img = Tensor::<u8>::image(width, height, fmt, memory)?;
-        decoder.decode_into(&mut img.map()?)?;
-        return Ok(TensorDyn::from(img));
+    // Reject destinations the CPU converter can't reach from the decoder's
+    // output so callers get a precise error rather than a downstream map
+    // failure. (`Grey → Grey` / `Rgb → Rgb` / etc. are identity pairs and
+    // are always valid.)
+    if decoded_fmt != dest_fmt
+        && !crate::cpu::CPUProcessor::support_conversion_pf(decoded_fmt, dest_fmt)
+    {
+        return Err(Error::NotSupported(format!(
+            "load_png: cannot convert decoder output {decoded_fmt:?} to {dest_fmt:?}"
+        )));
     }
 
-    let tmp = Tensor::<u8>::image(width, height, fmt, Some(TensorMemory::Mem))?;
-    decoder.decode_into(&mut tmp.map()?)?;
+    // Decode into a Mem staging buffer in the decoder's native format. For
+    // LumaA we allocate an extra byte-pair-per-pixel buffer since our Tensor
+    // API only knows 1-channel (Grey); after decode we compact to Grey.
+    let staging = if strip_luma_alpha {
+        // LumaA is 2 bytes per pixel in the raw decode; allocate a flat
+        // Tensor large enough to hold it, then compact to Grey in place.
+        let raw = Tensor::<u8>::new(&[height, width, 2], Some(TensorMemory::Mem), None)?;
+        decoder.decode_into(&mut raw.map()?)?;
+        let grey = Tensor::<u8>::image(width, height, PixelFormat::Grey, Some(TensorMemory::Mem))?;
+        {
+            let raw_map = raw.map()?;
+            let mut grey_map = grey.map()?;
+            let raw_bytes: &[u8] = &raw_map;
+            let grey_bytes: &mut [u8] = &mut grey_map;
+            for (pair, out) in raw_bytes.chunks_exact(2).zip(grey_bytes.iter_mut()) {
+                *out = pair[0];
+            }
+        }
+        grey
+    } else {
+        let staging =
+            Tensor::<u8>::image(width, height, decoded_fmt, Some(TensorMemory::Mem))?;
+        decoder.decode_into(&mut staging.map()?)?;
+        staging
+    };
 
-    rotate_flip_to_dyn(&tmp, fmt, rotation, flip, memory)
+    // Optional CPU format conversion before the final memory placement.
+    let packed = if decoded_fmt != dest_fmt {
+        let mut tmp =
+            Tensor::<u8>::image(width, height, dest_fmt, Some(TensorMemory::Mem))?;
+        CPUProcessor::convert_format_pf(&staging, &mut tmp, decoded_fmt, dest_fmt)?;
+        tmp
+    } else {
+        staging
+    };
+
+    if (rotation, flip) != (Rotation::None, Flip::None) {
+        return rotate_flip_to_dyn(&packed, dest_fmt, rotation, flip, memory);
+    }
+
+    // Final placement. When the caller wants DMA and the natural pitch
+    // would be rejected by the GPU's DMA-BUF import (see
+    // `padded_dma_pitch_for`), allocate a pitch-padded DMA tensor and
+    // row-copy. Otherwise allocate in the requested memory domain and
+    // linear-copy — or, when the caller asked for Mem, just return the
+    // staging tensor directly.
+    #[cfg(target_os = "linux")]
+    if let Some(aligned_pitch) = padded_dma_pitch_for(dest_fmt, width, &memory) {
+        let mut dma = Tensor::<u8>::image_with_stride(
+            width,
+            height,
+            dest_fmt,
+            aligned_pitch,
+            Some(TensorMemory::Dma),
+        )?;
+        copy_packed_to_padded_dma(&packed, &mut dma)?;
+        return Ok(TensorDyn::from(dma));
+    }
+
+    if matches!(memory, Some(TensorMemory::Mem)) {
+        return Ok(TensorDyn::from(packed));
+    }
+    // DMA (default on Linux) or Shm with naturally-aligned pitch.
+    let out = Tensor::<u8>::image(width, height, dest_fmt, memory)?;
+    {
+        let src_map = packed.map()?;
+        let mut dst_map = out.map()?;
+        let src_bytes: &[u8] = &src_map;
+        let dst_bytes: &mut [u8] = &mut dst_map;
+        dst_bytes.copy_from_slice(src_bytes);
+    }
+    Ok(TensorDyn::from(out))
 }
 
 /// Load an image from raw bytes (JPEG or PNG) and return a [`TensorDyn`].
@@ -3382,6 +3460,107 @@ mod image_tests {
         result.unwrap();
 
         compare_images(&loaded, &cpu_dst, 0.98, function!());
+    }
+
+    // Synthesise a small greyscale PNG in memory at `(width, height)` with a
+    // deterministic ramp pattern so multiple tests can cross-check output
+    // without bundling an extra fixture file.
+    fn make_grey_png(width: u32, height: u32) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity((width * height) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                bytes.push(((x + y) & 0xFF) as u8);
+            }
+        }
+        let img = image::GrayImage::from_vec(width, height, bytes).unwrap();
+        let mut buf = Vec::new();
+        img.write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)
+            .unwrap();
+        buf
+    }
+
+    /// Greyscale PNG with a width that forces a pitch-misaligned natural
+    /// row stride (612 bytes is not a multiple of the 64-byte GPU pitch
+    /// alignment) must still load via the pitch-padded DMA path. Gated on
+    /// DMA availability because `image_with_stride` is DMA-only.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_load_png_grey_misaligned_width_dma() {
+        use edgefirst_tensor::is_dma_available;
+        if !is_dma_available() {
+            eprintln!("SKIPPED: test_load_png_grey_misaligned_width_dma — DMA not available");
+            return;
+        }
+        let png = make_grey_png(612, 388);
+        let loaded = crate::load_png(&png, Some(PixelFormat::Grey), None).unwrap();
+        assert_eq!(loaded.width(), Some(612));
+        assert_eq!(loaded.height(), Some(388));
+        assert_eq!(loaded.format(), Some(PixelFormat::Grey));
+
+        // Round-trip pixels — natural-pitch DMA-BUFs pad the stride so we
+        // must indirect through row_stride() rather than assume width.
+        let map = loaded.as_u8().unwrap().map().unwrap();
+        let stride = loaded.row_stride().unwrap_or(612);
+        assert!(stride >= 612);
+        let bytes: &[u8] = &map;
+        for y in 0..388usize {
+            for x in 0..612usize {
+                let expected = ((x + y) & 0xFF) as u8;
+                let got = bytes[y * stride + x];
+                assert_eq!(
+                    got, expected,
+                    "grey png mismatch at ({x},{y}): got {got} expected {expected}"
+                );
+            }
+        }
+    }
+
+    /// Greyscale PNG loaded with explicit Mem backing — runs on any
+    /// platform (no DMA permission requirement) and covers the
+    /// decoder-native Luma → Grey no-conversion path.
+    #[test]
+    fn test_load_png_grey_mem() {
+        use edgefirst_tensor::TensorMemory;
+        let png = make_grey_png(612, 100);
+        let loaded =
+            crate::load_png(&png, Some(PixelFormat::Grey), Some(TensorMemory::Mem)).unwrap();
+        assert_eq!(loaded.width(), Some(612));
+        assert_eq!(loaded.height(), Some(100));
+        assert_eq!(loaded.format(), Some(PixelFormat::Grey));
+        let map = loaded.as_u8().unwrap().map().unwrap();
+        let bytes: &[u8] = &map;
+        // Mem allocation uses the natural pitch — 612 bytes per row, exact.
+        assert_eq!(bytes.len(), 612 * 100);
+        for y in 0..100 {
+            for x in 0..612 {
+                assert_eq!(bytes[y * 612 + x], ((x + y) & 0xFF) as u8);
+            }
+        }
+    }
+
+    /// Greyscale PNG decoded into RGB — exercises the decoder-colorspace
+    /// mismatch path (Luma → Rgb via CPU converter). Uses Mem memory to
+    /// stay portable to host-side test environments.
+    #[test]
+    fn test_load_png_grey_to_rgb_mem() {
+        use edgefirst_tensor::TensorMemory;
+        let png = make_grey_png(620, 240);
+        let loaded =
+            crate::load_png(&png, Some(PixelFormat::Rgb), Some(TensorMemory::Mem)).unwrap();
+        assert_eq!(loaded.width(), Some(620));
+        assert_eq!(loaded.height(), Some(240));
+        assert_eq!(loaded.format(), Some(PixelFormat::Rgb));
+
+        // Greyscale promoted to RGB replicates luma into each channel.
+        let map = loaded.as_u8().unwrap().map().unwrap();
+        let bytes: &[u8] = &map;
+        for (x, y) in [(0usize, 0usize), (100, 50), (619, 239)] {
+            let expected = ((x + y) & 0xFF) as u8;
+            let off = (y * 620 + x) * 3;
+            assert_eq!(bytes[off], expected, "R@{x},{y}");
+            assert_eq!(bytes[off + 1], expected, "G@{x},{y}");
+            assert_eq!(bytes[off + 2], expected, "B@{x},{y}");
+        }
     }
 
     #[test]

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -232,6 +232,109 @@ pub fn primary_plane_bpp(format: PixelFormat, elem: usize) -> Option<usize> {
     }
 }
 
+/// Return the GPU-aligned pitch in bytes when a DMA-backed image of
+/// `width × fmt` would need row-stride padding, or `None` when the
+/// natural pitch already satisfies `GPU_DMA_BUF_PITCH_ALIGNMENT_BYTES`
+/// or the caller has explicitly requested non-DMA memory.
+///
+/// Mali G310 (i.MX 95) rejects `eglCreateImage` from DMA-BUFs whose
+/// `PLANE0_PITCH_EXT` is not a multiple of 64 bytes, surfacing as
+/// `EGL_BAD_ALLOC`. Decoders like [`load_jpeg`]/[`load_png`] use this
+/// helper to decide whether to route through the two-buffer padded
+/// decode path.
+#[cfg(target_os = "linux")]
+pub(crate) fn padded_dma_pitch_for(
+    fmt: PixelFormat,
+    width: usize,
+    memory: &Option<TensorMemory>,
+) -> Option<usize> {
+    // Only pad when caller wants DMA (explicit or default). Padding for a
+    // Mem/Shm tensor would be surprising and waste bytes.
+    if !matches!(memory, None | Some(TensorMemory::Dma)) {
+        return None;
+    }
+    // Padding only applies to packed layouts — `Tensor::image_with_stride`
+    // rejects semi-planar / planar formats, and those take their own
+    // per-plane pitches on import anyway.
+    if fmt.layout() != PixelLayout::Packed {
+        return None;
+    }
+    let bpp = primary_plane_bpp(fmt, 1)?;
+    let natural = width.checked_mul(bpp)?;
+    let aligned = align_pitch_bytes_to_gpu_alignment(natural)?;
+    if aligned > natural {
+        Some(aligned)
+    } else {
+        None
+    }
+}
+
+/// Row-copy a tightly-packed `src` tensor into a `dst` tensor that has a
+/// larger row stride (typically a DMA-BUF allocated with GPU-aligned pitch).
+///
+/// Both tensors must share the same width, height and pixel format. The
+/// bytes between the end of each source row and the next destination row
+/// are left untouched — EGL import doesn't read past the row's valid
+/// width, so the padding can remain whatever the allocator produced.
+#[cfg(target_os = "linux")]
+pub(crate) fn copy_packed_to_padded_dma(
+    src: &Tensor<u8>,
+    dst: &mut Tensor<u8>,
+) -> Result<()> {
+    let width = dst.width().ok_or(Error::NotAnImage)?;
+    let height = dst.height().ok_or(Error::NotAnImage)?;
+    let fmt = dst.format().ok_or(Error::NotAnImage)?;
+    let bpp = primary_plane_bpp(fmt, 1).ok_or_else(|| {
+        Error::NotSupported(format!(
+            "copy_packed_to_padded_dma: unknown bpp for {fmt:?}"
+        ))
+    })?;
+    let natural = width.checked_mul(bpp).ok_or_else(|| {
+        Error::Internal(format!(
+            "copy_packed_to_padded_dma: width {width} × bpp {bpp} overflows"
+        ))
+    })?;
+    let dst_stride = dst.effective_row_stride().ok_or_else(|| {
+        Error::Internal(
+            "copy_packed_to_padded_dma: dst has no effective row stride".into(),
+        )
+    })?;
+
+    // `TensorMap` derefs to `[T]`, which gives us the slice without
+    // needing to import the `TensorMapTrait` at this call site.
+    let src_map = src.map()?;
+    let src_bytes: &[u8] = &src_map;
+    let mut dst_map = dst.map()?;
+    let dst_bytes: &mut [u8] = &mut dst_map;
+
+    if src_bytes.len() < natural.checked_mul(height).unwrap_or(usize::MAX) {
+        return Err(Error::Internal(format!(
+            "copy_packed_to_padded_dma: src has {} bytes, need {} ({}x{} @ {} bpp)",
+            src_bytes.len(),
+            natural * height,
+            width,
+            height,
+            bpp,
+        )));
+    }
+    if dst_bytes.len() < dst_stride.checked_mul(height).unwrap_or(usize::MAX) {
+        return Err(Error::Internal(format!(
+            "copy_packed_to_padded_dma: dst has {} bytes, need {} ({} stride × {} rows)",
+            dst_bytes.len(),
+            dst_stride * height,
+            dst_stride,
+            height,
+        )));
+    }
+
+    for row in 0..height {
+        let s = row * natural;
+        let d = row * dst_stride;
+        dst_bytes[d..d + natural].copy_from_slice(&src_bytes[s..s + natural]);
+    }
+    Ok(())
+}
+
 use edgefirst_decoder::{DetectBox, ProtoData, Segmentation};
 use edgefirst_tensor::{
     DType, PixelFormat, PixelLayout, Tensor, TensorDyn, TensorMemory, TensorTrait as _,
@@ -283,6 +386,36 @@ fn rotate_flip_to_dyn(
         Rotation::None | Rotation::Rotate180 => (src_w, src_h),
         Rotation::Clockwise90 | Rotation::CounterClockwise90 => (src_h, src_w),
     };
+
+    // Rotate/flip into Mem staging then row-copy into padded DMA when the
+    // caller wants DMA and the destination width would produce an
+    // unaligned pitch (see [`padded_dma_pitch_for`]).
+    #[cfg(target_os = "linux")]
+    if let Some(aligned_pitch) = padded_dma_pitch_for(src_fmt, dst_w, &memory) {
+        let tmp = Tensor::<u8>::image(dst_w, dst_h, src_fmt, Some(TensorMemory::Mem))?;
+        let src_map = src.map()?;
+        let mut tmp_map = tmp.map()?;
+        CPUProcessor::flip_rotate_ndarray_pf(
+            &src_map,
+            &mut tmp_map,
+            dst_w,
+            dst_h,
+            channels,
+            rotation,
+            flip,
+        )?;
+        drop(tmp_map);
+        drop(src_map);
+        let mut dma = Tensor::<u8>::image_with_stride(
+            dst_w,
+            dst_h,
+            src_fmt,
+            aligned_pitch,
+            Some(TensorMemory::Dma),
+        )?;
+        copy_packed_to_padded_dma(&tmp, &mut dma)?;
+        return Ok(TensorDyn::from(dma));
+    }
 
     let dst = Tensor::<u8>::image(dst_w, dst_h, src_fmt, memory)?;
     let src_map = src.map()?;
@@ -2150,6 +2283,13 @@ fn colorspace_to_pixelfmt(cs: ColorSpace) -> Option<PixelFormat> {
 }
 
 /// Load a JPEG image from raw bytes and return a [`TensorDyn`].
+// TODO: evaluate replacing zune-jpeg with libjpeg-turbo (via `turbojpeg`
+// crate). `tjDecompress2` accepts an explicit `pitch` parameter, which
+// would let us decode directly into a pitch-padded DMA-BUF and drop the
+// Mem-staging + row-copy introduced below for Mali G310 pitch alignment.
+// Dropping zune-jpeg also gets us a 2-4× faster SIMD decode on AArch64.
+// Blockers: adds a C dep (mozjpeg-sys / libturbojpeg) to the build;
+// cross-compilation story needs validating with zigbuild.
 fn load_jpeg(
     image: &[u8],
     format: Option<PixelFormat>,
@@ -2187,6 +2327,34 @@ fn load_jpeg(
     let h = image_info.height as usize;
 
     if (rotation, flip) == (Rotation::None, Flip::None) {
+        // When caller wants DMA and the natural pitch would be rejected by
+        // the GPU's DMA-BUF import (Mali G310 needs 64-byte pitch), decode
+        // into a tightly-packed Mem staging buffer and row-copy into a
+        // pitch-padded DMA tensor. zune-jpeg has no stride-aware decode,
+        // so the Mem intermediate is unavoidable until we swap decoders
+        // (see TODO below).
+        #[cfg(target_os = "linux")]
+        if let Some(aligned_pitch) = padded_dma_pitch_for(dest_fmt, w, &memory) {
+            let staging = Tensor::<u8>::image(w, h, converted_fmt, Some(TensorMemory::Mem))?;
+            decoder.decode_into(&mut staging.map()?)?;
+            let packed = if converted_fmt != dest_fmt {
+                let mut tmp = Tensor::<u8>::image(w, h, dest_fmt, Some(TensorMemory::Mem))?;
+                CPUProcessor::convert_format_pf(&staging, &mut tmp, converted_fmt, dest_fmt)?;
+                tmp
+            } else {
+                staging
+            };
+            let mut dma = Tensor::<u8>::image_with_stride(
+                w,
+                h,
+                dest_fmt,
+                aligned_pitch,
+                Some(TensorMemory::Dma),
+            )?;
+            copy_packed_to_padded_dma(&packed, &mut dma)?;
+            return Ok(TensorDyn::from(dma));
+        }
+
         let mut img = Tensor::<u8>::image(w, h, dest_fmt, memory)?;
 
         if converted_fmt != dest_fmt {
@@ -2234,28 +2402,41 @@ fn load_png(
         .png_set_decode_animated(false);
     let mut decoder = PngDecoder::new_with_options(image, options);
     decoder.decode_headers()?;
-    let image_info = decoder.get_info().ok_or(Error::Internal(
-        "PNG did not return decoded image info".to_string(),
-    ))?;
-
-    let (rotation, flip) = image_info
-        .exif
-        .as_ref()
-        .map(|x| read_exif_orientation(x))
-        .unwrap_or((Rotation::None, Flip::None));
+    let (width, height, rotation, flip) = {
+        let image_info = decoder.get_info().ok_or(Error::Internal(
+            "PNG did not return decoded image info".to_string(),
+        ))?;
+        let (rotation, flip) = image_info
+            .exif
+            .as_ref()
+            .map(|x| read_exif_orientation(x))
+            .unwrap_or((Rotation::None, Flip::None));
+        (image_info.width, image_info.height, rotation, flip)
+    };
 
     if (rotation, flip) == (Rotation::None, Flip::None) {
-        let img = Tensor::<u8>::image(image_info.width, image_info.height, fmt, memory)?;
+        // Same pitch-padding treatment as load_jpeg — see comment there.
+        #[cfg(target_os = "linux")]
+        if let Some(aligned_pitch) = padded_dma_pitch_for(fmt, width, &memory) {
+            let staging = Tensor::<u8>::image(width, height, fmt, Some(TensorMemory::Mem))?;
+            decoder.decode_into(&mut staging.map()?)?;
+            let mut dma = Tensor::<u8>::image_with_stride(
+                width,
+                height,
+                fmt,
+                aligned_pitch,
+                Some(TensorMemory::Dma),
+            )?;
+            copy_packed_to_padded_dma(&staging, &mut dma)?;
+            return Ok(TensorDyn::from(dma));
+        }
+
+        let img = Tensor::<u8>::image(width, height, fmt, memory)?;
         decoder.decode_into(&mut img.map()?)?;
         return Ok(TensorDyn::from(img));
     }
 
-    let tmp = Tensor::<u8>::image(
-        image_info.width,
-        image_info.height,
-        fmt,
-        Some(TensorMemory::Mem),
-    )?;
+    let tmp = Tensor::<u8>::image(width, height, fmt, Some(TensorMemory::Mem))?;
     decoder.decode_into(&mut tmp.map()?)?;
 
     rotate_flip_to_dyn(&tmp, fmt, rotation, flip, memory)

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -3460,6 +3460,7 @@ mod image_tests {
     /// compiled without its JPEG feature). Used to exercise the decoder /
     /// pitch-padding paths for arbitrary dimensions without having to bundle
     /// a fixture file per test size.
+    #[cfg(target_os = "linux")]
     fn make_rgb_jpeg(width: u32, height: u32) -> Vec<u8> {
         let mut bytes = Vec::with_capacity((width * height * 3) as usize);
         for y in 0..height {

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -3462,6 +3462,142 @@ mod image_tests {
         compare_images(&loaded, &cpu_dst, 0.98, function!());
     }
 
+    /// Synthesise an RGB JPEG with a deterministic pattern at `(width, height)`
+    /// using the workspace's `jpeg-encoder` crate (the `image` crate is
+    /// compiled without its JPEG feature). Used to exercise the decoder /
+    /// pitch-padding paths for arbitrary dimensions without having to bundle
+    /// a fixture file per test size.
+    fn make_rgb_jpeg(width: u32, height: u32) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity((width * height * 3) as usize);
+        for y in 0..height {
+            for x in 0..width {
+                bytes.push(((x + y) & 0xFF) as u8);
+                bytes.push(((x.wrapping_mul(3)) & 0xFF) as u8);
+                bytes.push(((y.wrapping_mul(5)) & 0xFF) as u8);
+            }
+        }
+        let mut out = Vec::new();
+        let encoder = jpeg_encoder::Encoder::new(&mut out, 85);
+        encoder
+            .encode(&bytes, width as u16, height as u16, jpeg_encoder::ColorType::Rgb)
+            .expect("jpeg-encoder must succeed on trivial input");
+        out
+    }
+
+    /// End-to-end: a 375×333 RGBA JPEG (width NOT divisible by 4) loaded
+    /// via the pitch-padded DMA path and letterboxed through the GL
+    /// backend must produce correct output. Before the Rgba/Bgra
+    /// width%4 relaxation in `DmaImportAttrs::from_tensor`, this case
+    /// failed the pre-check and forced a CPU texture upload fallback;
+    /// with the relaxation, EGL import succeeds at the driver level and
+    /// the GL fast path runs. Output correctness is checked against a
+    /// CPU reference (convert ran with `EDGEFIRST_FORCE_BACKEND=cpu`).
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[cfg(feature = "opengl")]
+    fn test_convert_rgba_non_4_aligned_width_end_to_end() {
+        use edgefirst_tensor::is_dma_available;
+        if !is_dma_available() {
+            eprintln!(
+                "SKIPPED: test_convert_rgba_non_4_aligned_width_end_to_end — DMA not available"
+            );
+            return;
+        }
+        // 375 is the canonical failure width from dataset loaders —
+        // 375 * 4 = 1500 bytes/row, pitch-padded to 1536. Width%4 = 3,
+        // so the old pre-check rejected it; new code accepts it.
+        let jpeg = make_rgb_jpeg(375, 333);
+        let src_gl = crate::load_jpeg(&jpeg, Some(PixelFormat::Rgba), None).unwrap();
+        assert_eq!(src_gl.width(), Some(375));
+        // Row stride must still be pitch-padded (separate concern from width).
+        let stride = src_gl.row_stride().unwrap();
+        assert_eq!(stride, 1536, "expected padded pitch 1536, got {stride}");
+
+        // GL-backed convert into a pitch-aligned 640×640 Rgba dest.
+        let mut gl_proc = ImageProcessor::new().unwrap();
+        let gl_dst = gl_proc
+            .create_image(640, 640, PixelFormat::Rgba, DType::U8, None)
+            .unwrap();
+        let (r_gl, _src_gl, gl_dst) = convert_img(
+            &mut gl_proc,
+            src_gl,
+            gl_dst,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        );
+        r_gl.expect("GL-backed convert must succeed for 375x333 Rgba src");
+
+        // CPU reference via a fresh load so the two paths start from
+        // byte-identical inputs. `with_config(backend=Cpu)` forces the
+        // CPU-only processor regardless of which backends the host has
+        // available.
+        let src_cpu = crate::load_jpeg(&jpeg, Some(PixelFormat::Rgba), Some(TensorMemory::Mem))
+            .unwrap();
+        let mut cpu_proc = ImageProcessor::with_config(ImageProcessorConfig {
+            backend: ComputeBackend::Cpu,
+            ..Default::default()
+        })
+        .unwrap();
+        let cpu_dst =
+            TensorDyn::image(640, 640, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Mem))
+                .unwrap();
+        let (r_cpu, _src_cpu, cpu_dst) = convert_img(
+            &mut cpu_proc,
+            src_cpu,
+            cpu_dst,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        );
+        r_cpu.unwrap();
+
+        // Structural similarity: the GL path may have gone through EGL
+        // import OR fallen back to CPU texture upload — either way, the
+        // output must match the CPU reference closely.
+        compare_images(&gl_dst, &cpu_dst, 0.95, function!());
+    }
+
+    /// Regression lock: loading a JPEG at a non-64-aligned RGBA pitch (e.g.
+    /// 500×333 → natural pitch 2000, needs to be padded to 2048) must go
+    /// through `image_with_stride` and set `row_stride()` / `effective_row_stride()`
+    /// to the padded value. The earlier pitch-padding commit fixed this in
+    /// `load_jpeg`; a regression would surface as `row_stride == None` or
+    /// `effective_row_stride == 2000`.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_load_jpeg_rgba_non_aligned_pitch_padded_dma() {
+        use edgefirst_tensor::is_dma_available;
+        if !is_dma_available() {
+            eprintln!(
+                "SKIPPED: test_load_jpeg_rgba_non_aligned_pitch_padded_dma — DMA not available"
+            );
+            return;
+        }
+        // Widths that force a non-64-aligned natural RGBA pitch. All three
+        // are divisible by 4 so the EGL width-alignment pre-check passes.
+        // The pitch-padding fix is what makes these importable at all.
+        for &w in &[500u32, 612, 428] {
+            let jpeg = make_rgb_jpeg(w, 333);
+            let loaded = crate::load_jpeg(&jpeg, Some(PixelFormat::Rgba), None).unwrap();
+            let natural = (w as usize) * 4;
+            let aligned = crate::align_pitch_bytes_to_gpu_alignment(natural).unwrap();
+            assert!(aligned > natural, "test sanity: width {w} should be unaligned");
+            let stride = loaded.row_stride().expect(
+                "padded DMA path must set an explicit row_stride — regression if None",
+            );
+            assert_eq!(
+                stride, aligned,
+                "width {w}: expected padded stride {aligned}, got {stride} \
+                 (regression: pitch-padding branch skipped?)"
+            );
+            let eff = loaded.effective_row_stride().unwrap();
+            assert_eq!(eff, aligned, "effective_row_stride must match stored stride");
+            assert_eq!(loaded.width(), Some(w as usize));
+            assert_eq!(loaded.height(), Some(333));
+        }
+    }
+
     // Synthesise a small greyscale PNG in memory at `(width, height)` with a
     // deterministic ramp pattern so multiple tests can cross-check output
     // without bundling an extra fixture file.

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -277,10 +277,7 @@ pub(crate) fn padded_dma_pitch_for(
 /// are left untouched — EGL import doesn't read past the row's valid
 /// width, so the padding can remain whatever the allocator produced.
 #[cfg(target_os = "linux")]
-pub(crate) fn copy_packed_to_padded_dma(
-    src: &Tensor<u8>,
-    dst: &mut Tensor<u8>,
-) -> Result<()> {
+pub(crate) fn copy_packed_to_padded_dma(src: &Tensor<u8>, dst: &mut Tensor<u8>) -> Result<()> {
     let width = dst.width().ok_or(Error::NotAnImage)?;
     let height = dst.height().ok_or(Error::NotAnImage)?;
     let fmt = dst.format().ok_or(Error::NotAnImage)?;
@@ -295,9 +292,7 @@ pub(crate) fn copy_packed_to_padded_dma(
         ))
     })?;
     let dst_stride = dst.effective_row_stride().ok_or_else(|| {
-        Error::Internal(
-            "copy_packed_to_padded_dma: dst has no effective row stride".into(),
-        )
+        Error::Internal("copy_packed_to_padded_dma: dst has no effective row stride".into())
     })?;
 
     // `TensorMap` derefs to `[T]`, which gives us the slice without
@@ -307,7 +302,7 @@ pub(crate) fn copy_packed_to_padded_dma(
     let mut dst_map = dst.map()?;
     let dst_bytes: &mut [u8] = &mut dst_map;
 
-    if src_bytes.len() < natural.checked_mul(height).unwrap_or(usize::MAX) {
+    if src_bytes.len() < natural.saturating_mul(height) {
         return Err(Error::Internal(format!(
             "copy_packed_to_padded_dma: src has {} bytes, need {} ({}x{} @ {} bpp)",
             src_bytes.len(),
@@ -317,7 +312,7 @@ pub(crate) fn copy_packed_to_padded_dma(
             bpp,
         )));
     }
-    if dst_bytes.len() < dst_stride.checked_mul(height).unwrap_or(usize::MAX) {
+    if dst_bytes.len() < dst_stride.saturating_mul(height) {
         return Err(Error::Internal(format!(
             "copy_packed_to_padded_dma: dst has {} bytes, need {} ({} stride × {} rows)",
             dst_bytes.len(),
@@ -2466,16 +2461,14 @@ fn load_png(
         }
         grey
     } else {
-        let staging =
-            Tensor::<u8>::image(width, height, decoded_fmt, Some(TensorMemory::Mem))?;
+        let staging = Tensor::<u8>::image(width, height, decoded_fmt, Some(TensorMemory::Mem))?;
         decoder.decode_into(&mut staging.map()?)?;
         staging
     };
 
     // Optional CPU format conversion before the final memory placement.
     let packed = if decoded_fmt != dest_fmt {
-        let mut tmp =
-            Tensor::<u8>::image(width, height, dest_fmt, Some(TensorMemory::Mem))?;
+        let mut tmp = Tensor::<u8>::image(width, height, dest_fmt, Some(TensorMemory::Mem))?;
         CPUProcessor::convert_format_pf(&staging, &mut tmp, decoded_fmt, dest_fmt)?;
         tmp
     } else {
@@ -3479,7 +3472,12 @@ mod image_tests {
         let mut out = Vec::new();
         let encoder = jpeg_encoder::Encoder::new(&mut out, 85);
         encoder
-            .encode(&bytes, width as u16, height as u16, jpeg_encoder::ColorType::Rgb)
+            .encode(
+                &bytes,
+                width as u16,
+                height as u16,
+                jpeg_encoder::ColorType::Rgb,
+            )
             .expect("jpeg-encoder must succeed on trivial input");
         out
     }
@@ -3532,16 +3530,21 @@ mod image_tests {
         // byte-identical inputs. `with_config(backend=Cpu)` forces the
         // CPU-only processor regardless of which backends the host has
         // available.
-        let src_cpu = crate::load_jpeg(&jpeg, Some(PixelFormat::Rgba), Some(TensorMemory::Mem))
-            .unwrap();
+        let src_cpu =
+            crate::load_jpeg(&jpeg, Some(PixelFormat::Rgba), Some(TensorMemory::Mem)).unwrap();
         let mut cpu_proc = ImageProcessor::with_config(ImageProcessorConfig {
             backend: ComputeBackend::Cpu,
             ..Default::default()
         })
         .unwrap();
-        let cpu_dst =
-            TensorDyn::image(640, 640, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Mem))
-                .unwrap();
+        let cpu_dst = TensorDyn::image(
+            640,
+            640,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Mem),
+        )
+        .unwrap();
         let (r_cpu, _src_cpu, cpu_dst) = convert_img(
             &mut cpu_proc,
             src_cpu,
@@ -3582,17 +3585,23 @@ mod image_tests {
             let loaded = crate::load_jpeg(&jpeg, Some(PixelFormat::Rgba), None).unwrap();
             let natural = (w as usize) * 4;
             let aligned = crate::align_pitch_bytes_to_gpu_alignment(natural).unwrap();
-            assert!(aligned > natural, "test sanity: width {w} should be unaligned");
-            let stride = loaded.row_stride().expect(
-                "padded DMA path must set an explicit row_stride — regression if None",
+            assert!(
+                aligned > natural,
+                "test sanity: width {w} should be unaligned"
             );
+            let stride = loaded
+                .row_stride()
+                .expect("padded DMA path must set an explicit row_stride — regression if None");
             assert_eq!(
                 stride, aligned,
                 "width {w}: expected padded stride {aligned}, got {stride} \
                  (regression: pitch-padding branch skipped?)"
             );
             let eff = loaded.effective_row_stride().unwrap();
-            assert_eq!(eff, aligned, "effective_row_stride must match stored stride");
+            assert_eq!(
+                eff, aligned,
+                "effective_row_stride must match stored stride"
+            );
             assert_eq!(loaded.width(), Some(w as usize));
             assert_eq!(loaded.height(), Some(333));
         }

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -1635,13 +1635,13 @@ impl ImageProcessor {
     ///
     /// Returns [`Error::NoConverter`] if the CPU backend is not available.
     pub fn materialize_masks(
-        &self,
+        &mut self,
         detect: &[DetectBox],
         proto_data: &ProtoData,
         letterbox: Option<[f32; 4]>,
         resolution: MaskResolution,
     ) -> Result<Vec<Segmentation>> {
-        let cpu = self.cpu.as_ref().ok_or(Error::NoConverter)?;
+        let cpu = self.cpu.as_mut().ok_or(Error::NoConverter)?;
         match resolution {
             MaskResolution::Proto => cpu.materialize_segmentations(detect, proto_data, letterbox),
             MaskResolution::Scaled { width, height } => {
@@ -1995,30 +1995,37 @@ impl ImageProcessorTrait for ImageProcessor {
         // full-GPU draw_proto_masks on all tested platforms: 27× on imx8mp,
         // 4× on imx95, 2.5× on rpi5, 1.6× on x86).
         // GL owns its own bg-blit / glClear — we pass the overlay through.
+        //
+        // CPU materialize needs `&mut` for its MaskScratch buffers; GL also
+        // needs `&mut`. The CPU borrow is scoped to its block so the
+        // subsequent GL borrow is free to take over `self`.
         #[cfg(target_os = "linux")]
         #[cfg(feature = "opengl")]
-        if let Some(opengl) = self.opengl.as_mut() {
-            let Some(cpu) = self.cpu.as_ref() else {
-                return Err(Error::Internal(
-                    "draw_proto_masks requires CPU backend for hybrid path".into(),
-                ));
-            };
-            log::trace!(
-                "draw_proto_masks started with hybrid (cpu+opengl) in {:?}",
-                start.elapsed()
-            );
-            let segmentation =
-                cpu.materialize_segmentations(detect, proto_data, overlay.letterbox)?;
-            match opengl.draw_decoded_masks(dst, render_detect, &segmentation, overlay) {
-                Ok(_) => {
+        if let (Some(_), Some(_)) = (self.cpu.as_ref(), self.opengl.as_ref()) {
+            let segmentation = match self.cpu.as_mut() {
+                Some(cpu) => {
                     log::trace!(
-                        "draw_proto_masks with hybrid (cpu+opengl) in {:?}",
+                        "draw_proto_masks started with hybrid (cpu+opengl) in {:?}",
                         start.elapsed()
                     );
-                    return Ok(());
+                    cpu.materialize_segmentations(detect, proto_data, overlay.letterbox)?
                 }
-                Err(e) => {
-                    log::trace!("draw_proto_masks hybrid path failed, falling back to cpu: {e:?}");
+                None => unreachable!("cpu presence checked above"),
+            };
+            if let Some(opengl) = self.opengl.as_mut() {
+                match opengl.draw_decoded_masks(dst, render_detect, &segmentation, overlay) {
+                    Ok(_) => {
+                        log::trace!(
+                            "draw_proto_masks with hybrid (cpu+opengl) in {:?}",
+                            start.elapsed()
+                        );
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        log::trace!(
+                            "draw_proto_masks hybrid path failed, falling back to cpu: {e:?}"
+                        );
+                    }
                 }
             }
         }

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -248,10 +248,19 @@ pub(crate) fn padded_dma_pitch_for(
     width: usize,
     memory: &Option<TensorMemory>,
 ) -> Option<usize> {
-    // Only pad when caller wants DMA (explicit or default). Padding for a
-    // Mem/Shm tensor would be surprising and waste bytes.
-    if !matches!(memory, None | Some(TensorMemory::Dma)) {
-        return None;
+    // Only pad when the caller explicitly requested DMA, or when they
+    // left memory selection to the allocator AND DMA is actually
+    // available. `Tensor::image_with_stride(..., None)` always routes
+    // through DMA allocation, so treating `None` as "DMA wanted"
+    // unconditionally would convert a normally-working image load into
+    // a hard failure on systems where DMA is unavailable (sandboxed
+    // CI, missing `/dev/dma_heap`, permission-denied containers) —
+    // whereas `Tensor::image(..., None)` would have fallen back to
+    // SHM/Mem there.
+    match memory {
+        Some(TensorMemory::Dma) => {}
+        None if edgefirst_tensor::is_dma_available() => {}
+        _ => return None,
     }
     // Padding only applies to packed layouts — `Tensor::image_with_stride`
     // rejects semi-planar / planar formats, and those take their own
@@ -315,7 +324,7 @@ pub(crate) fn copy_packed_to_padded_dma(src: &Tensor<u8>, dst: &mut Tensor<u8>) 
         return Err(Error::Internal(format!(
             "copy_packed_to_padded_dma: src has {} bytes, need {} ({}x{} @ {} bpp)",
             src_bytes.len(),
-            natural * height,
+            natural.saturating_mul(height),
             width,
             height,
             bpp,
@@ -325,7 +334,7 @@ pub(crate) fn copy_packed_to_padded_dma(src: &Tensor<u8>, dst: &mut Tensor<u8>) 
         return Err(Error::Internal(format!(
             "copy_packed_to_padded_dma: dst has {} bytes, need {} ({} stride × {} rows)",
             dst_bytes.len(),
-            dst_stride * height,
+            dst_stride.saturating_mul(height),
             dst_stride,
             height,
         )));
@@ -3614,6 +3623,65 @@ mod image_tests {
             );
             assert_eq!(loaded.width(), Some(w as usize));
             assert_eq!(loaded.height(), Some(333));
+        }
+    }
+
+    /// `padded_dma_pitch_for` must respect the caller's memory choice and
+    /// must NOT route into the pitch-padded DMA path when the caller left
+    /// the choice to the allocator (`None`) but DMA is unavailable on the
+    /// host. The padded path requires `image_with_stride`, which always
+    /// allocates DMA — taking it on a system without `/dev/dma_heap`
+    /// would convert a normally-working image load into a hard failure
+    /// (since `Tensor::image(..., None)` would have fallen back to
+    /// SHM/Mem).
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_padded_dma_pitch_for_respects_memory_choice() {
+        use edgefirst_tensor::{is_dma_available, TensorMemory};
+
+        // 500×4 = 2000 → padded to 2048 by GPU alignment. Use it for
+        // every case so any "no padding" answer is unambiguous.
+        let unaligned_w = 500;
+
+        // Caller asks for Mem / Shm: never pad, regardless of DMA.
+        assert_eq!(
+            crate::padded_dma_pitch_for(PixelFormat::Rgba, unaligned_w, &Some(TensorMemory::Mem),),
+            None,
+            "Mem must never trigger DMA padding"
+        );
+        assert_eq!(
+            crate::padded_dma_pitch_for(PixelFormat::Rgba, unaligned_w, &Some(TensorMemory::Shm),),
+            None,
+            "Shm must never trigger DMA padding"
+        );
+
+        // Caller explicitly asks for DMA: always pad if width needs it.
+        // Even if the runtime can't actually allocate DMA, the caller
+        // owns that decision and the resulting allocation error is
+        // their problem, not ours.
+        assert_eq!(
+            crate::padded_dma_pitch_for(PixelFormat::Rgba, unaligned_w, &Some(TensorMemory::Dma),),
+            Some(2048),
+            "explicit Dma must pad regardless of runtime DMA availability"
+        );
+
+        // Caller leaves it to the allocator: behaviour depends on
+        // host-runtime DMA availability. This is the case the fix
+        // guards against.
+        let none_result = crate::padded_dma_pitch_for(PixelFormat::Rgba, unaligned_w, &None);
+        if is_dma_available() {
+            assert_eq!(
+                none_result,
+                Some(2048),
+                "memory=None + DMA available → pad (will route through DMA)"
+            );
+        } else {
+            assert_eq!(
+                none_result, None,
+                "memory=None + DMA unavailable → must NOT pad (would force \
+                 image_with_stride into a DMA-only allocation that fails). \
+                 Regression: padded_dma_pitch_for ignored is_dma_available()."
+            );
         }
     }
 

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -281,6 +281,15 @@ pub(crate) fn copy_packed_to_padded_dma(src: &Tensor<u8>, dst: &mut Tensor<u8>) 
     let width = dst.width().ok_or(Error::NotAnImage)?;
     let height = dst.height().ok_or(Error::NotAnImage)?;
     let fmt = dst.format().ok_or(Error::NotAnImage)?;
+    let src_width = src.width().ok_or(Error::NotAnImage)?;
+    let src_height = src.height().ok_or(Error::NotAnImage)?;
+    let src_fmt = src.format().ok_or(Error::NotAnImage)?;
+    if src_width != width || src_height != height || src_fmt != fmt {
+        return Err(Error::Internal(format!(
+            "copy_packed_to_padded_dma: src and dst image metadata must match \
+             (src: {src_width}x{src_height} {src_fmt:?}, dst: {width}x{height} {fmt:?})"
+        )));
+    }
     let bpp = primary_plane_bpp(fmt, 1).ok_or_else(|| {
         Error::NotSupported(format!(
             "copy_packed_to_padded_dma: unknown bpp for {fmt:?}"

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -1114,7 +1114,7 @@ impl PyImageProcessor {
     ) -> Result<Vec<Bound<'py, numpy::PyArray3<u8>>>> {
         let detect = numpy_to_detect_boxes(&bbox, &scores, &classes)?;
         let resolution = resolution.map(|r| r.0).unwrap_or(MaskResolution::Proto);
-        let l = self
+        let mut l = self
             .0
             .lock()
             .map_err(|_| Error::InvalidArg("ImageProcessor lock poisoned".to_string()))?;


### PR DESCRIPTION
## Summary

Everything that was uncovered while investigating slow COCO mask validation on i.MX 95, now consolidated. Six logical commits:

1. **Schema v2 shape-truncation fix** + **batched-GEMM `materialize_masks`** (squashed, commit 1)
2. **Drop `fast_sigmoid` on scaled path** + **skip per-frame scratch zeroing** (commit 2)
3. **NEON kernels** for scaled upsample + i8 dequant (commit 3)
4. **GPU-aligned row stride** in `load_jpeg`/`load_png` DMA path (commit 4)
5. **Greyscale support + converter-reachable formats** in `load_png` (commit 5)
6. **Relaxed `width%4` pre-check** for Rgba/Bgra in EGL DMA-BUF import (commit 6)

Together these take the imx95 HAL output stage from ~160 ms avg / ~540 ms max down to tens of ms, and fix the remaining dataset-loader `BadAlloc` / `Unsupported image format` / `Invalid Yolo Split Boxes shape []` classes.

## Measured — `materialize_masks` at `MaskResolution::Scaled 640×640` (legacy → after)

| Platform | N=2 | N=8 | N=32 | N=100 |
|---|---|---|---|---|
| imx8mp-frdm  (4× A53)  | 29.8 → 18.0 (1.7×) | 115.5 → 22.1 (5.2×)  | 458 → 56  (8.2×)   | **1400 → 153 (9.1×)**  |
| imx95-frdm   (6× A55)  | 29.8 → 17.3 (1.7×) | 115.5 → 18.2 (6.4×)  | 458 → 44  (10.5×)  | **1400 → 114 (12.3×)** |
| rpi5-hailo   (4× A76)  |  9.7 →  3.8 (2.6×) |  37.6 →  5.2 (7.2×)  | 149 → 15  (10.2×)  | **466  →  42 (10.9×)** |
| x86-desktop  (20-core) |  9.6 →  3.5 (2.7×) |  37.2 →  2.2 (16.9×) | 148 →  4.0 (37.0×) | **461  →  10 (44.7×)** |

The imx95 N=100 number dropped further to ~44 ms after the NEON kernels (commit 3). Full per-N tables in `BENCHMARKS.md`.

## DMA-BUF / decoder fixes

- **Pitch padding** (commit 4): Mali G310 rejects `eglCreateImage` from DMA-BUFs whose `PLANE0_PITCH_EXT` is not a multiple of 64 bytes. `load_jpeg`/`load_png` now route through `padded_dma_pitch_for` + `image_with_stride` + `copy_packed_to_padded_dma` for widths like 500 / 612 / 428.
- **Greyscale PNG** (commit 5): `load_png` previously rejected anything other than Rgb/Rgba with `Unsupported image format`. Now accepts any destination format the CPU converter can reach from the decoder's native output (Luma / LumaA / RGB / RGBA); LumaA is normalised to Grey inline.
- **Width%4 relaxation** (commit 6): `DmaImportAttrs::from_tensor` had a blanket `width % 4 == 0` check that rejected Rgba/Bgra at widths like 375 / 427 / 443 (all fall through to CPU texture upload). Since 4-bpp packed formats have a trivially 4-byte-aligned row pitch at any width, the check is only necessary for 3-bpp (Rgb) and 1-bpp (Grey) where the natural pitch depends on width alignment. Empirically verified the relaxed constraint is accepted by Mali G310, Vivante GC7000UL, V3D 7.1, and Tegra at the DMA-BUF import level.

## API impact

Three signatures change from `&self` to `&mut self` (needed for `MaskScratch` pooling):

- `ImageProcessor::materialize_masks`
- `CPUProcessor::materialize_segmentations`
- `CPUProcessor::materialize_scaled_segmentations`

All in-tree callers updated (Python binding via `let mut l = self.0.lock()...`; C API already mutable through raw-ptr deref; GL hybrid `draw_proto_masks` path now scopes the CPU borrow before the GL borrow). External consumers calling on a `&` binding need a `let mut` binding — purely mechanical.

## Test plan

- [x] `cargo test --workspace --lib -- --test-threads=1` — all pass on x86
- [x] `cargo test -p edgefirst-image --lib` — 242 pass on imx95-frdm (cross-compiled via cargo-zigbuild)
- [x] Full suite (241 each) on imx8mp-frdm, imx95-frdm, rpi5-hailo, orin-nano — zero regressions
- [x] mask_benchmark A/B (`EDGEFIRST_LEGACY_MATERIALIZE=1`) on imx8mp-frdm, imx95-frdm, rpi5-hailo, x86-desktop
- [x] New DMA-BUF tests — 375/427/443-wide Rgba accept, Rgb/Grey reject, 500/612/428 Rgba pitch-padded — pass on all four aarch64 GPU targets
- [x] New PNG-Grey tests — Mem and DMA-padded paths — pass on imx95-frdm
- [ ] jetson-orin-nano mask_benchmark A/B (was unreachable at the time the benchmark tables were collected; later reachable and passed the full test suite + new DMA tests)