### PR TITLE
Defensive CHW decoder handling + C API for fused proto mask rendering

### DIFF
--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -1882,7 +1882,7 @@ int hal_image_processor_draw_masks(struct hal_image_processor *processor,
  * @param dst Destination image (RGBA, must not alias `background`)
  * @param detections Detection box list from `hal_decoder_decode_proto()`
  * @param proto Prototype data from `hal_decoder_decode_proto()`
- * @param background Optional source image to composite under masks (NULL = clear to black)
+ * @param background Optional source image to composite under masks (NULL = clear to transparent black)
  * @param opacity Mask opacity (0.0 = transparent, 1.0 = opaque)
  * @param letterbox Optional letterbox coordinates [x0, y0, x1, y1] in normalized
  *        coordinates (NULL = no letterbox correction)

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -1807,6 +1807,45 @@ int hal_image_processor_draw_masks(struct hal_image_processor *processor,
                                    struct hal_detect_box_list **out_boxes);
 
 /**
+ * Draw segmentation masks from pre-decoded boxes and prototype data.
+ *
+ * This is the split version of `hal_image_processor_draw_masks()`: the caller
+ * has already called `hal_decoder_decode_proto()` to obtain boxes and proto data,
+ * and now wants to render masks onto a destination image using the GPU-accelerated
+ * proto path.
+ *
+ * This avoids re-decoding when the same inference results need to be rendered
+ * onto multiple video frames (e.g., in a dual-pad overlay element where tensors
+ * and video arrive asynchronously at different rates).
+ *
+ * **Output contract:** `dst` is always fully written by this call — its prior
+ * contents are discarded.  See `hal_image_processor_draw_decoded_masks` for
+ * the four-case detections × background matrix.
+ *
+ * @param processor Image processor handle
+ * @param dst Destination image (RGBA, must not alias `background`)
+ * @param detections Detection box list from `hal_decoder_decode_proto()`
+ * @param proto Prototype data from `hal_decoder_decode_proto()`
+ * @param background Optional source image to composite under masks (NULL = clear to black)
+ * @param opacity Mask opacity (0.0 = transparent, 1.0 = opaque)
+ * @param letterbox Optional letterbox coordinates [x0, y0, x1, y1] in normalized
+ *        coordinates (NULL = no letterbox correction)
+ * @param color_mode How to assign colors to detections (HAL_COLOR_MODE_CLASS by default)
+ * @return 0 on success, -1 on error
+ * @par Errors (errno):
+ * - EINVAL: Invalid argument (NULL processor/dst/detections/proto, or `background` aliases `dst`)
+ * - EIO: Rendering failed
+ */
+int hal_image_processor_draw_proto_masks(struct hal_image_processor *processor,
+                                         struct hal_tensor *dst,
+                                         const struct hal_detect_box_list *detections,
+                                         const struct hal_proto_data *proto,
+                                         const struct hal_tensor *background,
+                                         float opacity,
+                                         const float *letterbox,
+                                         enum hal_color_mode color_mode);
+
+/**
  * Decode tracked model outputs and draw masks directly onto a destination image.
  *
  * This is the fused tracked path: for segmentation models, prototype data is

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -1137,7 +1137,7 @@ pub unsafe extern "C" fn hal_image_processor_draw_masks(
 /// @param dst Destination image (RGBA, must not alias `background`)
 /// @param detections Detection box list from `hal_decoder_decode_proto()`
 /// @param proto Prototype data from `hal_decoder_decode_proto()`
-/// @param background Optional source image to composite under masks (NULL = clear to black)
+/// @param background Optional source image to composite under masks (NULL = clear to transparent black)
 /// @param opacity Mask opacity (0.0 = transparent, 1.0 = opaque)
 /// @param letterbox Optional letterbox coordinates [x0, y0, x1, y1] in normalized
 ///        coordinates (NULL = no letterbox correction)

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -1118,6 +1118,65 @@ pub unsafe extern "C" fn hal_image_processor_draw_masks(
     0
 }
 
+/// Draw segmentation masks from pre-decoded boxes and prototype data.
+///
+/// This is the split version of `hal_image_processor_draw_masks()`: the caller
+/// has already called `hal_decoder_decode_proto()` to obtain boxes and proto data,
+/// and now wants to render masks onto a destination image using the GPU-accelerated
+/// proto path.
+///
+/// This avoids re-decoding when the same inference results need to be rendered
+/// onto multiple video frames (e.g., in a dual-pad overlay element where tensors
+/// and video arrive asynchronously at different rates).
+///
+/// **Output contract:** `dst` is always fully written by this call — its prior
+/// contents are discarded.  See `hal_image_processor_draw_decoded_masks` for
+/// the four-case detections × background matrix.
+///
+/// @param processor Image processor handle
+/// @param dst Destination image (RGBA, must not alias `background`)
+/// @param detections Detection box list from `hal_decoder_decode_proto()`
+/// @param proto Prototype data from `hal_decoder_decode_proto()`
+/// @param background Optional source image to composite under masks (NULL = clear to black)
+/// @param opacity Mask opacity (0.0 = transparent, 1.0 = opaque)
+/// @param letterbox Optional letterbox coordinates [x0, y0, x1, y1] in normalized
+///        coordinates (NULL = no letterbox correction)
+/// @param color_mode How to assign colors to detections (HAL_COLOR_MODE_CLASS by default)
+/// @return 0 on success, -1 on error
+/// @par Errors (errno):
+/// - EINVAL: Invalid argument (NULL processor/dst/detections/proto, or `background` aliases `dst`)
+/// - EIO: Rendering failed
+#[no_mangle]
+pub unsafe extern "C" fn hal_image_processor_draw_proto_masks(
+    processor: *mut HalImageProcessor,
+    dst: *mut HalTensor,
+    detections: *const HalDetectBoxList,
+    proto: *const HalProtoData,
+    background: *const HalTensor,
+    opacity: f32,
+    letterbox: *const f32,
+    color_mode: HalColorMode,
+) -> c_int {
+    check_null!(processor, dst, detections, proto);
+
+    // Reject same-HalTensor aliasing before borrowing through build_overlay
+    if !background.is_null() && std::ptr::eq(background, dst as *const _) {
+        return set_error(libc::EINVAL);
+    }
+
+    let overlay = build_overlay(background, opacity, letterbox, color_mode);
+
+    if let Err(e) = (*processor).inner.draw_proto_masks(
+        &mut (*dst).inner,
+        &(*detections).boxes,
+        &(*proto).inner,
+        overlay,
+    ) {
+        return set_error(draw_err_to_errno(&e));
+    }
+    0
+}
+
 /// Decode tracked model outputs and draw masks directly onto a destination image.
 ///
 /// This is the fused tracked path: for segmentation models, prototype data is

--- a/crates/decoder/src/decoder/merge.rs
+++ b/crates/decoder/src/decoder/merge.rs
@@ -716,7 +716,12 @@ fn execute_channel_concat(
 ) -> DecoderResult<ArrayD<f32>> {
     let mut parts = Vec::with_capacity(children.len());
     for child in children {
-        parts.push(find_and_dequantize(inputs, &child.shape, child.quant, used)?);
+        parts.push(find_and_dequantize(
+            inputs,
+            &child.shape,
+            child.quant,
+            used,
+        )?);
     }
     let views: Vec<_> = parts.iter().map(|a| a.view()).collect();
     let mut merged =
@@ -1935,5 +1940,125 @@ mod tests {
             "{}",
             scores_out[[0, 0, 2]]
         );
+    }
+
+    // ------------------------------------------------------------------
+    // find_and_dequantize: permutation-aware fallback tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn find_and_dequantize_exact_match_preferred() {
+        // When the tensor shape matches exactly, no permutation is applied.
+        let t = make_f32_tensor(&[1, 3, 4], &[1.0; 12]);
+        let inputs: Vec<&TensorDyn> = vec![&t];
+        let mut used = Vec::new();
+        let arr = find_and_dequantize(&inputs, &[1, 3, 4], None, &mut used).unwrap();
+        assert_eq!(arr.shape(), &[1, 3, 4]);
+        assert_eq!(used, vec![0]);
+    }
+
+    #[test]
+    fn find_and_dequantize_permuted_nhwc_to_nchw() {
+        // Tensor is NCHW [1, 3, 2, 2] but expected is NHWC [1, 2, 2, 3].
+        // The fallback should detect the axis permutation and transpose.
+        //
+        // Data in C-contiguous NCHW order (channel-major):
+        //   C0: [[1, 2], [3, 4]]
+        //   C1: [[5, 6], [7, 8]]
+        //   C2: [[9, 10], [11, 12]]
+        let t = make_f32_tensor(
+            &[1, 3, 2, 2],
+            &[
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ],
+        );
+        let inputs: Vec<&TensorDyn> = vec![&t];
+        let mut used = Vec::new();
+        let arr = find_and_dequantize(&inputs, &[1, 2, 2, 3], None, &mut used).unwrap();
+        assert_eq!(arr.shape(), &[1, 2, 2, 3]);
+        // After NCHW→NHWC, pixel (0,0) should have channels [1, 5, 9],
+        // pixel (0,1) should be [2, 6, 10], etc.
+        assert_eq!(arr[[0, 0, 0, 0]], 1.0);
+        assert_eq!(arr[[0, 0, 0, 1]], 5.0);
+        assert_eq!(arr[[0, 0, 0, 2]], 9.0);
+        assert_eq!(arr[[0, 0, 1, 0]], 2.0);
+        assert_eq!(arr[[0, 0, 1, 1]], 6.0);
+        assert_eq!(arr[[0, 0, 1, 2]], 10.0);
+        assert_eq!(arr[[0, 1, 0, 0]], 3.0);
+        assert_eq!(arr[[0, 1, 0, 1]], 7.0);
+        assert_eq!(arr[[0, 1, 0, 2]], 11.0);
+    }
+
+    #[test]
+    fn find_and_dequantize_stripped_trailing_unit_dim() {
+        // Tensor reported as [1, 6] (trailing unit dim stripped) but
+        // expected shape is [1, 6, 1]. The fallback should pad with
+        // trailing 1s and find an identity permutation.
+        let t = make_f32_tensor(&[1, 6], &[10.0, 20.0, 30.0, 40.0, 50.0, 60.0]);
+        let inputs: Vec<&TensorDyn> = vec![&t];
+        let mut used = Vec::new();
+        let arr = find_and_dequantize(&inputs, &[1, 6, 1], None, &mut used).unwrap();
+        assert_eq!(arr.shape(), &[1, 6, 1]);
+        assert_eq!(arr[[0, 0, 0]], 10.0);
+        assert_eq!(arr[[0, 5, 0]], 60.0);
+    }
+
+    #[test]
+    fn find_and_dequantize_skips_already_used() {
+        // Two tensors with same element count; the first is already
+        // consumed so the fallback must select the second.
+        let t0 = make_f32_tensor(&[2, 3], &[0.0; 6]);
+        let t1 = make_f32_tensor(&[3, 2], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let inputs: Vec<&TensorDyn> = vec![&t0, &t1];
+        let mut used = vec![0]; // t0 already consumed
+        let arr = find_and_dequantize(&inputs, &[2, 3], None, &mut used).unwrap();
+        assert_eq!(arr.shape(), &[2, 3]);
+        assert!(used.contains(&1));
+        // t1 is [3, 2] permuted to [2, 3]: rows of t1 become columns
+        assert_eq!(arr[[0, 0]], 1.0);
+        assert_eq!(arr[[0, 1]], 3.0);
+        assert_eq!(arr[[0, 2]], 5.0);
+        assert_eq!(arr[[1, 0]], 2.0);
+        assert_eq!(arr[[1, 1]], 4.0);
+        assert_eq!(arr[[1, 2]], 6.0);
+    }
+
+    #[test]
+    fn find_and_dequantize_no_match_returns_error() {
+        // Element count doesn't match any candidate.
+        let t = make_f32_tensor(&[2, 5], &[0.0; 10]);
+        let inputs: Vec<&TensorDyn> = vec![&t];
+        let mut used = Vec::new();
+        let result = find_and_dequantize(&inputs, &[3, 4], None, &mut used);
+        assert!(result.is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // find_axis_permutation unit tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn find_axis_permutation_identity() {
+        let perm = find_axis_permutation(&[1, 3, 4], &[1, 3, 4]);
+        assert_eq!(perm, Some(vec![0, 1, 2]));
+    }
+
+    #[test]
+    fn find_axis_permutation_nhwc_to_nchw() {
+        // NCHW [1, 3, 2, 2] → NHWC [1, 2, 2, 3]
+        // Perm should map: out[0]=in[0], out[1]=in[2], out[2]=in[3], out[3]=in[1]
+        let perm = find_axis_permutation(&[1, 3, 2, 2], &[1, 2, 2, 3]);
+        assert_eq!(perm, Some(vec![0, 2, 3, 1]));
+    }
+
+    #[test]
+    fn find_axis_permutation_no_match() {
+        // Different dimension multisets
+        assert_eq!(find_axis_permutation(&[1, 3, 4], &[1, 4, 5]), None);
+    }
+
+    #[test]
+    fn find_axis_permutation_different_lengths() {
+        assert_eq!(find_axis_permutation(&[1, 3], &[1, 3, 1]), None);
     }
 }

--- a/crates/decoder/src/decoder/merge.rs
+++ b/crates/decoder/src/decoder/merge.rs
@@ -1958,7 +1958,7 @@ mod tests {
     }
 
     #[test]
-    fn find_and_dequantize_permuted_nhwc_to_nchw() {
+    fn find_and_dequantize_permuted_nchw_to_nhwc() {
         // Tensor is NCHW [1, 3, 2, 2] but expected is NHWC [1, 2, 2, 3].
         // The fallback should detect the axis permutation and transpose.
         //
@@ -2044,7 +2044,7 @@ mod tests {
     }
 
     #[test]
-    fn find_axis_permutation_nhwc_to_nchw() {
+    fn find_axis_permutation_nchw_to_nhwc() {
         // NCHW [1, 3, 2, 2] → NHWC [1, 2, 2, 3]
         // Perm should map: out[0]=in[0], out[1]=in[2], out[2]=in[3], out[3]=in[1]
         let perm = find_axis_permutation(&[1, 3, 2, 2], &[1, 2, 2, 3]);

--- a/crates/decoder/src/decoder/merge.rs
+++ b/crates/decoder/src/decoder/merge.rs
@@ -454,8 +454,7 @@ fn execute_merge(
             quant,
             ..
         } => {
-            let t = find_unused_tensor_by_shape(inputs, shape, used)?;
-            let mut arr = tensor_to_f32(t, *quant)?;
+            let mut arr = find_and_dequantize(inputs, shape, *quant, used)?;
             for &ax in padding_axes {
                 if ax < arr.ndim() && arr.shape()[ax] == 1 {
                     arr = arr.remove_axis(Axis(ax));
@@ -518,6 +517,101 @@ fn find_unused_tensor_by_shape<'a>(
          bound tensors are excluded; pass inputs in schema child order, \
          or use name-keyed decode once available)"
     )))
+}
+
+/// Find tensor by shape, dequantize to f32, and transpose to match the
+/// expected shape if needed.
+///
+/// Tries exact shape match first. When that fails (common in GStreamer /
+/// NNStreamer pipelines where the framework reports dimensions in
+/// innermost-first order while the v2 schema uses standard row-major
+/// shapes), falls back to element-count matching with axis permutation.
+///
+/// The permutation is derived by matching dimension sizes between the
+/// tensor's natural shape and the expected shape. When the tensor has
+/// fewer dimensions (e.g. trailing unit dims were stripped), it is
+/// padded with trailing 1s before matching.
+fn find_and_dequantize(
+    inputs: &[&TensorDyn],
+    expected_shape: &[usize],
+    quant: Option<Quantization>,
+    used: &mut Vec<usize>,
+) -> DecoderResult<ArrayD<f32>> {
+    // Fast path: exact shape match
+    if let Ok(t) = find_unused_tensor_by_shape(inputs, expected_shape, used) {
+        return tensor_to_f32(t, quant);
+    }
+
+    // Fallback: element-count match with axis permutation
+    let expected_count: usize = expected_shape.iter().product();
+    for (i, t) in inputs.iter().enumerate() {
+        if used.contains(&i) {
+            continue;
+        }
+        let count: usize = t.shape().iter().product();
+        if count != expected_count {
+            continue;
+        }
+        // Pad tensor shape with trailing 1s to match expected ndim
+        let mut padded_shape = t.shape().to_vec();
+        while padded_shape.len() < expected_shape.len() {
+            padded_shape.push(1);
+        }
+        if let Some(perm) = find_axis_permutation(&padded_shape, expected_shape) {
+            used.push(i);
+            let arr = tensor_to_f32(t, quant)?;
+            // Reshape to padded ndim (adds trailing unit dims, no data move)
+            let mut arr = if arr.ndim() < expected_shape.len() {
+                arr.into_shape_with_order(IxDyn(&padded_shape))
+                    .map_err(DecoderError::NDArrayShape)?
+            } else {
+                arr
+            };
+            // Transpose axes to match expected shape. permuted_axes
+            // reorders strides (zero-copy view), then as_standard_layout
+            // produces a C-contiguous copy with data in the new order.
+            arr = arr.permuted_axes(IxDyn(&perm));
+            arr = arr.as_standard_layout().to_owned();
+            debug_assert_eq!(arr.shape(), expected_shape);
+            return Ok(arr);
+        }
+    }
+
+    Err(DecoderError::InvalidShape(format!(
+        "no remaining input tensor matches shape {expected_shape:?} \
+         (tried exact match and element-count + permutation; already \
+         bound tensors are excluded)"
+    )))
+}
+
+/// Find the axis permutation that transforms `from` into `to`.
+///
+/// Returns `None` if no permutation exists (different multiset of
+/// dimension sizes or different lengths). When repeated dimension
+/// sizes occur (e.g. 160×160 spatial dims), they are matched in order
+/// which preserves their relative axis positions.
+fn find_axis_permutation(from: &[usize], to: &[usize]) -> Option<Vec<usize>> {
+    if from.len() != to.len() {
+        return None;
+    }
+    let n = from.len();
+    let mut perm = vec![0usize; n];
+    let mut bound = vec![false; n];
+    for (i, &target_dim) in to.iter().enumerate() {
+        let mut found = false;
+        for (j, &source_dim) in from.iter().enumerate() {
+            if !bound[j] && source_dim == target_dim {
+                perm[i] = j;
+                bound[j] = true;
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            return None;
+        }
+    }
+    Some(perm)
 }
 
 /// Dequantize (if integer) or cast (if float) a TensorDyn to an owned
@@ -595,8 +689,7 @@ fn execute_channel_concat(
 ) -> DecoderResult<ArrayD<f32>> {
     let mut parts = Vec::with_capacity(children.len());
     for child in children {
-        let t = find_unused_tensor_by_shape(inputs, &child.shape, used)?;
-        parts.push(tensor_to_f32(t, child.quant)?);
+        parts.push(find_and_dequantize(inputs, &child.shape, child.quant, used)?);
     }
     let views: Vec<_> = parts.iter().map(|a| a.view()).collect();
     let mut merged =
@@ -647,8 +740,7 @@ fn execute_per_scale(
     let mut feature_count: Option<usize> = None;
     let mut batch: Option<usize> = None;
     for (idx, child) in children.iter().enumerate() {
-        let t = find_unused_tensor_by_shape(inputs, &child.shape, used)?;
-        let arr = tensor_to_f32(t, child.quant)?;
+        let arr = find_and_dequantize(inputs, &child.shape, child.quant, used)?;
         let (b, features, part) = child_to_batch_feature_spatial(arr, child)?;
         match batch {
             None => batch = Some(b),

--- a/crates/decoder/src/decoder/mod.rs
+++ b/crates/decoder/src/decoder/mod.rs
@@ -790,6 +790,14 @@ impl Decoder {
         outputs: &[&edgefirst_tensor::TensorDyn],
         output_boxes: &mut Vec<DetectBox>,
     ) -> Result<Option<ProtoData>, DecoderError> {
+        // Schema v2 merge path: dequantize physical children into
+        // logical float32 tensors, then feed through the float dispatch.
+        if let Some(program) = &self.decode_program {
+            let merged = program.execute(outputs)?;
+            let views: Vec<_> = merged.iter().map(|a| a.view()).collect();
+            return self.decode_float_proto(&views, output_boxes);
+        }
+
         let mapped = tensor_bridge::map_tensors(outputs)?;
         match &mapped {
             tensor_bridge::MappedOutputs::Quantized(maps) => {


### PR DESCRIPTION
## Summary

Two follow-up fixes on top of the batched-GEMM mask work that was already merged:

### fix(decoder): defensive handling of CHW dimension ordering in merge program
The Ara-2 tensor_filter now correctly reports dimensions in NNStreamer's innermost-first convention, but these changes add defensive handling so the decoder is resilient to any future dimension ordering variations.

- Add merge-program path to `decode_proto()` (was missing, only `decode()` had it)
- Add permutation-aware tensor matching in `find_and_dequantize()`: tries exact shape match first, falls back to element-count matching with axis permutation detection
- Add `find_axis_permutation()` helper for detecting dimension reordering (e.g. NHWC↔NCHW)
- Update `execute_merge()`, `execute_channel_concat()`, `execute_per_scale()` to use flexible matching

### feat(capi): add hal_image_processor_draw_proto_masks API
Add C API function for fused GPU-accelerated proto mask rendering. Takes pre-decoded boxes and raw `proto_data` from the decoder, computing `mask_coeff @ protos` at full output resolution with bilinear sampling via the GLES 3.1 compute shader path. Used by edgefirstoverlay's fused rendering path.

All 286 existing decoder tests pass.