### PR TITLE
EDGEAI-2168: Pre-NMS top-K + NCHW proto layout optimization (up to 62% mask decode reduction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- **`MaskResolution::Proto` now returns binary `{0, 255}` masks** instead of
-  continuous sigmoid `[0, 255]` values. The sign-threshold optimization
-  (`dot > 0 → 255`) gives the same segmentation result as `sigmoid(dot) > 0.5`
-  but eliminates the sigmoid computation entirely. Callers that relied on
-  intermediate confidence values should use `MaskResolution::Scaled` instead.
+- **`MaskResolution::Proto` and `MaskResolution::Scaled` now return binary
+  `{0, 255}` masks** instead of continuous sigmoid `[0, 255]` values. The
+  sign-threshold optimization (`dot > 0 → 255`) gives the same segmentation
+  result as `sigmoid(dot) > 0.5` but eliminates the sigmoid computation
+  entirely. Callers that relied on intermediate confidence values should apply
+  custom sigmoid to the raw `ProtoData` tensor (via `decode_proto()`).
 - **`impl_yolo_segdet_quant_proto` and `impl_yolo_split_segdet_quant_get_boxes`**
   gained `pre_nms_top_k` and `max_det` parameters. Downstream Rust callers
   using these internal APIs must update their call sites.
@@ -46,8 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deterministic ordering.
 - Python `max_boxes` parameter now enforces a hard output limit (truncates
   boxes, masks, and tracks to `max_boxes` after decode).
-- `decode_proto()` now always copies the actual model proto tensor, even when
-  zero detections survive NMS (previously fabricated a zero-filled tensor).
+- `decode_proto()` allocates proto tensors with the correct shape and layout
+  even when zero detections survive NMS (previously the shape did not reflect
+  the model's physical layout for NCHW protos).
 - Column-major argmax gracefully falls back to row-major when models have
   > 255 classes (previously panicked with an assertion failure).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-05-05
+
+### Breaking Changes
+
+- **`MaskResolution::Proto` now returns binary `{0, 255}` masks** instead of
+  continuous sigmoid `[0, 255]` values. The sign-threshold optimization
+  (`dot > 0 → 255`) gives the same segmentation result as `sigmoid(dot) > 0.5`
+  but eliminates the sigmoid computation entirely. Callers that relied on
+  intermediate confidence values should use `MaskResolution::Scaled` instead.
+- **`impl_yolo_segdet_quant_proto` and `impl_yolo_split_segdet_quant_get_boxes`**
+  gained `pre_nms_top_k` and `max_det` parameters. Downstream Rust callers
+  using these internal APIs must update their call sites.
+- **`ProtoData.protos` shape depends on layout.** When
+  `ProtoData.layout == ProtoLayout::Nchw`, the tensor shape is
+  `[num_protos, H, W]` instead of `[H, W, num_protos]`. Python callers should
+  check the new `ProtoData.layout` property; C callers should use
+  `hal_proto_data_layout()`.
+
+### Added
+
+- `ProtoData.layout` property in Python and `hal_proto_data_layout()` in C API
+  to query proto tensor memory layout (NHWC vs NCHW).
+- Pre-NMS top-K filtering (`Decoder.pre_nms_top_k`) to reduce O(N²) NMS cost.
+  Default: 300. Skipped when `nms=None` (bypass mode).
+- `Decoder.max_det` to cap post-NMS output count (default: 300, matches
+  Ultralytics convention).
+- NEON-accelerated column-major argmax for quantized score tensors on aarch64,
+  with automatic fallback to row-major for models with > 255 classes.
+- NCHW proto layout detection — skips the 3.1 ms NCHW→NHWC transpose on
+  Cortex-A53/A55 when the model outputs protos in channel-first order.
+- x86_64 F16C+FMA vectorized kernel for f16 proto mask materialization
+  (sign-threshold variant).
+
+### Changed
+
+- `pre_nms_top_k` is now ignored when `nms=None` (NMS bypass mode preserves
+  all above-threshold candidates).
+- Detection output is always sorted by descending score after NMS for
+  deterministic ordering.
+- Python `max_boxes` parameter now enforces a hard output limit (truncates
+  boxes, masks, and tracks to `max_boxes` after decode).
+- `decode_proto()` now always copies the actual model proto tensor, even when
+  zero detections survive NMS (previously fabricated a zero-filled tensor).
+- Column-major argmax gracefully falls back to row-major when models have
+  > 255 classes (previously panicked with an assertion failure).
+
+### Fixed
+
+- NCHW stride detection now uses exact stride matching `[W, 1, H*W]` instead
+  of the overly broad `strides()[2] > 1` check that could misclassify
+  arbitrary strided views as contiguous NCHW buffers.
+
 ## [0.18.1] - 2026-05-01
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.19.0] - 2026-05-05
-
 ### Breaking Changes
 
 - **`MaskResolution::Proto` now returns binary `{0, 255}` masks** instead of

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ rule exists, and [TESTING.md] for how to verify your integration follows it.
 | Construct one `ImageProcessor` per pipeline | Each instance owns its own GL context and EGL display | Multiple GL contexts contend on `GL_MUTEX`; see ARCHITECTURE.md |
 | Use native fp16 / AVX build overrides only on CPUs that support them | These flags unlock native widening/vector paths for local perf testing | Unsupported targets may fail to build or hit illegal instructions; portability loss |
 | Pass numpy arrays straight to `Tensor.from_numpy()` — do not pre-`ascontiguousarray()` | HAL detects strided sources and materialises via numpy's vectorized C strided→contig pass; a manual workaround above HAL adds a redundant copy | A redundant `np.ascontiguousarray` pre-copy on every call (size-dependent; e.g. ≈1.5 ms per call on a `(1, 116, 8400)` f32 view on rpi5-hailo) |
-| For COCO/IoU evaluation use `MaskResolution::Scaled(orig_w, orig_h)`, not `Proto` | `Scaled` upsamples the continuous-sigmoid proto plane *before* thresholding (clean edges); `Proto` returns continuous values but most callers threshold-then-resize, which produces blocky binary edges and lossy mAP | Mask mAP regression of up to 0.04–0.05 absolute (model- and dataset-dependent) when `Proto` is thresholded then nearest-upsampled |
+| For COCO/IoU evaluation use `MaskResolution::Scaled(orig_w, orig_h)`, not `Proto` | `Scaled` upsamples the proto plane *before* thresholding at full output resolution (clean sub-pixel edges); `Proto` thresholds at proto resolution (160×160) then callers typically nearest-upsample, producing blocky edges | Mask mAP regression of up to 0.04–0.05 absolute (model- and dataset-dependent) when `Proto` is nearest-upsampled |
 
 > [!IMPORTANT]
 > The single most common performance bug is calling
@@ -794,13 +794,11 @@ the perf bound (≤ 1.5× slower than the manual workaround).
 ### Rule 8 — Choose the correct `MaskResolution` for your evaluation
 
 `ImageProcessor.materialize_masks()` accepts a `MaskResolution`
-parameter that controls **where the sigmoid threshold is applied**
-along the materialisation pipeline. The choice changes both the
-output dtype and the achievable mask-mAP:
+parameter that controls the output resolution and pipeline:
 
-| Mode | Output | Sigmoid → threshold pipeline | When to use |
+| Mode | Output | Pipeline | When to use |
 |---|---|---|---|
-| `MaskResolution::Proto` (default) | `(roi_h, roi_w, 1)` u8 — **continuous sigmoid** [0, 255] at 160×160 proto resolution | dot → sigmoid → emit (no threshold) | Real-time visualisation where downstream code already does its own scale-aware thresholding, or when you specifically want continuous confidence values |
+| `MaskResolution::Proto` (default) | `(roi_h, roi_w, 1)` u8 — **binary** {0, 255} at 160×160 proto resolution | dot → sign threshold → emit | Real-time visualisation, rendering, or when proto-resolution binary masks suffice |
 | `MaskResolution::Scaled { width, height }` | `(roi_h, roi_w, 1)` u8 — **binary** {0, 255} at the requested resolution | dot → sigmoid → upsample to `(width, height)` → threshold (`>127`) | All COCO / IoU / mAP evaluation. Upsample-then-threshold preserves sub-proto-cell precision; the alternative (threshold-at-160 then upsample the binary mask) produces blocky 4-pixel-aligned edges and a measurable mAP regression |
 
 ```python

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -57,6 +57,16 @@ typedef void *hal_delegate_t;
 #include <stdio.h>
 
 /**
+ * Proto tensor layout constants for `hal_proto_data_layout()`.
+ */
+#define HAL_PROTO_LAYOUT_NHWC 0
+
+/**
+ * Proto tensor layout constants for `hal_proto_data_layout()`.
+ */
+#define HAL_PROTO_LAYOUT_NCHW 1
+
+/**
  * Maximum number of dimensions in a delegate tensor shape.
  */
 #define HAL_DMABUF_MAX_NDIM 8
@@ -1289,9 +1299,13 @@ void hal_proto_data_free(struct hal_proto_data *proto);
 /**
  * Take ownership of the proto tensor from a prototype data handle.
  *
- * Shape `[H, W, num_protos]`. For quantized models, the returned tensor
- * carries its quantization metadata (accessible via
- * `hal_tensor_quantization()`).
+ * Shape depends on the layout returned by `hal_proto_data_layout()`:
+ *
+ * - `HAL_PROTO_LAYOUT_NHWC` (0): shape is `[H, W, num_protos]`
+ * - `HAL_PROTO_LAYOUT_NCHW` (1): shape is `[num_protos, H, W]`
+ *
+ * For quantized models, the returned tensor carries its quantization
+ * metadata (accessible via `hal_tensor_quantization()`).
  *
  * After calling this, subsequent calls for protos on the same handle
  * return NULL. The proto data handle itself must still be freed via
@@ -1316,6 +1330,20 @@ struct hal_tensor *hal_proto_data_take_protos(struct hal_proto_data *proto);
  *         or NULL if `proto` is NULL or mask_coefficients have been taken
  */
 struct hal_tensor *hal_proto_data_take_mask_coefficients(struct hal_proto_data *proto);
+
+/**
+ * Query the physical memory layout of the prototype tensor.
+ *
+ * Returns `HAL_PROTO_LAYOUT_NHWC` (0) when the proto tensor shape is
+ * `[H, W, num_protos]`, or `HAL_PROTO_LAYOUT_NCHW` (1) when the shape
+ * is `[num_protos, H, W]`.
+ *
+ * Use this to interpret the tensor returned by `hal_proto_data_take_protos()`.
+ *
+ * @param proto Prototype data handle (may be NULL)
+ * @return Layout constant, or -1 if `proto` is NULL
+ */
+int32_t hal_proto_data_layout(const struct hal_proto_data *proto);
 
 /**
  * Get the number of detections in a list.
@@ -1788,10 +1816,10 @@ int hal_image_processor_draw_decoded_masks(struct hal_image_processor *processor
 /**
  * Materialize per-instance segmentation masks from prototype data.
  *
- * Computes `mask_coeff @ protos` with sigmoid activation for each detection,
- * producing compact masks at prototype resolution (e.g., 160×160 crops).
- * Mask values are continuous sigmoid confidence quantized to uint8
- * (0 = background, 255 = full confidence), NOT binary thresholded.
+ * Computes `mask_coeff @ protos` for each detection, producing compact
+ * binary masks at prototype resolution (e.g., 160×160 crops).
+ * Mask values are binary uint8 {0, 255} — pixels where the dot product
+ * is positive are foreground (255), otherwise background (0).
  *
  * The returned segmentation list can be:
  * - Inspected via `hal_segmentation_list_get_mask()` for analytics, IoU, etc.

--- a/crates/capi/src/decoder.rs
+++ b/crates/capi/src/decoder.rs
@@ -1222,9 +1222,13 @@ pub unsafe extern "C" fn hal_proto_data_free(proto: *mut HalProtoData) {
 
 /// Take ownership of the proto tensor from a prototype data handle.
 ///
-/// Shape `[H, W, num_protos]`. For quantized models, the returned tensor
-/// carries its quantization metadata (accessible via
-/// `hal_tensor_quantization()`).
+/// Shape depends on the layout returned by `hal_proto_data_layout()`:
+///
+/// - `HAL_PROTO_LAYOUT_NHWC` (0): shape is `[H, W, num_protos]`
+/// - `HAL_PROTO_LAYOUT_NCHW` (1): shape is `[num_protos, H, W]`
+///
+/// For quantized models, the returned tensor carries its quantization
+/// metadata (accessible via `hal_tensor_quantization()`).
 ///
 /// After calling this, subsequent calls for protos on the same handle
 /// return NULL. The proto data handle itself must still be freed via
@@ -1272,6 +1276,33 @@ pub unsafe extern "C" fn hal_proto_data_take_mask_coefficients(
         return std::ptr::null_mut();
     }
     Box::into_raw(Box::new(HalTensor { inner: taken }))
+}
+
+/// Proto tensor layout constants for `hal_proto_data_layout()`.
+pub const HAL_PROTO_LAYOUT_NHWC: i32 = 0;
+/// Proto tensor layout constants for `hal_proto_data_layout()`.
+pub const HAL_PROTO_LAYOUT_NCHW: i32 = 1;
+
+/// Query the physical memory layout of the prototype tensor.
+///
+/// Returns `HAL_PROTO_LAYOUT_NHWC` (0) when the proto tensor shape is
+/// `[H, W, num_protos]`, or `HAL_PROTO_LAYOUT_NCHW` (1) when the shape
+/// is `[num_protos, H, W]`.
+///
+/// Use this to interpret the tensor returned by `hal_proto_data_take_protos()`.
+///
+/// @param proto Prototype data handle (may be NULL)
+/// @return Layout constant, or -1 if `proto` is NULL
+#[no_mangle]
+pub unsafe extern "C" fn hal_proto_data_layout(proto: *const HalProtoData) -> i32 {
+    if proto.is_null() {
+        return -1;
+    }
+    let proto = unsafe { &*proto };
+    match proto.inner.layout {
+        edgefirst_decoder::ProtoLayout::Nhwc => HAL_PROTO_LAYOUT_NHWC,
+        edgefirst_decoder::ProtoLayout::Nchw => HAL_PROTO_LAYOUT_NCHW,
+    }
 }
 
 /// A zero-length `u8` sentinel (shape `[0]`) used by the `take_*` accessors

--- a/crates/capi/src/image.rs
+++ b/crates/capi/src/image.rs
@@ -954,10 +954,10 @@ pub unsafe extern "C" fn hal_image_processor_draw_decoded_masks(
 
 /// Materialize per-instance segmentation masks from prototype data.
 ///
-/// Computes `mask_coeff @ protos` with sigmoid activation for each detection,
-/// producing compact masks at prototype resolution (e.g., 160×160 crops).
-/// Mask values are continuous sigmoid confidence quantized to uint8
-/// (0 = background, 255 = full confidence), NOT binary thresholded.
+/// Computes `mask_coeff @ protos` for each detection, producing compact
+/// binary masks at prototype resolution (e.g., 160×160 crops).
+/// Mask values are binary uint8 {0, 255} — pixels where the dot product
+/// is positive are foreground (255), otherwise background (0).
 ///
 /// The returned segmentation list can be:
 /// - Inspected via `hal_segmentation_list_get_mask()` for analytics, IoU, etc.

--- a/crates/decoder/src/byte.rs
+++ b/crates/decoder/src/byte.rs
@@ -13,6 +13,82 @@ use ndarray::{
 use num_traits::{AsPrimitive, PrimInt};
 use rayon::slice::ParallelSliceMut;
 
+/// NEON-accelerated column max update for the column-major argmax path.
+///
+/// Processes 16 elements per iteration using SIMD max + bitwise select.
+/// Handles both unsigned (u8) and signed (i8) comparison semantics.
+///
+/// # Safety
+///
+/// - `col_ptr` must point to at least `n` valid bytes.
+/// - `max_ptr` must point to at least `n` valid mutable bytes.
+/// - `class_ptr` must point to at least `n` valid mutable bytes.
+#[cfg(target_arch = "aarch64")]
+unsafe fn column_max_update_neon(
+    col_ptr: *const u8,
+    max_ptr: *mut u8,
+    class_ptr: *mut u8,
+    n: usize,
+    class_idx: u8,
+    signed: bool,
+) {
+    use std::arch::aarch64::*;
+
+    let class_vec = vdupq_n_u8(class_idx);
+    let chunks = n / 16;
+    let remainder = n % 16;
+
+    if signed {
+        // Signed i8 comparison: interpret bytes as i8.
+        for chunk in 0..chunks {
+            let offset = chunk * 16;
+            let col = vld1q_s8(col_ptr.add(offset) as *const i8);
+            let cur_max = vld1q_s8(max_ptr.add(offset) as *const i8);
+            // mask[i] = 0xFF where col[i] >= cur_max[i], else 0x00
+            let mask = vcgeq_s8(col, cur_max);
+            // new_max = max(col, cur_max)
+            let new_max = vmaxq_s8(col, cur_max);
+            vst1q_s8(max_ptr.add(offset) as *mut i8, new_max);
+            // Select class_idx where mask is set, keep old class otherwise.
+            let cur_class = vld1q_u8(class_ptr.add(offset));
+            let new_class = vbslq_u8(mask, class_vec, cur_class);
+            vst1q_u8(class_ptr.add(offset), new_class);
+        }
+        // Scalar tail.
+        for i in (chunks * 16)..n {
+            let val = *(col_ptr.add(i) as *const i8);
+            let cur = *(max_ptr.add(i) as *const i8);
+            if val >= cur {
+                *(max_ptr.add(i) as *mut i8) = val;
+                *class_ptr.add(i) = class_idx;
+            }
+        }
+    } else {
+        // Unsigned u8 comparison.
+        for chunk in 0..chunks {
+            let offset = chunk * 16;
+            let col = vld1q_u8(col_ptr.add(offset));
+            let cur_max = vld1q_u8(max_ptr.add(offset));
+            let mask = vcgeq_u8(col, cur_max);
+            let new_max = vmaxq_u8(col, cur_max);
+            vst1q_u8(max_ptr.add(offset), new_max);
+            let cur_class = vld1q_u8(class_ptr.add(offset));
+            let new_class = vbslq_u8(mask, class_vec, cur_class);
+            vst1q_u8(class_ptr.add(offset), new_class);
+        }
+        // Scalar tail.
+        for i in (chunks * 16)..n {
+            let val = *col_ptr.add(i);
+            let cur = *max_ptr.add(i);
+            if val >= cur {
+                *max_ptr.add(i) = val;
+                *class_ptr.add(i) = class_idx;
+            }
+        }
+    }
+    let _ = remainder; // suppress unused warning
+}
+
 /// Fast argmax dispatching to NEON-optimized path for i8 on aarch64.
 #[inline(always)]
 fn fast_arg_max<T: PrimInt + Copy>(score: ArrayView1<T>) -> (T, usize) {
@@ -57,6 +133,17 @@ pub fn postprocess_boxes_quant<
 ) -> Vec<DetectBoxQuantized<Scores>> {
     assert_eq!(scores.dim().0, boxes.dim().0);
     assert_eq!(boxes.dim().1, 4);
+
+    // Use column-major path for transposed DMA-BUF views (see postprocess_boxes_index_quant).
+    if scores.strides()[0] == 1 && scores.as_slice().is_none() {
+        return postprocess_boxes_quant_column_major::<B, _, _>(
+            threshold,
+            boxes,
+            scores,
+            quant_boxes,
+        );
+    }
+
     Zip::from(scores.rows())
         .and(boxes.rows())
         .into_par_iter()
@@ -76,6 +163,110 @@ pub fn postprocess_boxes_quant<
         .collect()
 }
 
+/// Column-major optimized path for `postprocess_boxes_quant`.
+fn postprocess_boxes_quant_column_major<
+    B: BBoxTypeTrait,
+    Boxes: PrimInt + AsPrimitive<f32> + Send + Sync,
+    Scores: PrimInt + AsPrimitive<f32> + Send + Sync,
+>(
+    threshold: Scores,
+    boxes: ArrayView2<Boxes>,
+    scores: ArrayView2<Scores>,
+    quant_boxes: Quantization,
+) -> Vec<DetectBoxQuantized<Scores>> {
+    let (n_candidates, n_classes) = scores.dim();
+
+    assert!(
+        n_classes <= 255,
+        "column-major argmax requires <= 255 classes"
+    );
+    let mut max_scores = vec![Scores::min_value(); n_candidates];
+    let mut max_classes = vec![0u8; n_candidates];
+
+    for class_idx in 0..n_classes {
+        let col = scores.column(class_idx);
+        if let Some(slice) = col.as_slice() {
+            #[cfg(target_arch = "aarch64")]
+            {
+                if std::mem::size_of::<Scores>() == 1 {
+                    unsafe {
+                        column_max_update_neon(
+                            slice.as_ptr() as *const u8,
+                            max_scores.as_mut_ptr() as *mut u8,
+                            max_classes.as_mut_ptr(),
+                            n_candidates,
+                            class_idx as u8,
+                            Scores::min_value() < Scores::zero(),
+                        );
+                    }
+                    continue;
+                }
+            }
+            for (i, &val) in slice.iter().enumerate() {
+                if val >= max_scores[i] {
+                    max_scores[i] = val;
+                    max_classes[i] = class_idx as u8;
+                }
+            }
+        } else {
+            for (i, &val) in col.iter().enumerate() {
+                if val >= max_scores[i] {
+                    max_scores[i] = val;
+                    max_classes[i] = class_idx as u8;
+                }
+            }
+        }
+    }
+
+    // Copy boxes column-by-column if also transposed.
+    let boxes_buf: [Vec<Boxes>; 4] = if boxes.strides()[0] == 1 && boxes.as_slice().is_none() {
+        let mut cols: [Vec<Boxes>; 4] = [
+            vec![Boxes::zero(); n_candidates],
+            vec![Boxes::zero(); n_candidates],
+            vec![Boxes::zero(); n_candidates],
+            vec![Boxes::zero(); n_candidates],
+        ];
+        for (dim, col_buf) in cols.iter_mut().enumerate() {
+            let col = boxes.column(dim);
+            if let Some(slice) = col.as_slice() {
+                col_buf.copy_from_slice(slice);
+            } else {
+                for (i, &val) in col.iter().enumerate() {
+                    col_buf[i] = val;
+                }
+            }
+        }
+        cols
+    } else {
+        [vec![], vec![], vec![], vec![]]
+    };
+    let boxes_copied = !boxes_buf[0].is_empty();
+
+    let mut result = Vec::new();
+    for i in 0..n_candidates {
+        if max_scores[i] >= threshold {
+            let bbox_quant = if boxes_copied {
+                let raw = [
+                    boxes_buf[0][i],
+                    boxes_buf[1][i],
+                    boxes_buf[2][i],
+                    boxes_buf[3][i],
+                ];
+                B::to_xyxy_dequant(&raw, quant_boxes)
+            } else {
+                B::ndarray_to_xyxy_dequant(boxes.row(i), quant_boxes)
+            };
+            result.push(DetectBoxQuantized {
+                label: max_classes[i] as usize,
+                score: max_scores[i],
+                bbox: BoundingBox::from(bbox_quant),
+            });
+        }
+    }
+
+    result
+}
+
 /// Post processes boxes and scores tensors into quantized detection boxes,
 /// filtering out any boxes below the score threshold. The boxes tensor
 /// is converted to XYXY using the given BBoxTypeTrait. The order of the boxes
@@ -83,6 +274,10 @@ pub fn postprocess_boxes_quant<
 ///
 /// This function is very similar to `postprocess_boxes_quant` but will also
 /// return the index of the box. The boxes will be in ascending index order.
+///
+/// When scores originate from a transposed DMA-BUF view (stride-1 along axis 0),
+/// an optimized column-major scan is used to avoid catastrophic strided reads on
+/// uncacheable memory.
 #[doc(hidden)]
 pub fn postprocess_boxes_index_quant<
     B: BBoxTypeTrait,
@@ -96,6 +291,19 @@ pub fn postprocess_boxes_index_quant<
 ) -> Vec<(DetectBoxQuantized<Scores>, usize)> {
     assert_eq!(scores.dim().0, boxes.dim().0);
     assert_eq!(boxes.dim().1, 4);
+
+    // Detect transposed C-contiguous layout (e.g., from reversed_axes() on DMA-BUF).
+    // In this layout columns are contiguous (stride-1 along axis 0) but rows are not.
+    // The column-major path reads memory sequentially, avoiding cache-hostile strides.
+    if scores.strides()[0] == 1 && scores.as_slice().is_none() {
+        return postprocess_boxes_index_quant_column_major::<B, _, _>(
+            threshold,
+            boxes,
+            scores,
+            quant_boxes,
+        );
+    }
+
     let indices: Array1<usize> = (0..boxes.dim().0).collect();
     Zip::from(scores.rows())
         .and(boxes.rows())
@@ -119,6 +327,127 @@ pub fn postprocess_boxes_index_quant<
             ))
         })
         .collect()
+}
+
+/// Column-major optimized path for `postprocess_boxes_index_quant`.
+///
+/// When scores come from a transposed DMA-BUF view ([N_candidates, N_classes]
+/// with strides [1, N_candidates]), row iteration causes N_classes reads each
+/// N_candidates bytes apart — catastrophic on uncacheable memory. Instead, this
+/// iterates over classes (columns, which are contiguous), maintaining a running
+/// argmax per candidate in cacheable heap buffers.
+fn postprocess_boxes_index_quant_column_major<
+    B: BBoxTypeTrait,
+    Boxes: PrimInt + AsPrimitive<f32> + Send + Sync,
+    Scores: PrimInt + AsPrimitive<f32> + Send + Sync,
+>(
+    threshold: Scores,
+    boxes: ArrayView2<Boxes>,
+    scores: ArrayView2<Scores>,
+    quant_boxes: Quantization,
+) -> Vec<(DetectBoxQuantized<Scores>, usize)> {
+    let (n_candidates, n_classes) = scores.dim();
+
+    // Phase 1: Column-based argmax — sequential reads over contiguous columns.
+    // Use u8 for class indices (max 255 classes) for optimal NEON vectorization.
+    assert!(
+        n_classes <= 255,
+        "column-major argmax requires <= 255 classes"
+    );
+    let mut max_scores = vec![Scores::min_value(); n_candidates];
+    let mut max_classes = vec![0u8; n_candidates];
+    for class_idx in 0..n_classes {
+        let col = scores.column(class_idx);
+        if let Some(slice) = col.as_slice() {
+            // Use NEON-accelerated column max update on aarch64 for u8 scores.
+            #[cfg(target_arch = "aarch64")]
+            {
+                if std::mem::size_of::<Scores>() == 1 {
+                    // SAFETY: Scores is u8 or i8 (size == 1). We transmute the
+                    // slice pointers to the concrete byte type for NEON processing.
+                    unsafe {
+                        column_max_update_neon(
+                            slice.as_ptr() as *const u8,
+                            max_scores.as_mut_ptr() as *mut u8,
+                            max_classes.as_mut_ptr(),
+                            n_candidates,
+                            class_idx as u8,
+                            Scores::min_value() < Scores::zero(), // signed flag
+                        );
+                    }
+                    continue;
+                }
+            }
+            for (i, &val) in slice.iter().enumerate() {
+                if val >= max_scores[i] {
+                    max_scores[i] = val;
+                    max_classes[i] = class_idx as u8;
+                }
+            }
+        } else {
+            for (i, &val) in col.iter().enumerate() {
+                if val >= max_scores[i] {
+                    max_scores[i] = val;
+                    max_classes[i] = class_idx as u8;
+                }
+            }
+        }
+    }
+
+    // Phase 2: Copy boxes column-by-column into contiguous heap buffer.
+    // Boxes view is also transposed [N_candidates, 4] with strides [1, N_candidates],
+    // so column reads are sequential while row reads are strided.
+    let boxes_buf: [Vec<Boxes>; 4] = if boxes.strides()[0] == 1 && boxes.as_slice().is_none() {
+        let mut cols: [Vec<Boxes>; 4] = [
+            vec![Boxes::zero(); n_candidates],
+            vec![Boxes::zero(); n_candidates],
+            vec![Boxes::zero(); n_candidates],
+            vec![Boxes::zero(); n_candidates],
+        ];
+        for (dim, col_buf) in cols.iter_mut().enumerate() {
+            let col = boxes.column(dim);
+            if let Some(slice) = col.as_slice() {
+                col_buf.copy_from_slice(slice);
+            } else {
+                for (i, &val) in col.iter().enumerate() {
+                    col_buf[i] = val;
+                }
+            }
+        }
+        cols
+    } else {
+        // Boxes are contiguous or differently strided — read per-candidate below.
+        [vec![], vec![], vec![], vec![]]
+    };
+    let boxes_copied = !boxes_buf[0].is_empty();
+
+    // Phase 3: Threshold filter — collect candidates that pass.
+    let mut result = Vec::new();
+    for i in 0..n_candidates {
+        if max_scores[i] >= threshold {
+            let bbox_quant = if boxes_copied {
+                let raw = [
+                    boxes_buf[0][i],
+                    boxes_buf[1][i],
+                    boxes_buf[2][i],
+                    boxes_buf[3][i],
+                ];
+                B::to_xyxy_dequant(&raw, quant_boxes)
+            } else {
+                B::ndarray_to_xyxy_dequant(boxes.row(i), quant_boxes)
+            };
+            result.push((
+                DetectBoxQuantized {
+                    label: max_classes[i] as usize,
+                    score: max_scores[i],
+                    bbox: BoundingBox::from(bbox_quant),
+                },
+                i,
+            ));
+        }
+    }
+
+    result
 }
 
 /// Uses NMS to filter boxes based on the score and iou. Sorts boxes by score,
@@ -316,4 +645,128 @@ where
     let v = (score / quant.scale + quant.zero_point as f32).ceil();
     let v = v.clamp(T::min_value().as_(), T::max_value().as_());
     v.as_()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::XYWH;
+    use ndarray::Array2;
+
+    /// Verify that the column-major path produces identical results to the
+    /// row-major path for a transposed (non-contiguous) score array.
+    #[test]
+    fn column_major_matches_row_major() {
+        // Create scores in "model output" layout: [num_classes, num_candidates]
+        let n_classes = 80usize;
+        let n_candidates = 100usize;
+        let mut scores_physical = Array2::<u8>::zeros((n_classes, n_candidates));
+        // Fill with known pattern: class c, candidate i → (c * 3 + i * 7) % 256
+        for c in 0..n_classes {
+            for i in 0..n_candidates {
+                scores_physical[[c, i]] = ((c * 3 + i * 7) % 256) as u8;
+            }
+        }
+
+        // Create boxes: [4, num_candidates] i16
+        let mut boxes_physical = Array2::<i16>::zeros((4, n_candidates));
+        for i in 0..n_candidates {
+            boxes_physical[[0, i]] = (i * 10) as i16; // x
+            boxes_physical[[1, i]] = (i * 20) as i16; // y
+            boxes_physical[[2, i]] = (i * 10 + 50) as i16; // w
+            boxes_physical[[3, i]] = (i * 20 + 100) as i16; // h
+        }
+
+        let quant = Quantization {
+            scale: 0.00390625,
+            zero_point: 0,
+        };
+
+        let threshold: u8 = 10;
+
+        // Row-major path: contiguous [n_candidates, n_classes] array
+        let scores_contiguous = scores_physical.clone().reversed_axes().to_owned();
+        let boxes_contiguous = boxes_physical.clone().reversed_axes().to_owned();
+        let row_result = postprocess_boxes_index_quant::<XYWH, _, _>(
+            threshold,
+            boxes_contiguous.view(),
+            scores_contiguous.view(),
+            quant,
+        );
+
+        // Column-major path: non-contiguous reversed view
+        let scores_view = scores_physical.view().reversed_axes();
+        let boxes_view = boxes_physical.view().reversed_axes();
+        assert!(scores_view.as_slice().is_none(), "should be non-contiguous");
+        assert_eq!(scores_view.strides()[0], 1);
+        let col_result =
+            postprocess_boxes_index_quant::<XYWH, _, _>(threshold, boxes_view, scores_view, quant);
+
+        // Both paths should produce the same results
+        assert_eq!(
+            row_result.len(),
+            col_result.len(),
+            "different number of results: row={}, col={}",
+            row_result.len(),
+            col_result.len()
+        );
+        for (i, (row, col)) in row_result.iter().zip(col_result.iter()).enumerate() {
+            assert_eq!(
+                row.0.label, col.0.label,
+                "candidate {i}: label mismatch row={} col={}",
+                row.0.label, col.0.label
+            );
+            assert_eq!(row.0.score, col.0.score, "candidate {i}: score mismatch");
+            assert_eq!(row.1, col.1, "candidate {i}: index mismatch");
+            assert_eq!(row.0.bbox, col.0.bbox, "candidate {i}: bbox mismatch");
+        }
+    }
+
+    /// Test column-major path with i8 scores (signed, matches NEON argmax path).
+    #[test]
+    fn column_major_matches_row_major_i8() {
+        let n_classes = 80usize;
+        let n_candidates = 50usize;
+        let mut scores_physical = Array2::<i8>::zeros((n_classes, n_candidates));
+        for c in 0..n_classes {
+            for i in 0..n_candidates {
+                scores_physical[[c, i]] = ((c as i16 * 3 + i as i16 * 7) % 256 - 128) as i8;
+            }
+        }
+
+        let mut boxes_physical = Array2::<i16>::zeros((4, n_candidates));
+        for i in 0..n_candidates {
+            boxes_physical[[0, i]] = (i * 10) as i16;
+            boxes_physical[[1, i]] = (i * 20) as i16;
+            boxes_physical[[2, i]] = (i * 10 + 50) as i16;
+            boxes_physical[[3, i]] = (i * 20 + 100) as i16;
+        }
+
+        let quant = Quantization {
+            scale: 0.0256,
+            zero_point: -116,
+        };
+        let threshold: i8 = -100;
+
+        let scores_contiguous = scores_physical.clone().reversed_axes().to_owned();
+        let boxes_contiguous = boxes_physical.clone().reversed_axes().to_owned();
+        let row_result = postprocess_boxes_index_quant::<XYWH, _, _>(
+            threshold,
+            boxes_contiguous.view(),
+            scores_contiguous.view(),
+            quant,
+        );
+
+        let scores_view = scores_physical.view().reversed_axes();
+        let boxes_view = boxes_physical.view().reversed_axes();
+        let col_result =
+            postprocess_boxes_index_quant::<XYWH, _, _>(threshold, boxes_view, scores_view, quant);
+
+        assert_eq!(row_result.len(), col_result.len());
+        for (i, (row, col)) in row_result.iter().zip(col_result.iter()).enumerate() {
+            assert_eq!(row.0.label, col.0.label, "i8 candidate {i}: label mismatch");
+            assert_eq!(row.0.score, col.0.score, "i8 candidate {i}: score mismatch");
+            assert_eq!(row.1, col.1, "i8 candidate {i}: index mismatch");
+        }
+    }
 }

--- a/crates/decoder/src/byte.rs
+++ b/crates/decoder/src/byte.rs
@@ -1,15 +1,44 @@
 // SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(target_arch = "aarch64")]
+use crate::arg_max_i8;
 use crate::{
     arg_max, float::jaccard, BBoxTypeTrait, BoundingBox, DetectBoxQuantized, Quantization,
 };
 use ndarray::{
     parallel::prelude::{IntoParallelIterator, ParallelIterator as _},
-    Array1, ArrayView2, Zip,
+    Array1, ArrayView1, ArrayView2, Zip,
 };
 use num_traits::{AsPrimitive, PrimInt};
 use rayon::slice::ParallelSliceMut;
+
+/// Fast argmax dispatching to NEON-optimized path for i8 on aarch64.
+#[inline(always)]
+fn fast_arg_max<T: PrimInt + Copy>(score: ArrayView1<T>) -> (T, usize) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        // Check if this is an i8 slice and contiguous.
+        if std::mem::size_of::<T>() == 1 && score.as_slice().is_some() {
+            let slice = score.as_slice().unwrap();
+            // Safety: T is i8 when size_of::<T>() == 1 and PrimInt.
+            // PrimInt covers i8, u8, i16, etc. We only want to use the
+            // i8 NEON path for signed i8.
+            let ptr = slice.as_ptr() as *const i8;
+            let i8_slice = unsafe { std::slice::from_raw_parts(ptr, slice.len()) };
+            // Only valid for signed i8 (not u8). Check sign bit behavior:
+            // PrimInt for i8 means min_value() is negative.
+            if T::min_value() < T::zero() {
+                let (max_val, idx) = arg_max_i8(i8_slice);
+                // Safety: transmute i8 back to T (they have the same size and
+                // representation for i8).
+                let result: T = unsafe { std::mem::transmute_copy(&max_val) };
+                return (result, idx);
+            }
+        }
+    }
+    arg_max(score)
+}
 
 /// Post processes boxes and scores tensors into quantized detection boxes,
 /// filtering out any boxes below the score threshold. The boxes tensor
@@ -32,7 +61,7 @@ pub fn postprocess_boxes_quant<
         .and(boxes.rows())
         .into_par_iter()
         .filter_map(|(score, bbox)| {
-            let (score_, label) = arg_max(score);
+            let (score_, label) = fast_arg_max(score);
             if score_ < threshold {
                 return None;
             }
@@ -73,7 +102,7 @@ pub fn postprocess_boxes_index_quant<
         .and(&indices)
         .into_par_iter()
         .filter_map(|(score, bbox, index)| {
-            let (score_, label) = arg_max(score);
+            let (score_, label) = fast_arg_max(score);
             if score_ < threshold {
                 return None;
             }

--- a/crates/decoder/src/byte.rs
+++ b/crates/decoder/src/byte.rs
@@ -176,10 +176,25 @@ fn postprocess_boxes_quant_column_major<
 ) -> Vec<DetectBoxQuantized<Scores>> {
     let (n_candidates, n_classes) = scores.dim();
 
-    assert!(
-        n_classes <= 255,
-        "column-major argmax requires <= 255 classes"
-    );
+    // Column-major NEON path uses u8 class indices; fall back for >255 classes.
+    if n_classes > 255 {
+        return Zip::from(scores.rows())
+            .and(boxes.rows())
+            .into_par_iter()
+            .filter_map(|(score, bbox)| {
+                let (score_, label) = fast_arg_max(score);
+                if score_ < threshold {
+                    return None;
+                }
+                let bbox_quant = B::ndarray_to_xyxy_dequant(bbox.view(), quant_boxes);
+                Some(DetectBoxQuantized {
+                    label,
+                    score: score_,
+                    bbox: BoundingBox::from(bbox_quant),
+                })
+            })
+            .collect();
+    }
     let mut max_scores = vec![Scores::min_value(); n_candidates];
     let mut max_classes = vec![0u8; n_candidates];
 
@@ -350,10 +365,30 @@ fn postprocess_boxes_index_quant_column_major<
 
     // Phase 1: Column-based argmax — sequential reads over contiguous columns.
     // Use u8 for class indices (max 255 classes) for optimal NEON vectorization.
-    assert!(
-        n_classes <= 255,
-        "column-major argmax requires <= 255 classes"
-    );
+    // Fall back to row-major path for models with >255 classes.
+    if n_classes > 255 {
+        let indices: Array1<usize> = (0..n_candidates).collect();
+        return Zip::from(scores.rows())
+            .and(boxes.rows())
+            .and(&indices)
+            .into_par_iter()
+            .filter_map(|(score, bbox, index)| {
+                let (score_, label) = fast_arg_max(score);
+                if score_ < threshold {
+                    return None;
+                }
+                let bbox_quant = B::ndarray_to_xyxy_dequant(bbox.view(), quant_boxes);
+                Some((
+                    DetectBoxQuantized {
+                        label,
+                        score: score_,
+                        bbox: BoundingBox::from(bbox_quant),
+                    },
+                    *index,
+                ))
+            })
+            .collect();
+    }
     let mut max_scores = vec![Scores::min_value(); n_candidates];
     let mut max_classes = vec![0u8; n_candidates];
     for class_idx in 0..n_classes {

--- a/crates/decoder/src/decoder/builder.rs
+++ b/crates/decoder/src/decoder/builder.rs
@@ -60,7 +60,7 @@ impl Default for DecoderBuilder {
             iou_threshold: 0.5,
             score_threshold: 0.5,
             nms: Some(configs::Nms::ClassAgnostic),
-            pre_nms_top_k: 3000,
+            pre_nms_top_k: 300,
             max_det: 300,
         }
     }
@@ -771,7 +771,7 @@ impl DecoderBuilder {
     /// dramatically reducing the O(N²) NMS cost when many low-confidence
     /// proposals pass the threshold (common with mAP eval at 0.001).
     ///
-    /// Default: 3000.
+    /// Default: 300 (matches Ultralytics `max_det`).
     ///
     /// # Examples
     /// ```rust

--- a/crates/decoder/src/decoder/builder.rs
+++ b/crates/decoder/src/decoder/builder.rs
@@ -18,6 +18,8 @@ pub struct DecoderBuilder {
     /// NMS mode: Some(mode) applies NMS, None bypasses NMS (for end-to-end
     /// models)
     nms: Option<configs::Nms>,
+    pre_nms_top_k: usize,
+    max_det: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -58,6 +60,8 @@ impl Default for DecoderBuilder {
             iou_threshold: 0.5,
             score_threshold: 0.5,
             nms: Some(configs::Nms::ClassAgnostic),
+            pre_nms_top_k: 3000,
+            max_det: 300,
         }
     }
 }
