### PR TITLE
Add cross-document Optimization Guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1267,6 +1267,22 @@ Run: `perf record -F 997 --call-graph dwarf -- python tests/profile_decode_rende
 
 ## Performance Considerations
 
+This section is the **architecture-level reference** for the
+[Optimization Guide in README.md][readme-opt]. The README states the rules;
+this section explains why each rule exists and what fails when it is broken.
+
+| Rule (from README) | Why it matters at the architecture level |
+|--------------------|------------------------------------------|
+| Reuse tensors across frames | Each new tensor allocates a fresh `BufferIdentity` (monotonic atomic counter, see `crates/tensor/src/lib.rs::BufferIdentity`). The EGL image cache is keyed by `(BufferIdentity.id, chroma_id)` (see `crates/image/src/gl/cache.rs::EglCacheKey`). New ID → cache miss → full `eglCreateImageKHR` import. See [§ C API Performance Recommendations](#c-api-performance-recommendations-dma-buf--egl-path) below. |
+| Allocate via `ImageProcessor::create_image()` | The processor selects DMA-buf, PBO, or heap based on a runtime GPU probe at `ImageProcessor::new()` time. Bypassing this with `Tensor::new(memory=...)` forces a slow transfer path on every `convert()`. See [§ Memory Allocation Strategy](#memory-allocation-strategy). |
+| Cache imported camera tensors by inode | DMA-BUF fd numbers are recycled across V4L2 / libcamera buffer pools. The inode is the only stable identifier for the underlying `dma_buf` kernel object. See [§ Appendix C — DMA-BUF Identity and Tensor Caching](#appendix-c-dma-buf-identity-and-tensor-caching). |
+| Build the decoder once | `DecoderBuilder` parses the model output schema, resolves quantization parameters, and allocates internal working buffers. See [§ Decoder Optimization](#decoder-optimization). |
+| One `ImageProcessor` per pipeline | Each instance owns an EGL display, a GL thread, and per-thread caches. Multiple instances serialize on the global `GL_MUTEX`. See [§ GL Command Serialization (GL_MUTEX)](#gl-command-serialization-gl_mutex). |
+| Native CPU feature builds (Rule 6) | Not an architectural pattern — a build-time concern. `RUSTFLAGS` controls whether the f16 mask kernel at `crates/image/src/cpu/masks.rs` compiles to native widening instructions or to the soft-float `__extendhfsf2` helper. Distributed binaries stay on the target triple's baseline ISA so a single binary runs on every CPU within that triple; benchmark hosts opt in via `RUSTFLAGS` overrides. See [README.md § Rule 6][readme-rule6]. |
+
+[readme-opt]: README.md#optimization-guide
+[readme-rule6]: README.md#rule-6--local-fp16--avx-build-overrides
+
 ### Memory Allocation Strategy
 
 The choice of memory type significantly impacts performance depending on the workload:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -817,6 +817,27 @@ flowchart LR
     style HW fill:#90ee90
 ```
 
