### PR TITLE
Upgrade x86_64 CI runners to ubuntu-22.04-xlarge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,9 @@
 # - EnricoMi/publish-unit-test-result-action@34d7c956a59aed1bfebf31df77b8de55db9bbaaf (v2.21.0)
 #
 # Runner Notes:
-# - ubuntu-22.04: Standard GitHub-hosted runner (x86_64)
+# - ubuntu-22.04: Standard GitHub-hosted runner, 4 vCPU (x86_64, used for I/O-bound
+#   and aggregation jobs: checkout-lfs, sonarcloud)
+# - ubuntu-22.04-xlarge: GitHub-hosted larger runner, 16 vCPU (x86_64 builds & tests)
 # - ubuntu-22.04-arm-xlarge: GitHub ARM64 runner, 16 vCPU (aarch64 builds)
 # - ubuntu-22.04-arm: GitHub ARM64 runner, 4 vCPU (aarch64 tests, coverage)
 # - macos-latest: GitHub macOS runner (Apple Silicon)
@@ -96,7 +98,7 @@ jobs:
   # ===========================================================================
   doc-tests:
     name: Doc Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -127,7 +129,7 @@ jobs:
   # ===========================================================================
   build-and-test-x86:
     name: Build & Test (x86_64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     needs: checkout-lfs
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Switch `doc-tests` and `build-and-test-x86` to `ubuntu-22.04-xlarge` (16 vCPU), matching the existing `ubuntu-22.04-arm-xlarge` sizing on the aarch64 side.
- Keep the standard `ubuntu-22.04` runner for I/O-bound or aggregation-only jobs (`checkout-lfs`, `sonarcloud`).
- Update the runner-notes comment block at the top of `test.yml` to document the new SKU and the rationale for which jobs use which runner.

## Motivation

Today's CI has a runner asymmetry: aarch64 builds run on a 16 vCPU larger runner while x86_64 builds are stuck on the 4 vCPU standard runner. The x86_64 job does the heaviest work (clippy on all targets, `cargo llvm-cov nextest` across the workspace, C API build, Python wheel build, Python tests) and benefits the most from compile parallelism.

This is the first of several internal cleanup PRs improving CI performance and developer experience. The follow-up testdata-artifact diet (separate PR) is expected to deliver a larger absolute speedup on the hardware-test path; this PR addresses the x86_64 path.

## Test plan

- [ ] CI green on this branch
- [ ] Compare wall-clock of `doc-tests` against a recent main-branch run
- [ ] Compare wall-clock of `build-and-test-x86` against a recent main-branch run
- [ ] Confirm `ubuntu-22.04-xlarge` is provisioned for the org (no \"no runner matching\" errors)
- [ ] No regression in coverage output or SonarCloud reporting

## Notes

- Larger runners have a higher per-minute cost; expected total CI cost is roughly break-even or slightly net-positive given the runtime reduction, but worth tracking across a few PRs after merge.
- Standard runner kept for `checkout-lfs` (pure I/O) and `sonarcloud` (aggregation only) where 16 vCPU would be wasted.