@@ -762,6 +766,54 @@ impl DecoderBuilder {
         self
     }
 
+    /// Sets the maximum number of candidate boxes fed into NMS after score
+    /// filtering.  Uses partial sort (O(N)) to select the top-K candidates,
+    /// dramatically reducing the O(N²) NMS cost when many low-confidence
+    /// proposals pass the threshold (common with mAP eval at 0.001).
+    ///
+    /// Default: 3000.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
+    /// # fn main() -> DecoderResult<()> {
+    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// let decoder = DecoderBuilder::new()
+    ///     .with_config_json_str(config_json)
+    ///     .with_pre_nms_top_k(1000)
+    ///     .build()?;
+    /// assert_eq!(decoder.pre_nms_top_k, 1000);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_pre_nms_top_k(mut self, pre_nms_top_k: usize) -> Self {
+        self.pre_nms_top_k = pre_nms_top_k;
+        self
+    }
+
+    /// Sets the maximum number of detections returned after NMS.
+    /// Matches the Ultralytics `max_det` parameter.
+    ///
+    /// Default: 300.
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
+    /// # fn main() -> DecoderResult<()> {
+    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// let decoder = DecoderBuilder::new()
+    ///     .with_config_json_str(config_json)
+    ///     .with_max_det(100)
+    ///     .build()?;
+    /// assert_eq!(decoder.max_det, 100);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_max_det(mut self, max_det: usize) -> Self {
+        self.max_det = max_det;
+        self
+    }
+
     /// Builds the decoder with the given settings. If the config is a JSON or
     /// YAML string, this will deserialize the JSON or YAML and then parse the
     /// configuration information.
@@ -809,6 +861,8 @@ impl DecoderBuilder {
             iou_threshold: self.iou_threshold,
             score_threshold: self.score_threshold,
             nms,
+            pre_nms_top_k: self.pre_nms_top_k,
+            max_det: self.max_det,
             normalized,
             decode_program,
         })

--- a/crates/decoder/src/decoder/mod.rs
+++ b/crates/decoder/src/decoder/mod.rs
@@ -814,7 +814,7 @@ impl Decoder {
         }
 
         let mapped = tensor_bridge::map_tensors(outputs)?;
-        match &mapped {
+        let result = match &mapped {
             tensor_bridge::MappedOutputs::Quantized(maps) => {
                 let views = tensor_bridge::quantized_views(maps)?;
                 self.decode_quantized_proto(&views, output_boxes)
@@ -831,7 +831,8 @@ impl Decoder {
                 let views = tensor_bridge::f64_views(maps)?;
                 self.decode_float_proto(&views, output_boxes)
             }
-        }
+        };
+        result
     }
 }
 

--- a/crates/decoder/src/decoder/mod.rs
+++ b/crates/decoder/src/decoder/mod.rs
@@ -23,7 +23,7 @@ pub struct Decoder {
     /// Reduces O(N²) NMS cost when many low-confidence proposals pass the
     /// threshold (common during COCO mAP evaluation with threshold ≈ 0.001).
     /// Candidates are ranked by score; only the top `pre_nms_top_k` proceed
-    /// to NMS.  Default: 3000.
+    /// to NMS.  Default: 300.  Ignored when `nms` is `None`.
     pub pre_nms_top_k: usize,
     /// Maximum number of detections returned after NMS. Matches the
     /// Ultralytics `max_det` parameter.  Default: 300.

--- a/crates/decoder/src/decoder/mod.rs
+++ b/crates/decoder/src/decoder/mod.rs
@@ -19,6 +19,15 @@ pub struct Decoder {
     /// NMS mode: Some(mode) applies NMS, None bypasses NMS (for end-to-end
     /// models)
     pub nms: Option<configs::Nms>,
+    /// Maximum number of candidate boxes fed into NMS after score filtering.
+    /// Reduces O(N²) NMS cost when many low-confidence proposals pass the
+    /// threshold (common during COCO mAP evaluation with threshold ≈ 0.001).
+    /// Candidates are ranked by score; only the top `pre_nms_top_k` proceed
+    /// to NMS.  Default: 3000.
+    pub pre_nms_top_k: usize,
+    /// Maximum number of detections returned after NMS. Matches the
+    /// Ultralytics `max_det` parameter.  Default: 300.
+    pub max_det: usize,
     /// Whether decoded boxes are in normalized [0,1] coordinates.
     /// - `Some(true)`: Coordinates in [0,1] range
     /// - `Some(false)`: Pixel coordinates
@@ -40,6 +49,8 @@ impl PartialEq for Decoder {
             && self.iou_threshold == other.iou_threshold
             && self.score_threshold == other.score_threshold
             && self.nms == other.nms
+            && self.pre_nms_top_k == other.pre_nms_top_k
+            && self.max_det == other.max_det
             && self.normalized == other.normalized
             && self.decode_program.is_some() == other.decode_program.is_some()
     }

--- a/crates/decoder/src/decoder/mod.rs
+++ b/crates/decoder/src/decoder/mod.rs
@@ -24,9 +24,15 @@ pub struct Decoder {
     /// threshold (common during COCO mAP evaluation with threshold ≈ 0.001).
     /// Candidates are ranked by score; only the top `pre_nms_top_k` proceed
     /// to NMS.  Default: 300.  Ignored when `nms` is `None`.
+    ///
+    /// Applies to segmentation decode paths only. Detection-only models use
+    /// `output_boxes.capacity()` as their implicit output limit.
     pub pre_nms_top_k: usize,
     /// Maximum number of detections returned after NMS. Matches the
     /// Ultralytics `max_det` parameter.  Default: 300.
+    ///
+    /// Applies to segmentation decode paths only. Detection-only models are
+    /// bounded by `output_boxes.capacity()`.
     pub max_det: usize,
     /// Whether decoded boxes are in normalized [0,1] coordinates.
     /// - `Some(true)`: Coordinates in [0,1] range

--- a/crates/decoder/src/decoder/postprocess.rs
+++ b/crates/decoder/src/decoder/postprocess.rs
@@ -363,7 +363,8 @@ impl Decoder {
                     self.score_threshold,
                     self.iou_threshold,
                     self.nms,
-                    output_boxes.capacity(),
+                    self.pre_nms_top_k,
+                    self.max_det,
                 )
             })
         });
@@ -438,7 +439,8 @@ impl Decoder {
                 self.score_threshold,
                 self.iou_threshold,
                 self.nms,
-                output_boxes.capacity(),
+                self.pre_nms_top_k,
+                self.max_det,
             )
         });
 
@@ -1135,6 +1137,8 @@ impl Decoder {
                     self.score_threshold,
                     self.iou_threshold,
                     self.nms,
+                    self.pre_nms_top_k,
+                    self.max_det,
                     output_boxes,
                 )
             })
@@ -1167,6 +1171,8 @@ impl Decoder {
             self.score_threshold,
             self.iou_threshold,
             self.nms,
+            self.pre_nms_top_k,
+            self.max_det,
             output_boxes,
         ))
     }
@@ -1232,7 +1238,8 @@ impl Decoder {
                     self.score_threshold,
                     self.iou_threshold,
                     self.nms,
-                    output_boxes.capacity(),
+                    self.pre_nms_top_k,
+                    self.max_det,
                 )
             })
         });
@@ -1308,6 +1315,8 @@ impl Decoder {
             self.score_threshold,
             self.iou_threshold,
             self.nms,
+            self.pre_nms_top_k,
+            self.max_det,
             output_boxes,
         ))
     }
@@ -1360,7 +1369,8 @@ impl Decoder {
                 self.score_threshold,
                 self.iou_threshold,
                 self.nms,
-                output_boxes.capacity(),
+                self.pre_nms_top_k,
+                self.max_det,
             )
         });
 
@@ -1434,6 +1444,8 @@ impl Decoder {
             self.score_threshold,
             self.iou_threshold,
             self.nms,
+            self.pre_nms_top_k,
+            self.max_det,
             output_boxes,
         ))
     }
@@ -1688,7 +1700,8 @@ macro_rules! process_tracked_yolo_segmentation {
                     $self.score_threshold,
                     $self.iou_threshold,
                     $self.nms,
-                    $output_boxes.capacity(),
+                    $self.pre_nms_top_k,
+                    $self.max_det,
                 );
 
                 // Update tracker logic
@@ -1786,7 +1799,8 @@ macro_rules! process_tracked_yolo_segmentation_split {
                     $self.score_threshold,
                     $self.iou_threshold,
                     $self.nms,
-                    $output_boxes.capacity(),
+                    $self.pre_nms_top_k,
+                    $self.max_det,
                 )
             })
         });
@@ -1879,7 +1893,8 @@ macro_rules! process_tracked_yolo_segmentation_2way {
                 $self.score_threshold,
                 $self.iou_threshold,
                 $self.nms,
-                $output_boxes.capacity(),
+                $self.pre_nms_top_k,
+                $self.max_det,
             )
         });
 