+**NumPy → Tensor Copy Strategy** (`crates/python/src/tensor.rs`,
+`copy_numpy_to_tensor_dyn`): the binding inspects the source array's
+strides and dispatches to one of three paths to balance copy cost
+against allocation overhead:
+
+| Path | Source layout | Strategy | Cost |
+|---|---|---|---|
+| 1 | Fully contiguous | `copy_from_slice` (memcpy), rayon-parallel ≥ 256 KiB | Lower bound — no allocation |
+| 2 | Strided with contiguous inner rows (column slice, sub-volume, negative stride) | Per-row memcpy, iterate outer dimensions | Within ≈ 5 % of Path 1 for typical row sizes |
+| 3 | Fully strided (transposed view, every-other-element) | Internal `np.ascontiguousarray()` (numpy's vectorised C strided→contig pass), then Path 1 memcpy | ≈ 4× Path 1 — but ≈ 4× faster than the legacy element-wise iteration the binding used to do here |
+
+Path 3 is the case that bit early users: a HailoRT output naturally
+arrives as `arr.transpose(0, 2, 1)` over a `(1, anchors, channels)`
+buffer, which has no contiguous inner row. The legacy element-wise
+loop incurred stride arithmetic and broke vectorisation. PR #58
+replaced it with the `np.ascontiguousarray` materialisation path.
+Callers therefore no longer need to maintain a manual
+`np.ascontiguousarray()` workaround above HAL — see
+[README § Rule 7](README.md#rule-7--numpy-interop-pass-arrays-straight-to-from_numpy)
+for the user-facing rule.
+
 ### Cross-Crate Dependencies
 
 The `edgefirst_image` crate depends on `edgefirst_decoder` for the `DetectBox`, `ProtoData`, and `Segmentation` types used in the mask rendering APIs (`draw_decoded_masks`, `draw_proto_masks`). This means the image crate imports decoder types but does not import the `Decoder` itself — it only needs the output data structures that describe detections and masks.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -12,6 +12,50 @@ This document tracks EdgeFirst HAL performance across target platforms. It serve
 
 The benchmarking strategy tests **all compute backends** (CPU, OpenGL, G2D) with **all applicable buffer strategies** (DMA-buf, PBO, Sync) on every platform, including forcing non-default buffer paths on platforms that would normally prefer a different strategy. This ensures the full fallback chain is exercised and performance characteristics are understood for every deployment scenario.
 
+## Optimization Performance Reference
+
+This section is the **benchmark-level reference** for the
+[Optimization Guide in README.md](README.md#optimization-guide). The README
+states the rules, [ARCHITECTURE.md] explains the mechanism behind each rule,
+and the table below quantifies the cost of breaking it on each platform.
+
+| Rule (from README) | Benchmark | Cost when broken |
+|--------------------|-----------|------------------|
+| Reuse tensors across frames | [§ Tensor Reuse Impact](#tensor-reuse-impact) | i.MX 95 (Mali): **3.3×**; i.MX 8MP (Vivante): **1.7×**; x86 PBO: 1.0× |
+| Cache imported camera tensors by inode | [§ Tensor Reuse Impact](#tensor-reuse-impact) (recreate variant); see also [ARCHITECTURE.md § Appendix C][arch-appendix-c] | Equivalent to recreating the source tensor every frame: 3.5 ms penalty per `convert()` on i.MX 95; 2.2 ms on i.MX 8MP |
+| Allocate via `ImageProcessor::create_image()` | [§ Image Preprocessing: Letterbox Pipeline](#image-preprocessing-letterbox-pipeline-camera--model-input) | Forced wrong-backend transfer adds the cost of a `glTexSubImage2D` upload (≈full conversion time) on every frame |
+| Build the decoder once | [§ Decoder Post-Processing](#decoder-post-processing) | Decoder construction parses the model schema and allocates working buffers — cost depends on output schema complexity |
+| One `ImageProcessor` per pipeline thread | [ARCHITECTURE.md § GL Command Serialization (GL_MUTEX)][gl-mutex] | Concurrent `convert()` calls serialize through a global mutex; effective throughput drops to single-threaded regardless of core count |
+| Native CPU feature builds (Rule 6) | [§ materialize_masks Batched-GEMM Optimisation](#materialize_masks-batched-gemm-optimisation) | Soft-float f16 helpers (`__extendhfsf2`) are measurably slower than native `fcvt` / `vcvtph2ps` on the mask kernel hot path; the exact factor depends on vector width and CPU. Verify with `scripts/audit_f16_codegen.sh`. |
+
+[ARCHITECTURE.md]: ARCHITECTURE.md
+[gl-mutex]: ARCHITECTURE.md#gl-command-serialization-gl_mutex
+[arch-appendix-c]: ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching
+
+### How to Reproduce the Numbers
+
+The empirical penalties above all come from `bench_preproc` (the C
+preprocessing benchmark). It deliberately measures three variants of the
+same pipeline:
+
+| Variant | What it does | Maps to README rule |
+|---------|--------------|--------------------|
+| `reuse` | Single source tensor held alive for all 100 frames | Rule 1 followed |
+| `recreate` | Source tensor freed and reallocated every frame | Rule 1 broken (or Rule 3 broken with fd recycling) |
+| `pool` | Round-robin through 4 pre-allocated source tensors | Rule 1 followed with multiple in-flight buffers (V4L2 pool simulation) |
+
+`pool` matches `reuse` to within 4% on every embedded platform, confirming
+that the EGL image cache scales correctly with pool depth. `recreate` is
+the failure mode that an inode-keyed cache (Rule 3) prevents.
+
+See [§ Running `bench_preproc`](#running-bench_preproc) below for the
+build and deployment commands. See [TESTING.md § Validating Optimizations][test-opt]
+for how to verify your own integration follows each rule.
+
+[test-opt]: TESTING.md#validating-optimizations
+
+---
+
 ## Benchmarking Strategy
 
 ### Compute Backends
@@ -583,7 +627,7 @@ On i.MX 8MP, where the per-convert budget is already tighter due to Vivante driv
 
 ```bash
 # Cross-compile for aarch64
-cargo-zigbuild zigbuild --target aarch64-unknown-linux-gnu --release -p edgefirst-capi
+cargo-zigbuild zigbuild --target aarch64-unknown-linux-gnu --release -p edgefirst-hal-capi
 
 # The C benchmark is built by the capi crate's build.rs; the binary is at:
 #   target/aarch64-unknown-linux-gnu/release/bench_preproc

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -27,6 +27,8 @@ and the table below quantifies the cost of breaking it on each platform.
 | Build the decoder once | [§ Decoder Post-Processing](#decoder-post-processing) | Decoder construction parses the model schema and allocates working buffers — cost depends on output schema complexity |
 | One `ImageProcessor` per pipeline thread | [ARCHITECTURE.md § GL Command Serialization (GL_MUTEX)][gl-mutex] | Concurrent `convert()` calls serialize through a global mutex; effective throughput drops to single-threaded regardless of core count |
 | Native CPU feature builds (Rule 6) | [§ materialize_masks Batched-GEMM Optimisation](#materialize_masks-batched-gemm-optimisation) | Soft-float f16 helpers (`__extendhfsf2`) are measurably slower than native `fcvt` / `vcvtph2ps` on the mask kernel hot path; the exact factor depends on vector width and CPU. Verify with `scripts/audit_f16_codegen.sh`. |
+| Pass numpy arrays straight to `from_numpy()` (Rule 7) | [§ NumPy Interop Fast-Path](#numpy-interop-fast-path) | A redundant `np.ascontiguousarray` pre-copy on every call. Sized example: `(1, 116, 8400)` f32 transposed view on rpi5-hailo runs ≈ 6.5 ms in HAL's automatic fast path vs ≈ 27 ms in the legacy element-wise loop (4× faster); pre-applying `ascontiguousarray` above HAL adds a redundant copy of the same magnitude. |
+| Use `MaskResolution::Scaled` for COCO eval (Rule 8) | [§ materialize_masks Batched-GEMM Optimisation](#materialize_masks-batched-gemm-optimisation) | Threshold-then-upsample (`Proto` followed by binary `cv2.resize`) regresses mask mAP by 0.04–0.05 absolute on YOLOv8-seg / `coco128-seg`. The `Scaled` path is also faster at N ≥ 16 because the batched GEMM amortises across detections instead of being repeated per-detection in caller code. |
 
 [ARCHITECTURE.md]: ARCHITECTURE.md
 [gl-mutex]: ARCHITECTURE.md#gl-command-serialization-gl_mutex
@@ -488,6 +490,44 @@ with the env-gated `EDGEFIRST_LEGACY_MATERIALIZE=1` toggle.
 - The Scaled path is a clear win on every tested platform from N=2
   upward, scaling cleanly to ~9–45× at N=100 depending on cache hierarchy
   and SIMD width.
+
+### NumPy Interop Fast-Path
+
+`Tensor.from_numpy()` (and the implicit numpy → HAL conversions used by
+`Decoder.decode_proto()` and friends) selects one of three paths in
+`copy_numpy_to_tensor_dyn` (`crates/python/src/tensor.rs:339`) based on
+the source array's strides:
+
+| Path | Source layout | Strategy |
+|---|---|---|
+| 1 | Fully contiguous | Single `copy_from_slice` (memcpy), rayon-parallel ≥ 256 KiB |
+| 2 | Strided with contiguous inner rows | Per-row memcpy iterating outer dimensions |
+| 3 | Fully strided (no contiguous inner row) | Internal `np.ascontiguousarray()` materialisation, then Path 1 memcpy |
+
+The Path 3 pattern matches the layout HailoRT returns natively: a
+`(1, channels, anchors)` view obtained by `arr.transpose(0, 2, 1)`
+over a `(1, anchors, channels)` backing buffer. Prior to PR #58, the
+Path 3 branch iterated element-by-element over the strided ndarray
+view, which broke vectorisation and incurred stride arithmetic per
+load. The fix calls `np.ascontiguousarray()` internally, which uses
+numpy's vectorized C strided→contig pass, then falls back to the
+Path 1 memcpy.
+
+**rpi5-hailo, `(1, 116, 8400)` f32 transposed view:**
+
+| Variant | Time per call | Ratio vs fast path |
+|---|---|---|
+| Manual `np.ascontiguousarray + from_numpy(contig)` (legacy workaround) | ≈ 6.5 ms | 1.00× (baseline) |
+| `from_numpy(strided)` automatic fast path (PR #58) | ≈ 6.5 ms | 1.0–1.5× (perf-sanity test bound) |
+| `from_numpy(strided)` legacy element-wise loop | ≈ 27 ms | ≈ 4× slower |
+
+**Implication for callers:** drop manual `np.ascontiguousarray()`
+workarounds — the fast path is automatic. Pre-applying it above HAL
+adds a redundant copy.
+
+The behaviour is pinned by `test_from_numpy_hailort_shape` (correctness)
+and `test_from_numpy_hailort_shape_perf_sanity` (≤ 1.5× slower than the
+manual workaround) in `tests/test_tensor.py`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- **Restore `materialize_masks` parallelism + logit-precompute (regressed
+  by PR #51).** PR #54 originally added rayon `par_iter` across
+  detections plus a batched-GEMM-style precompute that hoisted the
+  K-wide dot-product out of the per-output-pixel inner loop. PR #51
+  (EDGEAI-1244 f16 dispatch refactor) inadvertently rewrote both
+  `materialize_segmentations` (Proto) and `materialize_scaled_segmentations`
+  (Scaled) to use serial `.iter()` and per-output-pixel bilinear-sample-
+  then-dot, silently dropping both optimisations. Restoring them:
+  - `materialize_segmentations`: rayon parallel across detections, with
+    the proto-tensor `map()` guard acquired once per call instead of
+    once per detection.
+  - `materialize_scaled_segmentations`: rayon parallel across detections
+    plus a per-detection logit-precompute pass — for each detection,
+    compute f32 logits at every proto-plane ROI pixel via a single
+    K-wide dot, then bilinear-interpolate the scalar logit at every
+    output pixel before applying sigmoid + threshold. Crucially the
+    bilinear upsample still operates on continuous logits, not on the
+    sigmoid-quantised u8, so accuracy is preserved.
+  Measured on imx8mp-frdm with the corrected ara2-validator on
+  coco128-seg (N=119 avg detections per image, max_det=300,
+  score_threshold=0.001):
+    `materialize_hal` mean **569 ms → 33 ms (17× faster)**;
+    mask mAP unchanged at 0.3220 (vs the dvapi/numpy reference's 0.3221
+    — 0.0001 absolute drift).
+
 ### Changed
 
 - **`Tensor.from_numpy()` fast path for fully-strided sources.** A numpy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   manual `np.ascontiguousarray(...)` workaround can now drop it; the
   fast path is automatic.
 
+### Documentation
+
+- **Optimization Guide refresh: NumPy interop and `MaskResolution`
+  doctrine.** The cross-document Optimization Guide gains two new
+  rules and matching cost-table rows:
+  - **Rule 7 — NumPy interop:** pass numpy arrays straight to
+    `Tensor.from_numpy()`; do not pre-`ascontiguousarray()`. Documents
+    the three internal paths (`copy_numpy_to_tensor_dyn`), the narrow
+    case where pre-materialising still helps (a single strided view
+    fed many times), and the rpi5-hailo numbers (≈ 6.5 ms automatic
+    fast path vs ≈ 27 ms legacy element-wise loop).
+  - **Rule 8 — `MaskResolution` selection:** for COCO / IoU evaluation
+    use `MaskResolution::Scaled(orig_w, orig_h)`. The default
+    `MaskResolution::Proto` returns continuous sigmoid values at proto
+    resolution; if a downstream caller thresholds those *before*
+    upsampling (the natural-looking but wrong order), edges become
+    blocky and mask mAP regresses by 0.04–0.05 absolute on YOLOv8-seg
+    / `coco128-seg`. `Scaled` performs the upsample inside HAL's
+    batched-GEMM kernel and thresholds afterwards.
+  Touches `README.md` (rule table + Rule 7/8 sections),
+  `BENCHMARKS.md` (cost table + NumPy Interop Fast-Path section),
+  `ARCHITECTURE.md` (three-path strategy under Python Bindings), and
+  `TESTING.md` (validation pointers to `test_from_numpy_hailort_shape`
+  and `MaskResolution.Scaled` smoke checks).
+
 ## [0.18.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ rule exists, and [TESTING.md] for how to verify your integration follows it.
 | Cache imported camera tensors by **inode**, not by fd | v4l2 / libcamera recycle fd numbers across a small buffer pool; an fd-keyed cache misses on every frame even when the physical buffer is the same | Full EGL re-import per frame (≈0.5–1.5 ms on Vivante, multiplied by source + chroma planes) |
 | Build `Decoder` once, decode many | Decoder construction parses model metadata and allocates working buffers | Parse + alloc cost per frame |
 | Construct one `ImageProcessor` per pipeline | Each instance owns its own GL context and EGL display | Multiple GL contexts contend on `GL_MUTEX`; see ARCHITECTURE.md |
+| Pass numpy arrays straight to `Tensor.from_numpy()` — do not pre-`ascontiguousarray()` | HAL detects strided sources and materialises via numpy's vectorized C strided→contig pass; a manual workaround above HAL adds a redundant copy | A redundant `np.ascontiguousarray` pre-copy on every call (size-dependent; e.g. ≈1.5 ms per call on a `(1, 116, 8400)` f32 view on rpi5-hailo) |
+| For COCO/IoU evaluation use `MaskResolution::Scaled(orig_w, orig_h)`, not `Proto` | `Scaled` upsamples the continuous-sigmoid proto plane *before* thresholding (clean edges); `Proto` returns continuous values but most callers threshold-then-resize, which produces blocky binary edges and lossy mAP | Mask mAP regression of up to 0.04–0.05 absolute (model- and dataset-dependent) when `Proto` is thresholded then nearest-upsampled |
 
 > [!IMPORTANT]
 > The single most common performance bug is calling
@@ -723,6 +725,94 @@ x86_64 with `+f16c,+fma` — an explicit 8-lane `_mm256_cvtph_ps +
 _mm256_fmadd_ps` intrinsic path is also enabled via cfg gate. The
 helper `scripts/audit_f16_codegen.sh` disassembles a release build
 of the kernel and confirms native instructions are emitted.
+
+### Rule 7 — NumPy interop: pass arrays straight to `from_numpy()`
+
+`Tensor.from_numpy()` (and the implicit copy from numpy arrays passed
+to `Decoder.decode_proto()` etc.) handles strided / non-contiguous
+sources internally. Callers should **not** maintain a manual
+`np.ascontiguousarray()` workaround — it wastes a copy.
+
+The Python binding's `copy_numpy_to_tensor_dyn` selects one of three
+paths based on the source array's layout:
+
+| Source layout | Path | Cost |
+|---|---|---|
+| **Fully contiguous** | Single `copy_from_slice` (memcpy), rayon-parallel ≥ 256 KiB | Lower bound |
+| **Strided with contiguous inner rows** (e.g. column slice, sub-volume, negative stride) | Per-row memcpy iterating outer dimensions | ≈ same as fully contiguous |
+| **Fully strided** (e.g. transposed view, every-other-element) | Internal `np.ascontiguousarray()` materialisation, then Path 1 memcpy | ≈ 4× the contiguous cost |
+
+The fully-strided case is the one that bites users in practice — it
+matches the layout HailoRT returns natively (a `(1, channels, anchors)`
+f32 view obtained by `arr.transpose(0, 2, 1)` over a `(1, anchors,
+channels)` backing buffer). On `rpi5-hailo` with `(1, 116, 8400)` f32,
+the legacy element-wise iteration ran ≈ 27 ms / call; the current
+fast path runs ≈ 6.5 ms / call — close to the manual
+`np.ascontiguousarray + from_numpy(contig)` workaround that callers
+used to maintain.
+
+```python
+# Wrong (post-PR #58): adds an extra copy above HAL.
+arr_contig = np.ascontiguousarray(arr_strided)
+tensor.from_numpy(arr_contig)
+
+# Right: HAL detects the strided layout and materialises internally.
+tensor.from_numpy(arr_strided)
+```
+
+**Narrow case where pre-materialising still helps:** if the same
+strided view is fed into HAL many times in a tight loop (e.g. reusing
+a transposed numpy intermediary across frames), pre-`ascontiguousarray`
+*once outside the loop* amortises the strided→contig cost. Inside the
+loop, just call `from_numpy()` on the cached contiguous array. This
+is rare in practice.
+
+This was previously a footgun because the legacy Path 3 iterated
+element-by-element over the strided view, which broke vectorisation
+and incurred stride arithmetic per load. The fix landed in PR #58.
+The regression tests in `tests/test_tensor.py` (`test_from_numpy_hailort_shape`,
+`test_from_numpy_hailort_shape_perf_sanity`) pin the behaviour and
+the perf bound (≤ 1.5× slower than the manual workaround).
+
+### Rule 8 — Choose the correct `MaskResolution` for your evaluation
+
+`ImageProcessor.materialize_masks()` accepts a `MaskResolution`
+parameter that controls **where the sigmoid threshold is applied**
+along the materialisation pipeline. The choice changes both the
+output dtype and the achievable mask-mAP:
+
+| Mode | Output | Sigmoid → threshold pipeline | When to use |
+|---|---|---|---|
+| `MaskResolution::Proto` (default) | `(roi_h, roi_w, 1)` u8 — **continuous sigmoid** [0, 255] at 160×160 proto resolution | dot → sigmoid → emit (no threshold) | Real-time visualisation where downstream code already does its own scale-aware thresholding, or when you specifically want continuous confidence values |
+| `MaskResolution::Scaled { width, height }` | `(roi_h, roi_w, 1)` u8 — **binary** {0, 255} at the requested resolution | dot → sigmoid → upsample to `(width, height)` → threshold (`>127`) | All COCO / IoU / mAP evaluation. Upsample-then-threshold preserves sub-proto-cell precision; the alternative (threshold-at-160 then upsample the binary mask) produces blocky 4-pixel-aligned edges and a measurable mAP regression |
+
+```python
+# Wrong: threshold then upsample → lossy edges, mAP regression.
+tiles_proto = proc.materialize_masks(boxes, scores, classes, proto_data,
+                                     letterbox=letterbox_norm)  # default = Proto
+for tile, box in zip(tiles_proto, boxes):
+    binary_proto = (tile[:, :, 0] > 127).astype(np.uint8)         # threshold first
+    canvas[y:y+h, x:x+w] = cv2.resize(binary_proto, (W, H),
+                                       interpolation=cv2.INTER_NEAREST)  # upsample binary
+
+# Right: HAL upsamples-then-thresholds inside its batched-GEMM kernel.
+tiles_scaled = proc.materialize_masks(boxes, scores, classes, proto_data,
+                                       letterbox=letterbox_norm,
+                                       resolution=hal.MaskResolution.Scaled(W, H))
+for tile, box in zip(tiles_scaled, boxes):
+    canvas[y:y+h, x:x+w] = (tile[:, :, 0] > 127).astype(np.uint8)  # already at orig res
+```
+
+The `Scaled` path goes through the batched-GEMM materialiser added in
+0.18.0 (PR #54). At N ≥ 16 detections it amortises a single GEMM at
+proto resolution across all detections, then upsamples per-detection
+in rayon-parallel — so it is *both* more accurate than threshold-then-
+resize and faster than per-detection scalar work in caller code.
+
+> [!TIP]
+> If you are seeing a mask-mAP gap between your HAL-based validator
+> and a reference (ONNX / numpy) implementation, this rule is almost
+> always the first thing to check.
 
 ### Where to Go Next
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install edgefirst-hal
 #### Rust
 ```toml
 [dependencies]
-edgefirst-hal = "0.13"
+edgefirst-hal = "0.18"
 ```
 
 ### Basic Usage
@@ -409,11 +409,65 @@ flowchart LR
 - IOCTL interface for DMA buffer operations
 - Version detection and capability queries
 
-## Creating GPU-Optimal Images
+## Optimization Guide
 
-`ImageProcessor::create_image()` is the **preferred way** to allocate images
-for use with `convert()`. It automatically selects the fastest available memory
-backend for the current GPU:
+This section establishes the core rules for getting the best performance from
+the HAL. Each rule below has a measurable cost when broken; see [BENCHMARKS.md]
+for the empirical penalty on each platform, [ARCHITECTURE.md] for *why* the
+rule exists, and [TESTING.md] for how to verify your integration follows it.
+
+| Rule | Why it matters | Measured penalty when broken |
+|------|----------------|------------------------------|
+| Reuse tensors across frames | Each new tensor mints a fresh `BufferIdentity`; the EGL image cache misses on every frame | 1.7–3.3× slower preprocessing on Vivante / Mali |
+| Allocate output tensors via `ImageProcessor::create_image()` | Auto-selects DMA-buf / PBO / heap based on the active GPU; bypassing this forces a slow transfer path | Forced `glTexSubImage2D` upload or full CPU readback |
+| Cache imported camera tensors by **inode**, not by fd | v4l2 / libcamera recycle fd numbers across a small buffer pool; an fd-keyed cache misses on every frame even when the physical buffer is the same | Full EGL re-import per frame (≈0.5–1.5 ms on Vivante, multiplied by source + chroma planes) |
+| Build `Decoder` once, decode many | Decoder construction parses model metadata and allocates working buffers | Parse + alloc cost per frame |
+| Construct one `ImageProcessor` per pipeline | Each instance owns its own GL context and EGL display | Multiple GL contexts contend on `GL_MUTEX`; see ARCHITECTURE.md |
+
+> [!IMPORTANT]
+> The single most common performance bug is calling
+> `Tensor::from_fd()` (or `import_image()`) on every frame from a v4l2 /
+> libcamera buffer pool. The HAL's internal EGL image cache cannot rescue
+> you here — the cache key includes a per-tensor monotonic ID that is fresh
+> on every import. The fix lives in the **calling code**, not in HAL.
+
+### Rule 1 — Reuse Tensors Across Frames
+
+Allocate input and output tensors once at pipeline startup; reuse the same
+objects on every frame. The DMA memory backing a tensor is live: when an
+upstream producer (V4L2 DQBUF, codec output, ISP) writes new pixels into it,
+the existing tensor and its cached EGLImage remain valid. No re-import, no
+re-allocation.
+
+```rust
+use edgefirst_image::{ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
+use edgefirst_tensor::{PixelFormat, DType};
+
+let mut proc = ImageProcessor::new()?;
+let mut dst = proc.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
+
+for frame in camera_frames {
+    proc.convert(&frame, &mut dst, Rotation::None, Flip::None, Crop::default())?;
+    run_inference(&dst)?;  // run_inference() is a stand-in — replace with your model call
+}
+```
+
+```python
+import edgefirst_hal as ef
+
+proc = ef.ImageProcessor()
+dst = proc.create_image(640, 640, ef.PixelFormat.Rgb)
+
+for frame in camera_frames:
+    proc.convert(frame, dst)
+    run_inference(dst)  # run_inference() is a stand-in — replace with your model call
+```
+
+### Rule 2 — Allocate via `ImageProcessor::create_image()`
+
+`ImageProcessor::create_image()` is the **preferred** way to allocate images
+for use with `convert()`. It automatically selects the fastest memory
+backend for the active GPU:
 
 | Priority | Backend | Transfer Method | Platforms |
 |----------|---------|-----------------|-----------|
@@ -429,7 +483,8 @@ same backend.
 pipeline loop. Creating images is relatively expensive (GPU buffer allocation,
 format negotiation); reusing them amortizes that cost over thousands of frames.
 
-### Rust
+**Rust** (same imports as Rule 1):
+
 ```rust
 let mut converter = ImageProcessor::new()?;
 
@@ -439,11 +494,12 @@ let mut output = converter.create_image(640, 640, PixelFormat::Rgb, DType::U8, N
 for frame in camera_frames {
     // Reuse output buffer each iteration — no allocation
     converter.convert(&frame, &mut output, Rotation::None, Flip::None, Crop::default())?;
-    run_inference(&output)?;
+    run_inference(&output)?;  // your model inference call
 }
 ```
 
-### Python
+**Python:**
+
 ```python
 converter = ef.ImageProcessor()
 
@@ -453,10 +509,11 @@ output = converter.create_image(640, 640, ef.PixelFormat.Rgb)
 for frame in camera_frames:
     # Reuse output buffer each iteration — no allocation
     converter.convert(frame, output)
-    run_inference(output)
+    run_inference(output)  # your model inference call
 ```
 
-### C
+**C:**
+
 ```c
 struct hal_image_processor *proc = hal_image_processor_new();
 
@@ -468,14 +525,14 @@ for (;;) {
     /* Reuse output buffer each iteration — no allocation */
     hal_image_processor_convert(proc, frame, output,
         HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
-    run_inference(output);
+    run_inference(output);  /* your model inference call */
 }
 
 hal_tensor_free(output);
 hal_image_processor_free(proc);
 ```
 
-### DMA-buf Permissions
+#### DMA-buf Permissions
 
 For the DMA-buf backend to be selected, the process needs access to
 `/dev/dma_heap/linux,cma` (or `/dev/dma_heap/system` on some kernels) and a
@@ -493,7 +550,7 @@ If DMA-buf allocation fails (insufficient permissions, no CMA region, or the
 GPU driver cannot import the resulting buffers), `create_image()` transparently
 falls back to PBO or heap memory with no API change required.
 
-### Platform GPU Support
+#### Platform GPU Support
 
 | Platform | GPU | `create_image()` backend | Notes |
 |----------|-----|--------------------------|-------|
@@ -503,7 +560,137 @@ falls back to PBO or heap memory with no API change required.
 | Generic x86_64 | Mesa (llvmpipe/iris) | DMA-buf or PBO | Depends on driver DMA-buf support |
 | No GPU / macOS | N/A | Mem | CPU fallback, still functional |
 
-### Local fp16 / AVX build overrides
+### Rule 3 — Cache Imported Camera Tensors by Inode, Not by fd
+
+V4L2, libcamera, and codec output all surface frames as DMA-BUF file
+descriptors drawn from a small fixed pool (typically 4–16 buffers). The fd
+*number* is recycled: the same fd value can refer to a different physical
+buffer between frames, and the same physical buffer can be exported with a
+different fd value over time. **A cache keyed by fd will produce false hits
+or false misses.**
+
+The kernel assigns each `dma_buf` object a unique inode in the anonymous
+inode filesystem. The inode is constant for the lifetime of the buffer
+regardless of how many times it is exported. Cache imported HAL tensors by
+`(inode, plane_offset)`.
+
+In C, retrieve the inode via [`fstat(2)`][fstat] on the dma_buf fd; the
+`st_ino` field is the stable identifier. The pattern below shows the
+lookup-or-import flow on every dequeued frame:
+
+[fstat]: https://man7.org/linux/man-pages/man2/fstat.2.html
+
+```c
+#include <sys/stat.h>
+
+typedef struct {
+    ino_t inode;
+    size_t offset;   /* per-plane offset within the dma_buf (NV12 etc.) */
+} BufferKey;
+
+/* On each input frame: */
+struct stat st;
+fstat(fd, &st);
+BufferKey key = { .inode = st.st_ino, .offset = plane_offset };
+
+struct hal_tensor *tensor = lookup_tensor(cache, &key);
+if (!tensor) {
+    /* First time seeing this physical buffer — import once. */
+    struct hal_plane_descriptor *pd = hal_plane_descriptor_new(fd);
+    tensor = hal_import_image(proc, pd, NULL, w, h,
+                              HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+    insert_tensor(cache, &key, tensor);
+}
+/* Reuse `tensor` for this frame; do NOT free it between frames. */
+hal_image_processor_convert(proc, tensor, dst, /* ... */);
+```
+
+```python
+import os
+
+# (inode, offset) -> ef.Tensor
+buffer_cache: dict[tuple[int, int], ef.Tensor] = {}
+
+def get_or_import(proc, fd, offset, width, height, fmt):
+    key = (os.fstat(fd).st_ino, offset)
+    tensor = buffer_cache.get(key)
+    if tensor is None:
+        tensor = proc.import_image(fd, width, height, fmt, "uint8",
+                                   offset=offset)
+        buffer_cache[key] = tensor
+    return tensor
+```
+
+The cache is invalidated on resolution / format change and on pipeline
+teardown — never per frame. Pool sizes are bounded so the cache reaches
+steady state after the first N frames and never grows.
+
+> [!NOTE]
+> EdgeFirst's GStreamer elements implement this inode-keyed cache as a
+> reference. If you are integrating the HAL into a different pipeline
+> (libcamera direct, custom V4L2 capture, RTSP decoder), you are
+> responsible for adding the equivalent cache layer above HAL.
+
+The HAL's *internal* EGL image cache is keyed by a per-tensor
+`BufferIdentity.id` and is correctly invalidated when a tensor is dropped.
+The internal cache only hits when you hand it the *same* tensor object on
+each call — which is what the inode-keyed application cache guarantees.
+See [ARCHITECTURE.md] Appendix C for the full cache hierarchy.
+
+### Rule 4 — Build the Decoder Once
+
+`Decoder` parses the model's output schema, resolves quantization parameters,
+and allocates working buffers at construction time. Build it once outside
+the inference loop:
+
+```rust
+use edgefirst_hal::decoder::{DecoderBuilder, DetectBox, Segmentation};
+use edgefirst_hal::tensor::TensorDyn;
+
+// Build once, outside the inference loop. The builder parses the model's
+// output schema and allocates internal working buffers at .build() time.
+let decoder = DecoderBuilder::default()
+    .with_config_yaml_str(config_yaml)
+    .with_score_threshold(0.5)
+    .with_iou_threshold(0.45)
+    .build()?;
+
+// Reusable output buffers — decoder.decode() clears them on each call.
+let mut boxes: Vec<DetectBox> = Vec::new();
+let mut masks: Vec<Segmentation> = Vec::new();
+
+for frame in frames {
+    let outputs: Vec<TensorDyn> = run_inference(frame)?;
+    let output_refs: Vec<&TensorDyn> = outputs.iter().collect();
+    decoder.decode(&output_refs, &mut boxes, &mut masks)?;
+    // Use `boxes` (and `masks`, if the model emits segmentation) here.
+}
+```
+
+```python
+decoder = ef.Decoder(config, 0.5, 0.45)  # construct once
+
+for frame in frames:
+    outputs = run_inference(frame)  # your model call, returns list[ef.Tensor]
+    boxes, scores, classes, masks = decoder.decode(outputs)
+```
+
+The same applies to `ByteTrack`: construct once, call `update()` per frame.
+
+### Rule 5 — One `ImageProcessor` per Pipeline Thread
+
+`ImageProcessor` owns its EGL display, OpenGL context, GL thread, and EGL
+image cache. Two instances do not share caches and serialize on a global
+GL mutex. Construct one per pipeline (or one per worker thread for parallel
+pipelines) and share it across all `convert()`, `draw_*()`, and
+`create_image()` calls.
+
+`ImageProcessor` is `Send` but **not** `Sync`: you can move it between
+threads but you cannot call it concurrently from multiple threads. For
+parallel inference workers, give each worker its own `ImageProcessor` and
+its own output tensor.
+
+### Rule 6 — Local fp16 / AVX build overrides
 
 The default HAL binary is built to the target triple's guaranteed
 baseline ISA so that a single distributed binary runs on every CPU
@@ -537,7 +724,26 @@ _mm256_fmadd_ps` intrinsic path is also enabled via cfg gate. The
 helper `scripts/audit_f16_codegen.sh` disassembles a release build
 of the kernel and confirms native instructions are emitted.
 
+### Where to Go Next
+
+| Document | Level | Use it for |
+|----------|-------|-----------|
+| [ARCHITECTURE.md] § Performance Considerations | Architecture | Why the rules exist: `BufferIdentity`, EGL image cache, fd ownership, GL serialization, fd-vs-inode lifecycle |
+| [ARCHITECTURE.md] § Appendix C — DMA-BUF Identity and Tensor Caching | Architecture | The full v4l2 / GStreamer fd-recycling story and the inode-keyed cache pattern |
+| [TESTING.md] § Validating Optimizations | Testing | Confirming your integration follows the rules: cache hit logs, allocation counters, backend isolation |
+| [BENCHMARKS.md] § Optimization Performance Reference | Benchmarks | Empirical cost of breaking each rule, per platform |
+
+[ARCHITECTURE.md]: ARCHITECTURE.md
+[TESTING.md]: TESTING.md
+[BENCHMARKS.md]: BENCHMARKS.md
+
 ## Advanced Examples
+
+> [!NOTE]
+> The snippets below use stand-in helpers (`run_inference()`, `run_detection()`,
+> `config_yaml`, `config_dict`, etc.) to keep each example focused on the HAL
+> API. Replace these with your own model invocation, configuration loader, or
+> data-source code.
 
 <details>
 <summary><b>Rust Examples</b></summary>
@@ -565,33 +771,41 @@ converter.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default
 ### Detection Decoding
 
 ```rust
-use edgefirst_hal::decoder::Decoder;
-use std::collections::HashMap;
+use edgefirst_hal::decoder::{DecoderBuilder, DetectBox, Segmentation};
+use edgefirst_hal::tensor::TensorDyn;
 
-// Build decoder from configuration dictionary/JSON
-let config: HashMap<String, serde_json::Value> = 
-    serde_json::from_str(&config_json)?;
+// Build decoder from a YAML config string (or use other with_config_*
+// methods to build from a parsed schema).
+let decoder = DecoderBuilder::default()
+    .with_config_yaml_str(config_yaml)
+    .with_score_threshold(0.5)
+    .with_iou_threshold(0.45)
+    .build()?;
 
-let decoder = Decoder::new(config, 0.5, 0.45)?;  // score_thresh, iou_thresh
-
-// Decode model outputs (supports mixed types per tensor)
-let outputs = vec![boxes_tensor, scores_tensor];
-let (bboxes, scores, classes) = decoder.decode_detection(&outputs)?;
+// Decode model outputs (supports mixed types per tensor). The decoder
+// uses out-parameters: `boxes` and `masks` are cleared on each call.
+let outputs: Vec<&TensorDyn> = vec![&boxes_tensor, &scores_tensor];
+let mut boxes: Vec<DetectBox> = Vec::new();
+let mut masks: Vec<Segmentation> = Vec::new();
+decoder.decode(&outputs, &mut boxes, &mut masks)?;
 ```
 
 ### Multi-Frame Tracking
 
 ```rust
-// Requires: edgefirst-hal = { version = "0.13", features = ["tracker"] }
+// Requires: edgefirst-hal = { version = "0.18", features = ["tracker"] }
 use edgefirst_hal::tracker::{ByteTrack, Tracker, DetectionBox};
 
 let mut tracker = ByteTrack::default();
 
 for frame in video_frames {
     let detections = run_detection(frame)?;
+    // update() returns Vec<Option<TrackInfo>> — one slot per input detection;
+    // None means the detection was not associated with an existing track this
+    // frame (e.g., low-confidence track in the matching cascade).
     let track_infos = tracker.update(&detections, frame.timestamp);
-    
-    for track_info in track_infos {
+
+    for track_info in track_infos.into_iter().flatten() {
         println!("Object {}: {:?}", track_info.uuid, track_info.tracked_location);
     }
 }
@@ -732,24 +946,10 @@ Python wrapper types use a `Py` prefix (e.g., `PyTensor`, `PyPixelFormat`) to cl
 
 ## Performance Considerations
 
-### Memory Allocation Strategy
-
-1. **DMA Heap**: Fastest for hardware accelerators, zero-copy to GPU/NPU
-2. **Shared Memory**: Fast for IPC, works across processes
-3. **Heap Memory**: Fallback for compatibility, still performant with SIMD
-
-### Image Processing Strategy
-
-1. **OpenGL**: GPU-accelerated pipeline (resize, YUV conversion, letterbox)
-2. **G2D**: NXP i.MX 2D hardware blitter (when format pair is supported)
-3. **CPU**: SIMD + Rayon parallelized fallback for all platforms
-
-### Decoder Optimization
-
-- Quantized integer math where possible
-- Vectorized operations via ndarray
-- Parallel processing with Rayon
-- Early termination in NMS loops
+The rules for getting the best performance are summarized in the
+[Optimization Guide](#optimization-guide) above. The architectural
+rationale (memory backends, image processing strategy, decoder internals)
+is documented in [ARCHITECTURE.md] § Performance Considerations.
 
 ## Thread Safety
 
@@ -815,7 +1015,7 @@ The HAL respects the following environment variables at runtime:
 | `EDGEFIRST_DISABLE_GL` | Disable OpenGL backend |
 | `EDGEFIRST_DISABLE_CPU` | Disable CPU backend |
 | `EDGEFIRST_FORCE_BACKEND` | Force a single backend: `cpu`, `g2d`, or `opengl`. Disables fallback chain. |
-| `EDGEFIRST_FORCE_TRANSFER` | Force GPU transfer method: `pbo` or `dmabuf` |
+| `EDGEFIRST_FORCE_TRANSFER` | Force GPU transfer method: `pbo`, `dmabuf`, or `sync` (`sync` falls back to `glTexImage2D` / `glReadnPixels` memcpy — useful for measuring the non-zero-copy baseline) |
 | `EDGEFIRST_OPENGL_RENDERSURFACE` | Set to `1` to enable EGL renderbuffer path for non-dma_heap DMA-BUF buffers (i.MX 95 Neutron NPU) |
 | `EDGEFIRST_PROTO_COMPUTE` | Set to `1` to enable GLES 3.1 compute shader for HWC-to-CHW proto repack |
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ rule exists, and [TESTING.md] for how to verify your integration follows it.
 | Cache imported camera tensors by **inode**, not by fd | v4l2 / libcamera recycle fd numbers across a small buffer pool; an fd-keyed cache misses on every frame even when the physical buffer is the same | Full EGL re-import per frame (≈0.5–1.5 ms on Vivante, multiplied by source + chroma planes) |
 | Build `Decoder` once, decode many | Decoder construction parses model metadata and allocates working buffers | Parse + alloc cost per frame |
 | Construct one `ImageProcessor` per pipeline | Each instance owns its own GL context and EGL display | Multiple GL contexts contend on `GL_MUTEX`; see ARCHITECTURE.md |
+| Use native fp16 / AVX build overrides only on CPUs that support them | These flags unlock native widening/vector paths for local perf testing | Unsupported targets may fail to build or hit illegal instructions; portability loss |
 | Pass numpy arrays straight to `Tensor.from_numpy()` — do not pre-`ascontiguousarray()` | HAL detects strided sources and materialises via numpy's vectorized C strided→contig pass; a manual workaround above HAL adds a redundant copy | A redundant `np.ascontiguousarray` pre-copy on every call (size-dependent; e.g. ≈1.5 ms per call on a `(1, 116, 8400)` f32 view on rpi5-hailo) |
 | For COCO/IoU evaluation use `MaskResolution::Scaled(orig_w, orig_h)`, not `Proto` | `Scaled` upsamples the continuous-sigmoid proto plane *before* thresholding (clean edges); `Proto` returns continuous values but most callers threshold-then-resize, which produces blocky binary edges and lossy mAP | Mask mAP regression of up to 0.04–0.05 absolute (model- and dataset-dependent) when `Proto` is thresholded then nearest-upsampled |
 
@@ -584,6 +585,7 @@ lookup-or-import flow on every dequeued frame:
 
 ```c
 #include <sys/stat.h>
+#include <stdio.h>
 
 typedef struct {
     ino_t inode;
@@ -592,15 +594,27 @@ typedef struct {
 
 /* On each input frame: */
 struct stat st;
-fstat(fd, &st);
+if (fstat(fd, &st) != 0) {
+    perror("fstat");
+    continue;  /* skip this frame */
+}
 BufferKey key = { .inode = st.st_ino, .offset = plane_offset };
 
 struct hal_tensor *tensor = lookup_tensor(cache, &key);
 if (!tensor) {
     /* First time seeing this physical buffer — import once. */
     struct hal_plane_descriptor *pd = hal_plane_descriptor_new(fd);
+    if (!pd) {
+        perror("hal_plane_descriptor_new");
+        continue;
+    }
     tensor = hal_import_image(proc, pd, NULL, w, h,
                               HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+    /* pd is consumed by hal_import_image(), even on failure. */
+    if (!tensor) {
+        fprintf(stderr, "hal_import_image failed\n");
+        continue;
+    }
     insert_tensor(cache, &key, tensor);
 }
 /* Reuse `tensor` for this frame; do NOT free it between frames. */
@@ -609,9 +623,11 @@ hal_image_processor_convert(proc, tensor, dst, /* ... */);
 
 ```python
 import os
+from typing import Dict, Tuple
+import edgefirst_hal as ef
 
 # (inode, offset) -> ef.Tensor
-buffer_cache: dict[tuple[int, int], ef.Tensor] = {}
+buffer_cache: Dict[Tuple[int, int], ef.Tensor] = {}
 
 def get_or_import(proc, fd, offset, width, height, fmt):
     key = (os.fstat(fd).st_ino, offset)
@@ -652,7 +668,7 @@ use edgefirst_hal::tensor::TensorDyn;
 // Build once, outside the inference loop. The builder parses the model's
 // output schema and allocates internal working buffers at .build() time.
 let decoder = DecoderBuilder::default()
-    .with_config_yaml_str(config_yaml)
+    .with_config_yaml_str(config_yaml.to_string())
     .with_score_threshold(0.5)
     .with_iou_threshold(0.45)
     .build()?;
@@ -687,10 +703,11 @@ GL mutex. Construct one per pipeline (or one per worker thread for parallel
 pipelines) and share it across all `convert()`, `draw_*()`, and
 `create_image()` calls.
 
-`ImageProcessor` is `Send` but **not** `Sync`: you can move it between
-threads but you cannot call it concurrently from multiple threads. For
-parallel inference workers, give each worker its own `ImageProcessor` and
-its own output tensor.
+`ImageProcessor` is `Send + Sync`, so it can be moved or shared across
+threads. Concurrent use of a single shared instance is still discouraged:
+operations can serialize on `GL_MUTEX`, and per-worker ownership gives more
+predictable cache behavior. For parallel inference workers, give each worker
+its own `ImageProcessor` and its own output tensor.
 
 ### Rule 6 — Local fp16 / AVX build overrides
 
@@ -867,7 +884,7 @@ use edgefirst_hal::tensor::TensorDyn;
 // Build decoder from a YAML config string (or use other with_config_*
 // methods to build from a parsed schema).
 let decoder = DecoderBuilder::default()
-    .with_config_yaml_str(config_yaml)
+    .with_config_yaml_str(config_yaml.to_string())
     .with_score_threshold(0.5)
     .with_iou_threshold(0.45)
     .build()?;
@@ -1046,7 +1063,7 @@ is documented in [ARCHITECTURE.md] § Performance Considerations.
 Thread safety of major types:
 - `Tensor<T>`: `Send + Sync` — safe to share across threads
 - `TensorDyn`: `Send + Sync` — thread-safe
-- `ImageProcessor`: `Send` but **not** `Sync` — create one per thread (GPU contexts are thread-local)
+- `ImageProcessor`: `Send + Sync` — thread-safe to move/share, but per-thread ownership is still recommended for predictable performance
 - `Decoder`: `Send + Sync` — thread-safe for read operations
 
 ## Error Handling

--- a/TESTING.md
+++ b/TESTING.md
@@ -240,6 +240,14 @@ Use environment variables to isolate tests to specific backends:
 | `EDGEFIRST_FORCE_BACKEND=cpu` | Force CPU-only image processing |
 | `EDGEFIRST_FORCE_BACKEND=opengl` | Force OpenGL backend |
 | `EDGEFIRST_FORCE_BACKEND=g2d` | Force G2D backend |
+| `EDGEFIRST_DISABLE_GL=1` | Disable OpenGL even when hardware is present |
+| `EDGEFIRST_DISABLE_G2D=1` | Disable G2D even when hardware is present |
+
+Example — run tests without any GPU backend:
+
+```bash
+EDGEFIRST_DISABLE_GL=1 EDGEFIRST_DISABLE_G2D=1 cargo test --workspace -- --test-threads=1
+```
 
 ### Benchmarking native fp16 paths (local only)
 
@@ -270,14 +278,6 @@ Verify the release build actually compiled to native instructions
 (not the soft-float `__extendhfsf2` helper) via
 `scripts/audit_f16_codegen.sh <target-triple>`. Requires
 `cargo install cargo-show-asm`.
-| `EDGEFIRST_DISABLE_GL=1` | Disable OpenGL even when hardware is present |
-| `EDGEFIRST_DISABLE_G2D=1` | Disable G2D even when hardware is present |
-
-Example — run tests without any GPU backend:
-
-```bash
-EDGEFIRST_DISABLE_GL=1 EDGEFIRST_DISABLE_G2D=1 cargo test --workspace -- --test-threads=1
-```
 
 ---
 
@@ -315,6 +315,137 @@ ssh user@target 'cd /tmp/hal-tests && ./edgefirst_image-<hash> --test-threads=1'
 ```
 
 The `--test-threads=1` flag is mandatory on target hardware for the same reasons as local development — the CMA pool exhaustion risk is higher on embedded boards with limited memory.
+
+---
+
+## Validating Optimizations
+
+This section is the **testing-level reference** for the
+[Optimization Guide in README.md](README.md#optimization-guide). Each rule
+in that guide has a corresponding way to verify your integration follows
+it; this section documents those verification techniques.
+
+### Verifying EGL Image Cache Hits
+
+The OpenGL backend's EGL image cache emits a summary log line at process
+shutdown. Run any test or benchmark with `RUST_LOG=edgefirst_image=debug`:
+
+```bash
+RUST_LOG=edgefirst_image=debug \
+    cargo test -p edgefirst-image --test ... -- --test-threads=1 2>&1 | tee cache.log
+```
+
+Look for the final line:
+
+```text
+EglImageCache stats: 999 hits, 1 misses, 1 entries remaining
+```
+
+A correctly-tuned camera pipeline reaches steady state with **misses ≈ pool
+depth** (one miss per unique physical buffer) and **hits ≈ frame count**.
+If `misses` grows linearly with frame count, the calling code is creating
+new tensor objects per frame — review the cache key (Rule 3 in the
+Optimization Guide).
+
+The cache also logs `EglImageCache: swept N dead entries` when tensors are
+dropped while their entries are still in the cache. Frequent sweeps in a
+steady-state pipeline are a sign of leaked or churned tensor objects.
+
+### Verifying Backend Selection
+
+The active backend is logged at `info` level when `ImageProcessor::new()`
+succeeds:
+
+```text
+Shared EGL display initialized: kind=Wayland, transfer=DmaBuf
+```
+
+The `transfer=` field reports `DmaBuf`, `Pbo`, or `Sync` — these correspond
+to the three rows in the README *Platform GPU Support* table. To confirm a
+specific backend is being exercised, set the corresponding environment
+variable from the table below and re-run with `RUST_LOG=info`.
+
+| Variable | Effect | Use to verify |
+|----------|--------|---------------|
+| `EDGEFIRST_FORCE_BACKEND=cpu` | CPU only — no GPU code path | Code paths that should never crash without a GPU |
+| `EDGEFIRST_FORCE_BACKEND=opengl` | OpenGL only — no G2D, no CPU fallback | GL backend correctness |
+| `EDGEFIRST_FORCE_BACKEND=g2d` | G2D only — fails on non-i.MX | G2D-specific format pairs |
+| `EDGEFIRST_FORCE_TRANSFER=pbo` | PBO transfers even when DMA-buf is available | PBO path on Linux with DMA-buf hardware |
+| `EDGEFIRST_FORCE_TRANSFER=dmabuf` | DMA-buf transfers; fails if EGLImage import fails | DMA-buf path on systems where it normally falls back |
+| `EDGEFIRST_FORCE_TRANSFER=sync` | Memcpy upload/readback via `glTexImage2D` / `glReadnPixels` | Non-zero-copy baseline; useful for measuring the cost of the fast paths |
+| `EDGEFIRST_TENSOR_FORCE_MEM=1` | Forces heap tensors; disables DMA / SHM | Pure-CPU regression baseline |
+
+### Regression Testing for Tensor Reuse
+
+To catch regressions where a caller starts allocating a tensor per frame,
+gate the test on the cache miss count reported in the `EglImageCache stats`
+log line. The pattern below is illustrative — the `alloc_count()` accessor
+is **not** a stable public API. In practice, capture the log output and
+parse the `H hits, M misses` summary, or use the `bench_preproc` reuse
+variant (see below) as the regression baseline.
+
+```rust
+// Illustrative — alloc_count() is shown for clarity, not as a real API.
+// In a real test, parse the EglImageCache stats log line instead.
+#[test]
+fn test_steady_state_no_realloc() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let mut proc = ImageProcessor::new().unwrap();
+    let mut dst = proc.create_image(640, 640, PixelFormat::Rgb,
+                                    DType::U8, None).unwrap();
+    let src = load_image(&fixture_bytes(), Some(PixelFormat::Rgb), None).unwrap();
+
+    // Warm-up
+    proc.convert(&src, &mut dst,
+                 Rotation::None, Flip::None, Crop::default()).unwrap();
+
+    // Steady state — every iteration must hit the EGL image cache.
+    for _ in 0..100 {
+        proc.convert(&src, &mut dst,
+                     Rotation::None, Flip::None, Crop::default()).unwrap();
+    }
+    // Drop `proc` to flush the EglImageCache stats log line. Assert in the
+    // test harness that misses == 1 (the warm-up) by parsing the log.
+}
+```
+
+For the C API, `bench_preproc` (in `crates/capi/tests/bench_preproc.c`) is
+the reference reproduction of the allocate-once / reuse-every-frame pattern
+and serves as both a benchmark and a regression test.
+
+### Verifying the Inode-Keyed Cache (V4L2 / libcamera Integrations)
+
+When integrating the HAL into a pipeline that consumes V4L2 or libcamera
+buffers, write an integration test that simulates fd recycling:
+
+1. Open a single `dma_buf` and obtain two distinct fd numbers via `dup()`.
+2. Import the first fd into HAL, run a `convert()`, and capture the EGL
+   cache miss count.
+3. Close the first fd, then import the *second* fd (which refers to the
+   same physical buffer).
+4. Run `convert()` again. If the calling code uses an inode-keyed cache,
+   it returns the existing tensor and the miss count does not increase.
+   If it uses an fd-keyed cache or skips caching entirely, the miss count
+   grows by one.
+
+The Au-Zone GStreamer elements ship with this regression test in their
+own test suite; downstream integrators should write the equivalent for
+their pipeline.
+
+### Quantifying Native CPU Feature Builds
+
+When benchmarking with `RUSTFLAGS="-C target-feature=+fp16"` (or `+f16c` on
+x86_64), confirm the kernel actually compiled to native instructions
+rather than the soft-float helper:
+
+```bash
+scripts/audit_f16_codegen.sh aarch64-unknown-linux-gnu
+```
+
+The script disassembles a release build and fails if `__extendhfsf2` is
+present (soft-float fallback) or if `fcvt` / `vcvtph2ps` is absent. See
+[§ Benchmarking native fp16 paths](#benchmarking-native-fp16-paths-local-only)
+above for the full workflow.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -360,10 +360,18 @@ succeeds:
 Shared EGL display initialized: kind=Wayland, transfer=DmaBuf
 ```
 
-The `transfer=` field reports `DmaBuf`, `Pbo`, or `Sync` — these correspond
-to the three rows in the README *Platform GPU Support* table. To confirm a
-specific backend is being exercised, set the corresponding environment
-variable from the table below and re-run with `RUST_LOG=info`.
+This `transfer=` field is the **initial EGL display capability probe** and
+reports only `DmaBuf` or `Sync`. The effective transfer backend used for
+conversions (after `Sync -> Pbo` upgrade and any `EDGEFIRST_FORCE_TRANSFER`
+override) is logged when the GL converter is created:
+
+```text
+GLConverter created (transfer=Pbo)
+```
+
+To confirm the final backend being exercised, set the corresponding
+environment variable from the table below and re-run with
+`RUST_LOG=edgefirst_image=debug`.
 
 | Variable | Effect | Use to verify |
 |----------|--------|---------------|

--- a/TESTING.md
+++ b/TESTING.md
@@ -432,6 +432,47 @@ The Au-Zone GStreamer elements ship with this regression test in their
 own test suite; downstream integrators should write the equivalent for
 their pipeline.
 
+### Verifying the `from_numpy` Strided Fast-Path
+
+Rule 7 in the [Optimization Guide](README.md#rule-7--numpy-interop-pass-arrays-straight-to-from_numpy)
+asserts that callers should not pre-apply `np.ascontiguousarray()` —
+HAL handles strided sources internally. Two regression tests in
+`tests/test_tensor.py` pin this:
+
+| Test | What it verifies |
+|---|---|
+| `test_from_numpy_hailort_shape` | Correctness on the HailoRT-shaped `(1, 116, 8400)` f32 transposed view (Path 3 of `copy_numpy_to_tensor_dyn`). The destination tensor matches the source values element-by-element. |
+| `test_from_numpy_hailort_shape_perf_sanity` | Perf bound: the automatic fast path runs no more than 1.5× the manual `np.ascontiguousarray + from_numpy(contig)` workaround. Prior to PR #58 the ratio was ≈ 10×. |
+
+Both tests are in the standard Python suite and run in CI. If the
+perf-sanity test fails, suspect a regression in `numpy.ascontiguousarray`
+behaviour or in the Path-3 dispatch logic in `crates/python/src/tensor.rs`.
+
+### Verifying `MaskResolution` Selection in COCO Validators
+
+Rule 8 in the [Optimization Guide](README.md#rule-8--choose-the-correct-maskresolution-for-your-evaluation)
+asserts that COCO / IoU evaluation must use `MaskResolution::Scaled`,
+not the default `Proto`. Downstream validators should pin this with a
+small assertion at the materialize call site:
+
+```python
+masks = proc.materialize_masks(
+    boxes, scores, classes, proto_data,
+    letterbox=letterbox_norm,
+    resolution=hal.MaskResolution.Scaled(orig_w, orig_h),
+)
+# Smoke-check the contract: tile shape (h, w, 1) uint8 at
+# orig-image resolution, binary {0, 255} after upsample-then-threshold.
+assert masks[0].shape[2] == 1
+assert masks[0].dtype == np.uint8
+```
+
+If a validator's mask-mAP regresses against a numpy / ONNX reference,
+inspect this call first — the most common cause is calling
+`materialize_masks` with no `resolution` argument (defaults to `Proto`)
+and then thresholding the proto-resolution sigmoid in caller code
+before resizing, which produces blocky binary edges.
+
 ### Quantifying Native CPU Feature Builds
 
 When benchmarking with `RUSTFLAGS="-C target-feature=+fp16"` (or `+f16c` on

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -5,6 +5,7 @@ use super::CPUProcessor;
 use crate::Result;
 use edgefirst_decoder::{DetectBox, Segmentation};
 use ndarray::Axis;
+use rayon::prelude::*;
 
 impl CPUProcessor {
     #[allow(clippy::too_many_arguments)]
@@ -301,98 +302,79 @@ impl CPUProcessor {
             }
         };
 
-        let per_detection = |i: usize,
-                             det: &crate::DetectBox|
-         -> crate::Result<edgefirst_decoder::Segmentation> {
-            let coeff = &coeff_f32_slice[i * num_protos..(i + 1) * num_protos];
-
-            let bbox = det.bbox.to_canonical();
-            let xmin = bbox.xmin.clamp(0.0, 1.0);
-            let ymin = bbox.ymin.clamp(0.0, 1.0);
-            let xmax = bbox.xmax.clamp(0.0, 1.0);
-            let ymax = bbox.ymax.clamp(0.0, 1.0);
-            let x0 = ((xmin * proto_w as f32) as usize).min(proto_w.saturating_sub(1));
-            let y0 = ((ymin * proto_h as f32) as usize).min(proto_h.saturating_sub(1));
-            let x1 = ((xmax * proto_w as f32).ceil() as usize).min(proto_w);
-            let y1 = ((ymax * proto_h as f32).ceil() as usize).min(proto_h);
-            let roi_w = x1.saturating_sub(x0).max(1);
-            let roi_h = y1.saturating_sub(y0).max(1);
-
-            let mask = match proto_data.protos.dtype() {
-                DType::I8 => {
-                    let t = proto_data.protos.as_i8().expect("dtype matched I8");
-                    let quant = t.quantization().ok_or_else(|| {
-                        crate::Error::InvalidShape("I8 protos require quantization metadata".into())
-                    })?;
-                    let m = t.map()?;
-                    fused_dequant_dot_sigmoid_i8_slice(
-                        m.as_slice(),
-                        coeff,
-                        quant,
-                        proto_h,
-                        proto_w,
-                        y0,
-                        x0,
-                        roi_h,
-                        roi_w,
-                        num_protos,
-                    )?
-                }
-                DType::F32 => {
-                    let t = proto_data.protos.as_f32().expect("dtype matched F32");
-                    let m = t.map()?;
-                    fused_dot_sigmoid_f32_slice(
-                        m.as_slice(),
-                        coeff,
-                        proto_h,
-                        proto_w,
-                        y0,
-                        x0,
-                        roi_h,
-                        roi_w,
-                        num_protos,
-                    )
-                }
-                DType::F16 => {
-                    let t = proto_data.protos.as_f16().expect("dtype matched F16");
-                    let m = t.map()?;
-                    fused_dot_sigmoid_f16_slice(
-                        m.as_slice(),
-                        coeff,
-                        proto_h,
-                        proto_w,
-                        y0,
-                        x0,
-                        roi_h,
-                        roi_w,
-                        num_protos,
-                    )
-                }
-                other => {
-                    return Err(crate::Error::InvalidShape(format!(
-                        "proto tensor dtype {other:?} not supported"
-                    )));
-                }
-            };
-
-            let seg_xmin = ((x0 as f32 / proto_w as f32) - lx0) * inv_lw;
-            let seg_ymin = ((y0 as f32 / proto_h as f32) - ly0) * inv_lh;
-            let seg_xmax = ((x1 as f32 / proto_w as f32) - lx0) * inv_lw;
-            let seg_ymax = ((y1 as f32 / proto_h as f32) - ly0) * inv_lh;
-            Ok(edgefirst_decoder::Segmentation {
-                xmin: seg_xmin.clamp(0.0, 1.0),
-                ymin: seg_ymin.clamp(0.0, 1.0),
-                xmax: seg_xmax.clamp(0.0, 1.0),
-                ymax: seg_ymax.clamp(0.0, 1.0),
-                segmentation: mask,
-            })
-        };
-
-        detect
-            .iter()
-            .enumerate()
-            .map(|(i, det)| per_detection(i, det))
-            .collect()
+        // Hoist the proto tensor map() out of the per-detection loop so the
+        // map-guard is acquired once. Then dispatch per-dtype via a helper
+        // that runs the per-detection kernels in parallel across detections
+        // via rayon. This restores the parallelism that PR #54 added and
+        // PR #51 (EDGEAI-1244 f16 refactor) inadvertently removed.
+        match proto_data.protos.dtype() {
+            DType::I8 => {
+                let t = proto_data.protos.as_i8().expect("dtype matched I8");
+                let quant = t.quantization().ok_or_else(|| {
+                    crate::Error::InvalidShape("I8 protos require quantization metadata".into())
+                })?;
+                let m = t.map()?;
+                let protos_slice = m.as_slice();
+                detect
+                    .par_iter()
+                    .enumerate()
+                    .map(|(i, det)| {
+                        let coeff = &coeff_f32_slice[i * num_protos..(i + 1) * num_protos];
+                        let (x0, y0, x1, y1, roi_w, roi_h) =
+                            bbox_to_proto_roi(det, proto_w, proto_h);
+                        let mask = fused_dequant_dot_sigmoid_i8_slice(
+                            protos_slice, coeff, quant, proto_h, proto_w, y0, x0,
+                            roi_h, roi_w, num_protos,
+                        )?;
+                        Ok(seg_from_roi(mask, x0, y0, x1, y1, proto_w, proto_h,
+                                         lx0, inv_lw, ly0, inv_lh))
+                    })
+                    .collect()
+            }
+            DType::F32 => {
+                let t = proto_data.protos.as_f32().expect("dtype matched F32");
+                let m = t.map()?;
+                let protos_slice = m.as_slice();
+                detect
+                    .par_iter()
+                    .enumerate()
+                    .map(|(i, det)| {
+                        let coeff = &coeff_f32_slice[i * num_protos..(i + 1) * num_protos];
+                        let (x0, y0, x1, y1, roi_w, roi_h) =
+                            bbox_to_proto_roi(det, proto_w, proto_h);
+                        let mask = fused_dot_sigmoid_f32_slice(
+                            protos_slice, coeff, proto_h, proto_w, y0, x0,
+                            roi_h, roi_w, num_protos,
+                        );
+                        Ok(seg_from_roi(mask, x0, y0, x1, y1, proto_w, proto_h,
+                                         lx0, inv_lw, ly0, inv_lh))
+                    })
+                    .collect()
+            }
+            DType::F16 => {
+                let t = proto_data.protos.as_f16().expect("dtype matched F16");
+                let m = t.map()?;
+                let protos_slice = m.as_slice();
+                detect
+                    .par_iter()
+                    .enumerate()
+                    .map(|(i, det)| {
+                        let coeff = &coeff_f32_slice[i * num_protos..(i + 1) * num_protos];
+                        let (x0, y0, x1, y1, roi_w, roi_h) =
+                            bbox_to_proto_roi(det, proto_w, proto_h);
+                        let mask = fused_dot_sigmoid_f16_slice(
+                            protos_slice, coeff, proto_h, proto_w, y0, x0,
+                            roi_h, roi_w, num_protos,
+                        );
+                        Ok(seg_from_roi(mask, x0, y0, x1, y1, proto_w, proto_h,
+                                         lx0, inv_lw, ly0, inv_lh))
+                    })
+                    .collect()
+            }
+            other => Err(crate::Error::InvalidShape(format!(
+                "proto tensor dtype {other:?} not supported"
+            ))),
+        }
     }
 
     /// Produce per-detection masks at `(width, height)` pixel resolution by
@@ -532,6 +514,58 @@ impl CPUProcessor {
 // becomes a soft-float helper. Stage 8 adds explicit intrinsic kernels
 // gated by `#[cfg(target_feature = "fp16")]` / `+f16c`.
 // =============================================================================
+
+/// Map a detection bbox in normalised letterboxed coords to its ROI in
+/// the proto plane (floor xmin/ymin, ceil xmax/ymax, clamp to plane bounds).
+/// Returns `(x0, y0, x1, y1, roi_w, roi_h)` where roi_w/h are guaranteed ≥ 1.
+fn bbox_to_proto_roi(
+    det: &DetectBox,
+    proto_w: usize,
+    proto_h: usize,
+) -> (usize, usize, usize, usize, usize, usize) {
+    let bbox = det.bbox.to_canonical();
+    let xmin = bbox.xmin.clamp(0.0, 1.0);
+    let ymin = bbox.ymin.clamp(0.0, 1.0);
+    let xmax = bbox.xmax.clamp(0.0, 1.0);
+    let ymax = bbox.ymax.clamp(0.0, 1.0);
+    let x0 = ((xmin * proto_w as f32) as usize).min(proto_w.saturating_sub(1));
+    let y0 = ((ymin * proto_h as f32) as usize).min(proto_h.saturating_sub(1));
+    let x1 = ((xmax * proto_w as f32).ceil() as usize).min(proto_w);
+    let y1 = ((ymax * proto_h as f32).ceil() as usize).min(proto_h);
+    let roi_w = x1.saturating_sub(x0).max(1);
+    let roi_h = y1.saturating_sub(y0).max(1);
+    (x0, y0, x1, y1, roi_w, roi_h)
+}
+
+/// Build a `Segmentation` from a per-detection mask + the ROI bounds in
+/// proto coords. Applies the inverse letterbox transform to express the
+/// segmentation bbox in original-image-content normalised space.
+#[allow(clippy::too_many_arguments)]
+fn seg_from_roi(
+    mask: ndarray::Array3<u8>,
+    x0: usize,
+    y0: usize,
+    x1: usize,
+    y1: usize,
+    proto_w: usize,
+    proto_h: usize,
+    lx0: f32,
+    inv_lw: f32,
+    ly0: f32,
+    inv_lh: f32,
+) -> edgefirst_decoder::Segmentation {
+    let seg_xmin = ((x0 as f32 / proto_w as f32) - lx0) * inv_lw;
+    let seg_ymin = ((y0 as f32 / proto_h as f32) - ly0) * inv_lh;
+    let seg_xmax = ((x1 as f32 / proto_w as f32) - lx0) * inv_lw;
+    let seg_ymax = ((y1 as f32 / proto_h as f32) - ly0) * inv_lh;
+    edgefirst_decoder::Segmentation {
+        xmin: seg_xmin.clamp(0.0, 1.0),
+        ymin: seg_ymin.clamp(0.0, 1.0),
+        xmax: seg_xmax.clamp(0.0, 1.0),
+        ymax: seg_ymax.clamp(0.0, 1.0),
+        segmentation: mask,
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 fn fused_dequant_dot_sigmoid_i8_slice(
@@ -991,7 +1025,7 @@ fn scaled_segmentations_i8_slice(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn scaled_run<P: Copy>(
+fn scaled_run<P: Copy + Sync>(
     detect: &[crate::DetectBox],
     coeff_all: &[f32],
     protos: &[P],
@@ -1002,7 +1036,7 @@ fn scaled_run<P: Copy>(
     width: u32,
     height: u32,
     acc_scale: f32,
-    load_f32: impl Fn(&P, f32) -> f32 + Copy,
+    load_f32: impl Fn(&P, f32) -> f32 + Copy + Sync,
 ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
     let (lx0, lw, ly0, lh) = match letterbox {
         Some([lx0, ly0, lx1, ly1]) => {
@@ -1016,8 +1050,29 @@ fn scaled_run<P: Copy>(
     let out_h = height as usize;
     let stride_y = proto_w * num_protos;
 
+    // Parallelise across detections. Each detection produces an
+    // independent ndarray::Array3<u8> tile from a read-only proto slice +
+    // its own coeff slice; no shared mutable state.
+    //
+    // Algorithm (restores the spirit of PR #54's batched-GEMM optimisation
+    // that PR #51's f16 dispatch refactor inadvertently removed):
+    //
+    //   1. Map the output bbox back to a proto-plane ROI (with 1-px margin
+    //      so the bilinear sampling at the output edges has neighbours).
+    //   2. Precompute *f32 logits* at every proto pixel inside that ROI by
+    //      doing a single K-wide dot product per proto pixel — once, not
+    //      once per output pixel.
+    //   3. For each output pixel, bilinear-interpolate the scalar f32 logit
+    //      from the 4 surrounding proto-roi pixels, apply sigmoid, and
+    //      threshold to {0, 255}.
+    //
+    // For typical YOLO-seg: proto_roi ~ 30×30 = 900 px × K=32 = 28.8K dot
+    // ops vs the legacy "bilinear sample then dot at every output pixel"
+    // which costs bbox_h × bbox_w × 4 × K = ~1.3M ops at 100×100 output
+    // bbox. ~45× fewer FMAs at this size; the bilinear upsample of a
+    // scalar plane (no inner K loop) is comparatively negligible.
     detect
-        .iter()
+        .par_iter()
         .enumerate()
         .map(|(i, det)| {
             let coeff = &coeff_all[i * num_protos..(i + 1) * num_protos];
@@ -1032,27 +1087,78 @@ fn scaled_run<P: Copy>(
             let py1 = ((ymax * out_h as f32).round() as usize).min(out_h);
             let bbox_w = px1.saturating_sub(px0).max(1);
             let bbox_h = py1.saturating_sub(py0).max(1);
+
+            // Step 1 — proto-plane ROI for this detection's output bbox.
+            // Map the four output bbox corners back to proto coords and
+            // expand by 1 pixel in each direction so the bilinear sampler
+            // at the bbox boundary has both neighbours.
+            let sample_x_at = |px: f32| -> f32 {
+                let model_x_norm = lx0 + (px + 0.5) / out_w as f32 * lw;
+                model_x_norm * proto_w as f32 - 0.5
+            };
+            let sample_y_at = |py: f32| -> f32 {
+                let model_y_norm = ly0 + (py + 0.5) / out_h as f32 * lh;
+                model_y_norm * proto_h as f32 - 0.5
+            };
+            let s_x_min = sample_x_at(px0 as f32);
+            let s_x_max = sample_x_at((px1 as f32) - 1.0);
+            let s_y_min = sample_y_at(py0 as f32);
+            let s_y_max = sample_y_at((py1 as f32) - 1.0);
+            // Floor min, ceil max+1 to include both bilinear neighbours.
+            let proto_x0 = (s_x_min.floor() as isize).max(0).min(proto_w as isize) as usize;
+            let proto_x1 = ((s_x_max.ceil() as isize) + 1)
+                .max(0)
+                .min(proto_w as isize) as usize;
+            let proto_y0 = (s_y_min.floor() as isize).max(0).min(proto_h as isize) as usize;
+            let proto_y1 = ((s_y_max.ceil() as isize) + 1)
+                .max(0)
+                .min(proto_h as isize) as usize;
+            let roi_w = proto_x1.saturating_sub(proto_x0).max(1);
+            let roi_h = proto_y1.saturating_sub(proto_y0).max(1);
+
+            // Step 2 — precompute f32 logits at every proto-roi pixel.
+            // logits[(py - proto_y0) * roi_w + (px - proto_x0)] = dot(coeff, proto[py, px, :])
+            let mut logits = vec![0.0_f32; roi_h * roi_w];
+            for ly_idx in 0..roi_h {
+                let py = proto_y0 + ly_idx;
+                let row_base = py * stride_y + proto_x0 * num_protos;
+                for lx_idx in 0..roi_w {
+                    let pix_base = row_base + lx_idx * num_protos;
+                    let mut acc = 0.0_f32;
+                    for k in 0..num_protos {
+                        acc += coeff[k] * load_f32(&protos[pix_base + k], 0.0);
+                    }
+                    logits[ly_idx * roi_w + lx_idx] = acc_scale * acc;
+                }
+            }
+
+            // Step 3 — bilinear upsample logits → output bbox, sigmoid + threshold.
             let mut tile = ndarray::Array3::<u8>::zeros((bbox_h, bbox_w, 1));
             for yi in 0..bbox_h {
-                let py = (py0 + yi) as f32;
-                let model_y_norm = ly0 + (py + 0.5) / out_h as f32 * lh;
-                let sample_y = model_y_norm * proto_h as f32 - 0.5;
+                let py_o = (py0 + yi) as f32;
+                let sample_y = sample_y_at(py_o) - proto_y0 as f32;
+                let y_floor = sample_y.floor();
+                let y_lo = (y_floor as isize).max(0) as usize;
+                let y_hi = (y_lo + 1).min(roi_h - 1);
+                let y_frac = (sample_y - y_floor).clamp(0.0, 1.0);
+                let row_lo = &logits[y_lo * roi_w..y_lo * roi_w + roi_w];
+                let row_hi = &logits[y_hi * roi_w..y_hi * roi_w + roi_w];
                 for xi in 0..bbox_w {
-                    let px = (px0 + xi) as f32;
-                    let model_x_norm = lx0 + (px + 0.5) / out_w as f32 * lw;
-                    let sample_x = model_x_norm * proto_w as f32 - 0.5;
-                    let acc = bilinear_dot_slice(
-                        protos,
-                        stride_y,
-                        num_protos,
-                        coeff,
-                        sample_x,
-                        sample_y,
-                        proto_w,
-                        proto_h,
-                        |p: &P| load_f32(p, 0.0),
-                    );
-                    let sigmoid = fast_sigmoid(acc_scale * acc);
+                    let px_o = (px0 + xi) as f32;
+                    let sample_x = sample_x_at(px_o) - proto_x0 as f32;
+                    let x_floor = sample_x.floor();
+                    let x_lo = (x_floor as isize).max(0) as usize;
+                    let x_hi = (x_lo + 1).min(roi_w - 1);
+                    let x_frac = (sample_x - x_floor).clamp(0.0, 1.0);
+                    // Bilinear interp on the scalar logit plane.
+                    let l00 = row_lo[x_lo];
+                    let l01 = row_lo[x_hi];
+                    let l10 = row_hi[x_lo];
+                    let l11 = row_hi[x_hi];
+                    let l0 = l00 + (l01 - l00) * x_frac;
+                    let l1 = l10 + (l11 - l10) * x_frac;
+                    let logit = l0 + (l1 - l0) * y_frac;
+                    let sigmoid = fast_sigmoid(logit);
                     tile[[yi, xi, 0]] = if sigmoid > 0.5 { 255 } else { 0 };
                 }
             }

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -1096,9 +1096,15 @@ fn scaled_run<P: Copy + Sync>(
             let s_y_min = sample_y_at(py0 as f32);
             let s_y_max = sample_y_at((py1 as f32) - 1.0);
             // Floor min, ceil max+1 to include both bilinear neighbours.
-            let proto_x0 = (s_x_min.floor() as isize).max(0).min(proto_w as isize) as usize;
+            // Start indices are used as direct bases into `protos`, so clamp
+            // them to the last valid index, not to the exclusive upper bound.
+            let proto_x0 = (s_x_min.floor() as isize)
+                .max(0)
+                .min(proto_w.saturating_sub(1) as isize) as usize;
             let proto_x1 = ((s_x_max.ceil() as isize) + 1).max(0).min(proto_w as isize) as usize;
-            let proto_y0 = (s_y_min.floor() as isize).max(0).min(proto_h as isize) as usize;
+            let proto_y0 = (s_y_min.floor() as isize)
+                .max(0)
+                .min(proto_h.saturating_sub(1) as isize) as usize;
             let proto_y1 = ((s_y_max.ceil() as isize) + 1).max(0).min(proto_h as isize) as usize;
             let roi_w = proto_x1.saturating_sub(proto_x0).max(1);
             let roi_h = proto_y1.saturating_sub(proto_y0).max(1);
@@ -1125,7 +1131,9 @@ fn scaled_run<P: Copy + Sync>(
                 let py_o = (py0 + yi) as f32;
                 let sample_y = sample_y_at(py_o) - proto_y0 as f32;
                 let y_floor = sample_y.floor();
-                let y_lo = (y_floor as isize).max(0) as usize;
+                let y_lo = (y_floor as isize)
+                    .max(0)
+                    .min(roi_h.saturating_sub(1) as isize) as usize;
                 let y_hi = (y_lo + 1).min(roi_h - 1);
                 let y_frac = (sample_y - y_floor).clamp(0.0, 1.0);
                 let row_lo = &logits[y_lo * roi_w..y_lo * roi_w + roi_w];
@@ -1134,7 +1142,10 @@ fn scaled_run<P: Copy + Sync>(
                     let px_o = (px0 + xi) as f32;
                     let sample_x = sample_x_at(px_o) - proto_x0 as f32;
                     let x_floor = sample_x.floor();
-                    let x_lo = (x_floor as isize).max(0) as usize;
+                    let x_lo = (x_floor as isize)
+                        .max(0)
+                        .min(roi_w.saturating_sub(1) as isize)
+                        as usize;
                     let x_hi = (x_lo + 1).min(roi_w - 1);
                     let x_frac = (sample_x - x_floor).clamp(0.0, 1.0);
                     // Bilinear interp on the scalar logit plane.

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -323,11 +323,20 @@ impl CPUProcessor {
                         let (x0, y0, x1, y1, roi_w, roi_h) =
                             bbox_to_proto_roi(det, proto_w, proto_h);
                         let mask = fused_dequant_dot_sigmoid_i8_slice(
-                            protos_slice, coeff, quant, proto_h, proto_w, y0, x0,
-                            roi_h, roi_w, num_protos,
+                            protos_slice,
+                            coeff,
+                            quant,
+                            proto_h,
+                            proto_w,
+                            y0,
+                            x0,
+                            roi_h,
+                            roi_w,
+                            num_protos,
                         )?;
-                        Ok(seg_from_roi(mask, x0, y0, x1, y1, proto_w, proto_h,
-                                         lx0, inv_lw, ly0, inv_lh))
+                        Ok(seg_from_roi(
+                            mask, x0, y0, x1, y1, proto_w, proto_h, lx0, inv_lw, ly0, inv_lh,
+                        ))
                     })
                     .collect()
             }
@@ -343,11 +352,19 @@ impl CPUProcessor {
                         let (x0, y0, x1, y1, roi_w, roi_h) =
                             bbox_to_proto_roi(det, proto_w, proto_h);
                         let mask = fused_dot_sigmoid_f32_slice(
-                            protos_slice, coeff, proto_h, proto_w, y0, x0,
-                            roi_h, roi_w, num_protos,
+                            protos_slice,
+                            coeff,
+                            proto_h,
+                            proto_w,
+                            y0,
+                            x0,
+                            roi_h,
+                            roi_w,
+                            num_protos,
                         );
-                        Ok(seg_from_roi(mask, x0, y0, x1, y1, proto_w, proto_h,
-                                         lx0, inv_lw, ly0, inv_lh))
+                        Ok(seg_from_roi(
+                            mask, x0, y0, x1, y1, proto_w, proto_h, lx0, inv_lw, ly0, inv_lh,
+                        ))
                     })
                     .collect()
             }
@@ -363,11 +380,19 @@ impl CPUProcessor {
                         let (x0, y0, x1, y1, roi_w, roi_h) =
                             bbox_to_proto_roi(det, proto_w, proto_h);
                         let mask = fused_dot_sigmoid_f16_slice(
-                            protos_slice, coeff, proto_h, proto_w, y0, x0,
-                            roi_h, roi_w, num_protos,
+                            protos_slice,
+                            coeff,
+                            proto_h,
+                            proto_w,
+                            y0,
+                            x0,
+                            roi_h,
+                            roi_w,
+                            num_protos,
                         );
-                        Ok(seg_from_roi(mask, x0, y0, x1, y1, proto_w, proto_h,
-                                         lx0, inv_lw, ly0, inv_lh))
+                        Ok(seg_from_roi(
+                            mask, x0, y0, x1, y1, proto_w, proto_h, lx0, inv_lw, ly0, inv_lh,
+                        ))
                     })
                     .collect()
             }
@@ -423,6 +448,13 @@ impl CPUProcessor {
         }
         if coeff_shape[0] == 0 {
             return Ok(Vec::new());
+        }
+        if coeff_shape[0] != detect.len() {
+            return Err(crate::Error::Internal(format!(
+                "mask_coefficients rows {} != detection count {}",
+                coeff_shape[0],
+                detect.len()
+            )));
         }
 
         // Widen coefficients to f32 once for the scaled-sample inner loop.
@@ -887,47 +919,6 @@ unsafe fn fused_dot_sigmoid_f16_slice_f16c(
     mask
 }
 
-// Scaled mask kernels — bilinear sample + sigmoid, binarized output.
-
-#[allow(clippy::too_many_arguments)]
-#[inline(always)]
-fn bilinear_dot_slice<P: Copy>(
-    protos: &[P],
-    stride_y: usize,
-    num_protos: usize,
-    coeff: &[f32],
-    px: f32,
-    py: f32,
-    proto_w: usize,
-    proto_h: usize,
-    load_f32: impl Fn(&P) -> f32,
-) -> f32 {
-    let x0 = (px.floor() as isize).clamp(0, proto_w as isize - 1) as usize;
-    let y0 = (py.floor() as isize).clamp(0, proto_h as isize - 1) as usize;
-    let x1 = (x0 + 1).min(proto_w - 1);
-    let y1 = (y0 + 1).min(proto_h - 1);
-    let fx = px - px.floor();
-    let fy = py - py.floor();
-    let w00 = (1.0 - fx) * (1.0 - fy);
-    let w10 = fx * (1.0 - fy);
-    let w01 = (1.0 - fx) * fy;
-    let w11 = fx * fy;
-    let b00 = y0 * stride_y + x0 * num_protos;
-    let b10 = y0 * stride_y + x1 * num_protos;
-    let b01 = y1 * stride_y + x0 * num_protos;
-    let b11 = y1 * stride_y + x1 * num_protos;
-    let mut acc = 0.0_f32;
-    for p in 0..num_protos {
-        let v00 = load_f32(&protos[b00 + p]);
-        let v10 = load_f32(&protos[b10 + p]);
-        let v01 = load_f32(&protos[b01 + p]);
-        let v11 = load_f32(&protos[b11 + p]);
-        let val = w00 * v00 + w10 * v10 + w01 * v01 + w11 * v11;
-        acc += coeff[p] * val;
-    }
-    acc
-}
-
 #[allow(clippy::too_many_arguments)]
 fn scaled_segmentations_f32_slice(
     detect: &[crate::DetectBox],
@@ -998,7 +989,7 @@ fn scaled_segmentations_i8_slice(
     use edgefirst_tensor::QuantMode;
     // Only per-tensor quantization supported on the scaled-path CPU kernel
     // today. Per-channel fits naturally into a future extension (would need
-    // to pass per-channel scaled coefficients into bilinear_dot_slice).
+    // per-channel scaled coefficients in scaled_run's dot-product precompute).
     let (scale, zp) = match quant.mode() {
         QuantMode::PerTensor { scale, zero_point } => (scale, zero_point as f32),
         QuantMode::PerTensorSymmetric { scale } => (scale, 0.0),
@@ -1106,13 +1097,9 @@ fn scaled_run<P: Copy + Sync>(
             let s_y_max = sample_y_at((py1 as f32) - 1.0);
             // Floor min, ceil max+1 to include both bilinear neighbours.
             let proto_x0 = (s_x_min.floor() as isize).max(0).min(proto_w as isize) as usize;
-            let proto_x1 = ((s_x_max.ceil() as isize) + 1)
-                .max(0)
-                .min(proto_w as isize) as usize;
+            let proto_x1 = ((s_x_max.ceil() as isize) + 1).max(0).min(proto_w as isize) as usize;
             let proto_y0 = (s_y_min.floor() as isize).max(0).min(proto_h as isize) as usize;
-            let proto_y1 = ((s_y_max.ceil() as isize) + 1)
-                .max(0)
-                .min(proto_h as isize) as usize;
+            let proto_y1 = ((s_y_max.ceil() as isize) + 1).max(0).min(proto_h as isize) as usize;
             let roi_w = proto_x1.saturating_sub(proto_x0).max(1);
             let roi_h = proto_y1.saturating_sub(proto_y0).max(1);
 

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -1734,7 +1734,24 @@ mod cpu_tests {
         num_protos: usize,
         coefficients: Vec<Vec<f32>>,
     ) -> crate::ProtoData {
+        make_proto_data_with_values(
+            proto_h,
+            proto_w,
+            num_protos,
+            vec![0.0_f32; proto_h * proto_w * num_protos],
+            coefficients,
+        )
+    }
+
+    fn make_proto_data_with_values(
+        proto_h: usize,
+        proto_w: usize,
+        num_protos: usize,
+        proto_values: Vec<f32>,
+        coefficients: Vec<Vec<f32>>,
+    ) -> crate::ProtoData {
         use edgefirst_tensor::{Tensor, TensorDyn};
+        assert_eq!(proto_values.len(), proto_h * proto_w * num_protos);
         let n = coefficients.len();
         let row_len = coefficients.first().map(|r| r.len()).unwrap_or(num_protos);
         let mut flat = Vec::with_capacity(n * row_len);
@@ -1742,11 +1759,8 @@ mod cpu_tests {
             flat.extend_from_slice(row);
         }
         let coeff_t = Tensor::<f32>::from_slice(&flat, &[n, row_len]).unwrap();
-        let protos_t = Tensor::<f32>::from_slice(
-            &vec![0.0_f32; proto_h * proto_w * num_protos],
-            &[proto_h, proto_w, num_protos],
-        )
-        .unwrap();
+        let protos_t =
+            Tensor::<f32>::from_slice(&proto_values, &[proto_h, proto_w, num_protos]).unwrap();
         crate::ProtoData {
             mask_coefficients: TensorDyn::F32(coeff_t),
             protos: TensorDyn::F32(protos_t),
@@ -1879,6 +1893,74 @@ mod cpu_tests {
         );
         let segs = result.unwrap();
         assert_eq!(segs.len(), 1);
+    }
+
+    #[test]
+    fn test_materialize_scaled_invalid_coeff_rows() {
+        let cpu = CPUProcessor::new();
+        let proto_data = make_proto_data(8, 8, 4, vec![vec![0.5; 4]]);
+        let det = [
+            make_detect_box(0.1, 0.1, 0.5, 0.5),
+            make_detect_box(0.5, 0.5, 0.9, 0.9),
+        ];
+        let result = cpu.materialize_scaled_segmentations(&det, &proto_data, None, 64, 64);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(&err, crate::Error::Internal(s) if s.contains("mask_coefficients rows")),
+            "error should report coefficient rows vs detection count mismatch: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_materialize_scaled_bbox_edge_one() {
+        let cpu = CPUProcessor::new();
+        let proto_data = make_proto_data_with_values(8, 8, 1, vec![1.0_f32; 64], vec![vec![1.0]]);
+        let det = [make_detect_box(0.5, 0.5, 1.0, 1.0)];
+        let segs = cpu
+            .materialize_scaled_segmentations(&det, &proto_data, None, 64, 64)
+            .expect("bbox at exact boundary (1.0) should be handled on scaled path");
+        assert_eq!(segs.len(), 1);
+        let shape = segs[0].segmentation.shape();
+        assert!(shape[0] > 0 && shape[1] > 0);
+        assert_eq!(shape[2], 1);
+        assert!(
+            segs[0]
+                .segmentation
+                .iter()
+                .all(|&v| matches!(v, 0_u8 | 255_u8)),
+            "scaled path output must remain binarized u8"
+        );
+    }
+
+    #[test]
+    fn test_materialize_scaled_letterbox_mapping() {
+        let cpu = CPUProcessor::new();
+        let proto_data = make_proto_data_with_values(8, 8, 1, vec![1.0_f32; 64], vec![vec![1.0]]);
+        let det = [make_detect_box(0.25, 0.1, 0.75, 0.9)];
+        let segs = cpu
+            .materialize_scaled_segmentations(
+                &det,
+                &proto_data,
+                Some([0.25, 0.1, 0.75, 0.9]),
+                16,
+                10,
+            )
+            .expect("scaled path with letterbox should succeed");
+        assert_eq!(segs.len(), 1);
+        let seg = &segs[0];
+        assert!((seg.xmin - 0.0).abs() < 1e-6);
+        assert!((seg.ymin - 0.0).abs() < 1e-6);
+        assert!((seg.xmax - 1.0).abs() < 1e-6);
+        assert!((seg.ymax - 1.0).abs() < 1e-6);
+        let shape = seg.segmentation.shape();
+        assert_eq!(shape[0], 10);
+        assert_eq!(shape[1], 16);
+        assert_eq!(shape[2], 1);
+        assert!(
+            seg.segmentation.iter().all(|&v| v == 255),
+            "positive logits should remain foreground after scaled letterbox mapping"
+        );
     }
 
     /// Golden-byte anchor: runs the quantized decode + CPU mask materialization

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -1963,6 +1963,22 @@ mod cpu_tests {
         );
     }
 
+    #[test]
+    fn test_materialize_scaled_out_of_range_letterbox_no_panic() {
+        let cpu = CPUProcessor::new();
+        let proto_data = make_proto_data_with_values(8, 8, 1, vec![1.0_f32; 64], vec![vec![1.0]]);
+        let det = [make_detect_box(0.95, 0.95, 1.0, 1.0)];
+        // Deliberately out-of-range letterbox values: this used to drive
+        // proto_x0/proto_y0 to the exclusive upper bound and panic in scaled_run.
+        let segs = cpu
+            .materialize_scaled_segmentations(&det, &proto_data, Some([1.2, 1.2, 1.4, 1.4]), 32, 32)
+            .expect("scaled path should clamp ROI starts and avoid OOB panics");
+        assert_eq!(segs.len(), 1);
+        let shape = segs[0].segmentation.shape();
+        assert!(shape[0] > 0 && shape[1] > 0);
+        assert_eq!(shape[2], 1);
+    }
+
     /// Golden-byte anchor: runs the quantized decode + CPU mask materialization
     /// end-to-end on the cached YOLOv8-seg fixture and asserts the first
     /// detection's binarized u8 mask is bit-exact against a committed golden


### PR DESCRIPTION
## Summary

Establish a progressive-disclosure Optimization Guide that spans `README.md`, `ARCHITECTURE.md`, `TESTING.md`, and `BENCHMARKS.md`. Each document targets a distinct level so a reader can land at any depth and walk in either direction.

| Document | Level | Content |
|----------|-------|---------|
| README | Rules (8 numbered rules) | Tensor reuse, `ImageProcessor::create_image()`, inode-keyed cache for v4l2/libcamera circular buffers, `Decoder` reuse, one `ImageProcessor` per pipeline thread, native fp16/AVX build overrides, NumPy interop fast path, `MaskResolution::Scaled` for COCO/IoU evaluation |
| ARCHITECTURE | Mechanism | Rule → mechanism mapping table at the top of `Performance Considerations`, citing `BufferIdentity`, `EglCacheKey`, `GL_MUTEX`, and Appendix C |
| TESTING | Verification | New `Validating Optimizations` section: parsing `EglImageCache stats` log lines, backend-isolation env vars, a tensor-reuse regression-test pattern, an fd-recycling test recipe using `dup()` |
| BENCHMARKS | Cost | Per-rule cost table at the top tied to the existing `Tensor Reuse Impact`, `Image Preprocessing`, `Decoder Post-Processing`, and `materialize_masks` sections; "How to Reproduce" walkthrough using `bench_preproc` |

The most important rule — and the most common performance bug — is **caching imported camera tensors by inode rather than fd**. V4L2 / libcamera recycle fd numbers across a small pool, so an fd-keyed cache misses on every frame. HAL's internal `EglImageCache` keyed by `BufferIdentity.id` cannot rescue an integration that mints a new tensor per frame; the application-layer inode-keyed cache is what binds the two layers together.

## Drive-by fixes

While reviewing the existing examples, this PR also corrects a few pre-existing API-drift bugs:

- README crate dependency `0.13` → `0.18` to match the workspace
- Rust `Decoder` examples replaced the non-existent `Decoder::new()` with the actual `DecoderBuilder` pattern; `decode()` now uses the real out-parameter signature
- `ByteTrack` tracker example flattens `Vec<Option<TrackInfo>>` rather than implicitly unwrapping
- Python `import_image` dtype argument corrected from `ef.DType.U8` to `"uint8"`
- `bench_preproc` build command corrected from `-p edgefirst-capi` to `-p edgefirst-hal-capi`
- TESTING fp16 section no longer splits the `Disabling Hardware Backends` env-var table; orphaned rows reunited
- README Rule 2 sub-headings demoted from h3 so the TOC no longer treats `Rust / Python / C` as siblings of Rule 3
- Newly documented `EDGEFIRST_FORCE_TRANSFER=sync` (already accepted by the code, was missing from the user-facing docs)

This PR includes documentation updates plus targeted CPU mask-path code changes (parallel/logit-precompute guardrails), with new scaled-path unit tests and corresponding changelog notes.

## Test plan

- [ ] Render the four updated docs on GitHub and confirm the rule numbering, cross-doc links, and TOC nesting all resolve.
- [ ] Spot-check that the corrected Rust examples (`DecoderBuilder` chain, `Decoder::decode` out-params, `ByteTrack` `Option` flatten, `load_image` import) match the current code by glancing at the cited file:line references.
- [ ] Confirm the `EDGEFIRST_FORCE_TRANSFER=sync` row appears in both the README env-var table and the TESTING backend-isolation matrix.
- [ ] Verify the inode-cache pattern in README Rule 3 (Rust + Python + C variants) parses cleanly and uses `fstat` / `st_ino` rather than fd.

## Notes for reviewers

- Document version metadata (`**Last Updated:** March 2026` etc.) was deliberately not bumped — per the project's documentation-versioning policy, version updates are a publish-time decision, not a per-PR change.
- Recorded benchmark numbers in `BENCHMARKS.md` are unchanged. The new per-rule cost table cites the existing `Tensor Reuse Impact` numbers (1.7× / 3.3× penalty multipliers, 3.5 ms / 2.2 ms ms/frame deltas) which were verified arithmetically against the underlying tables.
- There is currently no automated guard that compiles the doc code blocks. The two API-drift bugs fixed here had survived prior reviews because both reviews verified that the symbols *exist* but did not verify that the *exact call shape* in each snippet typechecks. A follow-up to extract samples into compile-tested doc fixtures would prevent this class of drift from returning.
