### PR TITLE
DE-2451: Add comprehensive tracing instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,7 @@ dependencies = [
  "procfs",
  "serde",
  "serde_json",
+ "tracing",
  "uuid",
 ]
 
@@ -693,6 +694,7 @@ dependencies = [
  "nalgebra 0.32.6",
  "ndarray 0.16.1",
  "num-traits",
+ "tracing",
  "uuid",
 ]
 
@@ -715,6 +717,7 @@ dependencies = [
  "rayon",
  "rustc_version",
  "serde_json",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tracing",
 ]
 
 [[package]]
@@ -598,6 +599,9 @@ dependencies = [
  "edgefirst-image",
  "edgefirst-tensor",
  "edgefirst-tracker",
+ "tracing",
+ "tracing-chrome",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -652,6 +656,7 @@ dependencies = [
  "rayon",
  "safetensors",
  "tokio",
+ "tracing",
  "yuv",
  "zune-jpeg",
  "zune-png",
@@ -1320,6 +1325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1651,15 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2350,6 +2370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,6 +2494,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,6 +2549,74 @@ name = "toml_writer"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "typenum"
@@ -2569,6 +2675,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml = "0.9.34"
 tokio = { version = "1.50.0", features = ["rt", "sync"] }
+tracing = "0.1"
+tracing-chrome = "0.7"
+tracing-subscriber = { version = "0.3", features = ["registry"] }
 uuid = { version = "1.22.0", features = ["v4"] }
 yuv = { version = "0.8.12", features = ["fast_mode"] }
 zune-jpeg = "0.4.21"

--- a/README.md
+++ b/README.md
@@ -1234,6 +1234,111 @@ python3 .github/scripts/generate_benchmark_tables.py --data-dir benchmarks/
 
 This prints markdown tables to stdout. Copy the relevant sections into [BENCHMARKS.md](BENCHMARKS.md), which contains the full results and analysis.
 
+## Performance Tracing
+
+The HAL includes built-in instrumentation for capturing detailed performance
+traces of decode and mask operations. Traces are written in Chrome JSON format
+and can be viewed in [Perfetto UI](https://ui.perfetto.dev/).
+
+### How It Works
+
+Library crates (`edgefirst-decoder`, `edgefirst-image`) emit `tracing` spans on
+hot paths. These spans have **zero overhead** when tracing is not active — each
+span site compiles to a single relaxed atomic load that short-circuits when no
+subscriber is installed.
+
+When a trace session is started via the API, a subscriber records all span
+enter/exit events with timestamps and structured metadata (detection counts,
+proto dimensions, layout, etc.) to a Chrome JSON file.
+
+### Instrumented Spans
+
+| Span | Location | Fields |
+|------|----------|--------|
+| `decode` | Decode pipeline | `n_candidates`, `n_after_topk`, `n_after_nms`, `n_detections` |
+| `score_filter` | Score threshold + argmax | — |
+| `top_k` | Pre-NMS top-K filter | `k` |
+| `nms` | Class-aware NMS | — |
+| `box_dequant` | Final box dequantization | `n` |
+| `extract_proto` | Proto tensor extraction | `n`, `num_protos`, `layout` |
+| `materialize_masks` | Mask materialization | `mode`, `n_detections`, `width`, `height` |
+
+### Enabling Tracing
+
+The tracing subscriber is gated behind the `tracing` Cargo feature on the
+`edgefirst-hal`, `edgefirst-hal-capi`, and `edgefirst_hal` (Python) crates.
+The instrumentation spans are always compiled (zero-cost), but the capture
+infrastructure is opt-in.
+
+#### Python
+
+Build the wheel with the `tracing` feature:
+
+```bash
+maturin build --release -m crates/python/Cargo.toml --features tracing
+```
+
+Use in code:
+
+```python
+import edgefirst_hal as hal
+
+with hal.Tracing("/tmp/trace.json"):
+    # ... run inference pipeline ...
+    pass
+# Trace file is ready — open in https://ui.perfetto.dev/
+```
+
+#### Rust
+
+Add the feature to your dependency:
+
+```toml
+[dependencies]
+edgefirst-hal = { version = "0.18", features = ["tracing"] }
+```
+
+```rust
+use edgefirst_hal::trace::{start_tracing, stop_tracing};
+
+start_tracing("/tmp/trace.json").expect("start tracing");
+// ... inference pipeline ...
+stop_tracing(); // flushes and closes the trace file
+```
+
+#### C
+
+Build with the `tracing` feature:
+
+```bash
+cargo build -p edgefirst-hal-capi --features tracing --release
+```
+
+```c
+#include <edgefirst/hal.h>
+
+hal_start_tracing("/tmp/trace.json");
+// ... inference pipeline ...
+hal_stop_tracing();
+```
+
+### Viewing Traces
+
+1. Open [ui.perfetto.dev](https://ui.perfetto.dev/)
+2. Drag the generated `.json` file onto the page
+3. Navigate the timeline to see decode and mask spans with timing and metadata
+
+Each span appears as a slice on the timeline. Click a slice to see its
+structured fields (detection counts, proto layout, etc.) in the "Current
+Selection" panel.
+
+### Limitations
+
+- Only one trace session per process lifetime (Rust global subscriber model)
+- Rayon worker thread spans are not automatically parented to the calling span
+- The `log::*` output (via `env_logger` / C callback logger) operates
+  independently from trace capture — both can be active simultaneously
+
 ## Dependencies
 
 ### Key External Dependencies

--- a/README.md
+++ b/README.md
@@ -1241,9 +1241,9 @@ and can be viewed in [Perfetto UI](https://ui.perfetto.dev/).
 ### How It Works
 
 Library crates (`edgefirst-decoder`, `edgefirst-image`) emit `tracing` spans on
-hot paths. These spans have **zero overhead** when tracing is not active — each
-span site compiles to a single relaxed atomic load that short-circuits when no
-subscriber is installed.
+hot paths. These spans have **near-zero overhead** when tracing is not active —
+each span site compiles to a single relaxed atomic load that short-circuits when
+no subscriber is installed.
 
 When a trace session is started via the API, a subscriber records all span
 enter/exit events with timestamps and structured metadata (detection counts,
@@ -1263,20 +1263,14 @@ proto dimensions, layout, etc.) to a Chrome JSON file.
 
 ### Enabling Tracing
 
-The tracing subscriber is gated behind the `tracing` Cargo feature on the
-`edgefirst-hal`, `edgefirst-hal-capi`, and `edgefirst_hal` (Python) crates.
-The instrumentation spans are always compiled (zero-cost), but the capture
-infrastructure is opt-in.
+The tracing infrastructure is included by default in all crate builds
+(`edgefirst-hal`, `edgefirst-hal-capi`, `edgefirst_hal` Python). No traces are
+captured until the application explicitly starts a session via the API — the
+runtime overhead is near-zero until then. The `tracing` Cargo feature can be
+disabled with `--no-default-features` to remove the capture infrastructure
+entirely (the span sites remain compiled but become true no-ops).
 
 #### Python
-
-Build the wheel with the `tracing` feature:
-
-```bash
-maturin build --release -m crates/python/Cargo.toml --features tracing
-```
-
-Use in code:
 
 ```python
 import edgefirst_hal as hal
@@ -1289,13 +1283,6 @@ with hal.Tracing("/tmp/trace.json"):
 
 #### Rust
 
-Add the feature to your dependency:
-
-```toml
-[dependencies]
-edgefirst-hal = { version = "0.18", features = ["tracing"] }
-```
-
 ```rust
 use edgefirst_hal::trace::{start_tracing, stop_tracing};
 
@@ -1305,12 +1292,6 @@ stop_tracing(); // flushes and closes the trace file
 ```
 
 #### C
-
-Build with the `tracing` feature:
-
-```bash
-cargo build -p edgefirst-hal-capi --features tracing --release
-```
 
 ```c
 #include <edgefirst/hal.h>

--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["staticlib", "cdylib"]
 name = "edgefirst_hal"
 
 [features]
-default = []
+default = ["tracing"]
 tracing = ["edgefirst-hal/tracing"]
 
 [dependencies]

--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -16,6 +16,10 @@ publish = false  # C library - distributed via GitHub Releases, not crates.io
 crate-type = ["staticlib", "cdylib"]
 name = "edgefirst_hal"
 
+[features]
+default = []
+tracing = ["edgefirst-hal/tracing"]
+
 [dependencies]
 edgefirst-hal = { workspace = true }
 edgefirst-tensor = { workspace = true }

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -2598,7 +2598,7 @@ bool hal_quantization_axis(const struct HalTensorQuant *q, size_t *axis_out);
  * @return 0 on success, -1 on error
  * @par Errors (errno):
  * - EINVAL:   `path` is NULL or not valid UTF-8
- * - EALREADY: a trace session is already active or was previously stopped
+ * - EALREADY: a trace session is already active or was previously started and stopped
  * - ENOTSUP: another tracing subscriber was already installed by user code
  * - ENOSYS:  tracing support not compiled in (built without `tracing` feature)
  *

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -2557,6 +2557,53 @@ bool hal_quantization_is_symmetric(const struct HalTensorQuant *q);
 bool hal_quantization_axis(const struct HalTensorQuant *q, size_t *axis_out);
 
 /**
+ * Start trace capture, writing Chrome JSON to the file at `path`.
+ *
+ * Installs a process-wide tracing subscriber that records all HAL internal
+ * spans (decode sub-steps, mask materialization, etc.) to the specified file.
+ * The trace can be viewed at https://ui.perfetto.dev/ after calling
+ * `hal_stop_tracing()`.
+ *
+ * Only one trace session per process lifetime is supported.
+ *
+ * @param path  Null-terminated UTF-8 file path for the trace output
+ * @return 0 on success, -1 on error
+ * @par Errors (errno):
+ * - EINVAL:   `path` is NULL or not valid UTF-8
+ * - EALREADY: a trace session is already active or was previously stopped
+ *
+ * @par Example
+ * @code{.c}
+ * hal_start_tracing("/tmp/trace.json");
+ * // ... inference pipeline ...
+ * hal_stop_tracing();
+ * @endcode
+ */
+int hal_start_tracing(const char *path);
+
+/**
+ * Stop trace capture and flush all buffered spans to the output file.
+ *
+ * After this call the trace file is complete and can be loaded into
+ * https://ui.perfetto.dev/. No-op if no session is active.
+ *
+ * @par Example
+ * @code{.c}
+ * hal_start_tracing("/tmp/trace.json");
+ * // ... work ...
+ * hal_stop_tracing();  // flushes and finalizes the trace file
+ * @endcode
+ */
+void hal_stop_tracing(void);
+
+/**
+ * Check whether a trace capture session is currently active.
+ *
+ * @return 1 if tracing is active, 0 otherwise
+ */
+int hal_is_tracing_active(void);
+
+/**
  * Create a new ByteTrack tracker with specified parameters.
  *
  * @param track_update Smoothness threshold for track updates (high = more stable tracks, low = more responsive to changes)

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -2599,6 +2599,8 @@ bool hal_quantization_axis(const struct HalTensorQuant *q, size_t *axis_out);
  * @par Errors (errno):
  * - EINVAL:   `path` is NULL or not valid UTF-8
  * - EALREADY: a trace session is already active or was previously stopped
+ * - ENOTSUP: another tracing subscriber was already installed by user code
+ * - ENOSYS:  tracing support not compiled in (built without `tracing` feature)
  *
  * @par Example
  * @code{.c}
@@ -2613,7 +2615,8 @@ int hal_start_tracing(const char *path);
  * Stop trace capture and flush all buffered spans to the output file.
  *
  * After this call the trace file is complete and can be loaded into
- * https://ui.perfetto.dev/. No-op if no session is active.
+ * https://ui.perfetto.dev/. No-op if no session is active or if tracing
+ * support is not compiled in.
  *
  * @par Example
  * @code{.c}
@@ -2627,7 +2630,7 @@ void hal_stop_tracing(void);
 /**
  * Check whether a trace capture session is currently active.
  *
- * @return 1 if tracing is active, 0 otherwise
+ * @return 1 if tracing is active, 0 otherwise (always 0 if tracing not compiled in)
  */
 int hal_is_tracing_active(void);
 

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -16,6 +16,8 @@ mod error;
 mod image;
 mod log;
 mod tensor;
+#[cfg(feature = "tracing")]
+mod trace;
 mod tracker;
 
 pub use decoder::*;
@@ -24,4 +26,6 @@ pub use error::*;
 pub use image::*;
 pub use log::*;
 pub use tensor::*;
+#[cfg(feature = "tracing")]
+pub use trace::*;
 pub use tracker::*;

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -16,7 +16,6 @@ mod error;
 mod image;
 mod log;
 mod tensor;
-#[cfg(feature = "tracing")]
 mod trace;
 mod tracker;
 

--- a/crates/capi/src/trace.rs
+++ b/crates/capi/src/trace.rs
@@ -23,10 +23,11 @@
 //! // Trace file is now ready to load in https://ui.perfetto.dev/
 //! ```
 //!
-//! # Build Requirements
+//! # Build Configuration
 //!
-//! The tracing API is only available when the `tracing` feature is enabled
-//! at compile time. Without this feature, these functions are not exported.
+//! The tracing feature is enabled by default. When compiled without the
+//! `tracing` feature, these functions remain available but return `ENOSYS`
+//! to indicate profiling support is not compiled in.
 
 use libc::{c_char, c_int};
 
@@ -44,6 +45,8 @@ use libc::{c_char, c_int};
 /// @par Errors (errno):
 /// - EINVAL:   `path` is NULL or not valid UTF-8
 /// - EALREADY: a trace session is already active or was previously stopped
+/// - ENOTSUP: another tracing subscriber was already installed by user code
+/// - ENOSYS:  tracing support not compiled in (built without `tracing` feature)
 ///
 /// @par Example
 /// @code{.c}
@@ -51,25 +54,37 @@ use libc::{c_char, c_int};
 /// // ... inference pipeline ...
 /// hal_stop_tracing();
 /// @endcode
-#[cfg(feature = "tracing")]
 #[no_mangle]
 pub unsafe extern "C" fn hal_start_tracing(path: *const c_char) -> c_int {
-    if path.is_null() {
-        errno::set_errno(errno::Errno(libc::EINVAL));
-        return -1;
+    #[cfg(not(feature = "tracing"))]
+    {
+        let _ = path;
+        errno::set_errno(errno::Errno(libc::ENOSYS));
+        -1
     }
-    let path_str = match std::ffi::CStr::from_ptr(path).to_str() {
-        Ok(s) => s,
-        Err(_) => {
+    #[cfg(feature = "tracing")]
+    {
+        if path.is_null() {
             errno::set_errno(errno::Errno(libc::EINVAL));
             return -1;
         }
-    };
-    match edgefirst_hal::trace::start_tracing(path_str) {
-        Ok(()) => 0,
-        Err(_) => {
-            errno::set_errno(errno::Errno(libc::EALREADY));
-            -1
+        let path_str = match std::ffi::CStr::from_ptr(path).to_str() {
+            Ok(s) => s,
+            Err(_) => {
+                errno::set_errno(errno::Errno(libc::EINVAL));
+                return -1;
+            }
+        };
+        match edgefirst_hal::trace::start_tracing(path_str) {
+            Ok(()) => 0,
+            Err(edgefirst_hal::trace::TracingError::AlreadyActive) => {
+                errno::set_errno(errno::Errno(libc::EALREADY));
+                -1
+            }
+            Err(edgefirst_hal::trace::TracingError::SubscriberInstallFailed(_)) => {
+                errno::set_errno(errno::Errno(libc::ENOTSUP));
+                -1
+            }
         }
     }
 }
@@ -77,7 +92,8 @@ pub unsafe extern "C" fn hal_start_tracing(path: *const c_char) -> c_int {
 /// Stop trace capture and flush all buffered spans to the output file.
 ///
 /// After this call the trace file is complete and can be loaded into
-/// https://ui.perfetto.dev/. No-op if no session is active.
+/// https://ui.perfetto.dev/. No-op if no session is active or if tracing
+/// support is not compiled in.
 ///
 /// @par Example
 /// @code{.c}
@@ -85,21 +101,22 @@ pub unsafe extern "C" fn hal_start_tracing(path: *const c_char) -> c_int {
 /// // ... work ...
 /// hal_stop_tracing();  // flushes and finalizes the trace file
 /// @endcode
-#[cfg(feature = "tracing")]
 #[no_mangle]
 pub extern "C" fn hal_stop_tracing() {
+    #[cfg(feature = "tracing")]
     edgefirst_hal::trace::stop_tracing();
 }
 
 /// Check whether a trace capture session is currently active.
 ///
-/// @return 1 if tracing is active, 0 otherwise
-#[cfg(feature = "tracing")]
+/// @return 1 if tracing is active, 0 otherwise (always 0 if tracing not compiled in)
 #[no_mangle]
 pub extern "C" fn hal_is_tracing_active() -> c_int {
-    if edgefirst_hal::trace::is_tracing_active() {
-        1
-    } else {
-        0
+    #[cfg(feature = "tracing")]
+    {
+        if edgefirst_hal::trace::is_tracing_active() {
+            return 1;
+        }
     }
+    0
 }

--- a/crates/capi/src/trace.rs
+++ b/crates/capi/src/trace.rs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! C-compatible trace capture API.
+//!
+//! Provides a simple start/stop interface for capturing performance traces
+//! from C/C++ applications. The trace output is Chrome JSON format, viewable
+//! at <https://ui.perfetto.dev/>.
+//!
+//! # Usage
+//!
+//! ```c
+//! #include <edgefirst/hal.h>
+//!
+//! // Start capturing traces to a file
+//! int rc = hal_start_tracing("/tmp/trace.json");
+//! if (rc != 0) { /* handle error */ }
+//!
+//! // ... run inference pipeline ...
+//!
+//! // Stop and flush the trace file
+//! hal_stop_tracing();
+//! // Trace file is now ready to load in https://ui.perfetto.dev/
+//! ```
+//!
+//! # Build Requirements
+//!
+//! The tracing API is only available when the `tracing` feature is enabled
+//! at compile time. Without this feature, these functions are not exported.
+
+use libc::{c_char, c_int};
+
+/// Start trace capture, writing Chrome JSON to the file at `path`.
+///
+/// Installs a process-wide tracing subscriber that records all HAL internal
+/// spans (decode sub-steps, mask materialization, etc.) to the specified file.
+/// The trace can be viewed at https://ui.perfetto.dev/ after calling
+/// `hal_stop_tracing()`.
+///
+/// Only one trace session per process lifetime is supported.
+///
+/// @param path  Null-terminated UTF-8 file path for the trace output
+/// @return 0 on success, -1 on error
+/// @par Errors (errno):
+/// - EINVAL:   `path` is NULL or not valid UTF-8
+/// - EALREADY: a trace session is already active or was previously stopped
+///
+/// @par Example
+/// @code{.c}
+/// hal_start_tracing("/tmp/trace.json");
+/// // ... inference pipeline ...
+/// hal_stop_tracing();
+/// @endcode
+#[cfg(feature = "tracing")]
+#[no_mangle]
+pub unsafe extern "C" fn hal_start_tracing(path: *const c_char) -> c_int {
+    if path.is_null() {
+        errno::set_errno(errno::Errno(libc::EINVAL));
+        return -1;
+    }
+    let path_str = match std::ffi::CStr::from_ptr(path).to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            errno::set_errno(errno::Errno(libc::EINVAL));
+            return -1;
+        }
+    };
+    match edgefirst_hal::trace::start_tracing(path_str) {
+        Ok(()) => 0,
+        Err(_) => {
+            errno::set_errno(errno::Errno(libc::EALREADY));
+            -1
+        }
+    }
+}
+
+/// Stop trace capture and flush all buffered spans to the output file.
+///
+/// After this call the trace file is complete and can be loaded into
+/// https://ui.perfetto.dev/. No-op if no session is active.
+///
+/// @par Example
+/// @code{.c}
+/// hal_start_tracing("/tmp/trace.json");
+/// // ... work ...
+/// hal_stop_tracing();  // flushes and finalizes the trace file
+/// @endcode
+#[cfg(feature = "tracing")]
+#[no_mangle]
+pub extern "C" fn hal_stop_tracing() {
+    edgefirst_hal::trace::stop_tracing();
+}
+
+/// Check whether a trace capture session is currently active.
+///
+/// @return 1 if tracing is active, 0 otherwise
+#[cfg(feature = "tracing")]
+#[no_mangle]
+pub extern "C" fn hal_is_tracing_active() -> c_int {
+    if edgefirst_hal::trace::is_tracing_active() {
+        1
+    } else {
+        0
+    }
+}

--- a/crates/capi/src/trace.rs
+++ b/crates/capi/src/trace.rs
@@ -44,7 +44,7 @@ use libc::{c_char, c_int};
 /// @return 0 on success, -1 on error
 /// @par Errors (errno):
 /// - EINVAL:   `path` is NULL or not valid UTF-8
-/// - EALREADY: a trace session is already active or was previously stopped
+/// - EALREADY: a trace session is already active or was previously started and stopped
 /// - ENOTSUP: another tracing subscriber was already installed by user code
 /// - ENOSYS:  tracing support not compiled in (built without `tracing` feature)
 ///
@@ -77,7 +77,8 @@ pub unsafe extern "C" fn hal_start_tracing(path: *const c_char) -> c_int {
         };
         match edgefirst_hal::trace::start_tracing(path_str) {
             Ok(()) => 0,
-            Err(edgefirst_hal::trace::TracingError::AlreadyActive) => {
+            Err(edgefirst_hal::trace::TracingError::AlreadyActive)
+            | Err(edgefirst_hal::trace::TracingError::SessionExhausted) => {
                 errno::set_errno(errno::Errno(libc::EALREADY));
                 -1
             }

--- a/crates/decoder/Cargo.toml
+++ b/crates/decoder/Cargo.toml
@@ -30,6 +30,7 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 edgefirst-bench = { workspace = true }

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -1047,8 +1047,17 @@ where
     let (boxes_tensor, quant_boxes) = boxes;
     let (scores_tensor, quant_scores) = scores;
 
-    let t_start = std::time::Instant::now();
+    let span = tracing::trace_span!(
+        "decode",
+        n_candidates = tracing::field::Empty,
+        n_after_topk = tracing::field::Empty,
+        n_after_nms = tracing::field::Empty,
+        n_detections = tracing::field::Empty,
+    );
+    let _guard = span.enter();
+
     let mut boxes = {
+        let _s = tracing::trace_span!("score_filter").entered();
         let score_threshold = quantize_score_threshold(score_threshold, quant_scores);
         postprocess_boxes_index_quant::<B, _, _>(
             score_threshold,
@@ -1057,19 +1066,30 @@ where
             quant_boxes,
         )
     };
-    truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
-    let mut boxes = dispatch_nms_extra_int(nms, iou_threshold, boxes);
+    span.record("n_candidates", boxes.len());
+
+    {
+        let _s = tracing::trace_span!("top_k", k = pre_nms_top_k).entered();
+        truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
+    }
+    span.record("n_after_topk", boxes.len());
+
+    let mut boxes = {
+        let _s = tracing::trace_span!("nms").entered();
+        dispatch_nms_extra_int(nms, iou_threshold, boxes)
+    };
+    span.record("n_after_nms", boxes.len());
+
     boxes.truncate(max_det);
-    let result: Vec<_> = boxes
-        .into_iter()
-        .map(|(b, i)| (dequant_detect_box(&b, quant_scores), i))
-        .collect();
-    let t_end = std::time::Instant::now();
-    log::trace!(
-        "get_boxes: {:.2}ms ({} detections)",
-        t_end.duration_since(t_start).as_secs_f64() * 1000.0,
-        result.len(),
-    );
+    let result: Vec<_> = {
+        let _s = tracing::trace_span!("box_dequant", n = boxes.len()).entered();
+        boxes
+            .into_iter()
+            .map(|(b, i)| (dequant_detect_box(&b, quant_scores), i))
+            .collect()
+    };
+    span.record("n_detections", result.len());
+
     result
 }
 
@@ -1468,8 +1488,17 @@ pub(crate) fn extract_proto_data_quant<
 ) -> ProtoData {
     use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
 
+    let span = tracing::trace_span!(
+        "extract_proto",
+        n = det_indices.len(),
+        num_protos = tracing::field::Empty,
+        layout = tracing::field::Empty,
+    );
+    let _guard = span.enter();
+
     let num_protos = mask_tensor.ncols();
     let n = det_indices.len();
+    span.record("num_protos", num_protos);
 
     // Keep mask coefficients in raw i8 with quantization metadata attached.
     // Consumers that need f32 can dequantize on the fly; the scaled-path
@@ -1586,6 +1615,8 @@ pub(crate) fn extract_proto_data_quant<
     let protos_tensor = protos_tensor
         .with_quantization(tensor_quant)
         .expect("per-tensor quantization on new Tensor<i8>");
+
+    span.record("layout", format!("{:?}", proto_layout).as_str());
 
     ProtoData {
         mask_coefficients,

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -741,6 +741,7 @@ pub(crate) fn impl_yolo_quant<B: BBoxTypeTrait, T: PrimInt + AsPrimitive<f32> + 
 ) where
     f32: AsPrimitive<T>,
 {
+    let _span = tracing::trace_span!("decode", mode = "quant_det").entered();
     let (boxes, quant_boxes) = output;
     let (boxes_tensor, scores_tensor) = postprocess_yolo(&boxes);
 
@@ -775,6 +776,7 @@ pub(crate) fn impl_yolo_float<B: BBoxTypeTrait, T: Float + AsPrimitive<f32> + Se
 ) where
     f32: AsPrimitive<T>,
 {
+    let _span = tracing::trace_span!("decode", mode = "float_det").entered();
     let (boxes_tensor, scores_tensor) = postprocess_yolo(&output);
     let boxes =
         postprocess_boxes_float::<B, _, _>(score_threshold.as_(), boxes_tensor, scores_tensor);
@@ -809,6 +811,7 @@ pub(crate) fn impl_yolo_split_quant<
 ) where
     f32: AsPrimitive<SCORE>,
 {
+    let _span = tracing::trace_span!("decode", mode = "split_quant_det").entered();
     let (boxes_tensor, quant_boxes) = boxes;
     let (scores_tensor, quant_scores) = scores;
 
@@ -855,6 +858,7 @@ pub(crate) fn impl_yolo_split_float<
 ) where
     f32: AsPrimitive<SCORE>,
 {
+    let _span = tracing::trace_span!("decode", mode = "split_float_det").entered();
     let boxes_tensor = boxes_tensor.reversed_axes();
     let scores_tensor = scores_tensor.reversed_axes();
     let boxes =
@@ -976,17 +980,37 @@ pub(crate) fn impl_yolo_segdet_get_boxes<
 where
     f32: AsPrimitive<SCORE>,
 {
-    let mut boxes = postprocess_boxes_index_float::<B, _, _>(
-        score_threshold.as_(),
-        boxes_tensor,
-        scores_tensor,
+    let span = tracing::trace_span!(
+        "decode",
+        n_candidates = tracing::field::Empty,
+        n_after_topk = tracing::field::Empty,
+        n_after_nms = tracing::field::Empty,
+        n_detections = tracing::field::Empty,
     );
+    let _guard = span.enter();
+
+    let mut boxes = {
+        let _s = tracing::trace_span!("score_filter").entered();
+        postprocess_boxes_index_float::<B, _, _>(score_threshold.as_(), boxes_tensor, scores_tensor)
+    };
+    span.record("n_candidates", boxes.len());
+
     if nms.is_some() {
+        let _s = tracing::trace_span!("top_k", k = pre_nms_top_k).entered();
         truncate_to_top_k_by_score(&mut boxes, pre_nms_top_k);
     }
-    let mut boxes = dispatch_nms_extra_float(nms, iou_threshold, boxes);
+    span.record("n_after_topk", boxes.len());
+
+    let mut boxes = {
+        let _s = tracing::trace_span!("nms").entered();
+        dispatch_nms_extra_float(nms, iou_threshold, boxes)
+    };
+    span.record("n_after_nms", boxes.len());
+
     boxes.sort_unstable_by(|a, b| b.0.score.total_cmp(&a.0.score));
     boxes.truncate(max_det);
+    span.record("n_detections", boxes.len());
+
     boxes
 }
 
@@ -1023,6 +1047,7 @@ pub(crate) fn impl_yolo_split_segdet_process_masks<
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError> {
+    let _span = tracing::trace_span!("process_masks", n = boxes.len(), mode = "float").entered();
     // Respect output capacity as a hard limit to avoid computing excess masks.
     let cap = output_boxes.capacity();
     if cap > 0 && boxes.len() > cap {
@@ -1124,6 +1149,7 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError> {
+    let _span = tracing::trace_span!("process_masks", n = boxes.len(), mode = "quant").entered();
     let (masks, quant_masks) = mask_coeff;
     let (protos, quant_protos) = protos;
 
@@ -1467,6 +1493,14 @@ pub(super) fn extract_proto_data_float<
     protos: ArrayView3<PROTO>,
     output_boxes: &mut Vec<DetectBox>,
 ) -> ProtoData {
+    let _span = tracing::trace_span!(
+        "extract_proto",
+        n = det_indices.len(),
+        num_protos = mask_tensor.ncols(),
+        layout = "nhwc",
+    )
+    .entered();
+
     let num_protos = mask_tensor.ncols();
     let n = det_indices.len();
 

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -1703,7 +1703,7 @@ pub(crate) fn extract_proto_data_quant<
         .with_quantization(tensor_quant)
         .expect("per-tensor quantization on new Tensor<i8>");
 
-    span.record("layout", format!("{:?}", proto_layout).as_str());
+    span.record("layout", tracing::field::debug(&proto_layout));
 
     ProtoData {
         mask_coefficients,

--- a/crates/hal/Cargo.toml
+++ b/crates/hal/Cargo.toml
@@ -17,9 +17,13 @@ default = ["ndarray", "opengl"]
 ndarray = ["edgefirst-tensor/ndarray"]
 opengl = ["edgefirst-image/opengl"]
 tracker = ["edgefirst-decoder/tracker", "edgefirst-image/tracker", "edgefirst-tracker"]
+tracing = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber"]
 
 [dependencies]
 edgefirst-decoder = { workspace = true }
 edgefirst-image = { workspace = true }
 edgefirst-tensor = { workspace = true }
 edgefirst-tracker = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+tracing-chrome = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }

--- a/crates/hal/Cargo.toml
+++ b/crates/hal/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["multimedia::images", "science", "embedded"]
 documentation = "https://docs.rs/edgefirst-hal"
 
 [features]
-default = ["ndarray", "opengl"]
+default = ["ndarray", "opengl", "tracing"]
 ndarray = ["edgefirst-tensor/ndarray"]
 opengl = ["edgefirst-image/opengl"]
 tracker = ["edgefirst-decoder/tracker", "edgefirst-image/tracker", "edgefirst-tracker"]

--- a/crates/hal/src/lib.rs
+++ b/crates/hal/src/lib.rs
@@ -6,3 +6,6 @@ pub use edgefirst_image as image;
 pub use edgefirst_tensor as tensor;
 #[cfg(feature = "tracker")]
 pub use edgefirst_tracker as tracker;
+
+#[cfg(feature = "tracing")]
+pub mod trace;

--- a/crates/hal/src/trace.rs
+++ b/crates/hal/src/trace.rs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Trace capture for performance analysis.
+//!
+//! Provides a simple start/stop API for capturing [`tracing`]-based spans
+//! emitted by HAL crates into Chrome JSON trace files viewable at
+//! <https://ui.perfetto.dev/>.
+//!
+//! # Design
+//!
+//! The HAL library crates (`edgefirst-decoder`, `edgefirst-image`) emit
+//! [`tracing::trace_span!`] spans on hot paths. These have near-zero overhead
+//! when no subscriber is active (a single relaxed atomic load per span site).
+//!
+//! This module installs a **process-wide subscriber** consisting of a Chrome
+//! trace layer writing spans to a JSON file for Perfetto. Existing `log::*`
+//! output (via `env_logger`) continues independently to stderr.
+//!
+//! The subscriber is installed once on the first call to [`start_tracing`].
+//! Only one trace capture session is supported per process lifetime (this is
+//! a limitation of Rust's global subscriber model and is acceptable for
+//! profiling workflows where a single trace per run is the norm).
+//!
+//! # Usage from Rust
+//!
+//! ```no_run
+//! # #[cfg(feature = "tracing")]
+//! # {
+//! use edgefirst_hal::trace::{start_tracing, stop_tracing};
+//!
+//! start_tracing("/tmp/trace.json").expect("start tracing");
+//! // ... run inference pipeline ...
+//! stop_tracing(); // flushes and closes the trace file
+//! # }
+//! ```
+//!
+//! # Usage from Python
+//!
+//! ```python
+//! import edgefirst_hal as hal
+//!
+//! with hal.Tracing("/tmp/trace.json"):
+//!     # ... run inference ...
+//!     pass
+//! # trace file is flushed on __exit__
+//! ```
+//!
+//! # Usage from C
+//!
+//! ```c
+//! #include "edgefirst_hal.h"
+//! hal_start_tracing("/tmp/trace.json");
+//! // ... run inference ...
+//! hal_stop_tracing(); // flushes trace file
+//! ```
+
+use std::sync::Mutex;
+
+use tracing_chrome::FlushGuard;
+use tracing_subscriber::prelude::*;
+
+/// Global flush guard for the active trace session.
+static GUARD: Mutex<Option<FlushGuard>> = Mutex::new(None);
+
+/// Errors from tracing operations.
+#[derive(Debug)]
+pub enum TracingError {
+    /// A trace capture session is already active.
+    AlreadyActive,
+    /// Failed to install the global subscriber (another was already set).
+    SubscriberInstallFailed(String),
+}
+
+impl std::fmt::Display for TracingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyActive => write!(f, "trace capture already active"),
+            Self::SubscriberInstallFailed(e) => {
+                write!(f, "failed to install tracing subscriber: {e}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TracingError {}
+
+/// Start trace capture, writing Chrome JSON to `path`.
+///
+/// Installs a global tracing subscriber (chrome layer only) on first call.
+/// The trace file is created immediately. All `tracing::trace_span!` spans
+/// emitted by HAL crates will be recorded until [`stop_tracing`] is called.
+///
+/// Only one session per process lifetime is supported.
+///
+/// # Errors
+///
+/// Returns [`TracingError::AlreadyActive`] if already capturing.
+/// Returns [`TracingError::SubscriberInstallFailed`] if another subscriber
+/// was previously installed by user code.
+pub fn start_tracing(path: &str) -> Result<(), TracingError> {
+    let mut lock = GUARD.lock().unwrap();
+    if lock.is_some() {
+        return Err(TracingError::AlreadyActive);
+    }
+
+    // Build chrome layer writing to the specified file.
+    let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+        .file(path)
+        .include_args(true)
+        .build();
+
+    // Install only the chrome layer. Existing log::* output continues through
+    // env_logger to stderr independently — no conflict.
+    let subscriber = tracing_subscriber::registry().with(chrome_layer);
+
+    tracing::subscriber::set_global_default(subscriber)
+        .map_err(|e| TracingError::SubscriberInstallFailed(e.to_string()))?;
+
+    *lock = Some(guard);
+    Ok(())
+}
+
+/// Stop trace capture, flushing all buffered spans to the output file.
+///
+/// No-op if no session is active. After this call the trace file is complete
+/// and can be loaded into <https://ui.perfetto.dev/>.
+pub fn stop_tracing() {
+    let mut lock = GUARD.lock().unwrap();
+    // Dropping the FlushGuard flushes remaining spans and closes the file.
+    lock.take();
+}
+
+/// Returns `true` if a trace capture session is currently active.
+pub fn is_tracing_active() -> bool {
+    GUARD.lock().unwrap().is_some()
+}

--- a/crates/hal/src/trace.rs
+++ b/crates/hal/src/trace.rs
@@ -55,6 +55,7 @@
 //! hal_stop_tracing(); // flushes trace file
 //! ```
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 use tracing_chrome::FlushGuard;
@@ -63,12 +64,19 @@ use tracing_subscriber::prelude::*;
 /// Global flush guard for the active trace session.
 static GUARD: Mutex<Option<FlushGuard>> = Mutex::new(None);
 
+/// Tracks whether a session has ever been started (remains true after stop).
+static SESSION_USED: AtomicBool = AtomicBool::new(false);
+
 /// Errors from tracing operations.
 #[derive(Debug)]
 pub enum TracingError {
     /// A trace capture session is already active.
     AlreadyActive,
-    /// Failed to install the global subscriber (another was already set).
+    /// The single-use trace session was already started and stopped.
+    /// Only one session per process lifetime is supported.
+    SessionExhausted,
+    /// Failed to install the global subscriber (another was already set
+    /// by user code outside the HAL).
     SubscriberInstallFailed(String),
 }
 
@@ -76,6 +84,10 @@ impl std::fmt::Display for TracingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::AlreadyActive => write!(f, "trace capture already active"),
+            Self::SessionExhausted => write!(
+                f,
+                "trace session already used (only one session per process lifetime)"
+            ),
             Self::SubscriberInstallFailed(e) => {
                 write!(f, "failed to install tracing subscriber: {e}")
             }
@@ -91,17 +103,23 @@ impl std::error::Error for TracingError {}
 /// The trace file is created immediately. All `tracing::trace_span!` spans
 /// emitted by HAL crates will be recorded until [`stop_tracing`] is called.
 ///
-/// Only one session per process lifetime is supported.
+/// Only one session per process lifetime is supported (a limitation of
+/// Rust's global subscriber model).
 ///
 /// # Errors
 ///
-/// Returns [`TracingError::AlreadyActive`] if already capturing.
-/// Returns [`TracingError::SubscriberInstallFailed`] if another subscriber
-/// was previously installed by user code.
+/// Returns [`TracingError::AlreadyActive`] if a session is currently capturing.
+/// Returns [`TracingError::SessionExhausted`] if a session was previously
+/// started and stopped (the global subscriber cannot be replaced).
+/// Returns [`TracingError::SubscriberInstallFailed`] if another tracing
+/// subscriber was installed by user code outside the HAL.
 pub fn start_tracing(path: &str) -> Result<(), TracingError> {
-    let mut lock = GUARD.lock().unwrap();
+    let mut lock = GUARD.lock().unwrap_or_else(|e| e.into_inner());
     if lock.is_some() {
         return Err(TracingError::AlreadyActive);
+    }
+    if SESSION_USED.load(Ordering::Relaxed) {
+        return Err(TracingError::SessionExhausted);
     }
 
     // Build chrome layer writing to the specified file.
@@ -117,6 +135,7 @@ pub fn start_tracing(path: &str) -> Result<(), TracingError> {
     tracing::subscriber::set_global_default(subscriber)
         .map_err(|e| TracingError::SubscriberInstallFailed(e.to_string()))?;
 
+    SESSION_USED.store(true, Ordering::Relaxed);
     *lock = Some(guard);
     Ok(())
 }
@@ -126,14 +145,14 @@ pub fn start_tracing(path: &str) -> Result<(), TracingError> {
 /// No-op if no session is active. After this call the trace file is complete
 /// and can be loaded into <https://ui.perfetto.dev/>.
 pub fn stop_tracing() {
-    let mut lock = GUARD.lock().unwrap();
+    let mut lock = GUARD.lock().unwrap_or_else(|e| e.into_inner());
     // Dropping the FlushGuard flushes remaining spans and closes the file.
     lock.take();
 }
 
 /// Returns `true` if a trace capture session is currently active.
 pub fn is_tracing_active() -> bool {
-    GUARD.lock().unwrap().is_some()
+    GUARD.lock().unwrap_or_else(|e| e.into_inner()).is_some()
 }
 
 #[cfg(test)]
@@ -178,11 +197,11 @@ mod tests {
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(!content.is_empty(), "trace file should not be empty");
 
-        // Third start fails because global subscriber is already installed
+        // Third start fails because session was already used
         let err = start_tracing(path_str).unwrap_err();
         assert!(
-            matches!(err, TracingError::SubscriberInstallFailed(_)),
-            "expected SubscriberInstallFailed, got: {err:?}"
+            matches!(err, TracingError::SessionExhausted),
+            "expected SessionExhausted, got: {err:?}"
         );
 
         // Clean up

--- a/crates/hal/src/trace.rs
+++ b/crates/hal/src/trace.rs
@@ -135,3 +135,57 @@ pub fn stop_tracing() {
 pub fn is_tracing_active() -> bool {
     GUARD.lock().unwrap().is_some()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    // Single test because the global subscriber is per-process lifetime.
+    #[test]
+    fn test_trace_lifecycle() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("hal_test_trace_lifecycle.json");
+        let path_str = path.to_str().unwrap();
+
+        // Clean up any previous test artifact
+        let _ = std::fs::remove_file(&path);
+
+        assert!(!is_tracing_active());
+
+        // First start should succeed
+        start_tracing(path_str).expect("start_tracing should succeed");
+        assert!(is_tracing_active());
+
+        // Second start while active should fail with AlreadyActive
+        let err = start_tracing(path_str).unwrap_err();
+        assert!(
+            matches!(err, TracingError::AlreadyActive),
+            "expected AlreadyActive, got: {err:?}"
+        );
+
+        // Emit a span to ensure the file gets content
+        {
+            let _span = tracing::trace_span!("test_span", key = "value").entered();
+        }
+
+        // Stop should deactivate
+        stop_tracing();
+        assert!(!is_tracing_active());
+
+        // Trace file should exist with content
+        assert!(Path::new(path_str).exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(!content.is_empty(), "trace file should not be empty");
+
+        // Third start fails because global subscriber is already installed
+        let err = start_tracing(path_str).unwrap_err();
+        assert!(
+            matches!(err, TracingError::SubscriberInstallFailed(_)),
+            "expected SubscriberInstallFailed, got: {err:?}"
+        );
+
+        // Clean up
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -39,6 +39,7 @@ ndarray = { workspace = true }
 opencv = { workspace = true, optional = true }
 rayon = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 yuv = { workspace = true }
 zune-jpeg = { workspace = true }
 zune-png = { workspace = true }

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -228,6 +228,13 @@ impl CPUProcessor {
     ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
         use edgefirst_tensor::{DType, TensorMapTrait, TensorTrait};
 
+        let _span = tracing::trace_span!(
+            "materialize_masks",
+            mode = "proto",
+            n_detections = detect.len(),
+        )
+        .entered();
+
         if detect.is_empty() {
             return Ok(Vec::new());
         }
@@ -496,6 +503,15 @@ impl CPUProcessor {
         height: u32,
     ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
         use edgefirst_tensor::{DType, TensorMapTrait, TensorTrait};
+
+        let _span = tracing::trace_span!(
+            "materialize_masks",
+            mode = "scaled",
+            n_detections = detect.len(),
+            width,
+            height,
+        )
+        .entered();
 
         if detect.is_empty() {
             return Ok(Vec::new());

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -824,6 +824,16 @@ fn proto_segmentations_i8_i8(
 ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
     use edgefirst_tensor::QuantMode;
 
+    let _span = tracing::trace_span!(
+        "mask_i8_fastpath",
+        n = detect.len(),
+        proto_h,
+        proto_w,
+        num_protos,
+        ?layout,
+    )
+    .entered();
+
     let zp_c: i32 = match coeff_quant.mode() {
         QuantMode::PerTensor { zero_point, .. } => zero_point,
         QuantMode::PerTensorSymmetric { .. } => 0,
@@ -1625,6 +1635,18 @@ fn scaled_segmentations_i8_i8(
     layout: edgefirst_decoder::ProtoLayout,
 ) -> crate::Result<Vec<edgefirst_decoder::Segmentation>> {
     use edgefirst_tensor::QuantMode;
+
+    let _span = tracing::trace_span!(
+        "mask_i8_fastpath",
+        n = detect.len(),
+        proto_h,
+        proto_w,
+        num_protos,
+        width,
+        height,
+        ?layout,
+    )
+    .entered();
 
     let zp_c: i32 = match coeff_quant.mode() {
         QuantMode::PerTensor { zero_point, .. } => zero_point,

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -586,6 +586,13 @@ impl CPUProcessor {
         let tmp;
         let tmp_fmt;
         if intermediate != src_fmt {
+            let _s = tracing::trace_span!(
+                "cpu_format_convert",
+                from = ?src_fmt,
+                to = ?intermediate,
+                pass = "pre_resize",
+            )
+            .entered();
             tmp_buffer = Tensor::<u8>::image(src_w, src_h, intermediate, Some(TensorMemory::Mem))?;
 
             Self::convert_format_pf(src, &mut tmp_buffer, src_fmt, intermediate)?;
@@ -599,8 +606,16 @@ impl CPUProcessor {
         // format must be RGB/RGBA/GREY
         debug_assert!(matches!(tmp_fmt, Rgb | Rgba | Grey));
         if tmp_fmt == dst_fmt {
+            let _s = tracing::trace_span!("cpu_resize").entered();
             self.resize_flip_rotate_pf(tmp, dst, dst_fmt, rotation, flip, crop)?;
         } else if !need_resize_flip_rotation {
+            let _s = tracing::trace_span!(
+                "cpu_format_convert",
+                from = ?tmp_fmt,
+                to = ?dst_fmt,
+                pass = "direct",
+            )
+            .entered();
             Self::convert_format_pf(tmp, dst, tmp_fmt, dst_fmt)?;
         } else {
             let mut tmp2 = Tensor::<u8>::image(dst_w, dst_h, tmp_fmt, Some(TensorMemory::Mem))?;
@@ -615,8 +630,20 @@ impl CPUProcessor {
             {
                 Self::convert_format_pf(dst, &mut tmp2, dst_fmt, tmp_fmt)?;
             }
-            self.resize_flip_rotate_pf(tmp, &mut tmp2, tmp_fmt, rotation, flip, crop)?;
-            Self::convert_format_pf(&tmp2, dst, tmp_fmt, dst_fmt)?;
+            {
+                let _s = tracing::trace_span!("cpu_resize").entered();
+                self.resize_flip_rotate_pf(tmp, &mut tmp2, tmp_fmt, rotation, flip, crop)?;
+            }
+            {
+                let _s = tracing::trace_span!(
+                    "cpu_format_convert",
+                    from = ?tmp_fmt,
+                    to = ?dst_fmt,
+                    pass = "post_resize",
+                )
+                .entered();
+                Self::convert_format_pf(&tmp2, dst, tmp_fmt, dst_fmt)?;
+            }
         }
         if let (Some(dst_rect), Some(dst_color)) = (crop.dst_rect, crop.dst_color) {
             let full_rect = Rect {

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -60,6 +60,12 @@ impl G2DProcessor {
         flip: Flip,
         crop: Crop,
     ) -> Result<()> {
+        let _span = tracing::trace_span!(
+            "g2d_convert",
+            src_fmt = ?src_dyn.format(),
+            dst_fmt = ?dst_dyn.format(),
+        )
+        .entered();
         if log::log_enabled!(log::Level::Trace) {
             log::trace!(
                 "G2D convert: {:?}({:?}/{:?}) → {:?}({:?}/{:?})",

--- a/crates/image/src/gl/processor.rs
+++ b/crates/image/src/gl/processor.rs
@@ -685,6 +685,15 @@ impl GLProcessorST {
         flip: Flip,
         crop: Crop,
     ) -> crate::Result<()> {
+        let _span = tracing::trace_span!(
+            "gl_convert",
+            ?src_fmt,
+            ?dst_fmt,
+            is_int8,
+            src_memory = ?src.memory(),
+            dst_memory = ?dst.memory(),
+        )
+        .entered();
         if !Self::check_src_format_supported(self.gl_context.transfer_backend, src, src_fmt) {
             if src_fmt == PixelFormat::Vyuy
                 && self.gl_context.transfer_backend.is_dma()
@@ -2776,6 +2785,7 @@ impl GLProcessorST {
         );
 
         // --- Pass 1: Render source → intermediate RGBA texture ---
+        let _pass1 = tracing::trace_span!("gl_pass1_to_rgba", dst_w, dst_h).entered();
         self.ensure_packed_rgb_intermediate(dst_w, dst_h)?;
         self.packed_rgb_fbo.bind();
         unsafe {
@@ -2793,8 +2803,10 @@ impl GLProcessorST {
         // It uses dst only for width/height in ROI coordinate math.
         // Handles: source binding (DMA EGLImage or upload), crop, letterbox, rotation, flip.
         self.convert_to(src, src_fmt, dst, dst_fmt, rotation, flip, crop)?;
+        drop(_pass1);
 
         // --- Pass 2: Pack intermediate RGBA → RGB DMA destination ---
+        let _pass2 = tracing::trace_span!("gl_pass2_pack_rgb", render_w, render_h).entered();
         self.convert_fbo.bind();
         let dest_egl = self.get_or_create_egl_image_rgb(
             dst,
@@ -2920,6 +2932,7 @@ impl GLProcessorST {
 
         // --- Pass 1: NV12→RGBA into intermediate texture ---
         // No int8 bias here — bias is applied in pass 2's planar shader.
+        let _pass1 = tracing::trace_span!("gl_pass1_to_rgba", dst_w, dst_h).entered();
         self.ensure_packed_rgb_intermediate(dst_w, dst_h)?;
         self.packed_rgb_fbo.bind();
         unsafe {
@@ -2938,11 +2951,13 @@ impl GLProcessorST {
         // output format is RGBA because we bound packed_rgb_fbo above. dst is used only for
         // width/height in ROI coordinate math.
         self.convert_to(src, src_fmt, dst, dst_fmt, rotation, flip, crop)?;
+        drop(_pass1);
 
         // --- Pass 2: RGBA→PlanarRgb to DMA destination ---
         // setup_renderbuffer_dma rebinds convert_fbo with the DMA destination EGLImage,
         // replacing packed_rgb_fbo that was active during pass 1. It also sets the viewport
         // to (dst_w, dst_h * 3) for the tall R8 planar renderbuffer.
+        let _pass2 = tracing::trace_span!("gl_pass2_to_planar", dst_w, dst_h).entered();
         self.setup_renderbuffer_dma(dst, dst_fmt)?;
 
         // Bias letterbox clear color for int8 — glClear bypasses the shader.

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -1816,6 +1816,16 @@ impl ImageProcessorTrait for ImageProcessor {
         let start = Instant::now();
         let src_fmt = src.format();
         let dst_fmt = dst.format();
+        let _span = tracing::trace_span!(
+            "image_convert",
+            ?src_fmt,
+            ?dst_fmt,
+            src_memory = ?src.memory(),
+            dst_memory = ?dst.memory(),
+            ?rotation,
+            ?flip,
+        )
+        .entered();
         log::trace!(
             "convert: {src_fmt:?}({:?}/{:?}) → {dst_fmt:?}({:?}/{:?}), \
              rotation={rotation:?}, flip={flip:?}, backend={:?}",
@@ -1930,6 +1940,12 @@ impl ImageProcessorTrait for ImageProcessor {
         segmentation: &[Segmentation],
         overlay: MaskOverlay<'_>,
     ) -> Result<()> {
+        let _span = tracing::trace_span!(
+            "draw_masks",
+            n_detections = detect.len(),
+            n_segmentations = segmentation.len(),
+        )
+        .entered();
         let start = Instant::now();
 
         if let Some(bg) = overlay.background {

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -32,6 +32,7 @@ pyo3 = { workspace = true, features = ["extension-module"] }
 rayon = { workspace = true }
 pythonize = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [build-dependencies]

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -14,7 +14,7 @@ publish = false  # Python bindings only - distributed via PyPI, not crates.io
 crate-type = ["cdylib"]
 
 [features]
-default = []
+default = ["tracing"]
 abi3-py38 = ["pyo3/abi3-py38"]
 abi3-py311 = ["pyo3/abi3-py311"]
 tracing = ["edgefirst-hal/tracing"]

--- a/crates/python/Cargo.toml
+++ b/crates/python/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib"]
 default = []
 abi3-py38 = ["pyo3/abi3-py38"]
 abi3-py311 = ["pyo3/abi3-py311"]
+tracing = ["edgefirst-hal/tracing"]
 
 [dependencies]
 edgefirst-hal = { workspace = true, features = ["tracker"] }

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -1696,3 +1696,74 @@ class ByteTrack:
         Get the list of currently active tracks.
         """
         ...
+
+class Tracing:
+    """Trace capture context manager for Perfetto/Chrome JSON output.
+
+    Records internal HAL tracing spans (decode sub-steps, mask materialization,
+    proto extraction, etc.) to a Chrome JSON file viewable at
+    https://ui.perfetto.dev/.
+
+    Only one trace session per process lifetime is supported.  The tracing
+    spans are always compiled into the library but have zero overhead (a single
+    atomic load) until a session is started via this API.
+
+    Build requirement: the ``tracing`` feature must be enabled when building
+    the wheel (``maturin build --features tracing``).
+
+    Usage as context manager (recommended):
+
+    .. code-block:: python
+
+        import edgefirst_hal as hal
+
+        with hal.Tracing("/tmp/trace.json"):
+            # ... inference pipeline ...
+            pass
+        # trace file is flushed and closed on __exit__
+
+    Usage with explicit start/stop:
+
+    .. code-block:: python
+
+        guard = hal.Tracing("/tmp/trace.json")
+        guard.start()
+        # ... inference pipeline ...
+        guard.stop()  # flushes trace file
+
+    The resulting JSON file can be dragged into https://ui.perfetto.dev/ to
+    visualize the timeline of decode and mask operations with per-span metadata
+    (detection counts, proto dimensions, layout, etc.).
+    """
+
+    def __init__(self, path: str) -> None:
+        """Create a tracing session targeting the given output file path.
+
+        Args:
+            path: File path for the Chrome JSON trace output. The file is
+                created on :meth:`start` (or ``__enter__``).
+        """
+        ...
+
+    def start(self) -> None:
+        """Start trace capture.
+
+        Installs a process-wide tracing subscriber and begins recording
+        spans to the configured file.
+
+        Raises:
+            RuntimeError: If a trace session is already active or was
+                previously stopped (only one session per process).
+        """
+        ...
+
+    def stop(self) -> None:
+        """Stop trace capture and flush the trace file.
+
+        After this call the trace file is complete and ready for viewing.
+        No-op if not currently active.
+        """
+        ...
+
+    def __enter__(self) -> "Tracing": ...
+    def __exit__(self, *args: object) -> bool: ...

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -1770,9 +1770,13 @@ class Tracing:
         Installs a process-wide tracing subscriber and begins recording
         spans to the configured file.
 
+        Only one trace session per process lifetime is supported. Once
+        started and stopped, subsequent calls will raise RuntimeError.
+
         Raises:
-            RuntimeError: If a trace session is already active or was
-                previously stopped (only one session per process).
+            RuntimeError: If a trace session is already active, was
+                previously started and stopped (only one session per
+                process lifetime), or if tracing support was not compiled in.
         """
         ...
 

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -685,6 +685,8 @@ impl PyDecoder {
         model_output: Vec<PyRef<'py, crate::tensor::PyTensor>>,
         max_boxes: usize,
     ) -> PyResult<PySegDetOutput<'py>> {
+        let _span =
+            tracing::trace_span!("py_decode", n_tensors = model_output.len(), max_boxes).entered();
         let tensor_refs: Vec<&edgefirst_hal::tensor::TensorDyn> =
             model_output.iter().map(|t| &t.0).collect();
         let mut output_boxes = Vec::with_capacity(max_boxes);
@@ -709,6 +711,13 @@ impl PyDecoder {
         model_output: Vec<PyRef<'py, crate::tensor::PyTensor>>,
         max_boxes: usize,
     ) -> PyResult<PySegDetTrackedOutput<'py>> {
+        let _span = tracing::trace_span!(
+            "py_decode_tracked",
+            n_tensors = model_output.len(),
+            max_boxes,
+            timestamp,
+        )
+        .entered();
         let tensor_refs: Vec<&edgefirst_hal::tensor::TensorDyn> =
             model_output.iter().map(|t| &t.0).collect();
         let mut output_boxes = Vec::with_capacity(max_boxes);
@@ -763,6 +772,9 @@ impl PyDecoder {
         model_output: Vec<PyRef<'py, crate::tensor::PyTensor>>,
         max_boxes: usize,
     ) -> PyResult<PyProtoDetOutput<'py>> {
+        let _span =
+            tracing::trace_span!("py_decode_proto", n_tensors = model_output.len(), max_boxes,)
+                .entered();
         let tensor_refs: Vec<&edgefirst_hal::tensor::TensorDyn> =
             model_output.iter().map(|t| &t.0).collect();
         let mut output_boxes = Vec::with_capacity(max_boxes);

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -975,6 +975,7 @@ impl PyImageProcessor {
         dst_crop: Option<PyRect>,
         dst_color: Option<[u8; 4]>,
     ) -> Result<()> {
+        let _span = tracing::trace_span!("py_convert").entered();
         let rotation = rotation.into();
         let flip = flip.into();
         let crop = Crop {
@@ -1110,6 +1111,7 @@ impl PyImageProcessor {
         resolution: Option<PyMaskResolution>,
         py: Python<'py>,
     ) -> Result<Vec<Bound<'py, numpy::PyArray3<u8>>>> {
+        let _span = tracing::trace_span!("py_materialize_masks").entered();
         let detect = numpy_to_detect_boxes(&bbox, &scores, &classes)?;
         let resolution = resolution.map(|r| r.0).unwrap_or(MaskResolution::Proto);
         let mut l = self
@@ -1149,6 +1151,12 @@ impl PyImageProcessor {
         color_mode: PyColorMode,
         py: Python<'py>,
     ) -> PyResult<Py<PyAny>> {
+        let _span = tracing::trace_span!(
+            "py_draw_masks",
+            n_tensors = model_output.len(),
+            tracked = tracker.is_some(),
+        )
+        .entered();
         let tensor_refs: Vec<&edgefirst_hal::tensor::TensorDyn> =
             model_output.iter().map(|t| &t.0).collect();
 

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -76,6 +76,9 @@ pub mod edgefirst_hal {
         m.add_class::<tracker::PyByteTrack>()?;
         m.add_class::<tracker::PyActiveTrackInfo>()?;
 
+        #[cfg(feature = "tracing")]
+        m.add_class::<PyTracing>()?;
+
         Ok(())
     }
 
@@ -97,5 +100,75 @@ pub mod edgefirst_hal {
             env!("CARGO_PKG_VERSION"),
             f16_impl
         )
+    }
+
+    /// Trace capture context manager for Perfetto/Chrome JSON output.
+    ///
+    /// Usage:
+    /// ```python
+    /// import edgefirst_hal as hal
+    ///
+    /// with hal.Tracing("/tmp/trace.json"):
+    ///     # ... inference pipeline runs here ...
+    ///     pass
+    /// # trace file flushed and closed
+    /// ```
+    ///
+    /// Or without context manager:
+    /// ```python
+    /// guard = hal.Tracing("/tmp/trace.json")
+    /// guard.start()
+    /// # ... work ...
+    /// guard.stop()
+    /// ```
+    #[cfg(feature = "tracing")]
+    #[pyclass(name = "Tracing")]
+    struct PyTracing {
+        path: String,
+        active: bool,
+    }
+
+    #[cfg(feature = "tracing")]
+    #[pymethods]
+    impl PyTracing {
+        #[new]
+        fn new(path: String) -> Self {
+            Self {
+                path,
+                active: false,
+            }
+        }
+
+        /// Start trace capture.
+        fn start(&mut self) -> PyResult<()> {
+            ::edgefirst_hal::trace::start_tracing(&self.path)
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+            self.active = true;
+            Ok(())
+        }
+
+        /// Stop trace capture and flush the trace file.
+        fn stop(&mut self) {
+            if self.active {
+                ::edgefirst_hal::trace::stop_tracing();
+                self.active = false;
+            }
+        }
+
+        fn __enter__(mut slf: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
+            slf.start()?;
+            Ok(slf)
+        }
+
+        #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
+        fn __exit__(
+            &mut self,
+            _exc_type: Option<&Bound<'_, pyo3::types::PyAny>>,
+            _exc_val: Option<&Bound<'_, pyo3::types::PyAny>>,
+            _exc_tb: Option<&Bound<'_, pyo3::types::PyAny>>,
+        ) -> bool {
+            self.stop();
+            false // don't suppress exceptions
+        }
     }
 }

--- a/crates/python/src/lib.rs
+++ b/crates/python/src/lib.rs
@@ -76,7 +76,6 @@ pub mod edgefirst_hal {
         m.add_class::<tracker::PyByteTrack>()?;
         m.add_class::<tracker::PyActiveTrackInfo>()?;
 
-        #[cfg(feature = "tracing")]
         m.add_class::<PyTracing>()?;
 
         Ok(())
@@ -121,14 +120,16 @@ pub mod edgefirst_hal {
     /// # ... work ...
     /// guard.stop()
     /// ```
-    #[cfg(feature = "tracing")]
+    ///
+    /// Note: Raises RuntimeError if tracing support was not compiled in
+    /// (built without the `tracing` feature).
     #[pyclass(name = "Tracing")]
+    #[allow(dead_code)]
     struct PyTracing {
         path: String,
         active: bool,
     }
 
-    #[cfg(feature = "tracing")]
     #[pymethods]
     impl PyTracing {
         #[new]
@@ -141,16 +142,30 @@ pub mod edgefirst_hal {
 
         /// Start trace capture.
         fn start(&mut self) -> PyResult<()> {
-            ::edgefirst_hal::trace::start_tracing(&self.path)
-                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
-            self.active = true;
-            Ok(())
+            #[cfg(not(feature = "tracing"))]
+            {
+                Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "tracing support not compiled in (built without 'tracing' feature)",
+                ))
+            }
+            #[cfg(feature = "tracing")]
+            {
+                ::edgefirst_hal::trace::start_tracing(&self.path)
+                    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+                self.active = true;
+                Ok(())
+            }
         }
 
         /// Stop trace capture and flush the trace file.
         fn stop(&mut self) {
+            #[cfg(feature = "tracing")]
             if self.active {
                 ::edgefirst_hal::trace::stop_tracing();
+                self.active = false;
+            }
+            #[cfg(not(feature = "tracing"))]
+            {
                 self.active = false;
             }
         }

--- a/crates/tensor/Cargo.toml
+++ b/crates/tensor/Cargo.toml
@@ -24,6 +24,7 @@ log = { workspace = true }
 ndarray = { workspace = true, optional = true }
 num-traits = { workspace = true }
 serde = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -1172,6 +1172,13 @@ where
     /// # }
     /// ```
     pub fn new(shape: &[usize], memory: Option<TensorMemory>, name: Option<&str>) -> Result<Self> {
+        let _span = tracing::trace_span!(
+            "tensor_alloc",
+            ?shape,
+            memory = ?memory,
+            dtype = std::any::type_name::<T>(),
+        )
+        .entered();
         TensorStorage::new(shape, memory, name).map(Self::wrap)
     }
 
@@ -1770,6 +1777,11 @@ where
     }
 
     fn map(&self) -> Result<TensorMap<T>> {
+        let _span = tracing::trace_span!(
+            "tensor_map",
+            memory = ?self.storage.memory(),
+        )
+        .entered();
         // CPU mapping of strided tensors is allowed only when the HAL
         // owns the underlying allocation — i.e. self-allocated DMA
         // tensors with pitch padding added by `image_with_stride()`

--- a/crates/tracker/Cargo.toml
+++ b/crates/tracker/Cargo.toml
@@ -19,6 +19,7 @@ log = { workspace = true }
 nalgebra = { workspace = true }
 ndarray = { workspace = true }
 num-traits = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/tracker/src/bytetrack.rs
+++ b/crates/tracker/src/bytetrack.rs
@@ -345,6 +345,14 @@ where
     T: DetectionBox,
 {
     fn update(&mut self, boxes: &[T], timestamp: u64) -> Vec<Option<TrackInfo>> {
+        let span = tracing::trace_span!(
+            "tracker_update",
+            n_detections = boxes.len(),
+            n_tracklets = self.tracklets.len(),
+            timestamp,
+        );
+        let _enter = span.enter();
+
         self.frame_count += 1;
 
         // Identify high-confidence detections
@@ -361,10 +369,14 @@ where
 
         // First pass: match high-confidence detections
         if !self.tracklets.is_empty() {
+            let _s = tracing::trace_span!("predict").entered();
             for track in &mut self.tracklets {
                 track.filter.predict();
             }
+        }
 
+        if !self.tracklets.is_empty() {
+            let _s = tracing::trace_span!("match_high_conf").entered();
             let costs = self.compute_costs(
                 boxes,
                 self.track_high_conf,
@@ -388,6 +400,7 @@ where
 
         // Second pass: match remaining tracklets to low-confidence detections
         if !self.tracklets.is_empty() {
+            let _s = tracing::trace_span!("match_low_conf").entered();
             let costs = self.compute_costs(boxes, 0.0, self.track_iou, &matched, &tracked);
             if let Ok(ans) = lapjv(&costs) {
                 self.process_assignments(


### PR DESCRIPTION
## Summary

performance analysis via Perfetto/Chrome trace files.

## Changes

### New span coverage (45+ sites total)

| Crate | Spans | What it captures |
|-------|-------|------------------|
| **tensor** | `tensor_alloc`, `tensor_map` | Allocation (shape, dtype, memory), DMA/SHM map |
| **image** | `image_convert`, `draw_masks` | Format conversion, mask rendering |
| **image/cpu** | `cpu_format_convert`, `cpu_resize` | Per-pass breakdown of multi-step CPU pipeline |
| **image/gl** | `gl_convert`, `gl_pass1_to_rgba`, `gl_pass2_pack_rgb`, `gl_pass2_to_planar` | Two-pass GL pipelines |
| **image/g2d** | `g2d_convert` | Hardware blit |
| **image/masks** | `mask_i8_fastpath` (×2) | Proto + scaled i8×i8 kernel |
| **decoder** | `decode` (×4 modes), `score_filter`, `top_k`, `nms`, `box_dequant`, `process_masks` (×2), `extract_proto` (×2) | Full decode pipeline |
| **tracker** | `tracker_update`, `predict`, `match_high_conf`, `match_low_conf` | ByteTrack phases |
| **python** | `py_decode`, `py_decode_tracked`, `py_decode_proto`, `py_convert`, `py_materialize_masks`, `py_draw_masks` | Python entry points |

### Multi-pass pipeline visibility

CPU, OpenGL, and G2D backends now have per-pass spans so each stage of a
multi-step conversion (format decode → resize → format pack) is individually
visible in Perfetto traces.

### Zero-cost guarantee

per site when no subscriber is active. No runtime cost in production builds
without explicit `start_tracing()`.

### New dependencies

- `edgefirst-tensor`: `tracing` (workspace)
- `edgefirst-tracker`: `tracing` (workspace)
- `edgefirst_hal` (python): `tracing` (workspace)

## Testing

- All 842 tests pass (`cargo test --workspace -- --test-threads=1`)
- `cargo clippy` clean (zero warnings)
- `cargo fmt` applied

## JIRA

[DE-2451](https://edgefirst.atlassian.net/browse/DE-2451)


[DE-2451]: https://au-zone.atlassian.net/browse/DE-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