@@ -2041,7 +2056,8 @@ impl Decoder {
             self.score_threshold,
             self.iou_threshold,
             self.nms,
-            output_boxes.capacity(),
+            self.pre_nms_top_k,
+            self.max_det,
         );
 
         let (new_boxes, old_boxes) =
@@ -2150,7 +2166,8 @@ impl Decoder {
             self.score_threshold,
             self.iou_threshold,
             self.nms,
-            output_boxes.capacity(),
+            self.pre_nms_top_k,
+            self.max_det,
         );
 
         let (new_boxes, old_boxes) =
@@ -2263,7 +2280,7 @@ impl Decoder {
             scores,
             classes,
             self.score_threshold,
-            output_boxes.capacity(),
+            self.max_det,
         );
 
         let (new_boxes, old_boxes) =
@@ -2377,7 +2394,7 @@ impl Decoder {
             scores,
             classes,
             self.score_threshold,
-            output_boxes.capacity(),
+            self.max_det,
         );
 
         let (new_boxes, old_boxes) =
@@ -2512,7 +2529,7 @@ impl Decoder {
             scores,
             classes,
             self.score_threshold,
-            output_boxes.capacity(),
+            self.max_det,
         );
 
         let (new_boxes, old_boxes) =
@@ -2661,7 +2678,7 @@ impl Decoder {
             scores,
             classes,
             self.score_threshold,
-            output_boxes.capacity(),
+            self.max_det,
         );
 
         let (new_boxes, old_boxes) =
@@ -2966,7 +2983,8 @@ impl Decoder {
             self.score_threshold,
             self.iou_threshold,
             self.nms,
-            output_boxes.capacity(),
+            self.pre_nms_top_k,
+            self.max_det,
         );
 
         // Tracker integrates after NMS, before mask materialization
@@ -3084,7 +3102,8 @@ impl Decoder {
             self.score_threshold,
             self.iou_threshold,
             self.nms,
-            output_boxes.capacity(),
+            self.pre_nms_top_k,
+            self.max_det,
         );
 
         // Tracker integrates before mask extraction

--- a/crates/decoder/src/decoder/postprocess.rs
+++ b/crates/decoder/src/decoder/postprocess.rs
@@ -256,7 +256,7 @@ impl Decoder {
                     self.iou_threshold,
                     self.nms,
                     self.pre_nms_top_k,
-                    self.max_det,
+                    self.max_det.min(output_boxes.capacity()),
                     output_boxes,
                     output_masks,
                 )
@@ -661,7 +661,7 @@ impl Decoder {
             self.iou_threshold,
             self.nms,
             self.pre_nms_top_k,
-            self.max_det,
+            self.max_det.min(output_boxes.capacity()),
             output_boxes,
             output_masks,
         )

--- a/crates/decoder/src/decoder/postprocess.rs
+++ b/crates/decoder/src/decoder/postprocess.rs
@@ -17,9 +17,10 @@ use crate::{
     },
     yolo::FloatProtoElem,
     yolo::{
-        decode_yolo_det, decode_yolo_det_float, decode_yolo_segdet_float, decode_yolo_segdet_quant,
-        decode_yolo_split_det_float, decode_yolo_split_det_quant, decode_yolo_split_segdet_float,
-        impl_yolo_split_segdet_quant_get_boxes, impl_yolo_split_segdet_quant_process_masks,
+        decode_yolo_det, decode_yolo_det_float, decode_yolo_split_det_float,
+        decode_yolo_split_det_quant, decode_yolo_split_segdet_float, impl_yolo_segdet_float,
+        impl_yolo_segdet_quant, impl_yolo_split_segdet_quant_get_boxes,
+        impl_yolo_split_segdet_quant_process_masks,
     },
     DecoderError, DetectBox, ProtoData, Quantization, Segmentation, XYWH,
 };
@@ -248,12 +249,14 @@ impl Decoder {
 
                 let protos_tensor = Self::swap_axes_if_needed(p, protos.into());
                 let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
-                decode_yolo_segdet_quant(
+                impl_yolo_segdet_quant::<XYWH, _, _>(
                     (box_tensor, quant_boxes),
                     (protos_tensor, quant_protos),
                     self.score_threshold,
                     self.iou_threshold,
                     self.nms,
+                    self.pre_nms_top_k,
+                    self.max_det,
                     output_boxes,
                     output_masks,
                 )
@@ -651,12 +654,14 @@ impl Decoder {
 
         let protos_tensor = Self::swap_axes_if_needed(protos_tensor, protos.into());
         let protos_tensor = protos_tensor.slice(s![0, .., .., ..]);
-        decode_yolo_segdet_float(
+        impl_yolo_segdet_float::<XYWH, _, _>(
             boxes_tensor,
             protos_tensor,
             self.score_threshold,
             self.iou_threshold,
             self.nms,
+            self.pre_nms_top_k,
+            self.max_det,
             output_boxes,
             output_masks,
         )

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -3830,4 +3830,84 @@ outputs:
             assert!(matches!(parsed, ConfigOutput::MaskCoefficients(_)));
         }
     }
+
+    /// Verify that a transposed `[K, H, W]` proto array (viewed as `[H, W, K]`
+    /// via `permuted_axes`) is detected as NCHW layout and copied correctly
+    /// without transposing.
+    #[test]
+    fn test_extract_proto_nchw_layout_detection() {
+        use crate::yolo::impl_yolo_segdet_quant_proto;
+        use crate::{Nms, ProtoLayout, Quantization, XYWH};
+
+        let boxes_raw = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../testdata/yolov8_boxes_116x8400.bin"
+        ));
+        let boxes_i8 =
+            unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
+        let boxes = ndarray::Array2::from_shape_vec((116, 8400), boxes_i8.to_vec()).unwrap();
+
+        // Create protos in physical NCHW layout [K, H, W] then view as [H, W, K].
+        let (k, h, w) = (32, 160, 160);
+        let protos_raw = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../testdata/yolov8_protos_160x160x32.bin"
+        ));
+        let protos_i8 = unsafe {
+            std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
+        };
+        // Create as [K, H, W] physical layout, then permute axes to [H, W, K].
+        // This mimics what DMA-BUF model outputs look like when the model
+        // produces NCHW protos that are axis-swapped at the ndarray level.
+        let protos_nchw = ndarray::Array3::from_shape_vec((k, h, w), protos_i8.to_vec()).unwrap();
+        let protos_hwk = protos_nchw.view().permuted_axes([1, 2, 0]);
+
+        // Verify the strides match our NCHW detection pattern [w, 1, h*w].
+        assert_eq!(
+            protos_hwk.strides(),
+            &[w as isize, 1, (h * w) as isize],
+            "permuted view should have NCHW strides"
+        );
+
+        let quant_boxes = Quantization::new(0.019_484_945, 20);
+        let quant_protos = Quantization::new(0.020_889_873, -115);
+
+        let mut output_boxes = Vec::with_capacity(50);
+        let proto_data = impl_yolo_segdet_quant_proto::<XYWH, _, _>(
+            (boxes.view(), quant_boxes),
+            (protos_hwk, quant_protos),
+            0.45,
+            0.45,
+            Some(Nms::ClassAgnostic),
+            crate::yolo::MAX_NMS_CANDIDATES,
+            300,
+            &mut output_boxes,
+        );
+
+        // NCHW layout should be detected.
+        assert_eq!(
+            proto_data.layout,
+            ProtoLayout::Nchw,
+            "Expected NCHW layout detection for transposed view"
+        );
+
+        // Proto tensor shape should be [K, H, W] (NCHW).
+        assert_eq!(
+            proto_data.protos.shape(),
+            &[k, h, w],
+            "NCHW proto shape should be [K, H, W]"
+        );
+
+        // Verify detections still produced (same model data).
+        assert!(
+            !output_boxes.is_empty(),
+            "Expected detections from NCHW proto path"
+        );
+
+        // Verify mask coefficients shape.
+        assert_eq!(
+            proto_data.mask_coefficients.shape(),
+            &[output_boxes.len(), k],
+        );
+    }
 }

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -3910,4 +3910,76 @@ outputs:
             &[output_boxes.len(), k],
         );
     }
+
+    #[test]
+    fn test_extract_proto_nchw_layout_zero_detections() {
+        use crate::yolo::impl_yolo_segdet_quant_proto;
+        use crate::{Nms, ProtoLayout, Quantization, XYWH};
+
+        // Use a very high score threshold so no detections survive NMS.
+        // The proto layout should still be correctly detected as NCHW.
+        let boxes_raw = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../testdata/yolov8_boxes_116x8400.bin"
+        ));
+        let boxes_i8 =
+            unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
+        let boxes = ndarray::Array2::from_shape_vec((116, 8400), boxes_i8.to_vec()).unwrap();
+
+        // Create NCHW protos (same as the non-zero-det test).
+        let (k, h, w) = (32, 160, 160);
+        let protos_raw = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../testdata/yolov8_protos_160x160x32.bin"
+        ));
+        let protos_i8 = unsafe {
+            std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
+        };
+        let protos_nchw = ndarray::Array3::from_shape_vec((k, h, w), protos_i8.to_vec()).unwrap();
+        let protos_hwk = protos_nchw.view().permuted_axes([1, 2, 0]);
+
+        let quant_boxes = Quantization::new(0.019_484_945, 20);
+        let quant_protos = Quantization::new(0.020_889_873, -115);
+
+        let mut output_boxes = Vec::with_capacity(50);
+        // score_threshold = 10.0 guarantees no detections survive (max dequantized
+        // i8 score ≈ 2.0 with scale=0.019, zp=20).
+        let proto_data = impl_yolo_segdet_quant_proto::<XYWH, _, _>(
+            (boxes.view(), quant_boxes),
+            (protos_hwk, quant_protos),
+            10.0,
+            0.45,
+            Some(Nms::ClassAgnostic),
+            crate::yolo::MAX_NMS_CANDIDATES,
+            300,
+            &mut output_boxes,
+        );
+
+        // Zero detections should result.
+        assert!(
+            output_boxes.is_empty(),
+            "score_threshold=1.0 should yield zero detections"
+        );
+
+        // NCHW layout should STILL be detected from the proto strides.
+        assert_eq!(
+            proto_data.layout,
+            ProtoLayout::Nchw,
+            "Zero-det path should detect NCHW layout from proto strides"
+        );
+
+        // Proto tensor shape should be [K, H, W] (NCHW).
+        assert_eq!(
+            proto_data.protos.shape(),
+            &[k, h, w],
+            "Zero-det NCHW proto shape should be [K, H, W]"
+        );
+
+        // Mask coefficients should have zero rows.
+        assert_eq!(
+            proto_data.mask_coefficients.shape(),
+            &[0, k],
+            "Zero-det mask coefficients should be [0, K]"
+        );
+    }
 }

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -2656,6 +2656,8 @@ outputs:
             0.45,
             0.45,
             Some(Nms::ClassAgnostic),
+            crate::yolo::MAX_NMS_CANDIDATES,
+            300,
             &mut output_boxes,
         );
 
@@ -2754,6 +2756,8 @@ outputs:
             0.45,
             0.45,
             Some(Nms::ClassAgnostic),
+            crate::yolo::MAX_NMS_CANDIDATES,
+            300,
             &mut ref_boxes,
         );
         assert!(
@@ -2774,6 +2778,8 @@ outputs:
             0.45,
             0.45,
             Some(Nms::ClassAgnostic),
+            crate::yolo::MAX_NMS_CANDIDATES,
+            300,
             &mut output_boxes,
         );
 
@@ -2857,6 +2863,8 @@ outputs:
             0.45,
             0.45,
             Some(Nms::ClassAgnostic),
+            crate::yolo::MAX_NMS_CANDIDATES,
+            300,
             &mut ref_boxes,
         );
         assert!(!ref_boxes.is_empty());
@@ -2876,6 +2884,8 @@ outputs:
             0.45,
             0.45,
             Some(Nms::ClassAgnostic),
+            crate::yolo::MAX_NMS_CANDIDATES,
+            300,
             &mut output_boxes,
         );
 

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -451,6 +451,23 @@ pub struct Segmentation {
     pub segmentation: Array3<u8>,
 }
 
+/// Memory layout of the prototype tensor within [`ProtoData`].
+///
+/// Models may output protos in either channel-last (NHWC) or channel-first
+/// (NCHW) layout. The mask materialisation kernels dispatch on this field to
+/// avoid a costly per-frame transpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtoLayout {
+    /// Channel-last: tensor shape is `[H, W, K]`, contiguous along K.
+    /// This is the traditional layout produced by the `extract_proto_data`
+    /// path after transposing from NCHW model outputs.
+    Nhwc,
+    /// Channel-first: tensor shape is `[K, H, W]`, each channel plane is
+    /// contiguous. Skipping the NCHW→NHWC transpose saves ~3 ms per frame
+    /// on Cortex-A53/A55 targets (819 KB for 32×160×160 protos).
+    Nchw,
+}
+
 /// Raw prototype data for fused decode+render pipelines.
 ///
 /// Holds post-NMS intermediate state before mask materialization, allowing the
@@ -479,8 +496,13 @@ pub struct Segmentation {
 pub struct ProtoData {
     /// Per-detection mask coefficients, shape `[num_detections, num_protos]`.
     pub mask_coefficients: edgefirst_tensor::TensorDyn,
-    /// Prototype tensor, shape `[proto_h, proto_w, num_protos]`.
+    /// Prototype tensor.
+    ///
+    /// - When `layout == ProtoLayout::Nhwc`: shape is `[proto_h, proto_w, num_protos]`.
+    /// - When `layout == ProtoLayout::Nchw`: shape is `[num_protos, proto_h, proto_w]`.
     pub protos: edgefirst_tensor::TensorDyn,
+    /// Physical memory layout of the `protos` tensor.
+    pub layout: ProtoLayout,
 }
 
 /// Turns a DetectBoxQuantized into a DetectBox by dequantizing the score.

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -691,6 +691,61 @@ fn arg_max<T: PartialOrd + Copy>(score: ArrayView1<T>) -> (T, usize) {
             }
         })
 }
+
+/// NEON-accelerated argmax for i8 slices on aarch64.
+///
+/// Finds the maximum value and its index (last index wins on ties, matching
+/// the semantics of [`arg_max`]).  Falls back to the scalar implementation
+/// on non-aarch64 targets or when the slice is too short to benefit from NEON.
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn arg_max_i8(scores: &[i8]) -> (i8, usize) {
+    use std::arch::aarch64::*;
+
+    let n = scores.len();
+    if n < 16 {
+        // Scalar fallback for very short slices.
+        let mut max = scores[0];
+        let mut idx = 0;
+        for (i, &s) in scores.iter().enumerate().skip(1) {
+            if s >= max {
+                max = s;
+                idx = i;
+            }
+        }
+        return (max, idx);
+    }
+
+    unsafe {
+        // Phase 1: Find the global max value using NEON horizontal max.
+        let chunks = n / 16;
+        let mut vmax = vld1q_s8(scores.as_ptr());
+        for i in 1..chunks {
+            let v = vld1q_s8(scores.as_ptr().add(i * 16));
+            vmax = vmaxq_s8(vmax, v);
+        }
+        let global_max = vmaxvq_s8(vmax);
+
+        // Handle remainder with scalar
+        let remainder_start = chunks * 16;
+        let mut final_max = global_max;
+        for &s in &scores[remainder_start..] {
+            if s > final_max {
+                final_max = s;
+            }
+        }
+
+        // Phase 2: Find the LAST index of `final_max` (preserves tie semantics).
+        // Scan backwards for the last occurrence.
+        let mut idx = 0;
+        for i in (0..n).rev() {
+            if scores[i] == final_max {
+                idx = i;
+                break;
+            }
+        }
+        (final_max, idx)
+    }
+}
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod decoder_tests {

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -1017,12 +1017,18 @@ pub(crate) fn impl_yolo_split_segdet_process_masks<
     MASK: Float + AsPrimitive<f32> + Send + Sync,
     PROTO: Float + AsPrimitive<f32> + Send + Sync,
 >(
-    boxes: Vec<(DetectBox, usize)>,
+    mut boxes: Vec<(DetectBox, usize)>,
     masks_tensor: ArrayView2<MASK>,
     protos_tensor: ArrayView3<PROTO>,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError> {
+    // Respect output capacity as a hard limit to avoid computing excess masks.
+    let cap = output_boxes.capacity();
+    if cap > 0 && boxes.len() > cap {
+        boxes.truncate(cap);
+    }
+
     let boxes = decode_segdet_f32(boxes, masks_tensor, protos_tensor)?;
     output_boxes.clear();
     output_masks.clear();
@@ -1094,7 +1100,7 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
     MASK: PrimInt + AsPrimitive<i64> + AsPrimitive<i128> + AsPrimitive<f32> + Send + Sync,
     PROTO: PrimInt + AsPrimitive<i64> + AsPrimitive<i128> + AsPrimitive<f32> + Send + Sync,
 >(
-    boxes: Vec<(DetectBox, usize)>,
+    mut boxes: Vec<(DetectBox, usize)>,
     mask_coeff: (ArrayView2<MASK>, Quantization),
     protos: (ArrayView3<PROTO>, Quantization),
     output_boxes: &mut Vec<DetectBox>,
@@ -1102,6 +1108,12 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
 ) -> Result<(), crate::DecoderError> {
     let (masks, quant_masks) = mask_coeff;
     let (protos, quant_protos) = protos;
+
+    // Respect output capacity as a hard limit to avoid computing excess masks.
+    let cap = output_boxes.capacity();
+    if cap > 0 && boxes.len() > cap {
+        boxes.truncate(cap);
+    }
 
     let boxes = decode_segdet_quant(boxes, masks, protos, quant_masks, quant_protos)?;
     output_boxes.clear();
@@ -1496,6 +1508,22 @@ pub(crate) fn extract_proto_data_quant<
     if n == 0 {
         output_boxes.clear();
         let (h, w, k) = protos.dim();
+
+        // Detect physical layout (same logic as the normal path).
+        let (proto_shape, proto_layout) = if std::any::TypeId::of::<PROTO>()
+            == std::any::TypeId::of::<i8>()
+        {
+            if protos.is_standard_layout() {
+                (&[h, w, k][..], ProtoLayout::Nhwc)
+            } else if protos.ndim() == 3 && protos.strides() == [w as isize, 1, (h * w) as isize] {
+                (&[k, h, w][..], ProtoLayout::Nchw)
+            } else {
+                (&[h, w, k][..], ProtoLayout::Nhwc)
+            }
+        } else {
+            (&[h, w, k][..], ProtoLayout::Nhwc)
+        };
+
         let coeff_tensor = Tensor::<i8>::new(&[0, num_protos], Some(TensorMemory::Mem), None)
             .expect("allocating empty mask_coefficients tensor");
         let coeff_quant =
@@ -1503,7 +1531,7 @@ pub(crate) fn extract_proto_data_quant<
         let coeff_tensor = coeff_tensor
             .with_quantization(coeff_quant)
             .expect("per-tensor quantization on mask coefficients");
-        let protos_tensor = Tensor::<i8>::new(&[h, w, k], Some(TensorMemory::Mem), None)
+        let protos_tensor = Tensor::<i8>::new(proto_shape, Some(TensorMemory::Mem), None)
             .expect("allocating protos tensor");
         let tensor_quant =
             edgefirst_tensor::Quantization::per_tensor(quant_protos.scale, quant_protos.zero_point);
@@ -1513,7 +1541,7 @@ pub(crate) fn extract_proto_data_quant<
         return ProtoData {
             mask_coefficients: TensorDyn::I8(coeff_tensor),
             protos: TensorDyn::I8(protos_tensor),
-            layout: ProtoLayout::Nhwc,
+            layout: proto_layout,
         };
     }
 

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -8,7 +8,6 @@ use ndarray::{
     s, Array2, Array3, ArrayView1, ArrayView2, ArrayView3,
 };
 use num_traits::{AsPrimitive, Float, PrimInt, Signed};
-use rayon::slice::ParallelSliceMut;
 
 use crate::{
     byte::{
@@ -39,28 +38,28 @@ use crate::{
 /// score thresholds where the cap activates the bottom of the
 /// candidate list is dominated by noise that NMS would discard
 /// anyway.
-pub(crate) const MAX_NMS_CANDIDATES: usize = 30_000;
+pub const MAX_NMS_CANDIDATES: usize = 30_000;
 
-/// Truncate `boxes` to the highest-scoring `MAX_NMS_CANDIDATES`
-/// entries in-place when the input exceeds the cap. No-op
-/// otherwise. The sort is unstable and parallel — order among
-/// equal-score boxes is not guaranteed.
-fn truncate_to_top_k_by_score<E: Send>(boxes: &mut Vec<(DetectBox, E)>) {
-    if boxes.len() > MAX_NMS_CANDIDATES {
-        boxes.par_sort_unstable_by(|a, b| b.0.score.total_cmp(&a.0.score));
-        boxes.truncate(MAX_NMS_CANDIDATES);
+/// Truncate `boxes` to the highest-scoring `top_k` entries in-place when the
+/// input exceeds the cap. Uses partial sort (O(N)) via `select_nth_unstable_by`
+/// to avoid full O(N log N) sort. No-op when input length ≤ `top_k`.
+fn truncate_to_top_k_by_score<E: Send>(boxes: &mut Vec<(DetectBox, E)>, top_k: usize) {
+    if boxes.len() > top_k {
+        boxes.select_nth_unstable_by(top_k, |a, b| b.0.score.total_cmp(&a.0.score));
+        boxes.truncate(top_k);
     }
 }
 
 /// Quantized counterpart of [`truncate_to_top_k_by_score`]. Sorts on
 /// the raw quantized score (which preserves order under monotonic
-/// dequantization).
+/// dequantization). Uses partial sort (O(N)) via `select_nth_unstable_by`.
 fn truncate_to_top_k_by_score_quant<S: PrimInt + AsPrimitive<f32> + Send + Sync, E: Send>(
     boxes: &mut Vec<(DetectBoxQuantized<S>, E)>,
+    top_k: usize,
 ) {
-    if boxes.len() > MAX_NMS_CANDIDATES {
-        boxes.par_sort_unstable_by(|a, b| b.0.score.cmp(&a.0.score));
-        boxes.truncate(MAX_NMS_CANDIDATES);
+    if boxes.len() > top_k {
+        boxes.select_nth_unstable_by(top_k, |a, b| b.0.score.cmp(&a.0.score));
+        boxes.truncate(top_k);
     }
 }
 
@@ -899,6 +898,7 @@ where
         score_threshold,
         iou_threshold,
         nms,
+        MAX_NMS_CANDIDATES,
         output_boxes.capacity(),
     );
 
@@ -944,6 +944,7 @@ where
         score_threshold,
         iou_threshold,
         nms,
+        MAX_NMS_CANDIDATES,
         output_boxes.capacity(),
     );
     impl_yolo_split_segdet_process_masks(boxes, mask_tensor, protos, output_boxes, output_masks)
@@ -959,7 +960,8 @@ pub(crate) fn impl_yolo_segdet_get_boxes<
     score_threshold: f32,
     iou_threshold: f32,
     nms: Option<Nms>,
-    max_boxes: usize,
+    pre_nms_top_k: usize,
+    max_det: usize,
 ) -> Vec<(DetectBox, usize)>
 where
     f32: AsPrimitive<SCORE>,
@@ -969,9 +971,9 @@ where
         boxes_tensor,
         scores_tensor,
     );
-    truncate_to_top_k_by_score(&mut boxes);
+    truncate_to_top_k_by_score(&mut boxes, pre_nms_top_k);
     let mut boxes = dispatch_nms_extra_float(nms, iou_threshold, boxes);
-    boxes.truncate(max_boxes);
+    boxes.truncate(max_det);
     boxes
 }
 
@@ -1036,7 +1038,8 @@ pub(crate) fn impl_yolo_split_segdet_quant_get_boxes<
     score_threshold: f32,
     iou_threshold: f32,
     nms: Option<Nms>,
-    max_boxes: usize,
+    pre_nms_top_k: usize,
+    max_det: usize,
 ) -> Vec<(DetectBox, usize)>
 where
     f32: AsPrimitive<SCORE>,
@@ -1053,9 +1056,9 @@ where
             quant_boxes,
         )
     };
-    truncate_to_top_k_by_score_quant(&mut boxes);
+    truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
     let mut boxes = dispatch_nms_extra_int(nms, iou_threshold, boxes);
-    boxes.truncate(max_boxes);
+    boxes.truncate(max_det);
     boxes
         .into_iter()
         .map(|(b, i)| (dequant_detect_box(&b, quant_scores), i))
@@ -1135,6 +1138,7 @@ where
         score_threshold,
         iou_threshold,
         nms,
+        MAX_NMS_CANDIDATES,
         output_boxes.capacity(),
     );
 
@@ -1188,6 +1192,7 @@ where
         score_threshold,
         iou_threshold,
         nms,
+        MAX_NMS_CANDIDATES,
         output_boxes.capacity(),
     );
     impl_yolo_split_segdet_process_masks(boxes, mask_tensor, protos, output_boxes, output_masks)
