### PR TITLE
DE-2490: MPK output shape compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `logical_to_legacy_config_output` is squeezing the padding dimension for 
-  MPK "boxes" output shape causing RuntimeError "Invalid ModelPack Boxes 
-  shape [1, 1935, 4]". Added condition to check if the decoder type is 
-  ModelPack, do not squeeze the padding dimension.
+- `logical_to_legacy_config_output` is squeezing the padding dimension for
+  MPK "boxes" output shape, causing RuntimeError "Invalid ModelPack Boxes
+  shape [1, 1935, 4]". Added a condition to check if the decoder type is
+  ModelPack and not squeeze the padding dimension.
 
 
 ## [0.22.0] - 2026-05-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `logical_to_legacy_config_output` is squeezing the padding dimension for 
+  MPK "boxes" output shape causing RuntimeError "Invalid ModelPack Boxes 
+  shape [1, 1935, 4]". Added condition to check if the decoder type is 
+  ModelPack, do not squeeze the padding dimension.
+
+
 ## [0.22.0] - 2026-05-11
 
 ### Breaking Changes

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -2400,6 +2400,36 @@ outputs:
     }
 
     #[test]
+    fn to_legacy_modelpack_boxes_preserves_padding_dim() {
+        // Regression: ModelPack boxes with shape [1, N, 1, 4] (padding dim
+        // present in dshape) were incorrectly squeezed to [1, N, 4] by
+        // `logical_to_legacy_config_output`, triggering "Invalid ModelPack
+        // Boxes shape [1, 1935, 4]". The ModelPack path must skip squeezing.
+        let j = r#"{
+          "schema_version": 2,
+          "outputs": [{
+            "name": "boxes",
+            "type": "boxes",
+            "shape": [1, 1935, 1, 4],
+            "dshape": [{"batch": 1}, {"num_boxes": 1935}, {"padding": 1}, {"box_coords": 4}],
+            "dtype": "float32",
+            "decoder": "modelpack",
+            "encoding": "anchor"
+          }]
+        }"#;
+        let schema = SchemaV2::parse_json(j).unwrap();
+        let legacy = schema.to_legacy_config_outputs().expect("lowers cleanly");
+        let boxes = match &legacy.outputs[0] {
+            crate::ConfigOutput::Boxes(b) => b,
+            other => panic!("expected Boxes, got {other:?}"),
+        };
+        // Must preserve the rank-4 shape — the padding dim must NOT be
+        // squeezed for ModelPack outputs.
+        assert_eq!(boxes.shape, vec![1, 1935, 1, 4]);
+        assert_eq!(boxes.dshape.len(), 4);
+    }
+
+    #[test]
     fn to_legacy_preserves_shape_for_v2_split_boxes_without_dshape() {
         // Regression: `Decoder({...v2 split boxes, shape:[1,4,8400], no dshape...})`
         // used to fail with `Invalid Yolo Split Boxes shape []` because

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -1255,8 +1255,12 @@ fn logical_to_legacy_config_output(logical: &LogicalOutput) -> DecoderResult<Con
     // Squeeze explicit `padding` dims before handing to the legacy
     // dispatch: the v1 decoder's `verify_yolo_*` helpers require rank-3
     // shapes, but v2 metadata often carries an explicit `padding: 1`
-    // axis (ARA-2).
-    let (shape, dshape) = squeeze_padding_dims(logical.shape.clone(), logical.dshape.clone());
+    // axis (ARA-2). ModelPack boxes are validated as 4D, so keep
+    // padding dims for ModelPack outputs.
+    let (shape, dshape) = match logical.decoder {
+        Some(DecoderKind::ModelPack) => (logical.shape.clone(), logical.dshape.clone()),
+        _ => squeeze_padding_dims(logical.shape.clone(), logical.dshape.clone()),
+    };
 
     let ty = logical.type_.ok_or_else(|| {
         // Defense-in-depth: `to_legacy_config_outputs` already filters

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -2407,15 +2407,12 @@ outputs:
         // Boxes shape [1, 1935, 4]". The ModelPack path must skip squeezing.
         let j = r#"{
           "schema_version": 2,
-          "outputs": [{
-            "name": "boxes",
-            "type": "boxes",
-            "shape": [1, 1935, 1, 4],
-            "dshape": [{"batch": 1}, {"num_boxes": 1935}, {"padding": 1}, {"box_coords": 4}],
-            "dtype": "float32",
-            "decoder": "modelpack",
-            "encoding": "anchor"
-          }]
+          "outputs": [
+            {"name":"boxes","type":"boxes",
+             "shape":[1,1935,1,4],
+             "dshape":[{"batch":1},{"num_boxes":1935},{"padding":1},{"box_coords":4}],
+             "decoder":"modelpack"}
+          ]
         }"#;
         let schema = SchemaV2::parse_json(j).unwrap();
         let legacy = schema.to_legacy_config_outputs().expect("lowers cleanly");
@@ -2426,7 +2423,15 @@ outputs:
         // Must preserve the rank-4 shape — the padding dim must NOT be
         // squeezed for ModelPack outputs.
         assert_eq!(boxes.shape, vec![1, 1935, 1, 4]);
-        assert_eq!(boxes.dshape.len(), 4);
+        assert_eq!(
+            boxes.dshape,
+            vec![
+                (DimName::Batch, 1),
+                (DimName::NumBoxes, 1935),
+                (DimName::Padding, 1),
+                (DimName::BoxCoords, 4),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Fixed
- `logical_to_legacy_config_output` is squeezing the padding dimension for 
  MPK "boxes" output shape causing RuntimeError "Invalid ModelPack Boxes 
  shape [1, 1935, 4]". Added condition to check if the decoder type is 
  ModelPack, do not squeeze the padding dimension.