### PR TITLE
DE-2557: NEON SIMD optimizations for decoder post-processing pipeline

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,8 +14,9 @@
 # TESTING.md for the documented incantations.
 
 # aarch64 Apple Silicon (M-series) is the one safe exception: every
-# M-series chip has ARMv8.2-FP16. Intel Macs build under the separate
-# `x86_64-apple-darwin` triple, so this entry cannot misfire on
-# non-FP16 hardware.
+# M-series chip (M1 through M4) is ARMv8.6-A+ and supports fp16,
+# dotprod (sdot/udot), and i8mm (smmla/ummla/usmmla). Intel Macs
+# build under the separate `x86_64-apple-darwin` triple, so this
+# entry cannot misfire on non-ARM hardware.
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "target-feature=+fp16"]
+rustflags = ["-C", "target-feature=+fp16,+dotprod,+i8mm"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,6 +326,7 @@ jobs:
         with:
           shared-key: rust-macos
           cache-on-failure: true
+          cache-bin: false  # Prevent overwriting rustup cargo shim with stale cached binary
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6  # v2.71.2

--- a/crates/decoder/src/byte.rs
+++ b/crates/decoder/src/byte.rs
@@ -89,6 +89,93 @@ unsafe fn column_max_update_neon(
     let _ = remainder; // suppress unused warning
 }
 
+/// NEON-accelerated column max update with software prefetch for DMA-BUF.
+///
+/// Adds PRFM (prefetch for load, L1 data cache, streaming) hints 2 cache
+/// lines ahead of the current read position to hide CMA memory latency.
+/// On Cortex-A55 (64B cache lines) this prefetches 128 bytes ahead; on
+/// Cortex-A76 (64B L1, 128B L2 lines) the same offset covers one L2 line.
+///
+/// # Safety
+///
+/// - `col_ptr` must point to at least `n` valid bytes.
+/// - `max_ptr` must point to at least `n` valid mutable bytes.
+/// - `class_ptr` must point to at least `n` valid mutable bytes.
+#[cfg(target_arch = "aarch64")]
+#[allow(dead_code)] // Reserved for DMA-BUF CMA paths where latency hiding helps.
+unsafe fn column_max_update_neon_prefetch(
+    col_ptr: *const u8,
+    max_ptr: *mut u8,
+    class_ptr: *mut u8,
+    n: usize,
+    class_idx: u8,
+    signed: bool,
+) {
+    use std::arch::aarch64::*;
+
+    const PREFETCH_AHEAD: usize = 128; // 2 cache lines on A55 (64B each)
+
+    let class_vec = vdupq_n_u8(class_idx);
+    let chunks = n / 16;
+
+    if signed {
+        for chunk in 0..chunks {
+            let offset = chunk * 16;
+            // Software prefetch: hint the next read 2 cache lines ahead.
+            if offset + PREFETCH_AHEAD < n {
+                core::arch::asm!(
+                    "prfm pldl1strm, [{ptr}]",
+                    ptr = in(reg) col_ptr.add(offset + PREFETCH_AHEAD),
+                    options(nostack, preserves_flags),
+                );
+            }
+            let col = vld1q_s8(col_ptr.add(offset) as *const i8);
+            let cur_max = vld1q_s8(max_ptr.add(offset) as *const i8);
+            let mask = vcgeq_s8(col, cur_max);
+            let new_max = vmaxq_s8(col, cur_max);
+            vst1q_s8(max_ptr.add(offset) as *mut i8, new_max);
+            let cur_class = vld1q_u8(class_ptr.add(offset));
+            let new_class = vbslq_u8(mask, class_vec, cur_class);
+            vst1q_u8(class_ptr.add(offset), new_class);
+        }
+        for i in (chunks * 16)..n {
+            let val = *(col_ptr.add(i) as *const i8);
+            let cur = *(max_ptr.add(i) as *const i8);
+            if val >= cur {
+                *(max_ptr.add(i) as *mut i8) = val;
+                *class_ptr.add(i) = class_idx;
+            }
+        }
+    } else {
+        for chunk in 0..chunks {
+            let offset = chunk * 16;
+            if offset + PREFETCH_AHEAD < n {
+                core::arch::asm!(
+                    "prfm pldl1strm, [{ptr}]",
+                    ptr = in(reg) col_ptr.add(offset + PREFETCH_AHEAD),
+                    options(nostack, preserves_flags),
+                );
+            }
+            let col = vld1q_u8(col_ptr.add(offset));
+            let cur_max = vld1q_u8(max_ptr.add(offset));
+            let mask = vcgeq_u8(col, cur_max);
+            let new_max = vmaxq_u8(col, cur_max);
+            vst1q_u8(max_ptr.add(offset), new_max);
+            let cur_class = vld1q_u8(class_ptr.add(offset));
+            let new_class = vbslq_u8(mask, class_vec, cur_class);
+            vst1q_u8(class_ptr.add(offset), new_class);
+        }
+        for i in (chunks * 16)..n {
+            let val = *col_ptr.add(i);
+            let cur = *max_ptr.add(i);
+            if val >= cur {
+                *max_ptr.add(i) = val;
+                *class_ptr.add(i) = class_idx;
+            }
+        }
+    }
+}
+
 /// Fast argmax dispatching to NEON-optimized path for i8 on aarch64.
 #[inline(always)]
 fn fast_arg_max<T: PrimInt + Copy>(score: ArrayView1<T>) -> (T, usize) {
@@ -205,6 +292,8 @@ fn postprocess_boxes_quant_column_major<
             {
                 if std::mem::size_of::<Scores>() == 1 {
                     unsafe {
+                        // Non-prefetch variant for heap-backed tensors;
+                        // prefetch variant reserved for DMA-BUF CMA paths.
                         column_max_update_neon(
                             slice.as_ptr() as *const u8,
                             max_scores.as_mut_ptr() as *mut u8,

--- a/crates/decoder/src/float.rs
+++ b/crates/decoder/src/float.rs
@@ -129,6 +129,11 @@ pub fn nms_float(iou: f32, max_det: Option<usize>, mut boxes: Vec<DetectBox>) ->
                 boxes[j].score = -1.0;
             }
         }
+
+        // NOTE: jaccard_batch4_neon is available for callers that can
+        // batch unsuppressed candidates externally. It is not used
+        // inline here because score=-1 marking creates sparse gaps
+        // that prevent contiguous 4-box batching.
         survivors += 1;
         if survivors >= cap {
             break;
@@ -359,6 +364,109 @@ pub fn jaccard(a: &BoundingBox, b: &BoundingBox, iou: f32) -> bool {
     intersection > iou * union
 }
 
+/// Batch IoU check: test one reference box `a` against 4 candidate boxes.
+///
+/// Returns a 4-element array of booleans: `result[i]` is true if
+/// `jaccard(a, boxes[i], iou)` would return true.
+///
+/// On aarch64, uses NEON `vmaxq_f32`/`vminq_f32` for vectorized
+/// intersection computation. On other architectures falls back to
+/// 4 scalar `jaccard` calls.
+#[inline]
+pub fn jaccard_batch4(a: &BoundingBox, boxes: &[BoundingBox; 4], iou: f32) -> [bool; 4] {
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: NEON is mandatory on aarch64.
+        unsafe { jaccard_batch4_neon(a, boxes, iou) }
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        [
+            jaccard(a, &boxes[0], iou),
+            jaccard(a, &boxes[1], iou),
+            jaccard(a, &boxes[2], iou),
+            jaccard(a, &boxes[3], iou),
+        ]
+    }
+}
+
+/// NEON-vectorized batch IoU for 4 candidate boxes against one reference.
+///
+/// Loads xmin/ymin/xmax/ymax of the 4 candidates into separate NEON
+/// registers (AoS→SoA transpose), then computes intersection, union,
+/// and the `intersection > iou * union` test in 4-wide SIMD.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn jaccard_batch4_neon(a: &BoundingBox, boxes: &[BoundingBox; 4], iou: f32) -> [bool; 4] {
+    use std::arch::aarch64::*;
+
+    let zero = vdupq_n_f32(0.0);
+    let iou_v = vdupq_n_f32(iou);
+
+    // Reference box broadcast.
+    let a_xmin = vdupq_n_f32(a.xmin);
+    let a_ymin = vdupq_n_f32(a.ymin);
+    let a_xmax = vdupq_n_f32(a.xmax);
+    let a_ymax = vdupq_n_f32(a.ymax);
+    let area_a = vmulq_f32(vsubq_f32(a_xmax, a_xmin), vsubq_f32(a_ymax, a_ymin));
+
+    // Load 4 boxes (each BoundingBox is [xmin, ymin, xmax, ymax]).
+    let b0 = vld1q_f32(&boxes[0].xmin as *const f32);
+    let b1 = vld1q_f32(&boxes[1].xmin as *const f32);
+    let b2 = vld1q_f32(&boxes[2].xmin as *const f32);
+    let b3 = vld1q_f32(&boxes[3].xmin as *const f32);
+
+    // AoS → SoA transpose (4×4).
+    let t01_lo = vtrn1q_f32(b0, b1); // xmin0,xmin1,xmax0,xmax1
+    let t01_hi = vtrn2q_f32(b0, b1); // ymin0,ymin1,ymax0,ymax1
+    let t23_lo = vtrn1q_f32(b2, b3);
+    let t23_hi = vtrn2q_f32(b2, b3);
+
+    let b_xmin = vreinterpretq_f32_f64(vtrn1q_f64(
+        vreinterpretq_f64_f32(t01_lo),
+        vreinterpretq_f64_f32(t23_lo),
+    ));
+    let b_ymin = vreinterpretq_f32_f64(vtrn1q_f64(
+        vreinterpretq_f64_f32(t01_hi),
+        vreinterpretq_f64_f32(t23_hi),
+    ));
+    let b_xmax = vreinterpretq_f32_f64(vtrn2q_f64(
+        vreinterpretq_f64_f32(t01_lo),
+        vreinterpretq_f64_f32(t23_lo),
+    ));
+    let b_ymax = vreinterpretq_f32_f64(vtrn2q_f64(
+        vreinterpretq_f64_f32(t01_hi),
+        vreinterpretq_f64_f32(t23_hi),
+    ));
+
+    // Intersection.
+    let left = vmaxq_f32(a_xmin, b_xmin);
+    let top = vmaxq_f32(a_ymin, b_ymin);
+    let right = vminq_f32(a_xmax, b_xmax);
+    let bottom = vminq_f32(a_ymax, b_ymax);
+    let w = vmaxq_f32(vsubq_f32(right, left), zero);
+    let h = vmaxq_f32(vsubq_f32(bottom, top), zero);
+    let intersection = vmulq_f32(w, h);
+
+    // Area B.
+    let area_b = vmulq_f32(vsubq_f32(b_xmax, b_xmin), vsubq_f32(b_ymax, b_ymin));
+
+    // Union = area_a + area_b - intersection.
+    let union = vsubq_f32(vaddq_f32(area_a, area_b), intersection);
+
+    // Test: intersection > iou * union (equivalent to IoU > threshold).
+    let iou_union = vmulq_f32(iou_v, union);
+    let mask = vcgtq_f32(intersection, iou_union);
+
+    // Extract per-lane results.
+    [
+        vgetq_lane_u32(mask, 0) != 0,
+        vgetq_lane_u32(mask, 1) != 0,
+        vgetq_lane_u32(mask, 2) != 0,
+        vgetq_lane_u32(mask, 3) != 0,
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -415,5 +523,26 @@ mod tests {
         let full = nms_float(0.5, None, boxes.clone());
         let capped = nms_float(0.5, Some(100), boxes);
         assert_eq!(full.len(), capped.len());
+    }
+
+    #[test]
+    fn jaccard_batch4_matches_scalar() {
+        let a = BoundingBox::new(0.0, 0.0, 10.0, 10.0);
+        let boxes = [
+            BoundingBox::new(5.0, 5.0, 15.0, 15.0),   // overlap
+            BoundingBox::new(20.0, 20.0, 30.0, 30.0), // no overlap
+            BoundingBox::new(0.0, 0.0, 10.0, 10.0),   // identical
+            BoundingBox::new(8.0, 8.0, 18.0, 18.0),   // small overlap
+        ];
+        let iou_threshold = 0.1;
+        let batch = jaccard_batch4(&a, &boxes, iou_threshold);
+        for (i, b) in boxes.iter().enumerate() {
+            let scalar = jaccard(&a, b, iou_threshold);
+            assert_eq!(
+                batch[i], scalar,
+                "batch4 mismatch at {i}: batch={} scalar={}",
+                batch[i], scalar
+            );
+        }
     }
 }

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -330,6 +330,7 @@ pub struct DetectBox {
 
 /// A bounding box with f32 coordinates in XYXY format
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[repr(C)]
 pub struct BoundingBox {
     /// left-most normalized coordinate of the bounding box
     pub xmin: f32,
@@ -340,6 +341,10 @@ pub struct BoundingBox {
     /// bottom-most normalized coordinate of the bounding box
     pub ymax: f32,
 }
+
+// Guarantee that BoundingBox is 4 contiguous f32 fields for NEON vld1q_f32 loads.
+const _: () = assert!(std::mem::size_of::<BoundingBox>() == 4 * std::mem::size_of::<f32>());
+const _: () = assert!(std::mem::align_of::<BoundingBox>() == std::mem::align_of::<f32>());
 
 impl BoundingBox {
     /// Creates a new BoundingBox from the given coordinates

--- a/crates/decoder/src/per_scale/kernels/dispatch.rs
+++ b/crates/decoder/src/per_scale/kernels/dispatch.rs
@@ -18,7 +18,11 @@ use edgefirst_tensor::DType;
 /// `Dfl*` variants run dequant → softmax → weighted-sum → dist2bbox.
 /// `Ltrb*` variants run dequant → dist2bbox.
 ///
-/// Phase 1 only emits `*Scalar` variants. Phase 2 adds NEON tiers.
+/// DFL NEON tiers: NeonBase (f32 exp) and NeonFp16 (fp16 exp via fused
+/// softmax+weighted_sum). DotProd/I8MM are not needed for DFL because
+/// the fused kernel computes weighted_sum as part of the exp loop
+/// using simple FMAs, which is faster than the quantize→integer_dot→
+/// dequantize roundtrip that DotProd/I8MM would provide.
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)] // Wired by Task 15.
 #[allow(clippy::enum_variant_names)] // tier suffix is meaningful (Phase 2 adds Neon variants)
@@ -94,9 +98,10 @@ impl BoxLevelDispatch {
     ) -> DecoderResult<Self> {
         use BoxLevelDispatch::*;
 
+        // Tier 2: FP16 (DFL only — LTRB has no softmax, fused kernel
+        // with fp16 exp is the best DFL path on cores with fp16).
         #[cfg(target_arch = "aarch64")]
         if features.neon_fp16 {
-            // FP16 tier wins for DFL only — LTRB has no softmax.
             match (encoding, input, output) {
                 (BoxEncoding::Dfl, DType::I8, DecodeDtype::F32) => return Ok(DflI8ToF32NeonFp16),
                 (BoxEncoding::Dfl, DType::U8, DecodeDtype::F32) => return Ok(DflU8ToF32NeonFp16),
@@ -206,6 +211,17 @@ pub(crate) enum ScoreLevelDispatch {
     I16ToF32NeonFp16,
     #[cfg(target_arch = "aarch64")]
     U16ToF32NeonFp16,
+
+    // Tier 1-fused: NEON fused dequant+sigmoid in one pass (no intermediate
+    // store/reload). Same CpuFeatures gate as NeonBase.
+    #[cfg(target_arch = "aarch64")]
+    I8ToF32NeonFused,
+    #[cfg(target_arch = "aarch64")]
+    U8ToF32NeonFused,
+    #[cfg(target_arch = "aarch64")]
+    I16ToF32NeonFused,
+    #[cfg(target_arch = "aarch64")]
+    U16ToF32NeonFused,
 }
 
 impl ScoreLevelDispatch {
@@ -214,36 +230,62 @@ impl ScoreLevelDispatch {
         output: DecodeDtype,
         features: &CpuFeatures,
     ) -> DecoderResult<Self> {
-        use ScoreLevelDispatch::*;
-        // Tier-1 NEON-base wins when the probe says it's available AND a
-        // NEON variant exists for this cell. Otherwise the scalar arm
-        // below is the fallback. This is the dispatch contract: a
-        // *NeonBase variant existing in the returned value means the
-        // CpuFeatures probe saw the corresponding hardware feature, so
-        // calls into the unsafe `target_feature` kernel are sound.
         #[cfg(target_arch = "aarch64")]
-        if features.neon_fp16 {
-            match (input, output) {
-                (DType::I8, DecodeDtype::F32) => return Ok(I8ToF32NeonFp16),
-                (DType::U8, DecodeDtype::F32) => return Ok(U8ToF32NeonFp16),
-                (DType::I16, DecodeDtype::F32) => return Ok(I16ToF32NeonFp16),
-                (DType::U16, DecodeDtype::F32) => return Ok(U16ToF32NeonFp16),
-                _ => {} // fall through to NeonBase
+        {
+            use ScoreLevelDispatch::*;
+            if features.neon_fp16 {
+                match (input, output) {
+                    (DType::I8, DecodeDtype::F32) => return Ok(I8ToF32NeonFp16),
+                    (DType::U8, DecodeDtype::F32) => return Ok(U8ToF32NeonFp16),
+                    (DType::I16, DecodeDtype::F32) => return Ok(I16ToF32NeonFp16),
+                    (DType::U16, DecodeDtype::F32) => return Ok(U16ToF32NeonFp16),
+                    _ => {} // fall through to NeonBase
+                }
+            }
+            if features.neon_baseline {
+                match (input, output) {
+                    // Fused dequant+sigmoid: preferred for score tensors.
+                    // MaskCoef/Proto callers use select_dequant_only() instead.
+                    (DType::I8, DecodeDtype::F32) => return Ok(I8ToF32NeonFused),
+                    (DType::U8, DecodeDtype::F32) => return Ok(U8ToF32NeonFused),
+                    (DType::I16, DecodeDtype::F32) => return Ok(I16ToF32NeonFused),
+                    (DType::U16, DecodeDtype::F32) => return Ok(U16ToF32NeonFused),
+                    _ => {} // fall through to scalar
+                }
             }
         }
-        #[cfg(target_arch = "aarch64")]
-        if features.neon_baseline {
-            match (input, output) {
-                (DType::I8, DecodeDtype::F32) => return Ok(I8ToF32NeonBase),
-                (DType::U8, DecodeDtype::F32) => return Ok(U8ToF32NeonBase),
-                (DType::I16, DecodeDtype::F32) => return Ok(I16ToF32NeonBase),
-                (DType::U16, DecodeDtype::F32) => return Ok(U16ToF32NeonBase),
-                _ => {} // fall through to scalar
-            }
-        }
-        #[cfg(not(target_arch = "aarch64"))]
-        let _ = features;
+        Self::select_scalar(input, output, features)
+    }
 
+    /// Dequant-only selector: picks NeonBase (no fused sigmoid) for
+    /// mc/proto paths that have no activation step.
+    pub(crate) fn select_dequant_only(
+        input: DType,
+        output: DecodeDtype,
+        features: &CpuFeatures,
+    ) -> DecoderResult<Self> {
+        #[cfg(target_arch = "aarch64")]
+        {
+            use ScoreLevelDispatch::*;
+            if features.neon_baseline {
+                match (input, output) {
+                    (DType::I8, DecodeDtype::F32) => return Ok(I8ToF32NeonBase),
+                    (DType::U8, DecodeDtype::F32) => return Ok(U8ToF32NeonBase),
+                    (DType::I16, DecodeDtype::F32) => return Ok(I16ToF32NeonBase),
+                    (DType::U16, DecodeDtype::F32) => return Ok(U16ToF32NeonBase),
+                    _ => {} // fall through to scalar
+                }
+            }
+        }
+        Self::select_scalar(input, output, features)
+    }
+
+    fn select_scalar(
+        input: DType,
+        output: DecodeDtype,
+        _features: &CpuFeatures,
+    ) -> DecoderResult<Self> {
+        use ScoreLevelDispatch::*;
         Ok(match (input, output) {
             (DType::I8, DecodeDtype::F32) => I8ToF32Scalar,
             (DType::U8, DecodeDtype::F32) => U8ToF32Scalar,
@@ -279,15 +321,9 @@ impl MaskCoefDispatch {
         output: DecodeDtype,
         f: &CpuFeatures,
     ) -> DecoderResult<Self> {
-        // FP16 brings no advantage to mc/proto (they're pure dequant —
-        // no exp/sigmoid/softmax) and the fp16 NEON variants don't have
-        // mc/proto kernels wired. Force the score selector to skip the
-        // fp16 tier for these consumers.
-        let f_no_fp16 = CpuFeatures {
-            neon_fp16: false,
-            ..*f
-        };
-        ScoreLevelDispatch::select(input, output, &f_no_fp16).map(Self)
+        // Pure dequant (no activation) — skip FP16 sigmoid and fused
+        // dequant+sigmoid tiers.
+        ScoreLevelDispatch::select_dequant_only(input, output, f).map(Self)
     }
 }
 
@@ -302,11 +338,8 @@ impl ProtoDispatch {
         output: DecodeDtype,
         f: &CpuFeatures,
     ) -> DecoderResult<Self> {
-        let f_no_fp16 = CpuFeatures {
-            neon_fp16: false,
-            ..*f
-        };
-        ScoreLevelDispatch::select(input, output, &f_no_fp16).map(Self)
+        // Pure dequant (no activation) — skip FP16 sigmoid and fused tiers.
+        ScoreLevelDispatch::select_dequant_only(input, output, f).map(Self)
     }
 }
 
@@ -354,10 +387,10 @@ use super::level_box::{
 };
 #[cfg(target_arch = "aarch64")]
 use super::level_box::{
-    decode_box_level_dfl_i16_to_f32_neon, decode_box_level_dfl_i16_to_f32_neon_fp16,
-    decode_box_level_dfl_i8_to_f32_neon, decode_box_level_dfl_i8_to_f32_neon_fp16,
-    decode_box_level_dfl_u16_to_f32_neon, decode_box_level_dfl_u16_to_f32_neon_fp16,
-    decode_box_level_dfl_u8_to_f32_neon, decode_box_level_dfl_u8_to_f32_neon_fp16,
+    decode_box_level_dfl_i16_to_f32_neon_fused, decode_box_level_dfl_i16_to_f32_neon_fused_fp16,
+    decode_box_level_dfl_i8_to_f32_neon_fused, decode_box_level_dfl_i8_to_f32_neon_fused_fp16,
+    decode_box_level_dfl_u16_to_f32_neon_fused, decode_box_level_dfl_u16_to_f32_neon_fused_fp16,
+    decode_box_level_dfl_u8_to_f32_neon_fused, decode_box_level_dfl_u8_to_f32_neon_fused_fp16,
     decode_box_level_ltrb_i16_to_f32_neon, decode_box_level_ltrb_i8_to_f32_neon,
     decode_box_level_ltrb_u16_to_f32_neon, decode_box_level_ltrb_u8_to_f32_neon,
 };
@@ -456,22 +489,22 @@ impl BoxLevelDispatch {
                 decode_box_level_ltrb_f32_to_f16(i, q, level, d)
             }
 
-            // Tier-1 NEON-base arms.
+            // Tier-1 NEON-base arms (fused softmax+weighted_sum).
             #[cfg(target_arch = "aarch64")]
             (DflI8ToF32NeonBase, InputView::I8(i), DstSliceMut::F32(d)) => {
-                decode_box_level_dfl_i8_to_f32_neon(i, q, level, d)
+                decode_box_level_dfl_i8_to_f32_neon_fused(i, q, level, d)
             }
             #[cfg(target_arch = "aarch64")]
             (DflU8ToF32NeonBase, InputView::U8(i), DstSliceMut::F32(d)) => {
-                decode_box_level_dfl_u8_to_f32_neon(i, q, level, d)
+                decode_box_level_dfl_u8_to_f32_neon_fused(i, q, level, d)
             }
             #[cfg(target_arch = "aarch64")]
             (DflI16ToF32NeonBase, InputView::I16(i), DstSliceMut::F32(d)) => {
-                decode_box_level_dfl_i16_to_f32_neon(i, q, level, d)
+                decode_box_level_dfl_i16_to_f32_neon_fused(i, q, level, d)
             }
             #[cfg(target_arch = "aarch64")]
             (DflU16ToF32NeonBase, InputView::U16(i), DstSliceMut::F32(d)) => {
-                decode_box_level_dfl_u16_to_f32_neon(i, q, level, d)
+                decode_box_level_dfl_u16_to_f32_neon_fused(i, q, level, d)
             }
             #[cfg(target_arch = "aarch64")]
             (LtrbI8ToF32NeonBase, InputView::I8(i), DstSliceMut::F32(d)) => {
@@ -490,22 +523,22 @@ impl BoxLevelDispatch {
                 decode_box_level_ltrb_u16_to_f32_neon(i, q, level, d)
             }
 
-            // Tier-2 NEON FP16 DFL arms.
+            // Tier-2 NEON FP16 DFL arms (fused softmax+weighted_sum, fp16 exp).
             #[cfg(target_arch = "aarch64")]
             (DflI8ToF32NeonFp16, InputView::I8(i), DstSliceMut::F32(d)) => {
-                decode_box_level_dfl_i8_to_f32_neon_fp16(i, q, level, d)
+                decode_box_level_dfl_i8_to_f32_neon_fused_fp16(i, q, level, d)
             }
             #[cfg(target_arch = "aarch64")]
             (DflU8ToF32NeonFp16, InputView::U8(i), DstSliceMut::F32(d)) => {
-                decode_box_level_dfl_u8_to_f32_neon_fp16(i, q, level, d)
+                decode_box_level_dfl_u8_to_f32_neon_fused_fp16(i, q, level, d)
             }
             #[cfg(target_arch = "aarch64")]
             (DflI16ToF32NeonFp16, InputView::I16(i), DstSliceMut::F32(d)) => {
-                decode_box_level_dfl_i16_to_f32_neon_fp16(i, q, level, d)
+                decode_box_level_dfl_i16_to_f32_neon_fused_fp16(i, q, level, d)
             }
             #[cfg(target_arch = "aarch64")]
             (DflU16ToF32NeonFp16, InputView::U16(i), DstSliceMut::F32(d)) => {
-                decode_box_level_dfl_u16_to_f32_neon_fp16(i, q, level, d)
+                decode_box_level_dfl_u16_to_f32_neon_fused_fp16(i, q, level, d)
             }
 
             (variant, _, _) => {
@@ -529,9 +562,11 @@ use super::level_score::{
 #[cfg(target_arch = "aarch64")]
 use super::level_score::{
     decode_score_level_i16_to_f32_neon, decode_score_level_i16_to_f32_neon_fp16,
-    decode_score_level_i8_to_f32_neon, decode_score_level_i8_to_f32_neon_fp16,
+    decode_score_level_i16_to_f32_neon_fused, decode_score_level_i8_to_f32_neon,
+    decode_score_level_i8_to_f32_neon_fp16, decode_score_level_i8_to_f32_neon_fused,
     decode_score_level_u16_to_f32_neon, decode_score_level_u16_to_f32_neon_fp16,
-    decode_score_level_u8_to_f32_neon, decode_score_level_u8_to_f32_neon_fp16,
+    decode_score_level_u16_to_f32_neon_fused, decode_score_level_u8_to_f32_neon,
+    decode_score_level_u8_to_f32_neon_fp16, decode_score_level_u8_to_f32_neon_fused,
 };
 use crate::per_scale::Activation;
 
@@ -620,6 +655,24 @@ impl ScoreLevelDispatch {
             #[cfg(target_arch = "aarch64")]
             (U16ToF32NeonFp16, InputView::U16(i), DstSliceMut::F32(d)) => {
                 decode_score_level_u16_to_f32_neon_fp16(i, q, num_classes, level, activation, d)
+            }
+
+            // Tier 1-fused: fused dequant+sigmoid NEON arms.
+            #[cfg(target_arch = "aarch64")]
+            (I8ToF32NeonFused, InputView::I8(i), DstSliceMut::F32(d)) => {
+                decode_score_level_i8_to_f32_neon_fused(i, q, num_classes, level, activation, d)
+            }
+            #[cfg(target_arch = "aarch64")]
+            (U8ToF32NeonFused, InputView::U8(i), DstSliceMut::F32(d)) => {
+                decode_score_level_u8_to_f32_neon_fused(i, q, num_classes, level, activation, d)
+            }
+            #[cfg(target_arch = "aarch64")]
+            (I16ToF32NeonFused, InputView::I16(i), DstSliceMut::F32(d)) => {
+                decode_score_level_i16_to_f32_neon_fused(i, q, num_classes, level, activation, d)
+            }
+            #[cfg(target_arch = "aarch64")]
+            (U16ToF32NeonFused, InputView::U16(i), DstSliceMut::F32(d)) => {
+                decode_score_level_u16_to_f32_neon_fused(i, q, num_classes, level, activation, d)
             }
             (variant, _, _) => {
                 return Err(DecoderError::KernelDispatchUnreachable(format!(

--- a/crates/decoder/src/per_scale/kernels/level_box.rs
+++ b/crates/decoder/src/per_scale/kernels/level_box.rs
@@ -215,7 +215,13 @@ macro_rules! impl_dfl_level_f32_neon {
                         );
                     }
                 }
-                let ltrb = weighted_sum_4sides_f32(&deq[..4 * reg_max], reg_max);
+                // NEON vectorized weighted-sum + scalar dist2bbox.
+                let ltrb = unsafe {
+                    crate::per_scale::kernels::neon_baseline::weighted_sum_4sides_f32_neon(
+                        &deq[..4 * reg_max],
+                        reg_max,
+                    )
+                };
                 let gx = level.grid_x[anchor];
                 let gy = level.grid_y[anchor];
                 let xywh = dist2bbox_anchor_f32(ltrb, gx, gy, level.stride);
@@ -296,19 +302,45 @@ macro_rules! impl_ltrb_level_f32_neon {
             debug_assert_eq!(input.len(), h * w * 4);
             debug_assert_eq!(dst.len(), 4 * h * w);
 
-            // Batch-dequant: NEON shines on the whole tensor (h*w*4 = up
-            // to 25600 elements at level 0); per-anchor 4 elements alone
-            // wouldn't fill a single NEON chunk. Heap scratch is small
-            // and Phase 2-B can move this to a reusable per-frame buffer
-            // (alongside the layout transpose scratch).
             let n = h * w * 4;
             let mut deq: Vec<f32> = vec![0.0_f32; n];
             // SAFETY: NEON mandatory on aarch64; dispatch contract.
             unsafe {
                 crate::per_scale::kernels::neon_baseline::$dequant_neon(input, q, &mut deq);
             }
-            // Per-anchor dist2bbox over the dequantized tensor.
-            for anchor in 0..(h * w) {
+
+            // Batch-4 NEON dist2bbox for the bulk of anchors.
+            let n_anchors = h * w;
+            let batch4 = n_anchors / 4;
+            for b in 0..batch4 {
+                let a0 = b * 4;
+                let ltrb_base = a0 * 4;
+                let gx_batch = [
+                    level.grid_x[a0],
+                    level.grid_x[a0 + 1],
+                    level.grid_x[a0 + 2],
+                    level.grid_x[a0 + 3],
+                ];
+                let gy_batch = [
+                    level.grid_y[a0],
+                    level.grid_y[a0 + 1],
+                    level.grid_y[a0 + 2],
+                    level.grid_y[a0 + 3],
+                ];
+                // SAFETY: NEON mandatory on aarch64. deq is contiguous
+                // [l0,t0,r0,b0, l1,t1,r1,b1, ...] — 16 floats per batch.
+                unsafe {
+                    crate::per_scale::kernels::neon_baseline::dist2bbox_4anchors_f32_neon(
+                        &deq[ltrb_base..ltrb_base + 16],
+                        &gx_batch,
+                        &gy_batch,
+                        level.stride,
+                        &mut dst[ltrb_base..ltrb_base + 16],
+                    );
+                }
+            }
+            // Scalar tail for remaining anchors.
+            for anchor in (batch4 * 4)..n_anchors {
                 let base = anchor * 4;
                 let dq = [deq[base], deq[base + 1], deq[base + 2], deq[base + 3]];
                 let gx = level.grid_x[anchor];
@@ -343,6 +375,119 @@ impl_ltrb_level_f32_neon!(
     decode_box_level_ltrb_u16_to_f32_neon,
     u16,
     dequant_u16_to_f32_neon
+);
+
+// ────────────────────────────────────────────────────────────────────────
+// Fused DFL box level kernels (online-softmax inspired)
+//
+// Replaces the separate softmax + weighted_sum calls with a single
+// fused kernel that computes Σ(exp(x-m)×i)/Σ(exp(x-m)) in-register.
+// Eliminates 256 memory ops per anchor (64 per side × 4 sides):
+//   - No intermediate probability store/reload
+//   - No normalize pass
+//   - Single scalar divide at the end
+//
+// Used as the default NEON DFL path (replaces the separate-pass version).
+// ────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_arch = "aarch64")]
+macro_rules! impl_dfl_level_f32_neon_fused {
+    ($name:ident, $i:ty, $dequant_neon:ident, $fused_ws:ident) => {
+        #[allow(dead_code)]
+        pub(crate) fn $name(input: &[$i], q: Quantization, level: &LevelPlan, dst: &mut [f32]) {
+            let h = level.h;
+            let w = level.w;
+            let reg_max = level.reg_max;
+            debug_assert_eq!(input.len(), h * w * 4 * reg_max);
+            debug_assert_eq!(dst.len(), 4 * h * w);
+            debug_assert!(reg_max <= MAX_REG_MAX);
+
+            let mut deq: [f32; 4 * MAX_REG_MAX] = [0.0_f32; 4 * MAX_REG_MAX];
+            for anchor in 0..(h * w) {
+                let in_base = anchor * 4 * reg_max;
+                // SAFETY: NEON mandatory on aarch64; dispatch contract.
+                unsafe {
+                    crate::per_scale::kernels::neon_baseline::$dequant_neon(
+                        &input[in_base..in_base + 4 * reg_max],
+                        q,
+                        &mut deq[..4 * reg_max],
+                    );
+                }
+                // Fused softmax+weighted_sum — no intermediate store.
+                let ltrb = unsafe {
+                    crate::per_scale::kernels::neon_baseline::$fused_ws(
+                        &deq[..4 * reg_max],
+                        reg_max,
+                    )
+                };
+                let gx = level.grid_x[anchor];
+                let gy = level.grid_y[anchor];
+                let xywh = dist2bbox_anchor_f32(ltrb, gx, gy, level.stride);
+                let out_base = anchor * 4;
+                dst[out_base..out_base + 4].copy_from_slice(&xywh);
+            }
+        }
+    };
+}
+
+// Fused f32 variants (Tier-1 NEON baseline).
+#[cfg(target_arch = "aarch64")]
+impl_dfl_level_f32_neon_fused!(
+    decode_box_level_dfl_i8_to_f32_neon_fused,
+    i8,
+    dequant_i8_to_f32_neon,
+    softmax_weighted_sum_4sides_f32_neon
+);
+#[cfg(target_arch = "aarch64")]
+impl_dfl_level_f32_neon_fused!(
+    decode_box_level_dfl_u8_to_f32_neon_fused,
+    u8,
+    dequant_u8_to_f32_neon,
+    softmax_weighted_sum_4sides_f32_neon
+);
+#[cfg(target_arch = "aarch64")]
+impl_dfl_level_f32_neon_fused!(
+    decode_box_level_dfl_i16_to_f32_neon_fused,
+    i16,
+    dequant_i16_to_f32_neon,
+    softmax_weighted_sum_4sides_f32_neon
+);
+#[cfg(target_arch = "aarch64")]
+impl_dfl_level_f32_neon_fused!(
+    decode_box_level_dfl_u16_to_f32_neon_fused,
+    u16,
+    dequant_u16_to_f32_neon,
+    softmax_weighted_sum_4sides_f32_neon
+);
+
+// Fused FP16 variants (Tier-2 FP16 exp path).
+#[cfg(target_arch = "aarch64")]
+impl_dfl_level_f32_neon_fused!(
+    decode_box_level_dfl_i8_to_f32_neon_fused_fp16,
+    i8,
+    dequant_i8_to_f32_neon,
+    softmax_weighted_sum_4sides_f32_neon_fp16
+);
+#[cfg(target_arch = "aarch64")]
+impl_dfl_level_f32_neon_fused!(
+    decode_box_level_dfl_u8_to_f32_neon_fused_fp16,
+    u8,
+    dequant_u8_to_f32_neon,
+    softmax_weighted_sum_4sides_f32_neon_fp16
+);
+#[cfg(target_arch = "aarch64")]
+impl_dfl_level_f32_neon_fused!(
+    decode_box_level_dfl_i16_to_f32_neon_fused_fp16,
+    i16,
+    dequant_i16_to_f32_neon,
+    softmax_weighted_sum_4sides_f32_neon_fp16
+);
+#[cfg(target_arch = "aarch64")]
+impl_dfl_level_f32_neon_fused!(
+    decode_box_level_dfl_u16_to_f32_neon_fused_fp16,
+    u16,
+    dequant_u16_to_f32_neon,
+    softmax_weighted_sum_4sides_f32_neon_fp16
 );
 
 #[cfg(test)]

--- a/crates/decoder/src/per_scale/kernels/level_score.rs
+++ b/crates/decoder/src/per_scale/kernels/level_score.rs
@@ -178,6 +178,71 @@ impl_score_level_f32_neon!(
     sigmoid_slice_f32_neon_fp16
 );
 
+// ────────────────────────────────────────────────────────────────────────
+// Fused dequant+sigmoid NEON score-level kernels
+//
+// For quantized integer inputs (i8, u8, i16, u16) with Sigmoid activation,
+// these use a single-pass kernel that dequants and applies sigmoid without
+// writing then re-reading the intermediate f32 buffer. When activation is
+// not Sigmoid, falls back to the two-pass NEON dequant path (no sigmoid).
+// ────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_arch = "aarch64")]
+macro_rules! impl_score_level_f32_neon_fused {
+    ($name:ident, $i:ty, $fused:ident, $dequant_neon:ident) => {
+        #[allow(dead_code)]
+        pub(crate) fn $name(
+            input: &[$i],
+            q: Quantization,
+            num_classes: usize,
+            level: &LevelPlan,
+            activation: Activation,
+            dst: &mut [f32],
+        ) {
+            let n = level.h * level.w * num_classes;
+            debug_assert_eq!(input.len(), n);
+            debug_assert_eq!(dst.len(), n);
+            // SAFETY: NEON is mandatory on aarch64; dispatch contract.
+            unsafe {
+                if activation == Activation::Sigmoid {
+                    crate::per_scale::kernels::neon_baseline::$fused(input, q, dst);
+                } else {
+                    crate::per_scale::kernels::neon_baseline::$dequant_neon(input, q, dst);
+                }
+            }
+        }
+    };
+}
+
+#[cfg(target_arch = "aarch64")]
+impl_score_level_f32_neon_fused!(
+    decode_score_level_i8_to_f32_neon_fused,
+    i8,
+    dequant_sigmoid_i8_to_f32_neon,
+    dequant_i8_to_f32_neon
+);
+#[cfg(target_arch = "aarch64")]
+impl_score_level_f32_neon_fused!(
+    decode_score_level_u8_to_f32_neon_fused,
+    u8,
+    dequant_sigmoid_u8_to_f32_neon,
+    dequant_u8_to_f32_neon
+);
+#[cfg(target_arch = "aarch64")]
+impl_score_level_f32_neon_fused!(
+    decode_score_level_i16_to_f32_neon_fused,
+    i16,
+    dequant_sigmoid_i16_to_f32_neon,
+    dequant_i16_to_f32_neon
+);
+#[cfg(target_arch = "aarch64")]
+impl_score_level_f32_neon_fused!(
+    decode_score_level_u16_to_f32_neon_fused,
+    u16,
+    dequant_sigmoid_u16_to_f32_neon,
+    dequant_u16_to_f32_neon
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/decoder/src/per_scale/kernels/neon_baseline.rs
+++ b/crates/decoder/src/per_scale/kernels/neon_baseline.rs
@@ -22,8 +22,7 @@
 //! to roughly the L2 cache bandwidth on Cortex-A53, which scalar code
 //! can't approach.
 //!
-//! Phase 2-A (this module) covers Tier-1 NEON. Tier-2 FP16 and Tier-3
-//! DotProd live in sibling `neon_fp16.rs` / `neon_dotprod.rs` modules.
+//! Phase 2-A (this module) covers Tier-1 NEON baseline and Tier-2 FP16.
 
 #![cfg(target_arch = "aarch64")]
 #![allow(dead_code)] // Wired into dispatch in subsequent N-* tasks.
@@ -889,6 +888,829 @@ pub(crate) unsafe fn softmax_inplace_f32_neon_fp16(buf: &mut [f32]) {
     }
 }
 
+// ────────────────────────────────────────────────────────────────────────
+// NEON weighted-sum for DFL (#3)
+//
+// Vectorizes `weighted_sum_4sides_f32` by processing 4 probability-bin
+// products per cycle via `vfmaq_n_f32`. For reg_max = 16 (the common
+// case) each side is exactly 4 NEON iterations, totalling 16 FMAs.
+// On Cortex-A53 (single-issue, 1 FMA/cycle) this replaces 16 scalar
+// multiply-add pairs with 4 NEON FMAs — a ~4× per-side speedup.
+// ────────────────────────────────────────────────────────────────────────
+
+/// NEON weighted-sum for 4 DFL sides.
+///
+/// `probs.len() == 4 * reg_max`, side-major layout. Returns `[d_left,
+/// d_top, d_right, d_bottom]` — same contract as the scalar version.
+///
+/// # Safety
+/// Caller must ensure NEON is available (always true on aarch64).
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn weighted_sum_4sides_f32_neon(probs: &[f32], reg_max: usize) -> [f32; 4] {
+    debug_assert_eq!(probs.len(), 4 * reg_max);
+    let mut d = [0.0_f32; 4];
+    let chunks_4 = reg_max / 4;
+    let ptr = probs.as_ptr();
+
+    for (side, slot) in d.iter_mut().enumerate() {
+        let base = side * reg_max;
+        let mut acc = vdupq_n_f32(0.0);
+        let mut bin_idx = 0usize;
+
+        for _ in 0..chunks_4 {
+            let p = vld1q_f32(ptr.add(base + bin_idx));
+            // Bin indices as f32: [bin_idx, bin_idx+1, bin_idx+2, bin_idx+3]
+            let bins = [
+                bin_idx as f32,
+                (bin_idx + 1) as f32,
+                (bin_idx + 2) as f32,
+                (bin_idx + 3) as f32,
+            ];
+            let bins_v = vld1q_f32(bins.as_ptr());
+            acc = vfmaq_f32(acc, p, bins_v);
+            bin_idx += 4;
+        }
+
+        // Horizontal sum of acc.
+        *slot = vaddvq_f32(acc);
+
+        // Scalar tail for reg_max not divisible by 4.
+        while bin_idx < reg_max {
+            *slot += *ptr.add(base + bin_idx) * (bin_idx as f32);
+            bin_idx += 1;
+        }
+    }
+    d
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// NEON fused softmax + weighted_sum
+//
+// Online-softmax-inspired fusion: computes the DFL weighted sum directly
+// from the dequantized logits WITHOUT materializing the intermediate
+// probability vector. For each side:
+//
+//   result = Σ(exp(x[i] - max) × i) / Σ(exp(x[i] - max))
+//
+// This is algebraically identical to softmax(x) · [0,1,...,reg_max-1],
+// but eliminates all intermediate memory traffic:
+//   - 16 stores (softmax writes exp values)
+//   - 16 loads  (softmax reads for normalize pass)
+//   - 16 stores (softmax writes normalized probs)
+//   - 16 loads  (weighted_sum reads probs)
+// = 64 memory ops eliminated per side × 4 sides = 256 per anchor.
+//
+// The kernel is 2-pass over the data instead of 5-pass:
+//   Pass 1: find max (NEON vmaxq_f32 reduction)
+//   Pass 2: exp(x-max) accumulated into sum + weighted_sum in-register
+//
+// For reg_max=16 (the common case), pass 2 processes 4 NEON vectors
+// with precomputed bin-index constants [0..3], [4..7], [8..11], [12..15].
+// Everything stays in registers — no store/reload between exp and the
+// final scalar divide.
+// ────────────────────────────────────────────────────────────────────────
+
+/// Fused softmax + weighted_sum for 4 DFL sides, NEON f32.
+///
+/// `logits` is a dequantized buffer with layout `[side0..side3]`, each
+/// side containing `reg_max` contiguous f32 values. Returns `[d_left,
+/// d_top, d_right, d_bottom]` — same contract as calling
+/// `softmax_inplace` then `weighted_sum_4sides_f32_neon` but faster.
+///
+/// # Safety
+/// Caller must ensure NEON is available (always true on aarch64).
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn softmax_weighted_sum_4sides_f32_neon(
+    logits: &[f32],
+    reg_max: usize,
+) -> [f32; 4] {
+    debug_assert_eq!(logits.len(), 4 * reg_max);
+    let mut d = [0.0_f32; 4];
+    let chunks_4 = reg_max / 4;
+    let ptr = logits.as_ptr();
+
+    for (side, slot) in d.iter_mut().enumerate() {
+        let base = side * reg_max;
+
+        // ── Pass 1: find max ──
+        let mut m = f32::NEG_INFINITY;
+        if chunks_4 > 0 {
+            let mut max_v = vld1q_f32(ptr.add(base));
+            for c in 1..chunks_4 {
+                let v = vld1q_f32(ptr.add(base + c * 4));
+                max_v = vmaxq_f32(max_v, v);
+            }
+            m = vmaxvq_f32(max_v);
+        }
+        // Scalar tail for non-multiple-of-4 reg_max.
+        let tail_start = chunks_4 * 4;
+        for i in tail_start..reg_max {
+            let v = *ptr.add(base + i);
+            if v > m {
+                m = v;
+            }
+        }
+
+        // ── Pass 2: fused exp + sum + weighted_sum ──
+        let m_v = vdupq_n_f32(m);
+        let mut sum_v = vdupq_n_f32(0.0);
+        let mut ws_v = vdupq_n_f32(0.0);
+        let mut bin_idx = 0usize;
+
+        for _ in 0..chunks_4 {
+            let v = vld1q_f32(ptr.add(base + bin_idx));
+            let e = expf_neon_f32x4(vsubq_f32(v, m_v));
+            sum_v = vaddq_f32(sum_v, e);
+            // Bin indices [bin_idx, bin_idx+1, bin_idx+2, bin_idx+3]
+            let bins = [
+                bin_idx as f32,
+                (bin_idx + 1) as f32,
+                (bin_idx + 2) as f32,
+                (bin_idx + 3) as f32,
+            ];
+            let bins_v = vld1q_f32(bins.as_ptr());
+            ws_v = vfmaq_f32(ws_v, e, bins_v);
+            bin_idx += 4;
+        }
+
+        let mut sum = vaddvq_f32(sum_v);
+        let mut ws = vaddvq_f32(ws_v);
+
+        // Scalar tail.
+        while bin_idx < reg_max {
+            let e = (*ptr.add(base + bin_idx) - m).exp();
+            sum += e;
+            ws += e * (bin_idx as f32);
+            bin_idx += 1;
+        }
+
+        // Single divide instead of per-element normalize.
+        *slot = if sum > 0.0 { ws / sum } else { 0.0 };
+    }
+    d
+}
+
+/// Fused softmax + weighted_sum for 4 DFL sides, FP16 exp path.
+///
+/// Same semantics as `softmax_weighted_sum_4sides_f32_neon` but uses the
+/// 8-lane FP16 exp approximation for ~2× exp throughput on Cortex-A55+.
+/// Max-finding and accumulation remain in f32 for precision.
+///
+/// # Safety
+/// Caller must ensure FP16 NEON is available (Cortex-A55+).
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn softmax_weighted_sum_4sides_f32_neon_fp16(
+    logits: &[f32],
+    reg_max: usize,
+) -> [f32; 4] {
+    debug_assert_eq!(logits.len(), 4 * reg_max);
+    let mut d = [0.0_f32; 4];
+    let chunks_8 = reg_max / 8;
+    let chunks_4 = reg_max / 4;
+    let ptr = logits.as_ptr();
+
+    for (side, slot) in d.iter_mut().enumerate() {
+        let base = side * reg_max;
+
+        // ── Pass 1: find max (f32 for precision) ──
+        let mut m = f32::NEG_INFINITY;
+        if chunks_4 > 0 {
+            let mut max_v = vld1q_f32(ptr.add(base));
+            for c in 1..chunks_4 {
+                let v = vld1q_f32(ptr.add(base + c * 4));
+                max_v = vmaxq_f32(max_v, v);
+            }
+            m = vmaxvq_f32(max_v);
+        }
+        let tail_start_4 = chunks_4 * 4;
+        for i in tail_start_4..reg_max {
+            let v = *ptr.add(base + i);
+            if v > m {
+                m = v;
+            }
+        }
+
+        // ── Pass 2: fused exp(fp16) + sum + weighted_sum ──
+        let m_v = vdupq_n_f32(m);
+        let mut sum_v = vdupq_n_f32(0.0);
+        let mut ws_v = vdupq_n_f32(0.0);
+        let mut bin_idx = 0usize;
+
+        // Process 8 elements at a time via FP16 exp.
+        for _ in 0..chunks_8 {
+            let lo = vld1q_f32(ptr.add(base + bin_idx));
+            let hi = vld1q_f32(ptr.add(base + bin_idx + 4));
+            let s_lo = vsubq_f32(lo, m_v);
+            let s_hi = vsubq_f32(hi, m_v);
+            let (e_lo, e_hi) = expf_neon_f32x8_via_f16(s_lo, s_hi);
+
+            sum_v = vaddq_f32(sum_v, e_lo);
+            sum_v = vaddq_f32(sum_v, e_hi);
+
+            let bins_lo = [
+                bin_idx as f32,
+                (bin_idx + 1) as f32,
+                (bin_idx + 2) as f32,
+                (bin_idx + 3) as f32,
+            ];
+            let bins_hi = [
+                (bin_idx + 4) as f32,
+                (bin_idx + 5) as f32,
+                (bin_idx + 6) as f32,
+                (bin_idx + 7) as f32,
+            ];
+            ws_v = vfmaq_f32(ws_v, e_lo, vld1q_f32(bins_lo.as_ptr()));
+            ws_v = vfmaq_f32(ws_v, e_hi, vld1q_f32(bins_hi.as_ptr()));
+            bin_idx += 8;
+        }
+
+        // Handle 4-element remainder (reg_max % 8 >= 4).
+        if bin_idx + 4 <= reg_max {
+            let v = vld1q_f32(ptr.add(base + bin_idx));
+            let e = expf_neon_f32x4(vsubq_f32(v, m_v));
+            sum_v = vaddq_f32(sum_v, e);
+            let bins = [
+                bin_idx as f32,
+                (bin_idx + 1) as f32,
+                (bin_idx + 2) as f32,
+                (bin_idx + 3) as f32,
+            ];
+            ws_v = vfmaq_f32(ws_v, e, vld1q_f32(bins.as_ptr()));
+            bin_idx += 4;
+        }
+
+        let mut sum = vaddvq_f32(sum_v);
+        let mut ws = vaddvq_f32(ws_v);
+
+        // Scalar tail.
+        while bin_idx < reg_max {
+            let e = (*ptr.add(base + bin_idx) - m).exp();
+            sum += e;
+            ws += e * (bin_idx as f32);
+            bin_idx += 1;
+        }
+
+        *slot = if sum > 0.0 { ws / sum } else { 0.0 };
+    }
+    d
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// NEON dist2bbox — batch 4 anchors (#4)
+//
+// Processes 4 anchors simultaneously by loading their LTRB distances,
+// grid centres, and stride into float32x4_t lanes. Each lane computes
+// one anchor's xc/yc/w/h independently. For an 80×80 FPN level (6400
+// anchors), this reduces 6400 scalar iterations to 1600 NEON batches.
+// ────────────────────────────────────────────────────────────────────────
+
+/// Batch dist2bbox for 4 anchors. `ltrb` is `[l0,t0,r0,b0, l1,t1,r1,b1,
+/// ...]` (anchor-major). `gx`/`gy` are 4 grid centres. Output is
+/// `[xc0,yc0,w0,h0, xc1,...,h3]` written to `dst`.
+///
+/// # Safety
+/// Caller must ensure `ltrb.len() >= 16`, `gx.len() >= 4`,
+/// `gy.len() >= 4`, `dst.len() >= 16`, and NEON is available.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dist2bbox_4anchors_f32_neon(
+    ltrb: &[f32],
+    gx: &[f32],
+    gy: &[f32],
+    stride: f32,
+    dst: &mut [f32],
+) {
+    debug_assert!(ltrb.len() >= 16);
+    debug_assert!(gx.len() >= 4 && gy.len() >= 4);
+    debug_assert!(dst.len() >= 16);
+
+    let half = vdupq_n_f32(0.5);
+    let stride_v = vdupq_n_f32(stride);
+
+    // Load LTRB for 4 anchors (each has 4 values, total 16 floats).
+    // Memory layout: [l0,t0,r0,b0, l1,t1,r1,b1, l2,t2,r2,b2, l3,t3,r3,b3]
+    // We need to transpose to get [l0,l1,l2,l3], [t0,...], [r0,...], [b0,...].
+    let a0 = vld1q_f32(ltrb.as_ptr()); // l0,t0,r0,b0
+    let a1 = vld1q_f32(ltrb.as_ptr().add(4)); // l1,t1,r1,b1
+    let a2 = vld1q_f32(ltrb.as_ptr().add(8)); // l2,t2,r2,b2
+    let a3 = vld1q_f32(ltrb.as_ptr().add(12)); // l3,t3,r3,b3
+
+    // 4×4 transpose using TRN + ZIP.
+    let t01_lo = vtrn1q_f32(a0, a1); // l0,l1,r0,r1
+    let t01_hi = vtrn2q_f32(a0, a1); // t0,t1,b0,b1
+    let t23_lo = vtrn1q_f32(a2, a3); // l2,l3,r2,r3
+    let t23_hi = vtrn2q_f32(a2, a3); // t2,t3,b2,b3
+
+    // Interleave 64-bit halves to finish the transpose.
+    let d_left = vreinterpretq_f32_f64(vtrn1q_f64(
+        vreinterpretq_f64_f32(t01_lo),
+        vreinterpretq_f64_f32(t23_lo),
+    )); // l0,l1,l2,l3
+    let d_top = vreinterpretq_f32_f64(vtrn1q_f64(
+        vreinterpretq_f64_f32(t01_hi),
+        vreinterpretq_f64_f32(t23_hi),
+    )); // t0,t1,t2,t3
+    let d_right = vreinterpretq_f32_f64(vtrn2q_f64(
+        vreinterpretq_f64_f32(t01_lo),
+        vreinterpretq_f64_f32(t23_lo),
+    )); // r0,r1,r2,r3
+    let d_bottom = vreinterpretq_f32_f64(vtrn2q_f64(
+        vreinterpretq_f64_f32(t01_hi),
+        vreinterpretq_f64_f32(t23_hi),
+    )); // b0,b1,b2,b3
+
+    let gx_v = vld1q_f32(gx.as_ptr());
+    let gy_v = vld1q_f32(gy.as_ptr());
+
+    // xc = (gx + (right - left) * 0.5) * stride
+    let xc = vmulq_f32(vfmaq_f32(gx_v, vsubq_f32(d_right, d_left), half), stride_v);
+    // yc = (gy + (bottom - top) * 0.5) * stride
+    let yc = vmulq_f32(vfmaq_f32(gy_v, vsubq_f32(d_bottom, d_top), half), stride_v);
+    // w = (left + right) * stride
+    let w = vmulq_f32(vaddq_f32(d_left, d_right), stride_v);
+    // h = (top + bottom) * stride
+    let h = vmulq_f32(vaddq_f32(d_top, d_bottom), stride_v);
+
+    // Transpose back: [xc0,yc0,w0,h0, xc1,...] — reverse the 4×4 transpose.
+    let r01_lo = vtrn1q_f32(xc, yc); // xc0,yc0,xc2,yc2
+    let r01_hi = vtrn2q_f32(xc, yc); // xc1,yc1,xc3,yc3
+    let r23_lo = vtrn1q_f32(w, h); // w0,h0,w2,h2
+    let r23_hi = vtrn2q_f32(w, h); // w1,h1,w3,h3
+
+    let out0 = vreinterpretq_f32_f64(vtrn1q_f64(
+        vreinterpretq_f64_f32(r01_lo),
+        vreinterpretq_f64_f32(r23_lo),
+    )); // xc0,yc0,w0,h0
+    let out1 = vreinterpretq_f32_f64(vtrn1q_f64(
+        vreinterpretq_f64_f32(r01_hi),
+        vreinterpretq_f64_f32(r23_hi),
+    )); // xc1,yc1,w1,h1
+    let out2 = vreinterpretq_f32_f64(vtrn2q_f64(
+        vreinterpretq_f64_f32(r01_lo),
+        vreinterpretq_f64_f32(r23_lo),
+    )); // xc2,yc2,w2,h2
+    let out3 = vreinterpretq_f32_f64(vtrn2q_f64(
+        vreinterpretq_f64_f32(r01_hi),
+        vreinterpretq_f64_f32(r23_hi),
+    )); // xc3,yc3,w3,h3
+
+    vst1q_f32(dst.as_mut_ptr(), out0);
+    vst1q_f32(dst.as_mut_ptr().add(4), out1);
+    vst1q_f32(dst.as_mut_ptr().add(8), out2);
+    vst1q_f32(dst.as_mut_ptr().add(12), out3);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Fused dequant+sigmoid (#5)
+//
+// The score-level pipeline currently runs two passes: dequant → sigmoid.
+// Each pass reads and writes the full score tensor (~80×80×80 = 512 KB
+// at level 0). Fusing into a single pass eliminates the intermediate
+// store→reload — saving ~10% decode time on bandwidth-bound Cortex-A53
+// where the L2→register round-trip dominates.
+// ────────────────────────────────────────────────────────────────────────
+
+/// Fused NEON i8 dequant + sigmoid. Output is sigmoid((in - zp) * scale).
+///
+/// # Safety
+/// See `dequant_i8_to_f32_neon`.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dequant_sigmoid_i8_to_f32_neon(
+    input: &[i8],
+    q: Quantization,
+    output: &mut [f32],
+) {
+    debug_assert_eq!(input.len(), output.len());
+    let scale = q.scale;
+    let bias_v = vdupq_n_f32(affine_bias(q));
+    let zero = vdupq_n_f32(0.0);
+    let one = vdupq_n_f32(1.0);
+    let n = input.len();
+    let chunks_16 = n / 16;
+    let mut i = 0usize;
+    let in_ptr = input.as_ptr();
+    let out_ptr = output.as_mut_ptr();
+
+    for _ in 0..chunks_16 {
+        let v_i8 = vld1q_s8(in_ptr.add(i));
+        let lo_i16 = vmovl_s8(vget_low_s8(v_i8));
+        let hi_i16 = vmovl_high_s8(v_i8);
+        let q0 = vmovl_s16(vget_low_s16(lo_i16));
+        let q1 = vmovl_high_s16(lo_i16);
+        let q2 = vmovl_s16(vget_low_s16(hi_i16));
+        let q3 = vmovl_high_s16(hi_i16);
+
+        // Dequant: bias + scale * in
+        let x0 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(q0), scale);
+        let x1 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(q1), scale);
+        let x2 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(q2), scale);
+        let x3 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(q3), scale);
+
+        // Inline sigmoid for each quad.
+        macro_rules! sigmoid4 {
+            ($x:expr) => {{
+                let mask = vcgeq_f32($x, zero);
+                let neg_x = vnegq_f32($x);
+                let exp_in = vbslq_f32(mask, neg_x, $x);
+                let e = expf_neon_f32x4(exp_in);
+                let one_plus_e = vaddq_f32(one, e);
+                let recip = vdivq_f32(one, one_plus_e);
+                let neg_branch = vmulq_f32(e, recip);
+                vbslq_f32(mask, recip, neg_branch)
+            }};
+        }
+
+        vst1q_f32(out_ptr.add(i), sigmoid4!(x0));
+        vst1q_f32(out_ptr.add(i + 4), sigmoid4!(x1));
+        vst1q_f32(out_ptr.add(i + 8), sigmoid4!(x2));
+        vst1q_f32(out_ptr.add(i + 12), sigmoid4!(x3));
+        i += 16;
+    }
+
+    // Scalar tail.
+    let zp = q.zero_point as f32;
+    while i < n {
+        let x = (*in_ptr.add(i) as f32 - zp) * scale;
+        *out_ptr.add(i) = if x >= 0.0 {
+            let e = (-x).exp();
+            1.0 / (1.0 + e)
+        } else {
+            let e = x.exp();
+            e / (1.0 + e)
+        };
+        i += 1;
+    }
+}
+
+/// Fused NEON u8 dequant + sigmoid.
+///
+/// # Safety
+/// See `dequant_i8_to_f32_neon`.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dequant_sigmoid_u8_to_f32_neon(
+    input: &[u8],
+    q: Quantization,
+    output: &mut [f32],
+) {
+    debug_assert_eq!(input.len(), output.len());
+    let scale = q.scale;
+    let bias_v = vdupq_n_f32(affine_bias(q));
+    let zero = vdupq_n_f32(0.0);
+    let one = vdupq_n_f32(1.0);
+    let n = input.len();
+    let chunks_16 = n / 16;
+    let mut i = 0usize;
+    let in_ptr = input.as_ptr();
+    let out_ptr = output.as_mut_ptr();
+
+    for _ in 0..chunks_16 {
+        let v_u8 = vld1q_u8(in_ptr.add(i));
+        let lo_u16 = vmovl_u8(vget_low_u8(v_u8));
+        let hi_u16 = vmovl_high_u8(v_u8);
+        let q0 = vmovl_u16(vget_low_u16(lo_u16));
+        let q1 = vmovl_high_u16(lo_u16);
+        let q2 = vmovl_u16(vget_low_u16(hi_u16));
+        let q3 = vmovl_high_u16(hi_u16);
+
+        let x0 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(q0), scale);
+        let x1 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(q1), scale);
+        let x2 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(q2), scale);
+        let x3 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(q3), scale);
+
+        macro_rules! sigmoid4 {
+            ($x:expr) => {{
+                let mask = vcgeq_f32($x, zero);
+                let neg_x = vnegq_f32($x);
+                let exp_in = vbslq_f32(mask, neg_x, $x);
+                let e = expf_neon_f32x4(exp_in);
+                let one_plus_e = vaddq_f32(one, e);
+                let recip = vdivq_f32(one, one_plus_e);
+                let neg_branch = vmulq_f32(e, recip);
+                vbslq_f32(mask, recip, neg_branch)
+            }};
+        }
+
+        vst1q_f32(out_ptr.add(i), sigmoid4!(x0));
+        vst1q_f32(out_ptr.add(i + 4), sigmoid4!(x1));
+        vst1q_f32(out_ptr.add(i + 8), sigmoid4!(x2));
+        vst1q_f32(out_ptr.add(i + 12), sigmoid4!(x3));
+        i += 16;
+    }
+
+    let zp = q.zero_point as f32;
+    while i < n {
+        let x = (*in_ptr.add(i) as f32 - zp) * scale;
+        *out_ptr.add(i) = if x >= 0.0 {
+            let e = (-x).exp();
+            1.0 / (1.0 + e)
+        } else {
+            let e = x.exp();
+            e / (1.0 + e)
+        };
+        i += 1;
+    }
+}
+
+/// Fused NEON i16 dequant + sigmoid.
+///
+/// # Safety
+/// See `dequant_i8_to_f32_neon`.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dequant_sigmoid_i16_to_f32_neon(
+    input: &[i16],
+    q: Quantization,
+    output: &mut [f32],
+) {
+    debug_assert_eq!(input.len(), output.len());
+    let scale = q.scale;
+    let bias_v = vdupq_n_f32(affine_bias(q));
+    let zero = vdupq_n_f32(0.0);
+    let one = vdupq_n_f32(1.0);
+    let n = input.len();
+    let chunks_8 = n / 8;
+    let mut i = 0usize;
+    let in_ptr = input.as_ptr();
+    let out_ptr = output.as_mut_ptr();
+
+    for _ in 0..chunks_8 {
+        let v_i16 = vld1q_s16(in_ptr.add(i));
+        let lo_i32 = vmovl_s16(vget_low_s16(v_i16));
+        let hi_i32 = vmovl_high_s16(v_i16);
+        let x0 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(lo_i32), scale);
+        let x1 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(hi_i32), scale);
+
+        macro_rules! sigmoid4 {
+            ($x:expr) => {{
+                let mask = vcgeq_f32($x, zero);
+                let neg_x = vnegq_f32($x);
+                let exp_in = vbslq_f32(mask, neg_x, $x);
+                let e = expf_neon_f32x4(exp_in);
+                let one_plus_e = vaddq_f32(one, e);
+                let recip = vdivq_f32(one, one_plus_e);
+                let neg_branch = vmulq_f32(e, recip);
+                vbslq_f32(mask, recip, neg_branch)
+            }};
+        }
+
+        vst1q_f32(out_ptr.add(i), sigmoid4!(x0));
+        vst1q_f32(out_ptr.add(i + 4), sigmoid4!(x1));
+        i += 8;
+    }
+
+    let zp = q.zero_point as f32;
+    while i < n {
+        let x = (*in_ptr.add(i) as f32 - zp) * scale;
+        *out_ptr.add(i) = if x >= 0.0 {
+            let e = (-x).exp();
+            1.0 / (1.0 + e)
+        } else {
+            let e = x.exp();
+            e / (1.0 + e)
+        };
+        i += 1;
+    }
+}
+
+/// Fused NEON u16 dequant + sigmoid.
+///
+/// # Safety
+/// See `dequant_i8_to_f32_neon`.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dequant_sigmoid_u16_to_f32_neon(
+    input: &[u16],
+    q: Quantization,
+    output: &mut [f32],
+) {
+    debug_assert_eq!(input.len(), output.len());
+    let scale = q.scale;
+    let bias_v = vdupq_n_f32(affine_bias(q));
+    let zero = vdupq_n_f32(0.0);
+    let one = vdupq_n_f32(1.0);
+    let n = input.len();
+    let chunks_8 = n / 8;
+    let mut i = 0usize;
+    let in_ptr = input.as_ptr();
+    let out_ptr = output.as_mut_ptr();
+
+    for _ in 0..chunks_8 {
+        let v_u16 = vld1q_u16(in_ptr.add(i));
+        let lo_u32 = vmovl_u16(vget_low_u16(v_u16));
+        let hi_u32 = vmovl_high_u16(v_u16);
+        let x0 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(lo_u32), scale);
+        let x1 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(hi_u32), scale);
+
+        macro_rules! sigmoid4 {
+            ($x:expr) => {{
+                let mask = vcgeq_f32($x, zero);
+                let neg_x = vnegq_f32($x);
+                let exp_in = vbslq_f32(mask, neg_x, $x);
+                let e = expf_neon_f32x4(exp_in);
+                let one_plus_e = vaddq_f32(one, e);
+                let recip = vdivq_f32(one, one_plus_e);
+                let neg_branch = vmulq_f32(e, recip);
+                vbslq_f32(mask, recip, neg_branch)
+            }};
+        }
+
+        vst1q_f32(out_ptr.add(i), sigmoid4!(x0));
+        vst1q_f32(out_ptr.add(i + 4), sigmoid4!(x1));
+        i += 8;
+    }
+
+    let zp = q.zero_point as f32;
+    while i < n {
+        let x = (*in_ptr.add(i) as f32 - zp) * scale;
+        *out_ptr.add(i) = if x >= 0.0 {
+            let e = (-x).exp();
+            1.0 / (1.0 + e)
+        } else {
+            let e = x.exp();
+            e / (1.0 + e)
+        };
+        i += 1;
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Half-precision dequant output (#6)
+//
+// NEON dequant kernels that output f16 directly via `fcvtn`, halving
+// write bandwidth. The dequant math runs in f32 (preserving precision),
+// then narrows to f16 on the store path. Uses inline asm `.arch_extension
+// fp16` for the `fcvtn`/`fcvtn2` instructions since stable Rust doesn't
+// expose f16 intrinsics.
+// ────────────────────────────────────────────────────────────────────────
+
+/// Convert 4 f32 lanes to 4 f16 lanes (lower half of a uint16x8_t).
+///
+/// # Safety
+/// Caller must ensure NEON is available.
+#[inline]
+#[target_feature(enable = "neon")]
+unsafe fn fcvtn_f16x4_from_f32x4(x: float32x4_t) -> uint16x4_t {
+    let result: uint16x4_t;
+    core::arch::asm!(
+        ".arch_extension fp16",
+        "fcvtn {r:v}.4h, {x:v}.4s",
+        r = out(vreg) result,
+        x = in(vreg) x,
+        options(pure, nomem, nostack),
+    );
+    result
+}
+
+/// NEON i8 → f16 dequant. Dequantizes in f32, narrows to f16 on store.
+///
+/// # Safety
+/// See `dequant_i8_to_f32_neon`. Additionally requires FP16 for `fcvtn`.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dequant_i8_to_f16_neon(input: &[i8], q: Quantization, output: &mut [u16]) {
+    debug_assert_eq!(input.len(), output.len());
+    let scale = q.scale;
+    let bias_v = vdupq_n_f32(affine_bias(q));
+    let n = input.len();
+    let chunks_16 = n / 16;
+    let mut i = 0usize;
+    let in_ptr = input.as_ptr();
+    let out_ptr = output.as_mut_ptr();
+
+    for _ in 0..chunks_16 {
+        let v_i8 = vld1q_s8(in_ptr.add(i));
+        let lo_i16 = vmovl_s8(vget_low_s8(v_i8));
+        let hi_i16 = vmovl_high_s8(v_i8);
+        let q0 = vmovl_s16(vget_low_s16(lo_i16));
+        let q1 = vmovl_high_s16(lo_i16);
+        let q2 = vmovl_s16(vget_low_s16(hi_i16));
+        let q3 = vmovl_high_s16(hi_i16);
+        let f0 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(q0), scale);
+        let f1 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(q1), scale);
+        let f2 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(q2), scale);
+        let f3 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(q3), scale);
+        // Narrow to f16 and store.
+        vst1_u16(out_ptr.add(i), fcvtn_f16x4_from_f32x4(f0));
+        vst1_u16(out_ptr.add(i + 4), fcvtn_f16x4_from_f32x4(f1));
+        vst1_u16(out_ptr.add(i + 8), fcvtn_f16x4_from_f32x4(f2));
+        vst1_u16(out_ptr.add(i + 12), fcvtn_f16x4_from_f32x4(f3));
+        i += 16;
+    }
+
+    let zp = q.zero_point as f32;
+    while i < n {
+        let val = (*in_ptr.add(i) as f32 - zp) * scale;
+        *out_ptr.add(i) = half::f16::from_f32(val).to_bits();
+        i += 1;
+    }
+}
+
+/// NEON u8 → f16 dequant.
+///
+/// # Safety
+/// See `dequant_i8_to_f16_neon`.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dequant_u8_to_f16_neon(input: &[u8], q: Quantization, output: &mut [u16]) {
+    debug_assert_eq!(input.len(), output.len());
+    let scale = q.scale;
+    let bias_v = vdupq_n_f32(affine_bias(q));
+    let n = input.len();
+    let chunks_16 = n / 16;
+    let mut i = 0usize;
+    let in_ptr = input.as_ptr();
+    let out_ptr = output.as_mut_ptr();
+
+    for _ in 0..chunks_16 {
+        let v_u8 = vld1q_u8(in_ptr.add(i));
+        let lo_u16 = vmovl_u8(vget_low_u8(v_u8));
+        let hi_u16 = vmovl_high_u8(v_u8);
+        let q0 = vmovl_u16(vget_low_u16(lo_u16));
+        let q1 = vmovl_high_u16(lo_u16);
+        let q2 = vmovl_u16(vget_low_u16(hi_u16));
+        let q3 = vmovl_high_u16(hi_u16);
+        let f0 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(q0), scale);
+        let f1 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(q1), scale);
+        let f2 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(q2), scale);
+        let f3 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(q3), scale);
+        vst1_u16(out_ptr.add(i), fcvtn_f16x4_from_f32x4(f0));
+        vst1_u16(out_ptr.add(i + 4), fcvtn_f16x4_from_f32x4(f1));
+        vst1_u16(out_ptr.add(i + 8), fcvtn_f16x4_from_f32x4(f2));
+        vst1_u16(out_ptr.add(i + 12), fcvtn_f16x4_from_f32x4(f3));
+        i += 16;
+    }
+
+    let zp = q.zero_point as f32;
+    while i < n {
+        let val = (*in_ptr.add(i) as f32 - zp) * scale;
+        *out_ptr.add(i) = half::f16::from_f32(val).to_bits();
+        i += 1;
+    }
+}
+
+/// NEON i16 → f16 dequant.
+///
+/// # Safety
+/// See `dequant_i8_to_f16_neon`.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dequant_i16_to_f16_neon(input: &[i16], q: Quantization, output: &mut [u16]) {
+    debug_assert_eq!(input.len(), output.len());
+    let scale = q.scale;
+    let bias_v = vdupq_n_f32(affine_bias(q));
+    let n = input.len();
+    let chunks_8 = n / 8;
+    let mut i = 0usize;
+    let in_ptr = input.as_ptr();
+    let out_ptr = output.as_mut_ptr();
+
+    for _ in 0..chunks_8 {
+        let v_i16 = vld1q_s16(in_ptr.add(i));
+        let lo_i32 = vmovl_s16(vget_low_s16(v_i16));
+        let hi_i32 = vmovl_high_s16(v_i16);
+        let f0 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(lo_i32), scale);
+        let f1 = vfmaq_n_f32(bias_v, vcvtq_f32_s32(hi_i32), scale);
+        vst1_u16(out_ptr.add(i), fcvtn_f16x4_from_f32x4(f0));
+        vst1_u16(out_ptr.add(i + 4), fcvtn_f16x4_from_f32x4(f1));
+        i += 8;
+    }
+
+    let zp = q.zero_point as f32;
+    while i < n {
+        let val = (*in_ptr.add(i) as f32 - zp) * scale;
+        *out_ptr.add(i) = half::f16::from_f32(val).to_bits();
+        i += 1;
+    }
+}
+
+/// NEON u16 → f16 dequant.
+///
+/// # Safety
+/// See `dequant_i8_to_f16_neon`.
+#[target_feature(enable = "neon")]
+pub(crate) unsafe fn dequant_u16_to_f16_neon(input: &[u16], q: Quantization, output: &mut [u16]) {
+    debug_assert_eq!(input.len(), output.len());
+    let scale = q.scale;
+    let bias_v = vdupq_n_f32(affine_bias(q));
+    let n = input.len();
+    let chunks_8 = n / 8;
+    let mut i = 0usize;
+    let in_ptr = input.as_ptr();
+    let out_ptr = output.as_mut_ptr();
+
+    for _ in 0..chunks_8 {
+        let v_u16 = vld1q_u16(in_ptr.add(i));
+        let lo_u32 = vmovl_u16(vget_low_u16(v_u16));
+        let hi_u32 = vmovl_high_u16(v_u16);
+        let f0 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(lo_u32), scale);
+        let f1 = vfmaq_n_f32(bias_v, vcvtq_f32_u32(hi_u32), scale);
+        vst1_u16(out_ptr.add(i), fcvtn_f16x4_from_f32x4(f0));
+        vst1_u16(out_ptr.add(i + 4), fcvtn_f16x4_from_f32x4(f1));
+        i += 8;
+    }
+
+    let zp = q.zero_point as f32;
+    while i < n {
+        let val = (*in_ptr.add(i) as f32 - zp) * scale;
+        *out_ptr.add(i) = half::f16::from_f32(val).to_bits();
+        i += 1;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1307,5 +2129,239 @@ mod tests {
         }
         let sum: f32 = neon_buf.iter().sum();
         assert!((sum - 1.0).abs() < 1e-3, "fp16 softmax sum drift: {sum}");
+    }
+
+    // ── Tests for #3: NEON weighted sum ──────────────────────────────
+    use crate::per_scale::kernels::box_primitives::weighted_sum_4sides_f32;
+
+    #[test]
+    fn weighted_sum_neon_matches_scalar_uniform() {
+        let probs = [0.25_f32; 64]; // 4 sides × 16 bins, uniform
+        let scalar = weighted_sum_4sides_f32(&probs, 16);
+        let neon = unsafe { weighted_sum_4sides_f32_neon(&probs, 16) };
+        for (i, (&s, &n)) in scalar.iter().zip(neon.iter()).enumerate() {
+            assert!(
+                (s - n).abs() < 1e-4,
+                "weighted_sum uniform mismatch side {i}: scalar={s} neon={n}"
+            );
+        }
+    }
+
+    #[test]
+    fn weighted_sum_neon_matches_scalar_one_hot() {
+        let mut probs = [0.0_f32; 64];
+        for side in 0..4 {
+            probs[side * 16 + 5] = 1.0;
+        }
+        let scalar = weighted_sum_4sides_f32(&probs, 16);
+        let neon = unsafe { weighted_sum_4sides_f32_neon(&probs, 16) };
+        for (i, (&s, &n)) in scalar.iter().zip(neon.iter()).enumerate() {
+            assert!(
+                (s - n).abs() < 1e-5,
+                "weighted_sum one-hot mismatch side {i}: scalar={s} neon={n}"
+            );
+        }
+    }
+
+    // ── Tests for #4: NEON dist2bbox ─────────────────────────────────
+    use crate::per_scale::kernels::box_primitives::dist2bbox_anchor_f32;
+
+    #[test]
+    fn dist2bbox_4anchors_matches_scalar() {
+        // 4 anchors with distinct LTRB values.
+        let ltrb = [
+            2.0_f32, 2.0, 2.0, 2.0, // anchor 0: symmetric
+            1.0, 0.0, 3.0, 0.0, // anchor 1: l/r only
+            0.0, 1.0, 0.0, 3.0, // anchor 2: t/b only
+            5.0, 3.0, 7.0, 1.0, // anchor 3: asymmetric
+        ];
+        let gx = [0.5_f32, 0.5, 0.5, 0.5];
+        let gy = [0.5_f32, 0.5, 0.5, 0.5];
+        let stride = 8.0;
+        let mut neon_out = [0.0_f32; 16];
+        unsafe {
+            dist2bbox_4anchors_f32_neon(&ltrb, &gx, &gy, stride, &mut neon_out);
+        }
+        for a in 0..4 {
+            let ltrb_a = [
+                ltrb[a * 4],
+                ltrb[a * 4 + 1],
+                ltrb[a * 4 + 2],
+                ltrb[a * 4 + 3],
+            ];
+            let scalar = dist2bbox_anchor_f32(ltrb_a, gx[a], gy[a], stride);
+            for c in 0..4 {
+                assert!(
+                    (scalar[c] - neon_out[a * 4 + c]).abs() < 1e-4,
+                    "dist2bbox mismatch anchor={a} coord={c}: scalar={} neon={}",
+                    scalar[c],
+                    neon_out[a * 4 + c]
+                );
+            }
+        }
+    }
+
+    // ── Tests for #5: fused dequant+sigmoid ──────────────────────────
+
+    #[test]
+    fn fused_dequant_sigmoid_i8_matches_two_pass() {
+        let q = Quantization::new(0.1, 0);
+        let input: Vec<i8> = (-64..64).collect();
+        let mut two_pass = vec![0.0_f32; input.len()];
+        let mut fused = vec![0.0_f32; input.len()];
+
+        dequant_i8_to_f32(&input, q, &mut two_pass);
+        sigmoid_slice_f32(&mut two_pass);
+
+        unsafe {
+            dequant_sigmoid_i8_to_f32_neon(&input, q, &mut fused);
+        }
+
+        for (i, (&t, &f)) in two_pass.iter().zip(fused.iter()).enumerate() {
+            assert!(
+                close_within_ulp(t, f, 8),
+                "fused i8 mismatch at {i}: two_pass={t} fused={f}"
+            );
+        }
+    }
+
+    #[test]
+    fn fused_dequant_sigmoid_u8_matches_two_pass() {
+        let q = Quantization::new(0.05, 128);
+        let input: Vec<u8> = (0..=255).collect();
+        let mut two_pass = vec![0.0_f32; input.len()];
+        let mut fused = vec![0.0_f32; input.len()];
+
+        dequant_u8_to_f32(&input, q, &mut two_pass);
+        sigmoid_slice_f32(&mut two_pass);
+
+        unsafe {
+            dequant_sigmoid_u8_to_f32_neon(&input, q, &mut fused);
+        }
+
+        for (i, (&t, &f)) in two_pass.iter().zip(fused.iter()).enumerate() {
+            assert!(
+                close_within_ulp(t, f, 8),
+                "fused u8 mismatch at {i}: two_pass={t} fused={f}"
+            );
+        }
+    }
+
+    // ── Tests for #6: half-precision dequant output ──────────────────
+
+    #[test]
+    fn dequant_i8_to_f16_neon_matches_scalar() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return; // FP16 instructions not available (e.g. Cortex-A53).
+        }
+        let q = Quantization::new(0.1, -10);
+        let input: Vec<i8> = (-20..20).collect();
+        let mut neon_out = vec![0u16; input.len()];
+        let mut scalar_f32 = vec![0.0_f32; input.len()];
+        dequant_i8_to_f32(&input, q, &mut scalar_f32);
+
+        unsafe {
+            dequant_i8_to_f16_neon(&input, q, &mut neon_out);
+        }
+
+        for (i, (&neon_bits, &sf)) in neon_out.iter().zip(scalar_f32.iter()).enumerate() {
+            let neon_f = half::f16::from_bits(neon_bits).to_f32();
+            let scalar_f16 = half::f16::from_f32(sf).to_f32();
+            assert!(
+                (neon_f - scalar_f16).abs() < 1e-2,
+                "i8→f16 mismatch at {i}: neon={neon_f} scalar_f16={scalar_f16}"
+            );
+        }
+    }
+
+    #[test]
+    fn dequant_u8_to_f16_neon_matches_scalar() {
+        if !std::arch::is_aarch64_feature_detected!("fp16") {
+            return; // FP16 instructions not available (e.g. Cortex-A53).
+        }
+        let q = Quantization::new(0.5, 0);
+        let input: Vec<u8> = (0..48).collect();
+        let mut neon_out = vec![0u16; input.len()];
+        let mut scalar_f32 = vec![0.0_f32; input.len()];
+        dequant_u8_to_f32(&input, q, &mut scalar_f32);
+
+        unsafe {
+            dequant_u8_to_f16_neon(&input, q, &mut neon_out);
+        }
+
+        for (i, (&neon_bits, &sf)) in neon_out.iter().zip(scalar_f32.iter()).enumerate() {
+            let neon_f = half::f16::from_bits(neon_bits).to_f32();
+            let scalar_f16 = half::f16::from_f32(sf).to_f32();
+            assert!(
+                (neon_f - scalar_f16).abs() < 1e-2,
+                "u8→f16 mismatch at {i}: neon={neon_f} scalar_f16={scalar_f16}"
+            );
+        }
+    }
+
+    #[test]
+    fn fused_softmax_weighted_sum_matches_separate() {
+        // Verify that the fused kernel produces the same result as
+        // separate softmax_inplace + weighted_sum for reg_max=16.
+        let reg_max = 16usize;
+        // Simulate 4 sides of dequantized DFL logits (typical range -3..3).
+        let logits: Vec<f32> = (0..(4 * reg_max))
+            .map(|i| ((i as f32) * 0.37 - 2.5).sin() * 3.0)
+            .collect();
+
+        // Reference: separate softmax + weighted_sum (scalar oracle).
+        let mut probs = logits.clone();
+        for side in 0..4 {
+            softmax_inplace_f32(&mut probs[side * reg_max..(side + 1) * reg_max]);
+        }
+        let mut ref_ws = [0.0_f32; 4];
+        for (side, ws) in ref_ws.iter_mut().enumerate() {
+            let base = side * reg_max;
+            for bin in 0..reg_max {
+                *ws += probs[base + bin] * (bin as f32);
+            }
+        }
+
+        // Fused NEON kernel.
+        let fused_ws = unsafe { softmax_weighted_sum_4sides_f32_neon(&logits, reg_max) };
+
+        for (side, (&fused, &reference)) in fused_ws.iter().zip(ref_ws.iter()).enumerate() {
+            let diff = (fused - reference).abs();
+            assert!(
+                diff < 1e-4,
+                "fused softmax+ws mismatch on side {side}: fused={fused} ref={reference} diff={diff}",
+            );
+        }
+    }
+
+    #[test]
+    fn fused_softmax_weighted_sum_reg_max_32() {
+        // Test with reg_max=32 to exercise multi-chunk path.
+        let reg_max = 32usize;
+        let logits: Vec<f32> = (0..(4 * reg_max))
+            .map(|i| ((i as f32) * 0.23 - 1.8).cos() * 2.5)
+            .collect();
+
+        let mut probs = logits.clone();
+        for side in 0..4 {
+            softmax_inplace_f32(&mut probs[side * reg_max..(side + 1) * reg_max]);
+        }
+        let mut ref_ws = [0.0_f32; 4];
+        for (side, ws) in ref_ws.iter_mut().enumerate() {
+            let base = side * reg_max;
+            for bin in 0..reg_max {
+                *ws += probs[base + bin] * (bin as f32);
+            }
+        }
+
+        let fused_ws = unsafe { softmax_weighted_sum_4sides_f32_neon(&logits, reg_max) };
+
+        for (side, (&fused, &reference)) in fused_ws.iter().zip(ref_ws.iter()).enumerate() {
+            let diff = (fused - reference).abs();
+            assert!(
+                diff < 1e-4,
+                "fused softmax+ws (reg_max=32) mismatch on side {side}: fused={fused} ref={reference} diff={diff}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add NEON-accelerated kernels for the DFL/LTRB post-processing pipeline with tiered dispatch (NeonBase, FP16, DotProd, I8MM) and runtime CPU feature detection.

## Key Optimizations

- **Fused softmax+weighted_sum kernel**: eliminates intermediate memory traffic by computing softmax and weighted sum in-register (2 passes instead of 5). Saves 256 memory ops per anchor.
- **NEON weighted_sum** with DotProd (`udot`) and I8MM (`usmmla`) fast paths
- **Vectorized dist2bbox** (LTRB→XYXY) processing 4 boxes per iteration
- **Fused dequant+sigmoid** with FP16 narrowing variant for Cortex-A55+
- **NEON column argmax** (16 elements/iteration, branchless `vbslq`)
- **NMS jaccard_batch4**: vectorized IoU for 4 candidates simultaneously

## Tiered Dispatch

Runtime CPU feature detection selects the optimal kernel tier:
```
NeonBase → FP16 → DotProd → I8MM
```
All DFL tiers route through the fused softmax+weighted_sum kernel (subsumes DotProd/I8MM weighted_sum advantage). LTRB retains separate tier dispatch where DotProd/I8MM are still beneficial.

## Benchmark Results

| Benchmark | Target | Baseline (v0.22.0) | Optimized | Speedup |
|-----------|--------|---------------------|-----------|---------|
| `dfl_i8_to_f32` | imx8mp (Cortex-A53) | 23.4ms | 14.6ms | **1.60×** |
| `dfl_i8_to_f32` | imx95 (Cortex-A55) | 15.7ms | 14.5ms | **1.08×** |
| `ltrb_i8_to_f32` | imx8mp (Cortex-A53) | 14.2ms | 8.5ms | **1.67×** |
| `ltrb_i8_to_f32` | imx95 (Cortex-A55) | 9.7ms | 8.8ms | **1.10×** |

No regressions in `quant/decode_boxes` or NMS benchmarks on either target.

## Testing

- All 63 tests pass (61 executed, 2 aarch64-only skipped on x86)
- 2 new unit tests for fused softmax+weighted_sum kernel parity
- Verified on real hardware: imx8mp-frdm (A53) and imx95-frdm (A55)
- `make format lint check test sbom` all pass

## Files Changed

- `crates/decoder/src/per_scale/kernels/neon_baseline.rs` — core NEON kernels (+1055 lines)
- `crates/decoder/src/per_scale/kernels/neon_dotprod.rs` — DotProd tier (new file)
- `crates/decoder/src/per_scale/kernels/neon_i8mm.rs` — I8MM tier (new file)
- `crates/decoder/src/per_scale/kernels/level_box.rs` — DFL/LTRB orchestrators
- `crates/decoder/src/per_scale/kernels/dispatch.rs` — tiered dispatch logic
- `crates/decoder/src/byte.rs` — NEON column argmax
- `crates/decoder/src/float.rs` — NMS jaccard_batch4