@@ -1199,6 +1204,7 @@ where
 
 /// Proto-extraction variant of `impl_yolo_segdet_quant`.
 /// Runs NMS but returns raw `ProtoData` instead of materialized masks.
+#[allow(clippy::too_many_arguments)]
 pub fn impl_yolo_segdet_quant_proto<
     B: BBoxTypeTrait,
     BOX: PrimInt
@@ -1221,6 +1227,8 @@ pub fn impl_yolo_segdet_quant_proto<
     score_threshold: f32,
     iou_threshold: f32,
     nms: Option<Nms>,
+    pre_nms_top_k: usize,
+    max_det: usize,
     output_boxes: &mut Vec<DetectBox>,
 ) -> ProtoData
 where
@@ -1238,7 +1246,8 @@ where
         score_threshold,
         iou_threshold,
         nms,
-        output_boxes.capacity(),
+        pre_nms_top_k,
+        max_det,
     );
 
     extract_proto_data_quant(
@@ -1253,6 +1262,7 @@ where
 
 /// Proto-extraction variant of `impl_yolo_segdet_float`.
 /// Runs NMS but returns raw `ProtoData` instead of materialized masks.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn impl_yolo_segdet_float_proto<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Copy + Send + Sync + FloatProtoElem,
@@ -1263,6 +1273,8 @@ pub(crate) fn impl_yolo_segdet_float_proto<
     score_threshold: f32,
     iou_threshold: f32,
     nms: Option<Nms>,
+    pre_nms_top_k: usize,
+    max_det: usize,
     output_boxes: &mut Vec<DetectBox>,
 ) -> ProtoData
 where
@@ -1277,7 +1289,8 @@ where
         score_threshold,
         iou_threshold,
         nms,
-        output_boxes.capacity(),
+        pre_nms_top_k,
+        max_det,
     );
 
     extract_proto_data_float(boxes, mask_tensor, protos, output_boxes)
@@ -1300,6 +1313,8 @@ pub(crate) fn impl_yolo_split_segdet_float_proto<
     score_threshold: f32,
     iou_threshold: f32,
     nms: Option<Nms>,
+    pre_nms_top_k: usize,
+    max_det: usize,
     output_boxes: &mut Vec<DetectBox>,
 ) -> ProtoData
 where
@@ -1313,7 +1328,8 @@ where
         score_threshold,
         iou_threshold,
         nms,
-        output_boxes.capacity(),
+        pre_nms_top_k,
+        max_det,
     );
 
     extract_proto_data_float(det_indices, mask_tensor, protos, output_boxes)
@@ -2427,6 +2443,8 @@ mod tests {
             0.5,
             0.7,
             Some(Nms::default()),
+            MAX_NMS_CANDIDATES,
+            300,
             &mut output_boxes,
         );
 
@@ -2476,8 +2494,9 @@ mod tests {
             scores.view(),
             0.1,
             1.0,
-            None,       // bypass NMS so we measure the cap, not suppression
-            usize::MAX, // no post-NMS truncation
+            None,                            // bypass NMS so we measure the cap, not suppression
+            crate::yolo::MAX_NMS_CANDIDATES, // pre_nms_top_k
+            usize::MAX,                      // no post-NMS truncation
         );
 
         assert_eq!(
@@ -2533,7 +2552,8 @@ mod tests {
             0.1,
             1.0,
             None,
-            usize::MAX,
+            crate::yolo::MAX_NMS_CANDIDATES, // pre_nms_top_k
+            usize::MAX,                      // no post-NMS truncation
         );
 
         assert_eq!(

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -971,9 +971,12 @@ where
         boxes_tensor,
         scores_tensor,
     );
-    truncate_to_top_k_by_score(&mut boxes, pre_nms_top_k);
+    if nms.is_some() {
+        truncate_to_top_k_by_score(&mut boxes, pre_nms_top_k);
+    }
     let mut boxes = dispatch_nms_extra_float(nms, iou_threshold, boxes);
     boxes.truncate(max_det);
+    boxes.sort_unstable_by(|a, b| b.0.score.total_cmp(&a.0.score));
     boxes
 }
 
@@ -1057,13 +1060,16 @@ where
             quant_boxes,
         )
     };
-    truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
+    if nms.is_some() {
+        truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
+    }
     let mut boxes = dispatch_nms_extra_int(nms, iou_threshold, boxes);
     boxes.truncate(max_det);
-    let result: Vec<_> = boxes
+    let mut result: Vec<_> = boxes
         .into_iter()
         .map(|(b, i)| (dequant_detect_box(&b, quant_scores), i))
         .collect();
+    result.sort_unstable_by(|a, b| b.0.score.total_cmp(&a.0.score));
     let t_end = std::time::Instant::now();
     log::trace!(
         "get_boxes: {:.2}ms ({} detections)",
@@ -1507,32 +1513,13 @@ pub(crate) fn extract_proto_data_quant<
     // transposing. The mask materialisation kernels dispatch on the layout.
     let (h, w, k) = protos.dim();
 
-    // Lazy extraction: if no detections survived NMS, return a minimal
-    // ProtoData without copying the 819KB proto tensor at all.
-    if n == 0 {
-        let tensor_quant =
-            edgefirst_tensor::Quantization::per_tensor(quant_protos.scale, quant_protos.zero_point);
-        // Empty protos with valid shape metadata so consumers can still
-        // inspect proto_h/proto_w/num_protos without panicking.
-        let empty_tensor = Tensor::<i8>::new(&[h, w, k], Some(TensorMemory::Mem), None)
-            .expect("allocating empty protos tensor");
-        let empty_tensor = empty_tensor
-            .with_quantization(tensor_quant)
-            .expect("per-tensor quantization on empty protos");
-        return ProtoData {
-            mask_coefficients,
-            protos: TensorDyn::I8(empty_tensor),
-            layout: ProtoLayout::Nhwc,
-        };
-    }
-
     // Determine physical layout and copy strategy.
     let (proto_shape, proto_layout) =
         if std::any::TypeId::of::<PROTO>() == std::any::TypeId::of::<i8>() {
             if protos.is_standard_layout() {
                 // Already NHWC [H, W, K] in contiguous memory.
                 (&[h, w, k][..], ProtoLayout::Nhwc)
-            } else if protos.ndim() == 3 && protos.strides()[2] > 1 {
+            } else if protos.ndim() == 3 && protos.strides() == [w as isize, 1, (h * w) as isize] {
                 // NCHW reinterpreted as NHWC via stride swap. Physical storage
                 // is [K, H, W] contiguous. Keep in NCHW — eliminates the costly
                 // 3.1ms transpose entirely.
@@ -1558,7 +1545,7 @@ pub(crate) fn extract_proto_data_quant<
                     std::slice::from_raw_parts(protos.as_ptr() as *const i8, protos.len())
                 };
                 dst.copy_from_slice(src);
-            } else if protos.ndim() == 3 && protos.strides()[2] > 1 {
+            } else if protos.ndim() == 3 && protos.strides() == [w as isize, 1, (h * w) as isize] {
                 // NCHW physical layout — sequential copy WITHOUT transpose.
                 // This saves ~3.1ms on A53/A55 by avoiding the tiled
                 // NCHW→NHWC transpose of the 819KB proto buffer.
@@ -2554,8 +2541,8 @@ mod tests {
             boxes.view(),
             scores.view(),
             0.1,
-            1.0,
-            None,                            // bypass NMS so we measure the cap, not suppression
+            1.0,                             // IoU 1.0 → NMS suppresses nothing
+            Some(Nms::ClassAgnostic),        // NMS enabled so pre_nms_top_k applies
             crate::yolo::MAX_NMS_CANDIDATES, // pre_nms_top_k
             usize::MAX,                      // no post-NMS truncation
         );
@@ -2611,8 +2598,8 @@ mod tests {
             (boxes.view(), quant_boxes),
             (scores.view(), quant_scores),
             0.1,
-            1.0,
-            None,
+            1.0,                             // IoU 1.0 → NMS suppresses nothing
+            Some(Nms::ClassAgnostic),        // NMS enabled so pre_nms_top_k applies
             crate::yolo::MAX_NMS_CANDIDATES, // pre_nms_top_k
             usize::MAX,                      // no post-NMS truncation
         );

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -1047,6 +1047,7 @@ where
     let (boxes_tensor, quant_boxes) = boxes;
     let (scores_tensor, quant_scores) = scores;
 
+    let t_start = std::time::Instant::now();
     let mut boxes = {
         let score_threshold = quantize_score_threshold(score_threshold, quant_scores);
         postprocess_boxes_index_quant::<B, _, _>(
@@ -1059,10 +1060,17 @@ where
     truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
     let mut boxes = dispatch_nms_extra_int(nms, iou_threshold, boxes);
     boxes.truncate(max_det);
-    boxes
+    let result: Vec<_> = boxes
         .into_iter()
         .map(|(b, i)| (dequant_detect_box(&b, quant_scores), i))
-        .collect()
+        .collect();
+    let t_end = std::time::Instant::now();
+    log::trace!(
+        "get_boxes: {:.2}ms ({} detections)",
+        t_end.duration_since(t_start).as_secs_f64() * 1000.0,
+        result.len(),
+    );
+    result
 }
 
 pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
@@ -1504,10 +1512,40 @@ pub(crate) fn extract_proto_data_quant<
         if std::any::TypeId::of::<PROTO>() == std::any::TypeId::of::<i8>() {
             // SAFETY: PROTO == i8 checked via TypeId; cast slice view is
             // size/alignment-compatible by construction.
-            let src: &[i8] =
-                unsafe { std::slice::from_raw_parts(protos.as_ptr() as *const i8, protos.len()) };
             if protos.is_standard_layout() {
+                let src: &[i8] = unsafe {
+                    std::slice::from_raw_parts(protos.as_ptr() as *const i8, protos.len())
+                };
                 dst.copy_from_slice(src);
+            } else if protos.ndim() == 3 && protos.strides()[2] > 1 {
+                // Transposed DMA-BUF view (NCHW reinterpreted as NHWC via stride
+                // swap). The backing store is physically [k, h, w] contiguous.
+                // Strategy: first bulk-copy the entire DMA-BUF sequentially into
+                // heap, then transpose NCHW→NHWC entirely in cacheable memory.
+                // This avoids the L2 thrashing that plane-by-plane scattered writes
+                // cause (output buffer = 819KB >> L2 = 256KB on A55).
+                let total = h * w * k;
+                let hw = h * w;
+                // SAFETY: The ArrayView was constructed from a contiguous slice of
+                // `total` elements. as_ptr() points to the base of that slice.
+                let src: &[i8] =
+                    unsafe { std::slice::from_raw_parts(protos.as_ptr() as *const i8, total) };
+                // Sequential DMA-BUF read → heap copy (~0.4ms for 819KB).
+                let heap_copy = src.to_vec();
+
+                // Tiled NCHW→NHWC transpose in heap memory.
+                // Process TILE pixels at a time so the write-target fits in L1.
+                const TILE: usize = 256;
+                for pixel_start in (0..hw).step_by(TILE) {
+                    let pixel_end = (pixel_start + TILE).min(hw);
+                    let dst_tile = &mut dst[pixel_start * k..pixel_end * k];
+                    for c in 0..k {
+                        let plane_chunk = &heap_copy[c * hw + pixel_start..c * hw + pixel_end];
+                        for (i, &val) in plane_chunk.iter().enumerate() {
+                            dst_tile[i * k + c] = val;
+                        }
+                    }
+                }
             } else {
                 for (d, s) in dst.iter_mut().zip(protos.iter()) {
                     let v_i8: i8 = s.as_();

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -183,6 +183,8 @@ where
         score_threshold,
         iou_threshold,
         nms,
+        MAX_NMS_CANDIDATES,
+        output_boxes.capacity(),
         output_boxes,
         output_masks,
     )
@@ -218,6 +220,8 @@ where
         score_threshold,
         iou_threshold,
         nms,
+        MAX_NMS_CANDIDATES,
+        output_boxes.capacity(),
         output_boxes,
         output_masks,
     )
@@ -872,6 +876,7 @@ pub(crate) fn impl_yolo_split_float<
 ///
 /// # Errors
 /// Returns `DecoderError::InvalidShape` if bounding boxes are not normalized.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn impl_yolo_segdet_quant<
     B: BBoxTypeTrait,
     BOX: PrimInt + AsPrimitive<i64> + AsPrimitive<i128> + AsPrimitive<f32> + Send + Sync,
@@ -882,6 +887,8 @@ pub(crate) fn impl_yolo_segdet_quant<
     score_threshold: f32,
     iou_threshold: f32,
     nms: Option<Nms>,
+    pre_nms_top_k: usize,
+    max_det: usize,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError>
@@ -898,8 +905,8 @@ where
         score_threshold,
         iou_threshold,
         nms,
-        MAX_NMS_CANDIDATES,
-        output_boxes.capacity(),
+        pre_nms_top_k,
+        max_det,
     );
 
     impl_yolo_split_segdet_quant_process_masks::<_, _>(
@@ -920,6 +927,7 @@ where
 ///
 /// # Panics
 /// Panics if shapes don't match the expected dimensions.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn impl_yolo_segdet_float<
     B: BBoxTypeTrait,
     BOX: Float + AsPrimitive<f32> + Send + Sync,
@@ -930,6 +938,8 @@ pub(crate) fn impl_yolo_segdet_float<
     score_threshold: f32,
     iou_threshold: f32,
     nms: Option<Nms>,
+    pre_nms_top_k: usize,
+    max_det: usize,
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError>
@@ -944,8 +954,8 @@ where
         score_threshold,
         iou_threshold,
         nms,
-        MAX_NMS_CANDIDATES,
-        output_boxes.capacity(),
+        pre_nms_top_k,
+        max_det,
     );
     impl_yolo_split_segdet_process_masks(boxes, mask_tensor, protos, output_boxes, output_masks)
 }
@@ -975,8 +985,8 @@ where
         truncate_to_top_k_by_score(&mut boxes, pre_nms_top_k);
     }
     let mut boxes = dispatch_nms_extra_float(nms, iou_threshold, boxes);
-    boxes.truncate(max_det);
     boxes.sort_unstable_by(|a, b| b.0.score.total_cmp(&a.0.score));
+    boxes.truncate(max_det);
     boxes
 }
 
@@ -1064,12 +1074,13 @@ where
         truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
     }
     let mut boxes = dispatch_nms_extra_int(nms, iou_threshold, boxes);
+    // Sort by score descending before truncation to keep top-scoring detections.
+    boxes.sort_unstable_by(|a, b| b.0.score.cmp(&a.0.score));
     boxes.truncate(max_det);
-    let mut result: Vec<_> = boxes
+    let result: Vec<_> = boxes
         .into_iter()
         .map(|(b, i)| (dequant_detect_box(&b, quant_scores), i))
         .collect();
-    result.sort_unstable_by(|a, b| b.0.score.total_cmp(&a.0.score));
     let t_end = std::time::Instant::now();
     log::trace!(
         "get_boxes: {:.2}ms ({} detections)",
@@ -1478,11 +1489,13 @@ pub(crate) fn extract_proto_data_quant<
     let n = det_indices.len();
 
     // Fast path: when no detections survive NMS, skip the expensive proto
-    // tensor copy (819KB for 160×160×32). Return a valid but minimal
-    // ProtoData with zero-row coefficients and a placeholder proto tensor.
+    // tensor copy (819KB for 160×160×32). Allocate with the correct shape
+    // (preserving the documented ProtoData.protos shape contract) but skip
+    // copying from the source tensor — the zeroed allocation is sufficient
+    // since materialize_masks early-returns on empty detect slices.
     if n == 0 {
         output_boxes.clear();
-        let (_h, _w, k) = protos.dim();
+        let (h, w, k) = protos.dim();
         let coeff_tensor = Tensor::<i8>::new(&[0, num_protos], Some(TensorMemory::Mem), None)
             .expect("allocating empty mask_coefficients tensor");
         let coeff_quant =
@@ -1490,11 +1503,7 @@ pub(crate) fn extract_proto_data_quant<
         let coeff_tensor = coeff_tensor
             .with_quantization(coeff_quant)
             .expect("per-tensor quantization on mask coefficients");
-        // Minimal proto placeholder — shape [1,1,K] (32 bytes) instead of
-        // the full [H,W,K] (819KB). With 0 coefficients no consumer will
-        // index into the proto data; materialize_masks early-returns on
-        // empty detect slices.
-        let protos_tensor = Tensor::<i8>::new(&[1, 1, k], Some(TensorMemory::Mem), None)
+        let protos_tensor = Tensor::<i8>::new(&[h, w, k], Some(TensorMemory::Mem), None)
             .expect("allocating protos tensor");
         let tensor_quant =
             edgefirst_tensor::Quantization::per_tensor(quant_protos.scale, quant_protos.zero_point);

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -1477,6 +1477,37 @@ pub(crate) fn extract_proto_data_quant<
     let num_protos = mask_tensor.ncols();
     let n = det_indices.len();
 
+    // Fast path: when no detections survive NMS, skip the expensive proto
+    // tensor copy (819KB for 160×160×32). Return a valid but minimal
+    // ProtoData with zero-row coefficients and a placeholder proto tensor.
+    if n == 0 {
+        output_boxes.clear();
+        let (_h, _w, k) = protos.dim();
+        let coeff_tensor = Tensor::<i8>::new(&[0, num_protos], Some(TensorMemory::Mem), None)
+            .expect("allocating empty mask_coefficients tensor");
+        let coeff_quant =
+            edgefirst_tensor::Quantization::per_tensor(quant_masks.scale, quant_masks.zero_point);
+        let coeff_tensor = coeff_tensor
+            .with_quantization(coeff_quant)
+            .expect("per-tensor quantization on mask coefficients");
+        // Minimal proto placeholder — shape [1,1,K] (32 bytes) instead of
+        // the full [H,W,K] (819KB). With 0 coefficients no consumer will
+        // index into the proto data; materialize_masks early-returns on
+        // empty detect slices.
+        let protos_tensor = Tensor::<i8>::new(&[1, 1, k], Some(TensorMemory::Mem), None)
+            .expect("allocating protos tensor");
+        let tensor_quant =
+            edgefirst_tensor::Quantization::per_tensor(quant_protos.scale, quant_protos.zero_point);
+        let protos_tensor = protos_tensor
+            .with_quantization(tensor_quant)
+            .expect("per-tensor quantization on protos tensor");
+        return ProtoData {
+            mask_coefficients: TensorDyn::I8(coeff_tensor),
+            protos: TensorDyn::I8(protos_tensor),
+            layout: ProtoLayout::Nhwc,
+        };
+    }
+
     // Keep mask coefficients in raw i8 with quantization metadata attached.
     // Consumers that need f32 can dequantize on the fly; the scaled-path
     // integer kernel uses raw i8 directly for i8×i8→i32 dot products.

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -20,8 +20,8 @@ use crate::{
         nms_class_aware_float, nms_extra_class_aware_float, nms_extra_float, nms_float,
         postprocess_boxes_float, postprocess_boxes_index_float,
     },
-    BBoxTypeTrait, BoundingBox, DetectBox, DetectBoxQuantized, ProtoData, Quantization,
-    Segmentation, XYWH, XYXY,
+    BBoxTypeTrait, BoundingBox, DetectBox, DetectBoxQuantized, ProtoData, ProtoLayout,
+    Quantization, Segmentation, XYWH, XYXY,
 };
 
 /// Maximum number of above-threshold candidates fed to NMS.
@@ -1443,6 +1443,7 @@ pub(super) fn extract_proto_data_float<
     ProtoData {
         mask_coefficients,
         protos: protos_tensor,
+        layout: ProtoLayout::Nhwc,
     }
 }
 
@@ -1502,9 +1503,49 @@ pub(crate) fn extract_proto_data_quant<
     let mask_coefficients = TensorDyn::I8(coeff_tensor);
 
     // Keep protos in raw i8 — consumers dequantize via protos.quantization().
-    // When PROTO is already i8, memcpy via to_owned(); else per-element as_().
+    // When PROTO is already i8, detect layout and copy efficiently without
+    // transposing. The mask materialisation kernels dispatch on the layout.
     let (h, w, k) = protos.dim();
-    let protos_tensor = Tensor::<i8>::new(&[h, w, k], Some(TensorMemory::Mem), None)
+
+    // Lazy extraction: if no detections survived NMS, return a minimal
+    // ProtoData without copying the 819KB proto tensor at all.
+    if n == 0 {
+        let tensor_quant =
+            edgefirst_tensor::Quantization::per_tensor(quant_protos.scale, quant_protos.zero_point);
+        // Empty protos with valid shape metadata so consumers can still
+        // inspect proto_h/proto_w/num_protos without panicking.
+        let empty_tensor = Tensor::<i8>::new(&[h, w, k], Some(TensorMemory::Mem), None)
+            .expect("allocating empty protos tensor");
+        let empty_tensor = empty_tensor
+            .with_quantization(tensor_quant)
+            .expect("per-tensor quantization on empty protos");
+        return ProtoData {
+            mask_coefficients,
+            protos: TensorDyn::I8(empty_tensor),
+            layout: ProtoLayout::Nhwc,
+        };
+    }
+
+    // Determine physical layout and copy strategy.
+    let (proto_shape, proto_layout) =
+        if std::any::TypeId::of::<PROTO>() == std::any::TypeId::of::<i8>() {
+            if protos.is_standard_layout() {
+                // Already NHWC [H, W, K] in contiguous memory.
+                (&[h, w, k][..], ProtoLayout::Nhwc)
+            } else if protos.ndim() == 3 && protos.strides()[2] > 1 {
+                // NCHW reinterpreted as NHWC via stride swap. Physical storage
+                // is [K, H, W] contiguous. Keep in NCHW — eliminates the costly
+                // 3.1ms transpose entirely.
+                (&[k, h, w][..], ProtoLayout::Nchw)
+            } else {
+                // Unknown layout — fall back to iter copy as NHWC.
+                (&[h, w, k][..], ProtoLayout::Nhwc)
+            }
+        } else {
+            (&[h, w, k][..], ProtoLayout::Nhwc)
+        };
+
+    let protos_tensor = Tensor::<i8>::new(proto_shape, Some(TensorMemory::Mem), None)
         .expect("allocating protos tensor");
     {
         let mut m = protos_tensor.map().expect("mapping protos tensor");
@@ -1518,34 +1559,15 @@ pub(crate) fn extract_proto_data_quant<
                 };
                 dst.copy_from_slice(src);
             } else if protos.ndim() == 3 && protos.strides()[2] > 1 {
-                // Transposed DMA-BUF view (NCHW reinterpreted as NHWC via stride
-                // swap). The backing store is physically [k, h, w] contiguous.
-                // Strategy: first bulk-copy the entire DMA-BUF sequentially into
-                // heap, then transpose NCHW→NHWC entirely in cacheable memory.
-                // This avoids the L2 thrashing that plane-by-plane scattered writes
-                // cause (output buffer = 819KB >> L2 = 256KB on A55).
+                // NCHW physical layout — sequential copy WITHOUT transpose.
+                // This saves ~3.1ms on A53/A55 by avoiding the tiled
+                // NCHW→NHWC transpose of the 819KB proto buffer.
                 let total = h * w * k;
-                let hw = h * w;
-                // SAFETY: The ArrayView was constructed from a contiguous slice of
+                // SAFETY: ArrayView was constructed from a contiguous slice of
                 // `total` elements. as_ptr() points to the base of that slice.
                 let src: &[i8] =
                     unsafe { std::slice::from_raw_parts(protos.as_ptr() as *const i8, total) };
-                // Sequential DMA-BUF read → heap copy (~0.4ms for 819KB).
-                let heap_copy = src.to_vec();
-
-                // Tiled NCHW→NHWC transpose in heap memory.
-                // Process TILE pixels at a time so the write-target fits in L1.
-                const TILE: usize = 256;
-                for pixel_start in (0..hw).step_by(TILE) {
-                    let pixel_end = (pixel_start + TILE).min(hw);
-                    let dst_tile = &mut dst[pixel_start * k..pixel_end * k];
-                    for c in 0..k {
-                        let plane_chunk = &heap_copy[c * hw + pixel_start..c * hw + pixel_end];
-                        for (i, &val) in plane_chunk.iter().enumerate() {
-                            dst_tile[i * k + c] = val;
-                        }
-                    }
-                }
+                dst.copy_from_slice(src);
             } else {
                 for (d, s) in dst.iter_mut().zip(protos.iter()) {
                     let v_i8: i8 = s.as_();
@@ -1568,6 +1590,7 @@ pub(crate) fn extract_proto_data_quant<
     ProtoData {
         mask_coefficients,
         protos: TensorDyn::I8(protos_tensor),
+        layout: proto_layout,
     }
 }
 

--- a/crates/image/benches/mask_benchmark.rs
+++ b/crates/image/benches/mask_benchmark.rs
@@ -77,6 +77,8 @@ fn decode_proto_data() -> (Vec<DetectBox>, ProtoData) {
         SCORE_THRESHOLD,
         IOU_THRESHOLD,
         Some(Nms::ClassAgnostic),
+        edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+        300,
         &mut output_boxes,
     );
     (output_boxes, proto_data)
@@ -362,6 +364,8 @@ fn bench_decode_masks(suite: &mut BenchSuite) {
                 SCORE_THRESHOLD,
                 IOU_THRESHOLD,
                 Some(Nms::ClassAgnostic),
+                edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+                300,
                 &mut output_boxes,
             );
         });
@@ -381,6 +385,8 @@ fn bench_decode_masks(suite: &mut BenchSuite) {
                 SCORE_THRESHOLD,
                 IOU_THRESHOLD,
                 Some(Nms::ClassAgnostic),
+                edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+                300,
                 &mut output_boxes,
             );
             let _seg = materialize_segmentations(&output_boxes, &proto_data);
@@ -409,6 +415,8 @@ fn bench_proto_extraction(suite: &mut BenchSuite) {
         SCORE_THRESHOLD,
         IOU_THRESHOLD,
         Some(Nms::ClassAgnostic),
+        edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+        300,
         &mut warmup_boxes,
     );
     let n_detect = warmup_boxes.len();
@@ -423,6 +431,8 @@ fn bench_proto_extraction(suite: &mut BenchSuite) {
             SCORE_THRESHOLD,
             IOU_THRESHOLD,
             Some(Nms::ClassAgnostic),
+            edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+            300,
             &mut output_boxes,
         );
     });

--- a/crates/image/benches/mask_benchmark.rs
+++ b/crates/image/benches/mask_benchmark.rs
@@ -24,7 +24,7 @@ mod common;
 use common::{run_bench, BenchSuite};
 
 use edgefirst_decoder::yolo::impl_yolo_segdet_quant_proto;
-use edgefirst_decoder::{DetectBox, Nms, ProtoData, Quantization, Segmentation, XYWH};
+use edgefirst_decoder::{DetectBox, Nms, ProtoData, ProtoLayout, Quantization, Segmentation, XYWH};
 use edgefirst_image::{CPUProcessor, ImageProcessor, ImageProcessorTrait, MaskResolution};
 use edgefirst_tensor::{DType, PixelFormat, Tensor, TensorDyn, TensorMapTrait, TensorTrait};
 use half::f16;
@@ -239,6 +239,7 @@ fn build_proto_dtypes(detect: &[DetectBox], proto_data_i8: &ProtoData) -> (Proto
     let proto_f32 = ProtoData {
         mask_coefficients: TensorDyn::F32(f32_coeffs),
         protos: TensorDyn::F32(f32_protos),
+        layout: ProtoLayout::Nhwc,
     };
 
     let protos_f16_vec: Vec<f16> = protos_f32_vec.iter().map(|v| f16::from_f32(*v)).collect();
@@ -248,6 +249,7 @@ fn build_proto_dtypes(detect: &[DetectBox], proto_data_i8: &ProtoData) -> (Proto
     let proto_f16 = ProtoData {
         mask_coefficients: TensorDyn::F16(f16_coeffs),
         protos: TensorDyn::F16(f16_protos),
+        layout: ProtoLayout::Nhwc,
     };
 
     (proto_f32, proto_f16)

--- a/crates/image/benches/mask_decode_benchmark.rs
+++ b/crates/image/benches/mask_decode_benchmark.rs
@@ -644,6 +644,25 @@ fn bench_nms_decode(suite: &mut BenchSuite) {
     result.print_summary();
     suite.record(&result);
 
+    // Pre-NMS top-K=300 (default — matches Ultralytics max_det=300)
+    let name = "nms_decode/topk_300";
+    let result = run_bench(name, WARMUP, ITERATIONS, || {
+        let mut output_boxes = Vec::with_capacity(300);
+        let proto_data = impl_yolo_segdet_quant_proto::<XYWH, _, _>(
+            (boxes.view(), QUANT_BOXES),
+            (protos.view(), QUANT_PROTOS),
+            SCORE_THRESHOLD,
+            IOU_THRESHOLD,
+            Some(Nms::ClassAgnostic),
+            300,
+            300,
+            &mut output_boxes,
+        );
+        std::hint::black_box((&output_boxes, &proto_data));
+    });
+    result.print_summary();
+    suite.record(&result);
+
     // Isolate: just score filtering + box decode (no NMS)
     let name = "nms_decode/score_filter_only";
     let result = run_bench(name, WARMUP, ITERATIONS, || {

--- a/crates/image/benches/mask_decode_benchmark.rs
+++ b/crates/image/benches/mask_decode_benchmark.rs
@@ -35,7 +35,7 @@ mod common;
 use common::{run_bench, BenchSuite};
 
 use edgefirst_decoder::yolo::impl_yolo_segdet_quant_proto;
-use edgefirst_decoder::{DetectBox, Nms, ProtoData, Quantization, XYWH};
+use edgefirst_decoder::{DetectBox, Nms, ProtoData, ProtoLayout, Quantization, XYWH};
 use edgefirst_image::CPUProcessor;
 use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorTrait};
 
@@ -218,6 +218,7 @@ fn load_from_safetensors(path: &Path) -> Result<(Vec<DetectBox>, ProtoData), Str
     let proto_data = ProtoData {
         mask_coefficients,
         protos: TensorDyn::I8(protos_tensor),
+        layout: ProtoLayout::Nhwc,
     };
 
     Ok((detect, proto_data))
@@ -499,6 +500,7 @@ fn bench_detection_count_scaling(suite: &mut BenchSuite) {
         let proto_data = ProtoData {
             mask_coefficients: TensorDyn::I8(coeff_tensor),
             protos: TensorDyn::I8(protos_tensor),
+            layout: ProtoLayout::Nhwc,
         };
 
         let name = format!("scaled_640x480/N={n}");

--- a/crates/image/benches/mask_decode_benchmark.rs
+++ b/crates/image/benches/mask_decode_benchmark.rs
@@ -100,6 +100,8 @@ fn decode_from_fixtures() -> (Vec<DetectBox>, ProtoData) {
         SCORE_THRESHOLD,
         IOU_THRESHOLD,
         Some(Nms::ClassAgnostic),
+        edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+        300,
         &mut output_boxes,
     );
     (output_boxes, proto_data)
@@ -559,6 +561,109 @@ fn bench_phase_breakdown(suite: &mut BenchSuite) {
     suite.record(&result);
 }
 
+/// Benchmark the NMS decode phase (score filter + NMS + proto extraction).
+/// This matches the `nms_decode` portion of the user's pipeline when called
+/// with COCO-eval score_threshold=0.001.
+fn bench_nms_decode(suite: &mut BenchSuite) {
+    println!("\n== nms_decode: score filter + NMS + proto extraction ==\n");
+
+    let boxes = load_boxes_i8();
+    let protos = load_protos_i8();
+    let n_proposals = boxes.dim().1;
+    let n_classes = boxes.dim().0 - 4 - 32; // 80
+
+    println!(
+        "  Tensor: [{}, {n_proposals}] I8 ({n_classes} classes + 4 box + 32 mask)",
+        boxes.dim().0
+    );
+    println!(
+        "  Protos: [{}, {}, {}] I8",
+        protos.dim().0,
+        protos.dim().1,
+        protos.dim().2
+    );
+    println!("  score_threshold={SCORE_THRESHOLD}, iou_threshold={IOU_THRESHOLD}");
+    println!();
+
+    // Full decode (argmax + NMS + proto extraction)
+    let name = "nms_decode/full_0.001";
+    let result = run_bench(name, WARMUP, ITERATIONS, || {
+        let mut output_boxes = Vec::with_capacity(300);
+        let proto_data = impl_yolo_segdet_quant_proto::<XYWH, _, _>(
+            (boxes.view(), QUANT_BOXES),
+            (protos.view(), QUANT_PROTOS),
+            SCORE_THRESHOLD,
+            IOU_THRESHOLD,
+            Some(Nms::ClassAgnostic),
+            edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+            300,
+            &mut output_boxes,
+        );
+        std::hint::black_box((&output_boxes, &proto_data));
+    });
+    let (detect, _) = decode_from_fixtures();
+    println!("  Survivors after NMS: {} detections", detect.len());
+    result.print_summary();
+    suite.record(&result);
+
+    // With typical inference threshold (0.25)
+    let name = "nms_decode/full_0.25";
+    let result = run_bench(name, WARMUP, ITERATIONS, || {
+        let mut output_boxes = Vec::with_capacity(300);
+        let proto_data = impl_yolo_segdet_quant_proto::<XYWH, _, _>(
+            (boxes.view(), QUANT_BOXES),
+            (protos.view(), QUANT_PROTOS),
+            0.25,
+            IOU_THRESHOLD,
+            Some(Nms::ClassAgnostic),
+            edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+            300,
+            &mut output_boxes,
+        );
+        std::hint::black_box((&output_boxes, &proto_data));
+    });
+    result.print_summary();
+    suite.record(&result);
+
+    // Pre-NMS top-K=3000 (the key optimization: reduces NMS from O(8400²) to O(3000²))
+    let name = "nms_decode/topk_3000";
+    let result = run_bench(name, WARMUP, ITERATIONS, || {
+        let mut output_boxes = Vec::with_capacity(300);
+        let proto_data = impl_yolo_segdet_quant_proto::<XYWH, _, _>(
+            (boxes.view(), QUANT_BOXES),
+            (protos.view(), QUANT_PROTOS),
+            SCORE_THRESHOLD,
+            IOU_THRESHOLD,
+            Some(Nms::ClassAgnostic),
+            3000,
+            300,
+            &mut output_boxes,
+        );
+        std::hint::black_box((&output_boxes, &proto_data));
+    });
+    result.print_summary();
+    suite.record(&result);
+
+    // Isolate: just score filtering + box decode (no NMS)
+    let name = "nms_decode/score_filter_only";
+    let result = run_bench(name, WARMUP, ITERATIONS, || {
+        let mut output_boxes = Vec::with_capacity(300);
+        let proto_data = impl_yolo_segdet_quant_proto::<XYWH, _, _>(
+            (boxes.view(), QUANT_BOXES),
+            (protos.view(), QUANT_PROTOS),
+            SCORE_THRESHOLD,
+            IOU_THRESHOLD,
+            None, // bypass NMS
+            edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+            300,
+            &mut output_boxes,
+        );
+        std::hint::black_box((&output_boxes, &proto_data));
+    });
+    result.print_summary();
+    suite.record(&result);
+}
+
 fn main() {
     let mut suite = BenchSuite::from_args();
 
@@ -574,6 +679,7 @@ fn main() {
         return;
     }
 
+    bench_nms_decode(&mut suite);
     bench_scaled_materialize(&mut suite);
     bench_detection_count_scaling(&mut suite);
     bench_phase_breakdown(&mut suite);

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -322,6 +322,12 @@ impl CPUProcessor {
         // or I8 (from quantized models — kept raw with quantization). For the
         // mask kernel we always need an f32 view (the multiply-accumulate is
         // done in f32 for precision). Map once and widen once outside the loop.
+        // NCHW layout is only supported in the i8×i8 integer fast path above.
+        if proto_data.layout == edgefirst_decoder::ProtoLayout::Nchw {
+            return Err(crate::Error::NotSupported(
+                "NCHW proto layout requires both protos and mask_coefficients to be I8".into(),
+            ));
+        }
         let coeff_f32_storage: Vec<f32>;
         let coeff_f32_slice: &[f32] = match proto_data.mask_coefficients.dtype() {
             DType::F32 => {
@@ -576,6 +582,12 @@ impl CPUProcessor {
         }
 
         // Fallback: widen coefficients to f32 for the float-path kernels.
+        // NCHW layout is only supported in the i8×i8 integer fast path above.
+        if proto_data.layout == edgefirst_decoder::ProtoLayout::Nchw {
+            return Err(crate::Error::NotSupported(
+                "NCHW proto layout requires both protos and mask_coefficients to be I8".into(),
+            ));
+        }
         let coeff_f32: Vec<f32> = match proto_data.mask_coefficients.dtype() {
             DType::F32 => {
                 let t = proto_data.mask_coefficients.as_f32().expect("F32");

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -237,7 +237,15 @@ impl CPUProcessor {
                 "protos tensor must be rank-3, got {proto_shape:?}"
             )));
         }
-        let (proto_h, proto_w, num_protos) = (proto_shape[0], proto_shape[1], proto_shape[2]);
+        // Interpret shape based on physical layout.
+        let (proto_h, proto_w, num_protos) = match proto_data.layout {
+            edgefirst_decoder::ProtoLayout::Nhwc => {
+                (proto_shape[0], proto_shape[1], proto_shape[2])
+            }
+            edgefirst_decoder::ProtoLayout::Nchw => {
+                (proto_shape[1], proto_shape[2], proto_shape[0])
+            }
+        };
         let coeff_shape = proto_data.mask_coefficients.shape();
         if coeff_shape.len() != 2 || coeff_shape[1] != num_protos {
             return Err(crate::Error::InvalidShape(format!(
@@ -306,6 +314,7 @@ impl CPUProcessor {
                 inv_lw,
                 ly0,
                 inv_lh,
+                proto_data.layout,
             );
         }
 
@@ -502,7 +511,15 @@ impl CPUProcessor {
                 "protos tensor must be rank-3, got {proto_shape:?}"
             )));
         }
-        let (proto_h, proto_w, num_protos) = (proto_shape[0], proto_shape[1], proto_shape[2]);
+        // Interpret shape based on physical layout.
+        let (proto_h, proto_w, num_protos) = match proto_data.layout {
+            edgefirst_decoder::ProtoLayout::Nhwc => {
+                (proto_shape[0], proto_shape[1], proto_shape[2])
+            }
+            edgefirst_decoder::ProtoLayout::Nchw => {
+                (proto_shape[1], proto_shape[2], proto_shape[0])
+            }
+        };
         let coeff_shape = proto_data.mask_coefficients.shape();
         if coeff_shape.len() != 2 || coeff_shape[1] != num_protos {
             return Err(crate::Error::InvalidShape(format!(
@@ -554,6 +571,7 @@ impl CPUProcessor {
                 letterbox,
                 width,
                 height,
+                proto_data.layout,
             );
         }
 
@@ -737,6 +755,7 @@ fn seg_from_roi(
 ///
 /// For each detection, computes the i8×i8 dot product at every proto-ROI pixel,
 /// applies the zero-point correction, and thresholds at sign(logit) → {0, 255}.
+/// Supports both NHWC and NCHW proto layouts.
 #[allow(clippy::too_many_arguments)]
 fn proto_segmentations_i8_i8(
     detect: &[crate::DetectBox],
@@ -751,6 +770,7 @@ fn proto_segmentations_i8_i8(
     inv_lw: f32,
     ly0: f32,
     inv_lh: f32,
+    layout: edgefirst_decoder::ProtoLayout,
 ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
     use edgefirst_tensor::QuantMode;
 
@@ -773,19 +793,31 @@ fn proto_segmentations_i8_i8(
         }
     };
 
-    let stride_y = proto_w * num_protos;
+    let hw = proto_h * proto_w;
 
     // Precompute per-pixel proto sums for zero-point correction.
     let proto_sums: Vec<i32> = if zp_c != 0 {
-        (0..proto_h * proto_w)
-            .map(|px_idx| {
-                let base = px_idx * num_protos;
-                protos[base..base + num_protos]
-                    .iter()
-                    .map(|&v| v as i32)
-                    .sum()
-            })
-            .collect()
+        match layout {
+            edgefirst_decoder::ProtoLayout::Nhwc => (0..hw)
+                .map(|px_idx| {
+                    let base = px_idx * num_protos;
+                    protos[base..base + num_protos]
+                        .iter()
+                        .map(|&v| v as i32)
+                        .sum()
+                })
+                .collect(),
+            edgefirst_decoder::ProtoLayout::Nchw => {
+                let mut sums = vec![0i32; hw];
+                for c in 0..num_protos {
+                    let plane = &protos[c * hw..];
+                    for (px, s) in sums.iter_mut().enumerate() {
+                        *s += plane[px] as i32;
+                    }
+                }
+                sums
+            }
+        }
     } else {
         Vec::new()
     };
@@ -806,69 +838,116 @@ fn proto_segmentations_i8_i8(
 
             let mut mask_buf = vec![0u8; roi_h * roi_w];
 
-            #[cfg(target_arch = "aarch64")]
-            {
-                if use_dotprod {
-                    for ly in 0..roi_h {
-                        let py = y0 + ly;
-                        let row_base = py * stride_y + x0 * num_protos;
-                        for lx in 0..roi_w {
-                            let pix_base = row_base + lx * num_protos;
-                            let proto_px = &protos[pix_base..pix_base + num_protos];
-                            let raw_dot = unsafe {
-                                dot_i8_neon_dotprod(coeff.as_ptr(), proto_px.as_ptr(), num_protos)
-                            };
-                            let correction = if zp_c != 0 {
-                                zp_c * proto_sums[py * proto_w + x0 + lx]
-                            } else {
-                                0
-                            };
-                            let logit = raw_dot - correction - bias;
-                            if logit > 0 {
-                                mask_buf[ly * roi_w + lx] = 255;
+            match layout {
+                edgefirst_decoder::ProtoLayout::Nhwc => {
+                    let stride_y = proto_w * num_protos;
+                    #[cfg(target_arch = "aarch64")]
+                    {
+                        if use_dotprod {
+                            for ly in 0..roi_h {
+                                let py = y0 + ly;
+                                let row_base = py * stride_y + x0 * num_protos;
+                                for lx in 0..roi_w {
+                                    let pix_base = row_base + lx * num_protos;
+                                    let proto_px = &protos[pix_base..pix_base + num_protos];
+                                    let raw_dot = unsafe {
+                                        dot_i8_neon_dotprod(
+                                            coeff.as_ptr(),
+                                            proto_px.as_ptr(),
+                                            num_protos,
+                                        )
+                                    };
+                                    let correction = if zp_c != 0 {
+                                        zp_c * proto_sums[py * proto_w + x0 + lx]
+                                    } else {
+                                        0
+                                    };
+                                    let logit = raw_dot - correction - bias;
+                                    if logit > 0 {
+                                        mask_buf[ly * roi_w + lx] = 255;
+                                    }
+                                }
+                            }
+                        } else {
+                            for ly in 0..roi_h {
+                                let py = y0 + ly;
+                                let row_base = py * stride_y + x0 * num_protos;
+                                for lx in 0..roi_w {
+                                    let pix_base = row_base + lx * num_protos;
+                                    let proto_px = &protos[pix_base..pix_base + num_protos];
+                                    let raw_dot = unsafe {
+                                        dot_i8_neon_base(
+                                            coeff.as_ptr(),
+                                            proto_px.as_ptr(),
+                                            num_protos,
+                                        )
+                                    };
+                                    let correction = if zp_c != 0 {
+                                        zp_c * proto_sums[py * proto_w + x0 + lx]
+                                    } else {
+                                        0
+                                    };
+                                    let logit = raw_dot - correction - bias;
+                                    if logit > 0 {
+                                        mask_buf[ly * roi_w + lx] = 255;
+                                    }
+                                }
                             }
                         }
                     }
-                } else {
-                    for ly in 0..roi_h {
-                        let py = y0 + ly;
-                        let row_base = py * stride_y + x0 * num_protos;
-                        for lx in 0..roi_w {
-                            let pix_base = row_base + lx * num_protos;
-                            let proto_px = &protos[pix_base..pix_base + num_protos];
-                            let raw_dot = unsafe {
-                                dot_i8_neon_base(coeff.as_ptr(), proto_px.as_ptr(), num_protos)
-                            };
-                            let correction = if zp_c != 0 {
-                                zp_c * proto_sums[py * proto_w + x0 + lx]
-                            } else {
-                                0
-                            };
-                            let logit = raw_dot - correction - bias;
-                            if logit > 0 {
-                                mask_buf[ly * roi_w + lx] = 255;
+                    #[cfg(not(target_arch = "aarch64"))]
+                    {
+                        for ly in 0..roi_h {
+                            let py = y0 + ly;
+                            let row_base = py * stride_y + x0 * num_protos;
+                            for lx in 0..roi_w {
+                                let pix_base = row_base + lx * num_protos;
+                                let proto_px = &protos[pix_base..pix_base + num_protos];
+                                let raw_dot = dot_i8_scalar(coeff, proto_px, num_protos);
+                                let correction = if zp_c != 0 {
+                                    zp_c * proto_sums[py * proto_w + x0 + lx]
+                                } else {
+                                    0
+                                };
+                                let logit = raw_dot - correction - bias;
+                                if logit > 0 {
+                                    mask_buf[ly * roi_w + lx] = 255;
+                                }
                             }
                         }
                     }
                 }
-            }
-            #[cfg(not(target_arch = "aarch64"))]
-            {
-                for ly in 0..roi_h {
-                    let py = y0 + ly;
-                    let row_base = py * stride_y + x0 * num_protos;
-                    for lx in 0..roi_w {
-                        let pix_base = row_base + lx * num_protos;
-                        let proto_px = &protos[pix_base..pix_base + num_protos];
-                        let raw_dot = dot_i8_scalar(coeff, proto_px, num_protos);
-                        let correction = if zp_c != 0 {
-                            zp_c * proto_sums[py * proto_w + x0 + lx]
-                        } else {
-                            0
-                        };
-                        let logit = raw_dot - correction - bias;
-                        if logit > 0 {
-                            mask_buf[ly * roi_w + lx] = 255;
+                edgefirst_decoder::ProtoLayout::Nchw => {
+                    // Channel-major accumulation: for each channel, accumulate
+                    // coeff[c] * proto[c, py, px] across the ROI. Each channel
+                    // plane is contiguous, giving excellent sequential read access.
+                    let mut accum = vec![0i32; roi_h * roi_w];
+                    for c in 0..num_protos {
+                        let plane = &protos[c * hw..];
+                        let coeff_c = coeff[c] as i32;
+                        for ly in 0..roi_h {
+                            let py = y0 + ly;
+                            let row_start = py * proto_w + x0;
+                            let out_row_start = ly * roi_w;
+                            for lx in 0..roi_w {
+                                accum[out_row_start + lx] += coeff_c * plane[row_start + lx] as i32;
+                            }
+                        }
+                    }
+                    // Apply zero-point correction and threshold.
+                    for ly in 0..roi_h {
+                        let py = y0 + ly;
+                        for lx in 0..roi_w {
+                            let idx = ly * roi_w + lx;
+                            let correction = if zp_c != 0 {
+                                zp_c * proto_sums[py * proto_w + x0 + lx]
+                            } else {
+                                0
+                            };
+                            let logit = accum[idx] - correction - bias;
+                            if logit > 0 {
+                                mask_buf[idx] = 255;
+                            }
                         }
                     }
                 }
@@ -1376,6 +1455,7 @@ fn scaled_segmentations_i8_i8(
     letterbox: Option<[f32; 4]>,
     width: u32,
     height: u32,
+    layout: edgefirst_decoder::ProtoLayout,
 ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
     use edgefirst_tensor::QuantMode;
 
@@ -1408,20 +1488,32 @@ fn scaled_segmentations_i8_i8(
     };
     let out_w = width as usize;
     let out_h = height as usize;
-    let stride_y = proto_w * num_protos;
+    let hw = proto_h * proto_w;
 
     // Precompute proto_sum for the entire proto tensor (zero-point correction).
     let proto_sums: Vec<i32> = if zp_c != 0 {
-        (0..proto_h * proto_w)
-            .map(|px_idx| {
-                let base = px_idx * num_protos;
-                let mut s: i32 = 0;
-                for k in 0..num_protos {
-                    s += protos[base + k] as i32;
+        match layout {
+            edgefirst_decoder::ProtoLayout::Nhwc => (0..hw)
+                .map(|px_idx| {
+                    let base = px_idx * num_protos;
+                    let mut s: i32 = 0;
+                    for k in 0..num_protos {
+                        s += protos[base + k] as i32;
+                    }
+                    s
+                })
+                .collect(),
+            edgefirst_decoder::ProtoLayout::Nchw => {
+                let mut sums = vec![0i32; hw];
+                for c in 0..num_protos {
+                    let plane = &protos[c * hw..];
+                    for (px, s) in sums.iter_mut().enumerate() {
+                        *s += plane[px] as i32;
+                    }
                 }
-                s
-            })
-            .collect()
+                sums
+            }
+        }
     } else {
         Vec::new()
     };
@@ -1429,6 +1521,9 @@ fn scaled_segmentations_i8_i8(
     // Detect dotprod support once, outside the hot loop.
     #[cfg(target_arch = "aarch64")]
     let use_dotprod = std::arch::is_aarch64_feature_detected!("dotprod");
+
+    // For NHWC layout, stride for row navigation.
+    let stride_y = proto_w * num_protos;
 
     detect
         .par_iter()
@@ -1477,57 +1572,90 @@ fn scaled_segmentations_i8_i8(
 
             // Step 2: Compute i32 logits at each proto-ROI pixel.
             let mut logits = vec![0_i32; roi_h * roi_w];
-            #[cfg(target_arch = "aarch64")]
-            {
-                if use_dotprod {
-                    compute_logits_dotprod(
-                        &mut logits,
-                        coeff,
-                        protos,
-                        &proto_sums,
-                        proto_w,
-                        proto_x0,
-                        proto_y0,
-                        roi_w,
-                        roi_h,
-                        stride_y,
-                        num_protos,
-                        zp_c,
-                        bias,
-                    );
-                } else {
-                    compute_logits_base(
-                        &mut logits,
-                        coeff,
-                        protos,
-                        &proto_sums,
-                        proto_w,
-                        proto_x0,
-                        proto_y0,
-                        roi_w,
-                        roi_h,
-                        stride_y,
-                        num_protos,
-                        zp_c,
-                        bias,
-                    );
-                }
-            }
-            #[cfg(not(target_arch = "aarch64"))]
-            {
-                for ly_idx in 0..roi_h {
-                    let py = proto_y0 + ly_idx;
-                    let row_base = py * stride_y + proto_x0 * num_protos;
-                    for lx_idx in 0..roi_w {
-                        let pix_base = row_base + lx_idx * num_protos;
-                        let proto_px = &protos[pix_base..pix_base + num_protos];
-                        let raw_dot = dot_i8_scalar(coeff, proto_px, num_protos);
-                        let correction = if zp_c != 0 {
-                            zp_c * proto_sums[py * proto_w + proto_x0 + lx_idx]
+            match layout {
+                edgefirst_decoder::ProtoLayout::Nhwc => {
+                    #[cfg(target_arch = "aarch64")]
+                    {
+                        if use_dotprod {
+                            compute_logits_dotprod(
+                                &mut logits,
+                                coeff,
+                                protos,
+                                &proto_sums,
+                                proto_w,
+                                proto_x0,
+                                proto_y0,
+                                roi_w,
+                                roi_h,
+                                stride_y,
+                                num_protos,
+                                zp_c,
+                                bias,
+                            );
                         } else {
-                            0
-                        };
-                        logits[ly_idx * roi_w + lx_idx] = raw_dot - correction - bias;
+                            compute_logits_base(
+                                &mut logits,
+                                coeff,
+                                protos,
+                                &proto_sums,
+                                proto_w,
+                                proto_x0,
+                                proto_y0,
+                                roi_w,
+                                roi_h,
+                                stride_y,
+                                num_protos,
+                                zp_c,
+                                bias,
+                            );
+                        }
+                    }
+                    #[cfg(not(target_arch = "aarch64"))]
+                    {
+                        for ly_idx in 0..roi_h {
+                            let py = proto_y0 + ly_idx;
+                            let row_base = py * stride_y + proto_x0 * num_protos;
+                            for lx_idx in 0..roi_w {
+                                let pix_base = row_base + lx_idx * num_protos;
+                                let proto_px = &protos[pix_base..pix_base + num_protos];
+                                let raw_dot = dot_i8_scalar(coeff, proto_px, num_protos);
+                                let correction = if zp_c != 0 {
+                                    zp_c * proto_sums[py * proto_w + proto_x0 + lx_idx]
+                                } else {
+                                    0
+                                };
+                                logits[ly_idx * roi_w + lx_idx] = raw_dot - correction - bias;
+                            }
+                        }
+                    }
+                }
+                edgefirst_decoder::ProtoLayout::Nchw => {
+                    // Channel-major accumulation: contiguous reads per channel plane.
+                    for c in 0..num_protos {
+                        let plane = &protos[c * hw..];
+                        let coeff_c = coeff[c] as i32;
+                        for ly_idx in 0..roi_h {
+                            let py = proto_y0 + ly_idx;
+                            let row_start = py * proto_w + proto_x0;
+                            let out_row_start = ly_idx * roi_w;
+                            for lx_idx in 0..roi_w {
+                                logits[out_row_start + lx_idx] +=
+                                    coeff_c * plane[row_start + lx_idx] as i32;
+                            }
+                        }
+                    }
+                    // Apply zero-point correction and per-detection bias.
+                    for ly_idx in 0..roi_h {
+                        let py = proto_y0 + ly_idx;
+                        for lx_idx in 0..roi_w {
+                            let idx = ly_idx * roi_w + lx_idx;
+                            let correction = if zp_c != 0 {
+                                zp_c * proto_sums[py * proto_w + proto_x0 + lx_idx]
+                            } else {
+                                0
+                            };
+                            logits[idx] -= correction + bias;
+                        }
                     }
                 }
             }

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -271,6 +271,44 @@ impl CPUProcessor {
             None => (0.0_f32, 1.0_f32, 0.0_f32, 1.0_f32),
         };
 
+        // Fast integer path: when both coefficients and protos are I8 with
+        // per-tensor quantization, use the all-integer kernel (same dot
+        // product infrastructure as the scaled path, but at proto resolution
+        // without bilinear upsampling). Output is binary {0, 255}.
+        if proto_data.mask_coefficients.dtype() == DType::I8
+            && proto_data.protos.dtype() == DType::I8
+        {
+            let coeff_t = proto_data
+                .mask_coefficients
+                .as_i8()
+                .expect("I8 coefficients");
+            let coeff_m = coeff_t.map()?;
+            let coeff_quant = coeff_t.quantization().ok_or_else(|| {
+                crate::Error::InvalidShape(
+                    "I8 mask_coefficients require quantization metadata".into(),
+                )
+            })?;
+            let proto_t = proto_data.protos.as_i8().expect("I8 protos");
+            let proto_m = proto_t.map()?;
+            let proto_quant = proto_t.quantization().ok_or_else(|| {
+                crate::Error::InvalidShape("I8 protos require quantization metadata".into())
+            })?;
+            return proto_segmentations_i8_i8(
+                detect,
+                coeff_m.as_slice(),
+                coeff_quant,
+                proto_m.as_slice(),
+                proto_quant,
+                proto_h,
+                proto_w,
+                num_protos,
+                lx0,
+                inv_lw,
+                ly0,
+                inv_lh,
+            );
+        }
+
         // Coefficients may be F32 (from f32 models), F16 (from fp16 models),
         // or I8 (from quantized models — kept raw with quantization). For the
         // mask kernel we always need an f32 view (the multiply-accumulate is
@@ -348,7 +386,7 @@ impl CPUProcessor {
                         let coeff = &coeff_f32_slice[i * num_protos..(i + 1) * num_protos];
                         let (x0, y0, x1, y1, roi_w, roi_h) =
                             bbox_to_proto_roi(det, proto_w, proto_h);
-                        let mask = fused_dequant_dot_sigmoid_i8_slice(
+                        let mask = fused_dequant_dot_sign_i8_slice(
                             protos_slice,
                             coeff,
                             quant,
@@ -377,7 +415,7 @@ impl CPUProcessor {
                         let coeff = &coeff_f32_slice[i * num_protos..(i + 1) * num_protos];
                         let (x0, y0, x1, y1, roi_w, roi_h) =
                             bbox_to_proto_roi(det, proto_w, proto_h);
-                        let mask = fused_dot_sigmoid_f32_slice(
+                        let mask = fused_dot_sign_f32_slice(
                             protos_slice,
                             coeff,
                             proto_h,
@@ -405,7 +443,7 @@ impl CPUProcessor {
                         let coeff = &coeff_f32_slice[i * num_protos..(i + 1) * num_protos];
                         let (x0, y0, x1, y1, roi_w, roi_h) =
                             bbox_to_proto_roi(det, proto_w, proto_h);
-                        let mask = fused_dot_sigmoid_f16_slice(
+                        let mask = fused_dot_sign_f16_slice(
                             protos_slice,
                             coeff,
                             proto_h,
@@ -685,8 +723,265 @@ fn seg_from_roi(
     }
 }
 
+// =============================================================================
+// Integer-domain proto-resolution kernel: i8 coefficients × i8 protos → i32
+// → sign threshold → binary {0, 255}.
+//
+// Reuses the same dot product infrastructure as the scaled path (NEON sdot on
+// A55+, smull+sadalp on A53, scalar fallback on x86). Since proto-resolution
+// produces masks at the native proto grid (~30×30 per ROI), there is no
+// bilinear upsampling — just a direct sign threshold per pixel.
+// =============================================================================
+
+/// Proto-resolution mask materialization using integer-domain math.
+///
+/// For each detection, computes the i8×i8 dot product at every proto-ROI pixel,
+/// applies the zero-point correction, and thresholds at sign(logit) → {0, 255}.
 #[allow(clippy::too_many_arguments)]
-fn fused_dequant_dot_sigmoid_i8_slice(
+fn proto_segmentations_i8_i8(
+    detect: &[crate::DetectBox],
+    coeff_all: &[i8],
+    coeff_quant: &edgefirst_tensor::Quantization,
+    protos: &[i8],
+    proto_quant: &edgefirst_tensor::Quantization,
+    proto_h: usize,
+    proto_w: usize,
+    num_protos: usize,
+    lx0: f32,
+    inv_lw: f32,
+    ly0: f32,
+    inv_lh: f32,
+) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
+    use edgefirst_tensor::QuantMode;
+
+    let zp_c: i32 = match coeff_quant.mode() {
+        QuantMode::PerTensor { zero_point, .. } => zero_point,
+        QuantMode::PerTensorSymmetric { .. } => 0,
+        _ => {
+            return Err(crate::Error::NotSupported(
+                "per-channel coeff quantization not supported on proto-res i8 path".into(),
+            ))
+        }
+    };
+    let zp_p: i32 = match proto_quant.mode() {
+        QuantMode::PerTensor { zero_point, .. } => zero_point,
+        QuantMode::PerTensorSymmetric { .. } => 0,
+        _ => {
+            return Err(crate::Error::NotSupported(
+                "per-channel proto quantization not supported on proto-res i8 path".into(),
+            ))
+        }
+    };
+
+    let stride_y = proto_w * num_protos;
+
+    // Precompute per-pixel proto sums for zero-point correction.
+    let proto_sums: Vec<i32> = if zp_c != 0 {
+        (0..proto_h * proto_w)
+            .map(|px_idx| {
+                let base = px_idx * num_protos;
+                protos[base..base + num_protos]
+                    .iter()
+                    .map(|&v| v as i32)
+                    .sum()
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    #[cfg(target_arch = "aarch64")]
+    let use_dotprod = std::arch::is_aarch64_feature_detected!("dotprod");
+
+    detect
+        .par_iter()
+        .enumerate()
+        .map(|(i, det)| {
+            let coeff = &coeff_all[i * num_protos..(i + 1) * num_protos];
+            let (x0, y0, x1, y1, roi_w, roi_h) = bbox_to_proto_roi(det, proto_w, proto_h);
+
+            // Per-detection bias: zp_p·Σc_raw - N·zp_c·zp_p
+            let coeff_sum: i32 = coeff.iter().map(|&c| c as i32).sum();
+            let bias = zp_p * coeff_sum - (num_protos as i32) * zp_c * zp_p;
+
+            let mut mask_buf = vec![0u8; roi_h * roi_w];
+
+            #[cfg(target_arch = "aarch64")]
+            {
+                if use_dotprod {
+                    for ly in 0..roi_h {
+                        let py = y0 + ly;
+                        let row_base = py * stride_y + x0 * num_protos;
+                        for lx in 0..roi_w {
+                            let pix_base = row_base + lx * num_protos;
+                            let proto_px = &protos[pix_base..pix_base + num_protos];
+                            let raw_dot = unsafe {
+                                dot_i8_neon_dotprod(coeff.as_ptr(), proto_px.as_ptr(), num_protos)
+                            };
+                            let correction = if zp_c != 0 {
+                                zp_c * proto_sums[py * proto_w + x0 + lx]
+                            } else {
+                                0
+                            };
+                            let logit = raw_dot - correction - bias;
+                            if logit > 0 {
+                                mask_buf[ly * roi_w + lx] = 255;
+                            }
+                        }
+                    }
+                } else {
+                    for ly in 0..roi_h {
+                        let py = y0 + ly;
+                        let row_base = py * stride_y + x0 * num_protos;
+                        for lx in 0..roi_w {
+                            let pix_base = row_base + lx * num_protos;
+                            let proto_px = &protos[pix_base..pix_base + num_protos];
+                            let raw_dot = unsafe {
+                                dot_i8_neon_base(coeff.as_ptr(), proto_px.as_ptr(), num_protos)
+                            };
+                            let correction = if zp_c != 0 {
+                                zp_c * proto_sums[py * proto_w + x0 + lx]
+                            } else {
+                                0
+                            };
+                            let logit = raw_dot - correction - bias;
+                            if logit > 0 {
+                                mask_buf[ly * roi_w + lx] = 255;
+                            }
+                        }
+                    }
+                }
+            }
+            #[cfg(not(target_arch = "aarch64"))]
+            {
+                for ly in 0..roi_h {
+                    let py = y0 + ly;
+                    let row_base = py * stride_y + x0 * num_protos;
+                    for lx in 0..roi_w {
+                        let pix_base = row_base + lx * num_protos;
+                        let proto_px = &protos[pix_base..pix_base + num_protos];
+                        let raw_dot = dot_i8_scalar(coeff, proto_px, num_protos);
+                        let correction = if zp_c != 0 {
+                            zp_c * proto_sums[py * proto_w + x0 + lx]
+                        } else {
+                            0
+                        };
+                        let logit = raw_dot - correction - bias;
+                        if logit > 0 {
+                            mask_buf[ly * roi_w + lx] = 255;
+                        }
+                    }
+                }
+            }
+
+            let mask = ndarray::Array3::from_shape_vec((roi_h, roi_w, 1), mask_buf)
+                .expect("mask_buf length matches roi_h * roi_w");
+            Ok(seg_from_roi(
+                mask, x0, y0, x1, y1, proto_w, proto_h, lx0, inv_lw, ly0, inv_lh,
+            ))
+        })
+        .collect()
+}
+
+// =============================================================================
+// Sign-threshold proto-resolution kernels (f32/f16/i8 protos with f32 coeffs).
+//
+// These replace the sigmoid-computing kernels for the non-i8×i8 fallback paths.
+// Since downstream always thresholds at > 127, computing sigmoid is wasteful;
+// sign(dot) > 0 ⟺ sigmoid(dot) > 0.5 gives the same binary result.
+// =============================================================================
+
+/// f32 protos × f32 coefficients → sign threshold → binary {0, 255}.
+#[allow(clippy::too_many_arguments)]
+fn fused_dot_sign_f32_slice(
+    protos: &[f32],
+    coeff: &[f32],
+    _proto_h: usize,
+    proto_w: usize,
+    y0: usize,
+    x0: usize,
+    roi_h: usize,
+    roi_w: usize,
+    num_protos: usize,
+) -> ndarray::Array3<u8> {
+    let stride_y = proto_w * num_protos;
+    let mut mask_buf = vec![0u8; roi_h * roi_w];
+    for y in 0..roi_h {
+        let row_base = (y0 + y) * stride_y + x0 * num_protos;
+        let out_row = &mut mask_buf[y * roi_w..(y + 1) * roi_w];
+        for (x, out_px) in out_row.iter_mut().enumerate() {
+            let base = row_base + x * num_protos;
+            let mut acc = 0.0_f32;
+            let mut k = 0;
+            let chunks = num_protos / 4;
+            for _ in 0..chunks {
+                acc += coeff[k] * protos[base + k]
+                    + coeff[k + 1] * protos[base + k + 1]
+                    + coeff[k + 2] * protos[base + k + 2]
+                    + coeff[k + 3] * protos[base + k + 3];
+                k += 4;
+            }
+            while k < num_protos {
+                acc += coeff[k] * protos[base + k];
+                k += 1;
+            }
+            if acc > 0.0 {
+                *out_px = 255;
+            }
+        }
+    }
+    ndarray::Array3::from_shape_vec((roi_h, roi_w, 1), mask_buf)
+        .expect("mask_buf length matches roi_h * roi_w")
+}
+
+/// f16 protos × f32 coefficients → sign threshold → binary {0, 255}.
+#[allow(clippy::too_many_arguments)]
+fn fused_dot_sign_f16_slice(
+    protos: &[half::f16],
+    coeff: &[f32],
+    _proto_h: usize,
+    proto_w: usize,
+    y0: usize,
+    x0: usize,
+    roi_h: usize,
+    roi_w: usize,
+    num_protos: usize,
+) -> ndarray::Array3<u8> {
+    let stride_y = proto_w * num_protos;
+    let mut mask_buf = vec![0u8; roi_h * roi_w];
+    for y in 0..roi_h {
+        let row_base = (y0 + y) * stride_y + x0 * num_protos;
+        let out_row = &mut mask_buf[y * roi_w..(y + 1) * roi_w];
+        for (x, out_px) in out_row.iter_mut().enumerate() {
+            let base = row_base + x * num_protos;
+            let mut acc = 0.0_f32;
+            let mut k = 0;
+            let chunks = num_protos / 4;
+            for _ in 0..chunks {
+                acc += coeff[k] * protos[base + k].to_f32()
+                    + coeff[k + 1] * protos[base + k + 1].to_f32()
+                    + coeff[k + 2] * protos[base + k + 2].to_f32()
+                    + coeff[k + 3] * protos[base + k + 3].to_f32();
+                k += 4;
+            }
+            while k < num_protos {
+                acc += coeff[k] * protos[base + k].to_f32();
+                k += 1;
+            }
+            if acc > 0.0 {
+                *out_px = 255;
+            }
+        }
+    }
+    ndarray::Array3::from_shape_vec((roi_h, roi_w, 1), mask_buf)
+        .expect("mask_buf length matches roi_h * roi_w")
+}
+
+/// i8 protos (with quant) × f32 coefficients → sign threshold → binary {0, 255}.
+/// Fallback for per-channel quant or mixed-dtype cases where the i8×i8 fast path
+/// doesn't apply.
+#[allow(clippy::too_many_arguments)]
+fn fused_dequant_dot_sign_i8_slice(
     protos: &[i8],
     coeff: &[f32],
     quant: &edgefirst_tensor::Quantization,
@@ -700,10 +995,8 @@ fn fused_dequant_dot_sigmoid_i8_slice(
 ) -> crate::Result<ndarray::Array3<u8>> {
     use edgefirst_tensor::QuantMode;
     let stride_y = proto_w * num_protos;
-    // Precompute scaled coefficients + zp_offset. Stack scratch covers
-    // `num_protos ≤ 64` (every production model today); larger proto counts
-    // fall back to a single heap allocation per kernel call so the kernel
-    // does not silently reject valid-but-larger models.
+
+    // Precompute scaled coefficients + zp_offset (same as the old sigmoid kernel).
     let mut stack_scratch = [0.0_f32; 64];
     let mut heap_scratch: Vec<f32>;
     let scaled_coeff: &mut [f32] = if num_protos <= stack_scratch.len() {
@@ -758,10 +1051,12 @@ fn fused_dequant_dot_sigmoid_i8_slice(
         }
     }
 
-    let mut mask = ndarray::Array3::<u8>::zeros((roi_h, roi_w, 1));
+    let mut mask_buf = vec![0u8; roi_h * roi_w];
     for y in 0..roi_h {
-        for x in 0..roi_w {
-            let base = (y0 + y) * stride_y + (x0 + x) * num_protos;
+        let row_base = (y0 + y) * stride_y + (x0) * num_protos;
+        let out_row = &mut mask_buf[y * roi_w..(y + 1) * roi_w];
+        for (x, out_px) in out_row.iter_mut().enumerate() {
+            let base = row_base + x * num_protos;
             let mut acc = 0.0_f32;
             let mut k = 0;
             let chunks = num_protos / 4;
@@ -780,229 +1075,13 @@ fn fused_dequant_dot_sigmoid_i8_slice(
                 acc += scaled_coeff[k] * protos[base + k] as f32;
                 k += 1;
             }
-            acc -= zp_offset;
-            let sigmoid = fast_sigmoid(acc);
-            mask[[y, x, 0]] = (sigmoid * 255.0 + 0.5) as u8;
+            if acc > zp_offset {
+                *out_px = 255;
+            }
         }
     }
-    Ok(mask)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn fused_dot_sigmoid_f32_slice(
-    protos: &[f32],
-    coeff: &[f32],
-    _proto_h: usize,
-    proto_w: usize,
-    y0: usize,
-    x0: usize,
-    roi_h: usize,
-    roi_w: usize,
-    num_protos: usize,
-) -> ndarray::Array3<u8> {
-    let stride_y = proto_w * num_protos;
-    let mut mask = ndarray::Array3::<u8>::zeros((roi_h, roi_w, 1));
-    for y in 0..roi_h {
-        for x in 0..roi_w {
-            let base = (y0 + y) * stride_y + (x0 + x) * num_protos;
-            let mut acc = 0.0_f32;
-            let mut k = 0;
-            let chunks = num_protos / 4;
-            for _ in 0..chunks {
-                acc += coeff[k] * protos[base + k]
-                    + coeff[k + 1] * protos[base + k + 1]
-                    + coeff[k + 2] * protos[base + k + 2]
-                    + coeff[k + 3] * protos[base + k + 3];
-                k += 4;
-            }
-            while k < num_protos {
-                acc += coeff[k] * protos[base + k];
-                k += 1;
-            }
-            let sigmoid = fast_sigmoid(acc);
-            mask[[y, x, 0]] = (sigmoid * 255.0 + 0.5) as u8;
-        }
-    }
-    mask
-}
-
-/// Native-f16 fused kernel.
-///
-/// Three code paths, selected at compile time:
-///
-/// 1. **x86_64 + F16C + FMA** — explicit intrinsic kernel (`_mm256_cvtph_ps`
-///    8-lane f16→f32 widening, `_mm256_fmadd_ps` FMA). Guaranteed to use
-///    hardware f16 conversion, not LLVM's autovectorizer (which is unreliable
-///    for this pattern per rust-lang/stdarch #1349).
-///
-/// 2. **aarch64 + FP16** — scalar `half::f16::to_f32()` at the FMA site.
-///    LLVM lowers each `.to_f32()` to a single `fcvt` instruction when
-///    `target-feature=+fp16` is active (e.g. `target-cpu=cortex-a78ae`).
-///    The stable f16-typed NEON intrinsics (`vcvt_f32_f16`, `vld1q_f16`)
-///    require nightly as of this commit; the scalar path is equally
-///    efficient at this granularity.
-///
-/// 3. **Fallback (Cortex-A53, targets without FP16)** — same scalar code.
-///    `half::f16::to_f32()` lowers to `__extendhfsf2` soft-float helper,
-///    one call per proto load. Correctness-preserving; ~15 cycles/load
-///    vs. ~3 cycles for the hardware path. Documented in
-///    `docs/orin-build.md`.
-#[allow(clippy::too_many_arguments)]
-fn fused_dot_sigmoid_f16_slice(
-    protos: &[half::f16],
-    coeff: &[f32],
-    proto_h: usize,
-    proto_w: usize,
-    y0: usize,
-    x0: usize,
-    roi_h: usize,
-    roi_w: usize,
-    num_protos: usize,
-) -> ndarray::Array3<u8> {
-    #[cfg(all(
-        target_arch = "x86_64",
-        target_feature = "f16c",
-        target_feature = "fma"
-    ))]
-    {
-        // SAFETY: target-feature gates both `vcvtph2ps` and `vfmadd*ps`;
-        // the caller's slice-bounds contract is identical to the scalar arm.
-        unsafe {
-            fused_dot_sigmoid_f16_slice_f16c(
-                protos, coeff, proto_h, proto_w, y0, x0, roi_h, roi_w, num_protos,
-            )
-        }
-    }
-    #[cfg(not(all(
-        target_arch = "x86_64",
-        target_feature = "f16c",
-        target_feature = "fma"
-    )))]
-    {
-        let _ = proto_h;
-        fused_dot_sigmoid_f16_slice_scalar(protos, coeff, proto_w, y0, x0, roi_h, roi_w, num_protos)
-    }
-}
-
-/// Scalar native-f16 kernel. `half::f16::to_f32()` at the FMA site is
-/// lowered to a single `fcvt` (aarch64+fp16) or a single `vcvtps_ps`
-/// (x86_64+f16c) by LLVM, or to the soft-float helper `__extendhfsf2` on
-/// targets without FP16 hardware. Loop unrolled by 4 to give the scheduler
-/// room to overlap loads with FMAs.
-#[allow(clippy::too_many_arguments, dead_code)]
-fn fused_dot_sigmoid_f16_slice_scalar(
-    protos: &[half::f16],
-    coeff: &[f32],
-    proto_w: usize,
-    y0: usize,
-    x0: usize,
-    roi_h: usize,
-    roi_w: usize,
-    num_protos: usize,
-) -> ndarray::Array3<u8> {
-    let stride_y = proto_w * num_protos;
-    let mut mask = ndarray::Array3::<u8>::zeros((roi_h, roi_w, 1));
-    for y in 0..roi_h {
-        for x in 0..roi_w {
-            let base = (y0 + y) * stride_y + (x0 + x) * num_protos;
-            let mut acc = 0.0_f32;
-            let mut k = 0;
-            let chunks = num_protos / 4;
-            for _ in 0..chunks {
-                let p0 = protos[base + k].to_f32();
-                let p1 = protos[base + k + 1].to_f32();
-                let p2 = protos[base + k + 2].to_f32();
-                let p3 = protos[base + k + 3].to_f32();
-                acc += coeff[k] * p0 + coeff[k + 1] * p1 + coeff[k + 2] * p2 + coeff[k + 3] * p3;
-                k += 4;
-            }
-            while k < num_protos {
-                acc += coeff[k] * protos[base + k].to_f32();
-                k += 1;
-            }
-            let sigmoid = fast_sigmoid(acc);
-            mask[[y, x, 0]] = (sigmoid * 255.0 + 0.5) as u8;
-        }
-    }
-    mask
-}
-
-/// x86_64 F16C + FMA explicit intrinsic kernel. Processes 8 f16 lanes per
-/// inner iteration via `_mm256_cvtph_ps` (8-lane f16→f32 widen) followed by
-/// `_mm256_fmadd_ps` (8-lane fused multiply-add). Horizontal reduce at the
-/// end of each pixel.
-///
-/// # Safety
-///
-/// Caller must ensure the target CPU supports F16C + FMA. The workspace's
-/// `.cargo/config.toml` sets these target-features on `x86_64-unknown-linux-gnu`
-/// and `x86_64-apple-darwin`, making this function statically callable on
-/// those targets.
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "f16c",
-    target_feature = "fma"
-))]
-#[allow(clippy::too_many_arguments)]
-#[target_feature(enable = "f16c,fma,avx")]
-unsafe fn fused_dot_sigmoid_f16_slice_f16c(
-    protos: &[half::f16],
-    coeff: &[f32],
-    _proto_h: usize,
-    proto_w: usize,
-    y0: usize,
-    x0: usize,
-    roi_h: usize,
-    roi_w: usize,
-    num_protos: usize,
-) -> ndarray::Array3<u8> {
-    use core::arch::x86_64::{
-        _mm256_castps256_ps128, _mm256_cvtph_ps, _mm256_extractf128_ps, _mm256_fmadd_ps,
-        _mm256_loadu_ps, _mm256_setzero_ps, _mm_add_ps, _mm_cvtss_f32, _mm_hadd_ps,
-        _mm_loadu_si128,
-    };
-
-    let stride_y = proto_w * num_protos;
-    let chunks8 = num_protos / 8;
-    let tail = num_protos % 8;
-    let mut mask = ndarray::Array3::<u8>::zeros((roi_h, roi_w, 1));
-
-    for y in 0..roi_h {
-        for x in 0..roi_w {
-            let base = (y0 + y) * stride_y + (x0 + x) * num_protos;
-            let mut acc_v = _mm256_setzero_ps();
-            let mut k = 0;
-            for _ in 0..chunks8 {
-                // Load 8 f16 (128 bits / 16 bytes) via a byte-level cast.
-                let p_ptr = protos
-                    .as_ptr()
-                    .add(base + k)
-                    .cast::<core::arch::x86_64::__m128i>();
-                let raw = _mm_loadu_si128(p_ptr);
-                let widened = _mm256_cvtph_ps(raw);
-                let coeffs_v = _mm256_loadu_ps(coeff.as_ptr().add(k));
-                acc_v = _mm256_fmadd_ps(coeffs_v, widened, acc_v);
-                k += 8;
-            }
-            // Horizontal reduce 8 → 1.
-            let lo = _mm256_castps256_ps128(acc_v);
-            let hi = _mm256_extractf128_ps::<1>(acc_v);
-            let sum4 = _mm_add_ps(lo, hi);
-            let sum2 = _mm_hadd_ps(sum4, sum4);
-            let sum1 = _mm_hadd_ps(sum2, sum2);
-            let mut acc = _mm_cvtss_f32(sum1);
-
-            // Scalar tail for num_protos % 8 (≤ 7 items).
-            while k < num_protos && k - chunks8 * 8 < tail {
-                acc += coeff[k] * protos[base + k].to_f32();
-                k += 1;
-            }
-
-            let sigmoid = fast_sigmoid(acc);
-            mask[[y, x, 0]] = (sigmoid * 255.0 + 0.5) as u8;
-        }
-    }
-    mask
+    Ok(ndarray::Array3::from_shape_vec((roi_h, roi_w, 1), mask_buf)
+        .expect("mask_buf length matches roi_h * roi_w"))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1661,8 +1740,8 @@ fn scaled_run<P: Copy + Sync>(
             // Step 3 — bilinear upsample logits → binary mask.
             //
             // O1: sigmoid(x) > 0.5 ⟺ x > 0 (sigmoid is strictly monotonic,
-            // and acc_scale > 0 preserves sign). Eliminates ~15 cycles/pixel
-            // from the fast_sigmoid approximation.
+            // and acc_scale > 0 preserves sign). The sign threshold replaces
+            // the old fast_sigmoid approximation, saving ~15 cycles/pixel.
             //
             // O5: Pre-compute bilinear sample coordinates. sample_x_at /
             // sample_y_at depend only on pixel index, not on logit values.
@@ -1715,22 +1794,4 @@ fn scaled_run<P: Copy + Sync>(
             })
         })
         .collect()
-}
-
-fn fast_sigmoid(x: f32) -> f32 {
-    if x >= 16.0 {
-        return 1.0;
-    }
-    if x <= -16.0 {
-        return 0.0;
-    }
-    // Fast exp(-x) via bit manipulation (Schraudolph's algorithm).
-    // f32 bits: 2^23 * log2(e) * x + (127 << 23) approximates exp(x).
-    const A: f32 = (1u32 << 23) as f32; // 8388608.0
-    const B: f32 = A * std::f32::consts::LOG2_E; // A / ln(2)
-    const C: u32 = 127 << 23; // exponent bias
-    let neg_x = -x;
-    let bits = (B * neg_x) as i32 + C as i32;
-    let exp_neg_x = f32::from_bits(bits as u32);
-    1.0 / (1.0 + exp_neg_x)
 }

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -283,6 +283,8 @@ impl CPUProcessor {
         // per-tensor quantization, use the all-integer kernel (same dot
         // product infrastructure as the scaled path, but at proto resolution
         // without bilinear upsampling). Output is binary {0, 255}.
+        // Falls through to the general f32 dequant path for per-channel
+        // quantization or other unsupported modes.
         if proto_data.mask_coefficients.dtype() == DType::I8
             && proto_data.protos.dtype() == DType::I8
         {
@@ -301,7 +303,7 @@ impl CPUProcessor {
             let proto_quant = proto_t.quantization().ok_or_else(|| {
                 crate::Error::InvalidShape("I8 protos require quantization metadata".into())
             })?;
-            return proto_segmentations_i8_i8(
+            match proto_segmentations_i8_i8(
                 detect,
                 coeff_m.as_slice(),
                 coeff_quant,
@@ -315,17 +317,26 @@ impl CPUProcessor {
                 ly0,
                 inv_lh,
                 proto_data.layout,
-            );
+            ) {
+                Ok(result) => return Ok(result),
+                Err(crate::Error::NotSupported(_)) => {
+                    // Fall through to the general f32 dequant path below for
+                    // per-channel quantization and other unsupported modes.
+                }
+                Err(e) => return Err(e),
+            }
         }
 
         // Coefficients may be F32 (from f32 models), F16 (from fp16 models),
         // or I8 (from quantized models — kept raw with quantization). For the
         // mask kernel we always need an f32 view (the multiply-accumulate is
         // done in f32 for precision). Map once and widen once outside the loop.
-        // NCHW layout is only supported in the i8×i8 integer fast path above.
+        // NCHW layout is only supported in the i8×i8 integer fast path above
+        // with per-tensor quantization. Reject here for all other combinations.
         if proto_data.layout == edgefirst_decoder::ProtoLayout::Nchw {
             return Err(crate::Error::NotSupported(
-                "NCHW proto layout requires both protos and mask_coefficients to be I8".into(),
+                "NCHW proto layout requires I8 protos and coefficients with per-tensor quantization"
+                    .into(),
             ));
         }
         let coeff_f32_storage: Vec<f32>;
@@ -547,6 +558,8 @@ impl CPUProcessor {
         // Fast integer path: when both coefficients and protos are I8, use
         // the all-integer kernel (i8×i8→i32 dot product, sign-shortcut
         // bilinear). No floating-point conversion at all.
+        // Falls through to the general f32 dequant path for per-channel
+        // quantization or other unsupported modes.
         if proto_data.mask_coefficients.dtype() == DType::I8
             && proto_data.protos.dtype() == DType::I8
         {
@@ -565,7 +578,7 @@ impl CPUProcessor {
             let proto_quant = proto_t.quantization().ok_or_else(|| {
                 crate::Error::InvalidShape("I8 protos require quantization metadata".into())
             })?;
-            return scaled_segmentations_i8_i8(
+            match scaled_segmentations_i8_i8(
                 detect,
                 coeff_m.as_slice(),
                 coeff_quant,
@@ -578,14 +591,23 @@ impl CPUProcessor {
                 width,
                 height,
                 proto_data.layout,
-            );
+            ) {
+                Ok(result) => return Ok(result),
+                Err(crate::Error::NotSupported(_)) => {
+                    // Fall through to the general f32 dequant path below for
+                    // per-channel quantization and other unsupported modes.
+                }
+                Err(e) => return Err(e),
+            }
         }
 
         // Fallback: widen coefficients to f32 for the float-path kernels.
-        // NCHW layout is only supported in the i8×i8 integer fast path above.
+        // NCHW layout is only supported in the i8×i8 integer fast path above
+        // with per-tensor quantization. Reject here for all other combinations.
         if proto_data.layout == edgefirst_decoder::ProtoLayout::Nchw {
             return Err(crate::Error::NotSupported(
-                "NCHW proto layout requires both protos and mask_coefficients to be I8".into(),
+                "NCHW proto layout requires I8 protos and coefficients with per-tensor quantization"
+                    .into(),
             ));
         }
         let coeff_f32: Vec<f32> = match proto_data.mask_coefficients.dtype() {

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -1014,11 +1014,51 @@ fn fused_dot_sign_f32_slice(
 }
 
 /// f16 protos × f32 coefficients → sign threshold → binary {0, 255}.
+///
+/// Two code paths:
+///
+/// 1. **x86_64 + F16C + FMA** — explicit intrinsic kernel using
+///    `_mm256_cvtph_ps` (8-lane f16→f32 widening) + `_mm256_fmadd_ps`.
+///
+/// 2. **Scalar fallback** — loop-unrolled by 4 with `half::f16::to_f32()`.
 #[allow(clippy::too_many_arguments)]
 fn fused_dot_sign_f16_slice(
     protos: &[half::f16],
     coeff: &[f32],
     _proto_h: usize,
+    proto_w: usize,
+    y0: usize,
+    x0: usize,
+    roi_h: usize,
+    roi_w: usize,
+    num_protos: usize,
+) -> ndarray::Array3<u8> {
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "f16c",
+        target_feature = "fma"
+    ))]
+    {
+        // SAFETY: target-feature gates guarantee F16C + FMA support.
+        unsafe {
+            fused_dot_sign_f16_slice_f16c(protos, coeff, proto_w, y0, x0, roi_h, roi_w, num_protos)
+        }
+    }
+    #[cfg(not(all(
+        target_arch = "x86_64",
+        target_feature = "f16c",
+        target_feature = "fma"
+    )))]
+    {
+        fused_dot_sign_f16_slice_scalar(protos, coeff, proto_w, y0, x0, roi_h, roi_w, num_protos)
+    }
+}
+
+/// Scalar f16 sign-threshold kernel — loop-unrolled by 4.
+#[allow(clippy::too_many_arguments)]
+fn fused_dot_sign_f16_slice_scalar(
+    protos: &[half::f16],
+    coeff: &[f32],
     proto_w: usize,
     y0: usize,
     x0: usize,
@@ -1047,6 +1087,83 @@ fn fused_dot_sign_f16_slice(
                 acc += coeff[k] * protos[base + k].to_f32();
                 k += 1;
             }
+            if acc > 0.0 {
+                *out_px = 255;
+            }
+        }
+    }
+    ndarray::Array3::from_shape_vec((roi_h, roi_w, 1), mask_buf)
+        .expect("mask_buf length matches roi_h * roi_w")
+}
+
+/// x86_64 F16C + FMA intrinsic kernel for f16 sign-threshold.
+///
+/// Uses `_mm256_cvtph_ps` for hardware 8-lane f16→f32 widening and
+/// `_mm256_fmadd_ps` for fused multiply-add. Only the sign of the
+/// accumulated dot product is checked (no sigmoid needed).
+///
+/// # Safety
+///
+/// Caller must ensure the target CPU supports F16C + FMA.
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "f16c",
+    target_feature = "fma"
+))]
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "f16c,fma,avx")]
+unsafe fn fused_dot_sign_f16_slice_f16c(
+    protos: &[half::f16],
+    coeff: &[f32],
+    proto_w: usize,
+    y0: usize,
+    x0: usize,
+    roi_h: usize,
+    roi_w: usize,
+    num_protos: usize,
+) -> ndarray::Array3<u8> {
+    use core::arch::x86_64::{
+        _mm256_castps256_ps128, _mm256_cvtph_ps, _mm256_extractf128_ps, _mm256_fmadd_ps,
+        _mm256_loadu_ps, _mm256_setzero_ps, _mm_add_ps, _mm_cvtss_f32, _mm_hadd_ps,
+        _mm_loadu_si128,
+    };
+
+    let stride_y = proto_w * num_protos;
+    let chunks8 = num_protos / 8;
+    let mut mask_buf = vec![0u8; roi_h * roi_w];
+
+    for y in 0..roi_h {
+        let row_base = (y0 + y) * stride_y + x0 * num_protos;
+        let out_row = &mut mask_buf[y * roi_w..(y + 1) * roi_w];
+        for (x, out_px) in out_row.iter_mut().enumerate() {
+            let base = row_base + x * num_protos;
+            let mut acc_v = _mm256_setzero_ps();
+            let mut k = 0;
+            for _ in 0..chunks8 {
+                let p_ptr = protos
+                    .as_ptr()
+                    .add(base + k)
+                    .cast::<core::arch::x86_64::__m128i>();
+                let raw = _mm_loadu_si128(p_ptr);
+                let widened = _mm256_cvtph_ps(raw);
+                let coeffs_v = _mm256_loadu_ps(coeff.as_ptr().add(k));
+                acc_v = _mm256_fmadd_ps(coeffs_v, widened, acc_v);
+                k += 8;
+            }
+            // Horizontal reduce 8 → 1.
+            let lo = _mm256_castps256_ps128(acc_v);
+            let hi = _mm256_extractf128_ps::<1>(acc_v);
+            let sum4 = _mm_add_ps(lo, hi);
+            let sum2 = _mm_hadd_ps(sum4, sum4);
+            let sum1 = _mm_hadd_ps(sum2, sum2);
+            let mut acc = _mm_cvtss_f32(sum1);
+
+            // Scalar tail for num_protos % 8.
+            while k < num_protos {
+                acc += coeff[k] * protos[base + k].to_f32();
+                k += 1;
+            }
+
             if acc > 0.0 {
                 *out_px = 255;
             }

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -2201,6 +2201,58 @@ mod cpu_tests {
         );
     }
 
+    #[test]
+    fn test_materialize_per_channel_i8_falls_through_to_f32() {
+        // Verify that I8 protos with per-channel quantization fall through
+        // from the i8×i8 fast path to the general f32 dequant path.
+        // This tests the regression fix: previously the i8 fast path returned
+        // NotSupported without falling back.
+        use edgefirst_tensor::{Quantization, Tensor, TensorDyn};
+        let cpu = CPUProcessor::new();
+        let (proto_h, proto_w, num_protos) = (4, 4, 2);
+
+        // NHWC protos: [H, W, K] = [4, 4, 2]
+        // Channel 0: all +10, Channel 1: all -10
+        let mut proto_values = vec![0_i8; proto_h * proto_w * num_protos];
+        for y in 0..proto_h {
+            for x in 0..proto_w {
+                let base = (y * proto_w + x) * num_protos;
+                proto_values[base] = 10; // channel 0
+                proto_values[base + 1] = -10; // channel 1
+            }
+        }
+        let mut protos_t =
+            Tensor::<i8>::from_slice(&proto_values, &[proto_h, proto_w, num_protos]).unwrap();
+        // Per-channel symmetric quantization on axis 2 (channel axis).
+        let scales = vec![0.1_f32; num_protos];
+        protos_t
+            .set_quantization(Quantization::per_channel_symmetric(scales, 2).unwrap())
+            .unwrap();
+
+        // Per-tensor coeff: [1, 0] → selects channel 0 only
+        let coeff_values = vec![1_i8, 0_i8];
+        let mut coeff_t = Tensor::<i8>::from_slice(&coeff_values, &[1, num_protos]).unwrap();
+        coeff_t
+            .set_quantization(Quantization::per_tensor(1.0, 0))
+            .unwrap();
+
+        let proto_data = crate::ProtoData {
+            mask_coefficients: TensorDyn::I8(coeff_t),
+            protos: TensorDyn::I8(protos_t),
+            layout: edgefirst_decoder::ProtoLayout::Nhwc,
+        };
+        let det = [make_detect_box(0.0, 0.0, 1.0, 1.0)];
+        let segs = cpu
+            .materialize_segmentations(&det, &proto_data, None)
+            .expect("per-channel I8 protos should fall through to f32 path");
+        assert_eq!(segs.len(), 1);
+        // Channel 0 is positive (10 * 0.1 = 1.0), coeff selects it → dot > 0 → 255
+        assert!(
+            segs[0].segmentation.iter().all(|&v| v == 255),
+            "per-channel i8 fallback: positive dot should yield all-255"
+        );
+    }
+
     /// Golden-byte anchor: runs the quantized decode + CPU mask materialization
     /// file.
     ///

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -2115,6 +2115,92 @@ mod cpu_tests {
         );
     }
 
+    #[test]
+    fn test_materialize_nchw_i8_asymmetric_quantization() {
+        // Verify that NCHW i8 kernel handles non-zero zero-points correctly.
+        // Asymmetric quantization: real_value = (raw - zero_point) * scale
+        // Proto: zp=5, scale=0.1 → raw 15 means (15-5)*0.1 = 1.0
+        // Coeff: zp=10, scale=0.5 → raw 12 means (12-10)*0.5 = 1.0
+        //
+        // With K=2 channels: proto ch0=15 (→1.0), proto ch1=5 (→0.0)
+        // coeff = [12, 10] (→[1.0, 0.0])
+        // dot = 1.0*1.0 + 0.0*0.0 = 1.0 > 0 → mask = 255
+        use edgefirst_tensor::{Quantization, Tensor, TensorDyn};
+        let cpu = CPUProcessor::new();
+        let (proto_h, proto_w, num_protos) = (4, 4, 2);
+
+        // NCHW physical: [K=2, H=4, W=4]
+        let mut proto_values = vec![0_i8; num_protos * proto_h * proto_w];
+        let proto_zp: i8 = 5;
+        // Channel 0: raw = 15 → dequant = (15-5)*0.1 = 1.0
+        // Channel 1: raw = 5 → dequant = (5-5)*0.1 = 0.0
+        for i in 0..proto_h * proto_w {
+            proto_values[i] = 15; // channel 0
+            proto_values[proto_h * proto_w + i] = proto_zp; // channel 1 (at zero-point)
+        }
+        let mut protos_t =
+            Tensor::<i8>::from_slice(&proto_values, &[num_protos, proto_h, proto_w]).unwrap();
+        protos_t
+            .set_quantization(Quantization::per_tensor(0.1, proto_zp as i32))
+            .unwrap();
+
+        // Coefficient: zp=10, scale=0.5
+        // raw=[12, 10] → dequant=[(12-10)*0.5, (10-10)*0.5] = [1.0, 0.0]
+        let coeff_zp: i8 = 10;
+        let coeff_values = vec![12_i8, coeff_zp];
+        let mut coeff_t = Tensor::<i8>::from_slice(&coeff_values, &[1, num_protos]).unwrap();
+        coeff_t
+            .set_quantization(Quantization::per_tensor(0.5, coeff_zp as i32))
+            .unwrap();
+
+        let proto_data = crate::ProtoData {
+            mask_coefficients: TensorDyn::I8(coeff_t),
+            protos: TensorDyn::I8(protos_t),
+            layout: edgefirst_decoder::ProtoLayout::Nchw,
+        };
+        let det = [make_detect_box(0.0, 0.0, 1.0, 1.0)];
+        let segs = cpu
+            .materialize_segmentations(&det, &proto_data, None)
+            .expect("NCHW i8 asymmetric quantization should succeed");
+        assert_eq!(segs.len(), 1);
+        // Dot product = 1.0 > 0 → all 255
+        assert!(
+            segs[0].segmentation.iter().all(|&v| v == 255),
+            "NCHW i8 with non-zero zero-points: positive dot should yield all-255"
+        );
+
+        // Now test case where dot < 0: use coeff that selects a negative channel.
+        // coeff raw=[10, 12] → dequant=[0.0, 1.0]; ch1 is at zero_point → 0.0
+        // dot = 1.0*0.0 + 0.0*1.0 = 0.0 → NOT > 0 → mask = 0
+        let coeff_neg = vec![coeff_zp, 12_i8]; // selects channel 1 which is zero
+        let mut coeff_t_neg = Tensor::<i8>::from_slice(&coeff_neg, &[1, num_protos]).unwrap();
+        coeff_t_neg
+            .set_quantization(Quantization::per_tensor(0.5, coeff_zp as i32))
+            .unwrap();
+
+        // Recreate protos tensor (Tensor doesn't implement Clone)
+        let mut protos_t2 =
+            Tensor::<i8>::from_slice(&proto_values, &[num_protos, proto_h, proto_w]).unwrap();
+        protos_t2
+            .set_quantization(Quantization::per_tensor(0.1, proto_zp as i32))
+            .unwrap();
+
+        let proto_data_neg = crate::ProtoData {
+            mask_coefficients: TensorDyn::I8(coeff_t_neg),
+            protos: TensorDyn::I8(protos_t2),
+            layout: edgefirst_decoder::ProtoLayout::Nchw,
+        };
+        let segs_neg = cpu
+            .materialize_segmentations(&det, &proto_data_neg, None)
+            .expect("NCHW i8 asymmetric: zero-dot case");
+        assert_eq!(segs_neg.len(), 1);
+        // dot = 0 → NOT > 0 → mask should be 0
+        assert!(
+            segs_neg[0].segmentation.iter().all(|&v| v == 0),
+            "NCHW i8 with non-zero zero-points: zero dot should yield all-0"
+        );
+    }
+
     /// Golden-byte anchor: runs the quantized decode + CPU mask materialization
     /// file.
     ///

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -1980,7 +1980,99 @@ mod cpu_tests {
         assert_eq!(shape[2], 1);
     }
 
-    /// Golden-byte anchor: runs the quantized decode + CPU mask materialization
+    #[test]
+    fn test_materialize_nchw_i8_produces_correct_mask() {
+        // Verify that materialize_segmentations handles NCHW layout correctly.
+        // Proto data is stored as [K, H, W] (NCHW physical) with K=2, H=4, W=4.
+        // Channel 0 filled with +10, channel 1 filled with -10.
+        // Coefficient [+1, +1] → dot > 0 for all pixels (positive + negative = 0,
+        // but with symmetric scale the sum should still be evaluated correctly).
+        // Use coefficients [1, 0] to select only channel 0 → all positive → 255.
+        use edgefirst_tensor::{Quantization, Tensor, TensorDyn};
+        let cpu = CPUProcessor::new();
+        let (proto_h, proto_w, num_protos) = (4, 4, 2);
+        // NCHW physical: [K=2, H=4, W=4] → flat = [ch0 16 values, ch1 16 values]
+        let mut proto_values = vec![0_i8; num_protos * proto_h * proto_w];
+        // Channel 0: all +10, Channel 1: all -10
+        for i in 0..proto_h * proto_w {
+            proto_values[i] = 10; // channel 0
+            proto_values[proto_h * proto_w + i] = -10; // channel 1
+        }
+        let mut protos_t =
+            Tensor::<i8>::from_slice(&proto_values, &[num_protos, proto_h, proto_w]).unwrap();
+        protos_t
+            .set_quantization(Quantization::per_tensor(0.1, 0))
+            .unwrap();
+        // Coefficient selects channel 0 only: [+1, 0] (raw i8 with scale=1.0)
+        let coeff_values = vec![1_i8, 0_i8];
+        let mut coeff_t = Tensor::<i8>::from_slice(&coeff_values, &[1, num_protos]).unwrap();
+        coeff_t
+            .set_quantization(Quantization::per_tensor(1.0, 0))
+            .unwrap();
+        let proto_data = crate::ProtoData {
+            mask_coefficients: TensorDyn::I8(coeff_t),
+            protos: TensorDyn::I8(protos_t),
+            layout: edgefirst_decoder::ProtoLayout::Nchw,
+        };
+        let det = [make_detect_box(0.0, 0.0, 1.0, 1.0)];
+        let segs = cpu
+            .materialize_segmentations(&det, &proto_data, None)
+            .expect("NCHW i8 proto layout should be handled");
+        assert_eq!(segs.len(), 1);
+        // All pixels should be 255 (positive dot product from channel 0)
+        assert!(
+            segs[0].segmentation.iter().all(|&v| v == 255),
+            "NCHW proto with positive channel selected should yield all-255 mask"
+        );
+    }
+
+    #[test]
+    fn test_materialize_nchw_float_rejected() {
+        // NCHW layout with non-i8 protos should return NotSupported error.
+        use edgefirst_tensor::{Tensor, TensorDyn};
+        let cpu = CPUProcessor::new();
+        let proto_values = vec![1.0_f32; 2 * 4 * 4];
+        let protos_t = Tensor::<f32>::from_slice(&proto_values, &[2, 4, 4]).unwrap();
+        let coeff_values = vec![1.0_f32; 2];
+        let coeff_t = Tensor::<f32>::from_slice(&coeff_values, &[1, 2]).unwrap();
+        let proto_data = crate::ProtoData {
+            mask_coefficients: TensorDyn::F32(coeff_t),
+            protos: TensorDyn::F32(protos_t),
+            layout: edgefirst_decoder::ProtoLayout::Nchw,
+        };
+        let det = [make_detect_box(0.0, 0.0, 1.0, 1.0)];
+        let result = cpu.materialize_segmentations(&det, &proto_data, None);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(&err, crate::Error::NotSupported(s) if s.contains("NCHW")),
+            "NCHW with non-i8 protos should return NotSupported: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_materialize_scaled_nchw_float_rejected() {
+        // NCHW layout with non-i8 protos on the scaled path should also error.
+        use edgefirst_tensor::{Tensor, TensorDyn};
+        let cpu = CPUProcessor::new();
+        let proto_values = vec![1.0_f32; 2 * 4 * 4];
+        let protos_t = Tensor::<f32>::from_slice(&proto_values, &[2, 4, 4]).unwrap();
+        let coeff_values = vec![1.0_f32; 2];
+        let coeff_t = Tensor::<f32>::from_slice(&coeff_values, &[1, 2]).unwrap();
+        let proto_data = crate::ProtoData {
+            mask_coefficients: TensorDyn::F32(coeff_t),
+            protos: TensorDyn::F32(protos_t),
+            layout: edgefirst_decoder::ProtoLayout::Nchw,
+        };
+        let det = [make_detect_box(0.1, 0.1, 0.9, 0.9)];
+        let result = cpu.materialize_scaled_segmentations(&det, &proto_data, None, 64, 64);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(&err, crate::Error::NotSupported(s) if s.contains("NCHW")),
+            "NCHW with non-i8 protos should return NotSupported: {err:?}"
+        );
+    }
     /// end-to-end on the cached YOLOv8-seg fixture and asserts the first
     /// detection's binarized u8 mask is bit-exact against a committed golden
     /// file.

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -1764,6 +1764,7 @@ mod cpu_tests {
         crate::ProtoData {
             mask_coefficients: TensorDyn::F32(coeff_t),
             protos: TensorDyn::F32(protos_t),
+            layout: edgefirst_decoder::ProtoLayout::Nhwc,
         }
     }
 
@@ -2140,6 +2141,7 @@ mod cpu_tests {
         crate::ProtoData {
             mask_coefficients: TensorDyn::I8(coeff_t),
             protos: TensorDyn::I8(protos_t),
+            layout: edgefirst_decoder::ProtoLayout::Nhwc,
         }
     }
 

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -2073,8 +2073,49 @@ mod cpu_tests {
             "NCHW with non-i8 protos should return NotSupported: {err:?}"
         );
     }
-    /// end-to-end on the cached YOLOv8-seg fixture and asserts the first
-    /// detection's binarized u8 mask is bit-exact against a committed golden
+
+    #[test]
+    fn test_materialize_scaled_nchw_i8_produces_correct_mask() {
+        // Verify that the scaled path handles NCHW i8 layout correctly.
+        use edgefirst_tensor::{Quantization, Tensor, TensorDyn};
+        let cpu = CPUProcessor::new();
+        let (proto_h, proto_w, num_protos) = (4, 4, 2);
+        // NCHW physical: [K=2, H=4, W=4]
+        let mut proto_values = vec![0_i8; num_protos * proto_h * proto_w];
+        // Channel 0: all +10, Channel 1: all -10
+        for i in 0..proto_h * proto_w {
+            proto_values[i] = 10;
+            proto_values[proto_h * proto_w + i] = -10;
+        }
+        let mut protos_t =
+            Tensor::<i8>::from_slice(&proto_values, &[num_protos, proto_h, proto_w]).unwrap();
+        protos_t
+            .set_quantization(Quantization::per_tensor(0.1, 0))
+            .unwrap();
+        // Coefficient selects channel 0 only: [+1, 0]
+        let coeff_values = vec![1_i8, 0_i8];
+        let mut coeff_t = Tensor::<i8>::from_slice(&coeff_values, &[1, num_protos]).unwrap();
+        coeff_t
+            .set_quantization(Quantization::per_tensor(1.0, 0))
+            .unwrap();
+        let proto_data = crate::ProtoData {
+            mask_coefficients: TensorDyn::I8(coeff_t),
+            protos: TensorDyn::I8(protos_t),
+            layout: edgefirst_decoder::ProtoLayout::Nchw,
+        };
+        let det = [make_detect_box(0.0, 0.0, 1.0, 1.0)];
+        let segs = cpu
+            .materialize_scaled_segmentations(&det, &proto_data, None, 16, 16)
+            .expect("NCHW i8 scaled path should succeed");
+        assert_eq!(segs.len(), 1);
+        // All pixels should be 255 (positive dot product from channel 0)
+        assert!(
+            segs[0].segmentation.iter().all(|&v| v == 255),
+            "NCHW i8 scaled path with positive channel should yield all-255 mask"
+        );
+    }
+
+    /// Golden-byte anchor: runs the quantized decode + CPU mask materialization
     /// file.
     ///
     /// Regression-protection intent: any refactor that changes the i8 fused

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -2028,6 +2028,8 @@ mod cpu_tests {
             0.45,
             0.45,
             Some(Nms::ClassAgnostic),
+            edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+            300,
             &mut detections,
         );
         assert!(!detections.is_empty(), "fixture produced no detections");

--- a/crates/image/src/gl/processor.rs
+++ b/crates/image/src/gl/processor.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
 // SPDX-License-Identifier: Apache-2.0
 
-use edgefirst_decoder::{DetectBox, ProtoData, Segmentation};
+use edgefirst_decoder::{DetectBox, ProtoData, ProtoLayout, Segmentation};
 use edgefirst_tensor::{
     PixelFormat, PixelLayout, Tensor, TensorMapTrait, TensorMemory, TensorTrait,
 };
@@ -4330,7 +4330,11 @@ impl GLProcessorST {
                 "protos tensor must be rank-3, got {proto_shape:?}"
             )));
         }
-        let (height, width, num_protos) = (proto_shape[0], proto_shape[1], proto_shape[2]);
+        // Interpret shape based on physical layout.
+        let (height, width, num_protos) = match proto_data.layout {
+            ProtoLayout::Nhwc => (proto_shape[0], proto_shape[1], proto_shape[2]),
+            ProtoLayout::Nchw => (proto_shape[1], proto_shape[2], proto_shape[0]),
+        };
         let coeff_shape = proto_data.mask_coefficients.shape();
         if coeff_shape.len() != 2 || coeff_shape[1] != num_protos {
             return Err(crate::Error::InvalidShape(format!(
@@ -4399,6 +4403,17 @@ impl GLProcessorST {
                 )));
             }
         };
+
+        // The GL shader upload path assumes NHWC layout for ArrayView3 creation.
+        // NCHW protos would require a transpose to NHWC before texture upload —
+        // return NotSupported so the caller falls back to the CPU path.
+        if proto_data.layout == ProtoLayout::Nchw {
+            return Err(crate::Error::NotSupported(
+                "GL segmentation path does not yet support NCHW proto layout; \
+                 caller should use CPU fallback"
+                    .into(),
+            ));
+        }
 
         // Each proto-dtype arm holds its `TensorMap` for the duration of the
         // GL upload and passes an `ArrayView3` borrowed from the mapped slice

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -1875,6 +1875,8 @@ mod gl_tests {
             0.45,
             0.45,
             Some(Nms::ClassAgnostic),
+            edgefirst_decoder::yolo::MAX_NMS_CANDIDATES,
+            300,
             &mut output_boxes,
         );
         assert!(!output_boxes.is_empty(), "No detections from model");

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -348,6 +348,8 @@ pub(crate) fn copy_packed_to_padded_dma(src: &Tensor<u8>, dst: &mut Tensor<u8>) 
     Ok(())
 }
 
+#[cfg(test)]
+use edgefirst_decoder::ProtoLayout;
 use edgefirst_decoder::{DetectBox, ProtoData, Segmentation};
 use edgefirst_tensor::{
     DType, PixelFormat, PixelLayout, Tensor, TensorDyn, TensorMemory, TensorTrait as _,
@@ -6687,6 +6689,7 @@ mod image_tests {
             ProtoData {
                 mask_coefficients: TensorDyn::F32(coeff_t),
                 protos: TensorDyn::F32(protos_t),
+                layout: ProtoLayout::Nhwc,
             }
         };
         let result =
@@ -6738,6 +6741,7 @@ mod image_tests {
             ProtoData {
                 mask_coefficients: TensorDyn::F32(coeff_t),
                 protos: TensorDyn::F32(protos_t),
+                layout: ProtoLayout::Nhwc,
             }
         };
         let result =
@@ -6859,6 +6863,7 @@ mod image_tests {
             ProtoData {
                 mask_coefficients: TensorDyn::F32(coeff_t),
                 protos: TensorDyn::F32(protos_t),
+                layout: ProtoLayout::Nhwc,
             }
         };
         processor
@@ -6890,6 +6895,7 @@ mod image_tests {
             ProtoData {
                 mask_coefficients: TensorDyn::F32(coeff_t),
                 protos: TensorDyn::F32(protos_t),
+                layout: ProtoLayout::Nhwc,
             }
         };
         processor

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -327,12 +327,26 @@ class ProtoData:
     instead of a ``ProtoData`` instance.
     """
 
+    @property
+    def layout(self) -> str:
+        """Physical memory layout of the prototype tensor.
+
+        Returns ``"nhwc"`` when protos shape is ``(H, W, K)`` or ``"nchw"``
+        when shape is ``(K, H, W)``. Use this to interpret the tensor returned
+        by :meth:`take_protos`.
+        """
+        ...
+
     def take_protos(self) -> Optional[Tensor]:
         """Take ownership of the prototype masks tensor.
 
-        Returns a Tensor with shape ``(H, W, num_protos)``. For quantized
-        models the returned tensor carries quantization metadata accessible
-        via the ``quantization`` property.
+        Returns a Tensor whose shape depends on :attr:`layout`:
+
+        - ``"nhwc"``: shape is ``(H, W, num_protos)``
+        - ``"nchw"``: shape is ``(num_protos, H, W)``
+
+        For quantized models the returned tensor carries quantization metadata
+        accessible via the ``quantization`` property.
 
         Consumes the proto data's ``protos`` field — subsequent calls
         return ``None``.

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -587,7 +587,7 @@ class Decoder:
     def pre_nms_top_k(self) -> int:
         """
         Maximum candidates fed into NMS after score filtering.
-        Uses O(N) partial sort to cap O(N²) NMS cost. Default: 3000.
+        Uses O(N) partial sort to cap O(N²) NMS cost. Default: 300.
         """
         ...
 

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -503,6 +503,7 @@ class Decoder:
         Args:
             model_output: List of HAL Tensor objects from model inference.
             max_boxes: Maximum number of detections to return (default: 100).
+                Effective limit is ``min(max_boxes, decoder.max_det)``.
         """
         ...
 
@@ -533,7 +534,10 @@ class Decoder:
 
         Args:
             model_output: List of HAL Tensor objects from model inference.
-            max_boxes: Maximum number of detections to return (default: 100).
+            max_boxes: Pre-allocation hint (default: 100). The actual output
+                count is bounded by ``decoder.max_det`` (default: 300).
+                The returned ``ProtoData.mask_coefficients`` always matches
+                the detection count.
 
         Returns:
             ``(boxes, scores, classes, proto_data)`` where ``proto_data`` is
@@ -566,6 +570,7 @@ class Decoder:
             timestamp: Frame timestamp in nanoseconds.
             model_output: List of HAL Tensor objects from model inference.
             max_boxes: Maximum number of detections to return (default: 100).
+                Effective limit is ``min(max_boxes, decoder.max_det)``.
         """
         ...
 

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -584,6 +584,25 @@ class Decoder:
         ...
 
     @property
+    def pre_nms_top_k(self) -> int:
+        """
+        Maximum candidates fed into NMS after score filtering.
+        Uses O(N) partial sort to cap O(N²) NMS cost. Default: 3000.
+        """
+        ...
+
+    @pre_nms_top_k.setter
+    def pre_nms_top_k(self, value: int): ...
+    @property
+    def max_det(self) -> int:
+        """
+        Maximum detections returned after NMS. Default: 300.
+        """
+        ...
+
+    @max_det.setter
+    def max_det(self, value: int): ...
+    @property
     def normalized_boxes(self) -> Optional[bool]:
         """
         Whether decoded bounding boxes are normalized to [0, 1] range.

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -783,7 +783,7 @@ impl PyDecoder {
     }
 
     /// Maximum number of candidates fed into NMS after score filtering.
-    /// Uses O(N) partial sort to reduce O(N²) NMS cost. Default: 3000.
+    /// Uses O(N) partial sort to reduce O(N²) NMS cost. Default: 300.
     #[getter(pre_nms_top_k)]
     fn get_pre_nms_top_k(&self) -> usize {
         self.decoder.pre_nms_top_k

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -4,7 +4,7 @@
 use crate::tracker::{PyByteTrack, PyTrackInfo};
 use edgefirst_hal::decoder::{
     configs, configs::Nms, schema::SchemaV2, ConfigOutput, ConfigOutputs, Decoder, DecoderBuilder,
-    DetectBox, ProtoData, Segmentation,
+    DetectBox, ProtoData, ProtoLayout, Segmentation,
 };
 
 /// NMS (Non-Maximum Suppression) mode for filtering overlapping detections.
@@ -466,8 +466,12 @@ pub struct PyProtoData(pub(crate) ProtoData);
 impl PyProtoData {
     /// Take ownership of the prototype masks tensor.
     ///
-    /// Returns a Tensor with shape ``(H, W, num_protos)``. For quantized
-    /// models, the returned tensor carries quantization metadata
+    /// Returns a Tensor whose shape depends on :attr:`layout`:
+    ///
+    /// - ``"nhwc"``: shape is ``(H, W, num_protos)``
+    /// - ``"nchw"``: shape is ``(num_protos, H, W)``
+    ///
+    /// For quantized models, the returned tensor carries quantization metadata
     /// accessible via the ``quantization`` property.
     ///
     /// Consumes the proto data's ``protos`` field — subsequent calls
@@ -494,6 +498,19 @@ impl PyProtoData {
             return None;
         }
         Some(crate::tensor::PyTensor(taken))
+    }
+
+    /// Physical memory layout of the prototype tensor.
+    ///
+    /// Returns ``"nhwc"`` when protos shape is ``(H, W, K)`` or ``"nchw"``
+    /// when shape is ``(K, H, W)``. Use this to interpret the tensor returned
+    /// by :meth:`take_protos`.
+    #[getter]
+    fn layout(&self) -> &'static str {
+        match self.0.layout {
+            ProtoLayout::Nhwc => "nhwc",
+            ProtoLayout::Nchw => "nchw",
+        }
     }
 }
 
@@ -676,6 +693,8 @@ impl PyDecoder {
             .decoder
             .decode(&tensor_refs, &mut output_boxes, &mut output_masks)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
+        output_boxes.truncate(max_boxes);
+        output_masks.truncate(max_boxes);
         let py = self_.py();
         let (boxes, scores, classes) = convert_detect_box(py, &output_boxes);
         let masks = convert_seg_mask(py, &output_masks);
@@ -706,6 +725,9 @@ impl PyDecoder {
                 &mut output_tracks,
             )
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
+        output_boxes.truncate(max_boxes);
+        output_masks.truncate(max_boxes);
+        output_tracks.truncate(max_boxes);
         let py = self_.py();
         let (boxes, scores, classes) = convert_detect_box(py, &output_boxes);
         let masks = convert_seg_mask(py, &output_masks);
@@ -748,6 +770,7 @@ impl PyDecoder {
             .decoder
             .decode_proto(&tensor_refs, &mut output_boxes)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
+        output_boxes.truncate(max_boxes);
         let py = self_.py();
         let (boxes, scores, classes) = convert_detect_box(py, &output_boxes);
         Ok((boxes, scores, classes, proto_data.map(PyProtoData)))

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -770,7 +770,9 @@ impl PyDecoder {
             .decoder
             .decode_proto(&tensor_refs, &mut output_boxes)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e:#?}")))?;
-        output_boxes.truncate(max_boxes);
+        // Note: output_boxes and proto_data.mask_coefficients must stay in sync
+        // (same row count). Truncation here would break materialize_masks.
+        // The decoder's max_det (default 300) already caps output count.
         let py = self_.py();
         let (boxes, scores, classes) = convert_detect_box(py, &output_boxes);
         Ok((boxes, scores, classes, proto_data.map(PyProtoData)))

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -782,6 +782,32 @@ impl PyDecoder {
         self.decoder.nms.map(|nms| nms.into())
     }
 
+    /// Maximum number of candidates fed into NMS after score filtering.
+    /// Uses O(N) partial sort to reduce O(N²) NMS cost. Default: 3000.
+    #[getter(pre_nms_top_k)]
+    fn get_pre_nms_top_k(&self) -> usize {
+        self.decoder.pre_nms_top_k
+    }
+
+    #[setter(pre_nms_top_k)]
+    fn set_pre_nms_top_k(&mut self, value: usize) -> PyResult<()> {
+        self.decoder.pre_nms_top_k = value;
+        Ok(())
+    }
+
+    /// Maximum number of detections returned after NMS.
+    /// Matches the Ultralytics max_det parameter. Default: 300.
+    #[getter(max_det)]
+    fn get_max_det(&self) -> usize {
+        self.decoder.max_det
+    }
+
+    #[setter(max_det)]
+    fn set_max_det(&mut self, value: usize) -> PyResult<()> {
+        self.decoder.max_det = value;
+        Ok(())
+    }
+
     /// Returns the box coordinate format if known from the model config.
     ///
     /// - `True`: Boxes are in normalized [0,1] coordinates

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -1091,14 +1091,13 @@ impl PyImageProcessor {
     ///     normalized coordinates, or ``None`` if no letterboxing was applied
     /// :param resolution: optional mask materialization mode. When ``None`` or
     ///     :class:`MaskResolution.Proto`, returns per-detection tiles at
-    ///     proto-plane resolution with continuous sigmoid mask values. When
+    ///     proto-plane resolution with binary mask values ``{0, 255}``. When
     ///     :class:`MaskResolution.Scaled` ``(width, height)``, HAL upsamples
     ///     the full proto plane once and returns per-detection tiles at the
-    ///     target resolution with binary mask values encoded as
-    ///     ``uint8 {0, 255}``. The same ``> 127`` threshold works for both.
-    /// :returns: list of ``(H, W, 1)`` uint8 numpy arrays. Contents depend on
-    ///     ``resolution``: continuous sigmoid values for ``Proto``, binary
-    ///     ``{0, 255}`` for ``Scaled``.
+    ///     target resolution with binary mask values ``{0, 255}``.
+    ///     Both modes use ``> 127`` as the threshold convention.
+    /// :returns: list of ``(H, W, 1)`` uint8 numpy arrays with binary
+    ///     ``{0, 255}`` mask values.
     /// :rtype: list[numpy.ndarray]
     #[pyo3(signature = (bbox, scores, classes, proto_data, letterbox=None, resolution=None))]
     #[allow(clippy::too_many_arguments)]

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -1064,11 +1064,10 @@ impl PyImageProcessor {
 
     /// Materialize per-instance segmentation masks from prototype data.
     ///
-    /// Computes ``mask_coeff @ protos`` with sigmoid activation for each
-    /// detection, producing compact masks at prototype resolution (e.g.,
-    /// 160×160 crops). Mask values are **continuous sigmoid confidence**
-    /// quantized to uint8 (0 = background, 255 = full confidence), **not**
-    /// binary thresholded.
+    /// Computes ``mask_coeff @ protos`` for each detection, producing compact
+    /// binary masks at prototype resolution (e.g., 160×160 crops). Mask values
+    /// are **binary** ``uint8 {0, 255}`` — pixels where the dot product is
+    /// positive are foreground (255), otherwise background (0).
     ///
     /// The returned masks can be:
     ///
@@ -1452,17 +1451,15 @@ impl From<PyColorMode> for image::ColorMode {
 /// Construct via classmethods:
 ///
 /// - ``MaskResolution.Proto()`` — per-detection tiles at proto-plane
-///   resolution (historical default). Mask values are continuous sigmoid
-///   ``uint8 [0, 255]``.
+///   resolution (historical default). Mask values are binary ``uint8 {0, 255}``.
 /// - ``MaskResolution.Scaled(width, height)`` — per-detection tiles at
 ///   caller-specified pixel resolution, produced by upsampling the full
-///   proto plane once (correct edge-clamp bilinear) and cropping by bbox
-///   after sigmoid. Mask values are binary ``uint8 {0, 255}`` —
-///   interchangeable with the continuous sigmoid output via the same
-///   ``> 127`` test. If a ``letterbox`` is also passed to
-///   ``materialize_masks``, ``(width, height)`` are interpreted as
-///   original-content pixel dims and the inverse letterbox transform is
-///   applied during the upsample.
+///   proto plane once (correct edge-clamp bilinear) and cropping by bbox.
+///   Mask values are binary ``uint8 {0, 255}``.
+///   Both modes use ``> 127`` as the threshold convention. If a ``letterbox``
+///   is also passed to ``materialize_masks``, ``(width, height)`` are
+///   interpreted as original-content pixel dims and the inverse letterbox
+///   transform is applied during the upsample.
 #[pyclass(name = "MaskResolution")]
 #[derive(Debug, Clone, Copy)]
 pub struct PyMaskResolution(pub(crate) MaskResolution);

--- a/testdata/yolov8_mask0_160x160.bin
+++ b/testdata/yolov8_mask0_160x160.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aeedbd9a235a7f37f8c60d7483ee83b28e5f27c294bcf63384ebc1f559ee5450
+oid sha256:825829ccee91982a7d6e7a8145f96f512d16a995ad9b7c6d52196a820a3dd250
 size 2617


### PR DESCRIPTION
## Summary

Multi-commit optimization of the YOLO instance segmentation post-processing pipeline targeting Cortex-A53/A55 embedded platforms.

## Commits

### 1. Pre-NMS top-K filtering
Add pre-NMS top-K filtering to reduce the O(N²) NMS cost when many low-confidence proposals pass the score threshold.

- **Pre-NMS top-K** (`pre_nms_top_k`, default 300): After score filtering, only the top-K highest-scoring candidates enter NMS via `select_nth_unstable_by` (O(N) partial sort).
- **`max_det`** (default 300): Caps final output after NMS, matching Ultralytics `max_det`.
- **NEON `arg_max_i8`**: Vectorized argmax for i8 score tensors on aarch64.
- **Python bindings**: `decoder.pre_nms_top_k` and `decoder.max_det` properties.

### 2. NEON SIMD argmax + tiled proto transpose for DMA-BUF
- Tiled transpose for the NCHW proto extraction path (cache-friendly 16×16 tiles).
- NEON SIMD argmax improvements.

### 3. Eliminate NCHW→NHWC proto transpose in mask decode (NEW)
- **`ProtoLayout` enum** (`Nhwc`/`Nchw`): explicit layout tag on `ProtoData`.
- **`extract_proto_data_quant`**: detects NCHW layout via strides, stores protos as `[K,H,W]` without transposing (saves 3.1ms/frame on A53).
- **Lazy extraction**: skips 819KB memcpy when 0 detections.
- **NCHW kernels**: channel-major accumulation in both `proto_segmentations_i8_i8` and `scaled_segmentations_i8_i8`.
- **GL path**: returns `NotSupported` for NCHW (falls back to CPU).

## Benchmark Results

### NMS (pre-NMS top-K)
`nms_decode` with `score_threshold=0.001`, 8400 proposals, 80 classes:

| Target | Baseline (all 8400 → NMS) | topk=300 (default) | Speedup |
|--------|---------------------------|---------------------|---------|
| imx95-frdm (A55) | 12.4ms | **2.8ms** | **4.4×** |
| imx8mp-frdm (A53) | 12.9ms | **2.7ms** | **4.8×** |

### Mask Decode (NCHW proto layout)
`nms_decode` mask materialization with `score_threshold=0.5`, COCO128:

| Target | Before | After | Reduction |
|--------|--------|-------|-----------|
| imx8mp-frdm (A53) | 4.8ms | **2.24ms** | **53%** |
| imx95-frdm (A55) | 5.5ms | **2.08ms** | **62%** |

## API

```python
decoder = hal.Decoder.new_from_outputs(outputs, ...)
# Defaults: pre_nms_top_k=300, max_det=300
decoder.pre_nms_top_k = 3000  # override for COCO mAP evaluation
```

## Testing

- All workspace tests pass (847 tests, single-threaded)
- Clippy clean (`-D warnings`), `cargo fmt` clean
- Cross-compiled and validated on both targets with ara2-validator
- No mAP regression (identical COCO128 scores before/after)
