### PR TITLE
CI/CD cleanup: action upgrades + xlarge runner + testdata runtime reads

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -141,7 +141,7 @@ jobs:
           echo "=== DMA heap ===" && ls -la /dev/dma_heap/ 2>/dev/null || echo "Not found"
           echo "=== G2D ===" && ls -la /dev/galcore 2>/dev/null || echo "Not found"
 
-          export EDGEFIRST_TESTDATA=$(pwd)/testdata
+          export EDGEFIRST_TESTDATA_DIR=$(pwd)/testdata
 
           for bench in benchmark-binaries/*; do
             if [ -f "$bench" ] && [ -x "$bench" ]; then
@@ -202,7 +202,7 @@ jobs:
           uname -a
           python3 --version
 
-          export EDGEFIRST_TESTDATA=$(pwd)/testdata
+          export EDGEFIRST_TESTDATA_DIR=$(pwd)/testdata
 
           # Run pytest-benchmark if benchmark files exist
           if find tests/ -name "bench_*.py" -o -name "*_bench.py" | grep -q .; then

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,12 +7,12 @@
 #   build-benchmarks (aarch64) → run-benchmarks (imx8mp) → process-results (charts + summary)
 #
 # Action Versions (hash-pinned per SPS v2.1):
-# - actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 (v4)
-# - actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 (v5)
-# - actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 (v4)
-# - actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 (v4)
-# - dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b (stable)
-# - Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 (v2.8.2)
+# - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd (v6.0.2)
+# - actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 (v6.2.0)
+# - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a (v7.0.1)
+# - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c (v8.0.1)
+# - dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 (v1)
+# - Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 (v2.9.1)
 
 name: Benchmarks
 
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true
 
@@ -45,12 +45,12 @@ jobs:
           sudo apt-get install -y build-essential python3-dev clang libclang-dev libopencv-dev
 
       - name: Set up Rust stable toolchain
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: rust-aarch64-bench
           cache-on-failure: true
@@ -67,7 +67,7 @@ jobs:
           ls -la benchmark-binaries/
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -82,21 +82,21 @@ jobs:
             --release
 
       - name: Upload benchmark binaries
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: benchmark-binaries-aarch64
           path: benchmark-binaries/
           retention-days: 7
 
       - name: Upload Python wheel
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: benchmark-wheel-aarch64
           path: target/wheels/*.whl
           retention-days: 7
 
       - name: Upload testdata
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: benchmark-testdata
           path: testdata/
@@ -116,13 +116,13 @@ jobs:
         run: rm -rf benchmark-binaries/ benchmark-results/ testdata/ 2>/dev/null || true
 
       - name: Download benchmark binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: benchmark-binaries-aarch64
           path: benchmark-binaries/
 
       - name: Download testdata
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: benchmark-testdata
           path: testdata/
@@ -153,7 +153,7 @@ jobs:
           done
 
       - name: Upload Rust benchmark results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: rust-benchmark-results
           path: benchmark-results/
@@ -170,18 +170,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: false
 
       - name: Download Python wheel
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: benchmark-wheel-aarch64
           path: wheels/
 
       - name: Download testdata
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: benchmark-testdata
           path: testdata/
@@ -223,7 +223,7 @@ jobs:
           fi
 
       - name: Upload Python benchmark results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-benchmark-results
           path: python-benchmark-results/
@@ -239,16 +239,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download Rust benchmark results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: rust-benchmark-results
           path: rust-benchmark-results/
 
       - name: Download Python benchmark results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: python-benchmark-results
           path: python-benchmark-results/
@@ -608,7 +608,7 @@ jobs:
           echo "</details>" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload processed results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: benchmark-results
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,14 @@
 # on tagged releases. Supports both stable releases (X.Y.Z) and release candidates (X.Y.ZrcN).
 #
 # Action Versions (hash-pinned for security per Au-Zone SPS v2.1):
-# - actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 (v4)
-# - actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 (v5)
-# - actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 (v4)
-# - actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 (v4)
-# - dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b (stable)
-# - rust-lang/crates-io-auth-action@v1 (trusted publishing)
-# - pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e (release/v1)
-# - softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe (v2.4.2)
+# - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd (v6.0.2)
+# - actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 (v6.2.0)
+# - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a (v7.0.1)
+# - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c (v8.0.1)
+# - dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 (v1)
+# - rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe (v1.0.4)
+# - pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b (v1.14.0)
+# - softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda (v3.0.0)
 #
 # Trusted Publisher Configuration:
 # - PyPI: https://pypi.org/manage/project/edgefirst-hal/settings/publishing/
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true
 
@@ -71,12 +71,12 @@ jobs:
         run: git lfs checkout
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -94,7 +94,7 @@ jobs:
           maturin build --release -m crates/python/Cargo.toml --features abi3-py38 ${ARGS//--sdist/}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: wheels-${{ matrix.name }}
           path: target/wheels/*
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true
 
@@ -125,7 +125,7 @@ jobs:
         run: git lfs checkout
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
 
@@ -181,7 +181,7 @@ jobs:
           echo "PKG_NAME=${PKG_NAME}" >> "$GITHUB_ENV"
 
       - name: Upload C API artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: capi-${{ matrix.target }}
           path: ${{ env.PKG_NAME }}.tar.gz
@@ -199,14 +199,14 @@ jobs:
 
     steps:
       - name: Download wheel artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: wheels-*
           path: dist
           merge-multiple: true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           skip-existing: true
 
@@ -224,15 +224,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
 
       - name: Authenticate to crates.io (Trusted Publishing)
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
         id: auth
 
       - name: Publish crates to crates.io
@@ -250,17 +250,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download wheel artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: wheels-*
           path: dist
           merge-multiple: true
 
       - name: Download C API artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: capi-*
           path: dist
@@ -273,7 +273,7 @@ jobs:
           awk "/## \[$VERSION\]/,/^## \[/{if (/^## \[/ && !found) {found=1; next} if (/^## \[/ && found) exit; if (found) print}" CHANGELOG.md > RELEASE_NOTES.md || echo "Release $VERSION" > RELEASE_NOTES.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe  # v2.4.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           files: dist/*
           body_path: RELEASE_NOTES.md

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -7,12 +7,12 @@
 # Uses cargo-cyclonedx for Rust dependencies and scancode-toolkit for source files.
 #
 # Action Versions (hash-pinned for security per Au-Zone SPS v2.1):
-# - actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 (v4)
-# - actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 (v5)
-# - actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 (v4)
-# - actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 (v4)
-# - dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b (stable)
-# - softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe (v2.4.2)
+# - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd (v6.0.2)
+# - actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 (v6.2.0)
+# - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a (v7.0.1)
+# - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c (v8.0.1)
+# - dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 (v1)
+# - softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda (v3.0.0)
 
 name: SBOM Generation & License Compliance
 
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: stable
 
@@ -42,7 +42,7 @@ jobs:
         run: cargo install cargo-cyclonedx
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 
@@ -67,7 +67,7 @@ jobs:
         run: cyclonedx validate --input-file sbom.json
 
       - name: Upload SBOM Artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: sbom-${{ github.sha }}
           path: |
@@ -90,12 +90,12 @@ jobs:
 
     steps:
       - name: Download SBOM Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: sbom-${{ github.sha }}
 
       - name: Attach SBOM to Release
-        uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe  # v2.4.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           files: |
             sbom.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -586,6 +586,10 @@ jobs:
       - name: Run pre-built Rust tests
         env:
           LLVM_PROFILE_FILE: ${{ github.workspace }}/build/profraw/rust-%p-%m.profraw
+          # Test binaries were cross-compiled on build-arm; their baked-in
+          # CARGO_MANIFEST_DIR paths don't resolve on this runner. Point
+          # edgefirst_bench::testdata at the downloaded testdata directory.
+          EDGEFIRST_TESTDATA_DIR: ${{ github.workspace }}/testdata
         run: |
 
           mkdir -p build/profraw build/rust-test-results
@@ -608,6 +612,8 @@ jobs:
           [ $TEST_FAILED -eq 0 ] || exit 1
 
       - name: Run C API tests
+        env:
+          EDGEFIRST_TESTDATA_DIR: ${{ github.workspace }}/testdata
         run: |
 
           if [ -d "hardware-capi-tests" ] && [ -f "hardware-capi-tests/test_all" ]; then
@@ -622,6 +628,7 @@ jobs:
       - name: Run Python tests with coverage
         env:
           LLVM_PROFILE_FILE: ${{ github.workspace }}/build/profraw/py-%p-%m.profraw
+          EDGEFIRST_TESTDATA_DIR: ${{ github.workspace }}/testdata
         run: |
 
           mkdir -p build/profraw
@@ -776,6 +783,7 @@ jobs:
       - name: Run Python tests with coverage
         env:
           LLVM_PROFILE_FILE: ${{ github.workspace }}/build/profraw/%p-%m.profraw
+          EDGEFIRST_TESTDATA_DIR: ${{ github.workspace }}/testdata
         run: |
           mkdir -p build/profraw
           export LD_LIBRARY_PATH=$(pwd)/target/profiling:$LD_LIBRARY_PATH
@@ -803,6 +811,10 @@ jobs:
         env:
           LD_LIBRARY_PATH: ${{ github.workspace }}/target/profiling:$LD_LIBRARY_PATH
           LLVM_PROFILE_FILE: ${{ github.workspace }}/build/profraw/rust-%p-%m.profraw
+          # Cross-compiled binaries cannot use their compile-time CARGO_MANIFEST_DIR
+          # path on this runner; point edgefirst_bench::testdata at the downloaded
+          # testdata directory.
+          EDGEFIRST_TESTDATA_DIR: ${{ github.workspace }}/testdata
         run: |
           # Only run tests that exercise hardware (G2D, OpenGL/EGL, DMA).
           # CPU-only tests already run on the ubuntu-22.04-arm-xlarge runner.
@@ -851,6 +863,8 @@ jobs:
           [ $TEST_FAILED -eq 0 ] || exit 1
 
       - name: Run C API tests
+        env:
+          EDGEFIRST_TESTDATA_DIR: ${{ github.workspace }}/testdata
         run: |
 
           if [ -d "hardware-capi-tests" ] && [ -f "hardware-capi-tests/test_all" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,15 @@
 #                               → hardware-test (on-target tests) ─────┤→ process-hardware-coverage → sonarcloud
 #
 # Action Versions (hash-pinned per SPS v2.1):
-# - actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 (v4)
-# - actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 (v5)
-# - actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 (v4)
-# - actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 (v4)
-# - dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b (stable)
-# - Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 (v2.8.2)
-# - taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6 (v2.71.2)
-# - SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 (v6.0.0)
-# - EnricoMi/publish-unit-test-result-action@34d7c956a59aed1bfebf31df77b8de55db9bbaaf (v2.21.0)
+# - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd (v6.0.2)
+# - actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 (v6.2.0)
+# - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a (v7.0.1)
+# - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c (v8.0.1)
+# - dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 (v1)
+# - Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 (v2.9.1)
+# - taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 (v2.78.0)
+# - SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 (v8.0.0)
+# - EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 (v2.23.0)
 #
 # Runner Notes:
 # - ubuntu-22.04: Standard GitHub-hosted runner (x86_64)
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code with LFS
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true
 
@@ -85,7 +85,7 @@ jobs:
         run: git lfs checkout
 
       - name: Upload testdata as artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: testdata-lfs
           path: testdata/
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true  # Doc tests use include_str!/include_bytes! which need LFS at compile time
 
@@ -109,12 +109,12 @@ jobs:
           sudo apt-get install -y clang libclang-dev libopencv-dev
 
       - name: Set up Rust stable toolchain
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: rust-x86_64-doc
           cache-on-failure: true
@@ -136,13 +136,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           lfs: false  # LFS files downloaded separately
 
       - name: Download LFS testdata
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: testdata-lfs
           path: testdata/
@@ -153,7 +153,7 @@ jobs:
           sudo apt-get install -y clang libclang-dev libopencv-dev
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -166,13 +166,13 @@ jobs:
           venv/bin/pip install tensorflow pyyaml numpy pillow opencv-python-headless psutil safetensors
 
       - name: Set up Rust stable toolchain
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
           components: llvm-tools-preview, clippy, rustfmt
 
       - name: Set up Rust nightly toolchain (for Python builds)
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # nightly
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: llvm-tools-preview, rustfmt, clippy
@@ -181,13 +181,13 @@ jobs:
         run: rustup default ${{ env.RUST_STABLE_VERSION }}
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: rust-x86_64
           cache-on-failure: true
 
       - name: Install cargo tools
-        uses: taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6  # v2.71.2
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4  # v2.78.0
         with:
           tool: cargo-llvm-cov@0.6.16,cargo-nextest
 
@@ -258,7 +258,7 @@ jobs:
           awk '/^SF:.*crates\/python/{found=1; file=$0} found && /^DA:/{print file": "$0} found && /^end_of_record/{found=0}' target/coverage_rust.lcov | head -20 || true
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: coverage-x86_64
@@ -268,7 +268,7 @@ jobs:
           retention-days: 30
 
       - name: Upload test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-results-x86_64
@@ -281,7 +281,7 @@ jobs:
           retention-days: 30
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@34d7c956a59aed1bfebf31df77b8de55db9bbaaf  # v2.21.0
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2.23.0
         if: always()
         with:
           files: |
@@ -305,31 +305,31 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: false  # LFS files downloaded separately
 
       - name: Download LFS testdata
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: testdata-lfs
           path: testdata/
 
       - name: Set up Rust stable toolchain
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
           components: clippy, rustfmt
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: rust-macos
           cache-on-failure: true
           cache-bin: false  # Prevent overwriting rustup cargo shim with stale cached binary
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6  # v2.71.2
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4  # v2.78.0
         with:
           tool: cargo-nextest
 
@@ -353,7 +353,7 @@ jobs:
           make test 2>&1 | tee ../../../target/test-metrics-capi-macos.txt
 
       - name: Upload test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-results-macos
@@ -372,13 +372,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           lfs: false  # LFS files downloaded separately
 
       - name: Download LFS testdata
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: testdata-lfs
           path: testdata/
@@ -389,7 +389,7 @@ jobs:
           sudo apt-get install -y build-essential python3-dev clang libclang-dev libopencv-dev
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -404,13 +404,13 @@ jobs:
           venv/bin/pip install maturin[patchelf,zig]
 
       - name: Set up Rust stable toolchain
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
           components: llvm-tools-preview
 
       - name: Set up Rust nightly toolchain (for Python builds)
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # nightly
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: llvm-tools-preview
@@ -419,13 +419,13 @@ jobs:
         run: rustup default ${{ env.RUST_STABLE_VERSION }}
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           shared-key: rust-aarch64
           cache-on-failure: true
 
       - name: Install cargo tools
-        uses: taiki-e/install-action@d858f8113943481093e02986a7586a4819a3bfd6  # v2.71.2
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4  # v2.78.0
         with:
           tool: cargo-llvm-cov@0.6.16,cargo-nextest
 
@@ -501,7 +501,7 @@ jobs:
           ls -la hardware-capi-tests/
 
       - name: Upload runner test artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: runner-test-artifacts
           path: |
@@ -513,7 +513,7 @@ jobs:
           retention-days: 7
 
       - name: Upload hardware test artifacts (binaries + wheels only)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: hardware-test-binaries
           path: |
@@ -523,7 +523,7 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage instrumented binaries (for profraw processing)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-binaries-aarch64
           path: |
@@ -545,25 +545,25 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           lfs: false  # LFS files downloaded separately
 
       - name: Download LFS testdata
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: testdata-lfs
           path: testdata/
 
       - name: Download runner test artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: runner-test-artifacts
           path: .  # Download to workspace root to preserve directory structure
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -578,7 +578,7 @@ jobs:
           venv/bin/pip install target/wheels/*.whl
 
       - name: Set up Rust stable toolchain
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
           components: llvm-tools-preview
@@ -689,7 +689,7 @@ jobs:
           grep '^SF:.*crates/python' target/coverage_rust.lcov || echo "  (none found)"
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: coverage-aarch64
@@ -699,7 +699,7 @@ jobs:
           retention-days: 30
 
       - name: Upload test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-results-aarch64
@@ -711,7 +711,7 @@ jobs:
           retention-days: 30
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@34d7c956a59aed1bfebf31df77b8de55db9bbaaf  # v2.21.0
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2.23.0
         if: always()
         with:
           files: |
@@ -740,18 +740,18 @@ jobs:
           find . -name "*.gcda" -o -name "*.profraw" -delete 2>/dev/null || true
 
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: false  # LFS files downloaded separately
 
       - name: Download LFS testdata
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: testdata-lfs
           path: testdata/
 
       - name: Download aarch64 test artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: hardware-test-binaries
           path: .  # Download to workspace root to preserve directory structure
@@ -880,7 +880,7 @@ jobs:
         run: python3 .github/scripts/generate_junit_xml.py build/rust-test-results build/rust_hardware_results.xml
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: coverage-imx8mp
@@ -890,7 +890,7 @@ jobs:
           retention-days: 30
 
       - name: Upload test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-results-imx8mp
@@ -929,22 +929,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download coverage instrumented binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: coverage-binaries-aarch64
           path: target/llvm-cov-target/profiling/deps/
 
       - name: Download imx8mp coverage (contains profraw files)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: coverage-imx8mp
           path: coverage-imx8mp/
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9  # v1
         with:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
           components: llvm-tools-preview
@@ -991,7 +991,7 @@ jobs:
           echo "Generated coverage_rust_imx8mp.lcov: $(wc -l < output/coverage_rust_imx8mp.lcov) lines"
 
       - name: Upload processed coverage
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-imx8mp-processed
           path: |
@@ -1013,12 +1013,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: coverage-*
           path: coverage/
@@ -1042,7 +1042,7 @@ jobs:
           echo "PYTHON_COVERAGE_PATHS=$PYTHON_REPORTS" >> $GITHUB_ENV
 
       - name: Run SonarCloud scan
-        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602  # v6.0.0
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432  # v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -500,6 +500,56 @@ jobs:
           echo "C API test artifacts:"
           ls -la hardware-capi-tests/
 
+      - name: Prepare stripped binaries for hardware deployment
+        run: |
+          set -euo pipefail
+          # Cross-compiled aarch64 test binaries built with --profile profiling
+          # carry full DWARF debug info AND coverage instrumentation. The
+          # `__llvm_prf_*` ELF sections that drive profraw generation are
+          # independent of DWARF — `strip --strip-debug` removes the debug
+          # info while preserving the instrumentation, shrinking each binary
+          # ~5-10× and proportionally reducing the artifact download on the
+          # on-target runner. The unstripped originals stay in place for:
+          #   - test-arm (in-place coverage processing, uses runner-test-binaries/)
+          #   - process-hardware-coverage (host-side llvm-cov export, uses
+          #     coverage-binaries-aarch64)
+          # so source-line attribution still works for both Rust and Python
+          # profraw files captured on hardware.
+
+          mkdir -p hardware-test-binaries-stripped
+          cp -a hardware-test-binaries/. hardware-test-binaries-stripped/
+          for bin in hardware-test-binaries-stripped/*; do
+            [ -x "$bin" ] && file "$bin" 2>/dev/null | grep -q "ELF" \
+              && strip --strip-debug "$bin"
+          done
+
+          mkdir -p hardware-capi-tests-stripped
+          cp -a hardware-capi-tests/. hardware-capi-tests-stripped/
+          # libedgefirst_hal.a is consumed at link time only; running tests
+          # on the target dynamic-links against the .so. Drop the static
+          # archive from the hardware deployment artifact.
+          rm -f hardware-capi-tests-stripped/libedgefirst_hal.a
+          for bin in hardware-capi-tests-stripped/test_all \
+                     hardware-capi-tests-stripped/libedgefirst_hal.so*; do
+            [ -f "$bin" ] && strip --strip-debug "$bin" 2>/dev/null || true
+          done
+
+          mkdir -p target/wheels-stripped
+          for whl_in in target/wheels/*.whl; do
+            [ -f "$whl_in" ] || continue
+            whl_name=$(basename "$whl_in")
+            tmp=$(mktemp -d)
+            ( cd "$tmp" && unzip -q "$GITHUB_WORKSPACE/$whl_in" )
+            find "$tmp" -name "*.so" -exec strip --strip-debug {} \;
+            ( cd "$tmp" && zip -qrX "$GITHUB_WORKSPACE/target/wheels-stripped/$whl_name" . )
+            rm -rf "$tmp"
+          done
+
+          echo "=== Hardware deployment artifact sizes (stripped vs original) ==="
+          du -sh hardware-test-binaries/ hardware-test-binaries-stripped/
+          du -sh hardware-capi-tests/ hardware-capi-tests-stripped/
+          du -sh target/wheels/ target/wheels-stripped/
+
       - name: Upload runner test artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
@@ -512,14 +562,14 @@ jobs:
             target/release/libedgefirst_hal.so.0
           retention-days: 7
 
-      - name: Upload hardware test artifacts (binaries + wheels only)
+      - name: Upload hardware test artifacts (stripped, fast on-target download)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: hardware-test-binaries
           path: |
-            target/wheels/*.whl
-            hardware-test-binaries/
-            hardware-capi-tests/
+            target/wheels-stripped/*.whl
+            hardware-test-binaries-stripped/
+            hardware-capi-tests-stripped/
           retention-days: 7
 
       - name: Upload coverage instrumented binaries (for profraw processing)
@@ -743,7 +793,9 @@ jobs:
     steps:
       - name: Clean workspace
         run: |
-          rm -rf build/ venv/ target/ rust-tests/ testdata/ 2>/dev/null || true
+          rm -rf build/ venv/ target/ rust-tests/ testdata/ \
+                 hardware-test-binaries-stripped/ \
+                 hardware-capi-tests-stripped/ 2>/dev/null || true
           find . -name "*.gcda" -o -name "*.profraw" -delete 2>/dev/null || true
 
       - name: Checkout code
@@ -769,8 +821,10 @@ jobs:
           echo "${{ github.workspace }}/venv/bin" >> $GITHUB_PATH
           venv/bin/pip install --upgrade pip setuptools wheel
           venv/bin/pip install slipcover pytest pytest-timeout pytest-benchmark numpy pillow psutil safetensors
-          # Install Python bindings from pre-built wheel (built with profiling profile on aarch64)
-          venv/bin/pip install target/wheels/*.whl
+          # Install Python bindings from pre-built wheel (stripped for fast
+          # download; coverage processing on the host uses the unstripped
+          # copy from coverage-binaries-aarch64).
+          venv/bin/pip install target/wheels-stripped/*.whl
 
       - name: Debug environment info
         run: |
@@ -778,7 +832,7 @@ jobs:
           echo "=== DMA heap ===" && ls -la /dev/dma_heap/ 2>/dev/null || echo "Not found"
           echo "=== G2D ===" && ls -la /dev/galcore 2>/dev/null || echo "Not found"
           echo "=== Downloaded artifacts ===" && find . -name "*.so*" -o -name "profiling" -type d 2>/dev/null || echo "Not found"
-          echo "=== Test binaries ===" && ls -la hardware-test-binaries/ 2>/dev/null || echo "Not found"
+          echo "=== Test binaries ===" && ls -la hardware-test-binaries-stripped/ 2>/dev/null || echo "Not found"
 
       - name: Run Python tests with coverage
         env:
@@ -843,7 +897,7 @@ jobs:
             fi
           }
 
-          for test_bin in hardware-test-binaries/*; do
+          for test_bin in hardware-test-binaries-stripped/*; do
             [[ -x "$test_bin" && -f "$test_bin" ]] || continue
             [[ "$test_bin" == *.so ]] && continue
             test_name=$(basename "$test_bin")
@@ -867,15 +921,15 @@ jobs:
           EDGEFIRST_TESTDATA_DIR: ${{ github.workspace }}/testdata
         run: |
 
-          if [ -d "hardware-capi-tests" ] && [ -f "hardware-capi-tests/test_all" ]; then
+          if [ -d "hardware-capi-tests-stripped" ] && [ -f "hardware-capi-tests-stripped/test_all" ]; then
             echo "=== Running C API tests on hardware ==="
-            chmod +x hardware-capi-tests/test_all
-            export LD_LIBRARY_PATH=$(pwd)/hardware-capi-tests:$LD_LIBRARY_PATH
+            chmod +x hardware-capi-tests-stripped/test_all
+            export LD_LIBRARY_PATH=$(pwd)/hardware-capi-tests-stripped:$LD_LIBRARY_PATH
             # Same SIGABRT-on-exit issue as Python tests — the Vivante EGL
             # driver may crash during library unload after all tests pass.
             # Use the test summary output as the source of truth.
             EXIT_CODE=0
-            hardware-capi-tests/test_all 2>&1 | tee build/test-metrics-capi-imx8mp.txt || EXIT_CODE=$?
+            hardware-capi-tests-stripped/test_all 2>&1 | tee build/test-metrics-capi-imx8mp.txt || EXIT_CODE=$?
 
             if [ $EXIT_CODE -ne 0 ]; then
               if grep -q 'Failed: 0' build/test-metrics-capi-imx8mp.txt; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,9 @@
 # - EnricoMi/publish-unit-test-result-action@34d7c956a59aed1bfebf31df77b8de55db9bbaaf (v2.21.0)
 #
 # Runner Notes:
-# - ubuntu-22.04: Standard GitHub-hosted runner (x86_64)
+# - ubuntu-22.04: Standard GitHub-hosted runner, 4 vCPU (x86_64, used for I/O-bound
+#   and aggregation jobs: checkout-lfs, sonarcloud)
+# - ubuntu-22.04-xlarge: GitHub-hosted larger runner, 16 vCPU (x86_64 builds & tests)
 # - ubuntu-22.04-arm-xlarge: GitHub ARM64 runner, 16 vCPU (aarch64 builds)
 # - ubuntu-22.04-arm: GitHub ARM64 runner, 4 vCPU (aarch64 tests, coverage)
 # - macos-latest: GitHub macOS runner (Apple Silicon)
@@ -96,7 +98,7 @@ jobs:
   # ===========================================================================
   doc-tests:
     name: Doc Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -127,7 +129,7 @@ jobs:
   # ===========================================================================
   build-and-test-x86:
     name: Build & Test (x86_64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-xlarge
     needs: checkout-lfs
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -534,14 +534,18 @@ jobs:
             [ -f "$bin" ] && strip --strip-debug "$bin" 2>/dev/null || true
           done
 
+          # Python wheels — use the venv's `wheel` to unpack and repack so the
+          # PEP 376 RECORD manifest (SHA256 hashes of every file) is
+          # regenerated after the embedded .so files are stripped. pip will
+          # warn or fail on RECORD mismatch otherwise.
           mkdir -p target/wheels-stripped
           for whl_in in target/wheels/*.whl; do
             [ -f "$whl_in" ] || continue
-            whl_name=$(basename "$whl_in")
             tmp=$(mktemp -d)
-            ( cd "$tmp" && unzip -q "$GITHUB_WORKSPACE/$whl_in" )
+            venv/bin/wheel unpack --dest "$tmp" "$whl_in"
             find "$tmp" -name "*.so" -exec strip --strip-debug {} \;
-            ( cd "$tmp" && zip -qrX "$GITHUB_WORKSPACE/target/wheels-stripped/$whl_name" . )
+            unpacked_dir=$(ls -d "$tmp"/*/ | head -1)
+            venv/bin/wheel pack --dest-dir target/wheels-stripped "$unpacked_dir"
             rm -rf "$tmp"
           done
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ name = "edgefirst-hal-capi"
 version = "0.22.0"
 dependencies = [
  "cbindgen",
+ "edgefirst-bench",
  "edgefirst-decoder",
  "edgefirst-hal",
  "edgefirst-image",

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -7,6 +7,10 @@
 //! making it safe for GPU hardware that cannot survive `fork()` (EGL, G2D,
 //! Vulkan).
 //!
+//! The [`testdata`] module provides runtime testdata resolution so that
+//! tests and benches can load fixtures from disk instead of embedding them
+//! into binaries with `include_bytes!` / `include_str!`.
+//!
 //! # Usage
 //!
 //! ```rust,no_run
@@ -19,6 +23,8 @@
 //! // or with throughput:
 //! result.print_summary_with_throughput(1920 * 1080 * 4);
 //! ```
+
+pub mod testdata;
 
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 

--- a/crates/bench/src/testdata.rs
+++ b/crates/bench/src/testdata.rs
@@ -86,8 +86,7 @@ pub fn path(rel: impl AsRef<Path>) -> PathBuf {
 /// resolved absolute path to aid debugging.
 pub fn read(rel: impl AsRef<Path>) -> Vec<u8> {
     let p = path(rel.as_ref());
-    std::fs::read(&p)
-        .unwrap_or_else(|e| panic!("read testdata {}: {}", p.display(), e))
+    std::fs::read(&p).unwrap_or_else(|e| panic!("read testdata {}: {}", p.display(), e))
 }
 
 /// Reads the testdata file at `rel` as a UTF-8 string.
@@ -97,8 +96,7 @@ pub fn read(rel: impl AsRef<Path>) -> Vec<u8> {
 /// Panics if the file cannot be read or is not valid UTF-8.
 pub fn read_to_string(rel: impl AsRef<Path>) -> String {
     let p = path(rel.as_ref());
-    std::fs::read_to_string(&p)
-        .unwrap_or_else(|e| panic!("read testdata {}: {}", p.display(), e))
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read testdata {}: {}", p.display(), e))
 }
 
 #[cfg(test)]

--- a/crates/bench/src/testdata.rs
+++ b/crates/bench/src/testdata.rs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright 2025-2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Testdata path resolution for tests, benchmarks, and doctests.
+//!
+//! Replaces compile-time [`include_bytes!`] / [`include_str!`] calls with
+//! runtime filesystem reads. Keeps test and bench binaries small by avoiding
+//! testdata embedding — critical for cross-compiled binaries deployed to
+//! target hardware, where embedded testdata bloats artifact downloads.
+//!
+//! # Resolution order
+//!
+//! 1. `EDGEFIRST_TESTDATA_DIR` environment variable. Set this in CI or
+//!    when running tests from an unusual location. The value is used
+//!    verbatim with no further validation.
+//! 2. `<workspace>/testdata`, derived from this crate's compile-time
+//!    `CARGO_MANIFEST_DIR` (always `<workspace>/crates/bench`).
+//!
+//! If neither resolution yields a real directory, [`root`] panics with a
+//! diagnostic message — testdata absence is a developer / CI setup error,
+//! not a runtime condition that callers should handle.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use edgefirst_bench::testdata;
+//!
+//! // Read a JSON schema fixture
+//! let schema = testdata::read_to_string("per_scale/synthetic_yolov8n_schema.json");
+//!
+//! // Read a binary tensor dump
+//! let bytes = testdata::read("yolov8s_80_classes.bin");
+//!
+//! // Get just the path (useful when handing to another reader)
+//! let path = testdata::path("decoder/yolo11n-seg.safetensors");
+//! ```
+
+use std::path::{Path, PathBuf};
+
+/// Environment variable name that overrides the default testdata location.
+pub const ENV_VAR: &str = "EDGEFIRST_TESTDATA_DIR";
+
+/// Returns the root testdata directory.
+///
+/// See the [module-level documentation](self) for the resolution order.
+///
+/// # Panics
+///
+/// Panics if neither `EDGEFIRST_TESTDATA_DIR` is set nor the
+/// workspace-relative `testdata/` directory exists.
+pub fn root() -> PathBuf {
+    if let Ok(dir) = std::env::var(ENV_VAR) {
+        return PathBuf::from(dir);
+    }
+    // CARGO_MANIFEST_DIR for this crate is <workspace>/crates/bench at
+    // compile time, so `testdata/` is two levels up.
+    let candidate = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("testdata");
+    if candidate.is_dir() {
+        return candidate;
+    }
+    panic!(
+        "testdata directory not found: ${ENV_VAR} is unset and {} does not exist. \
+         Set ${ENV_VAR} to the testdata directory or run from a workspace checkout.",
+        candidate.display(),
+    );
+}
+
+/// Returns the absolute path to a file or directory under `testdata/`.
+///
+/// The `rel` argument is joined onto [`root`] verbatim and is not
+/// validated to exist — callers will get a clear filesystem error when
+/// they attempt to open the result. Use [`read`] or [`read_to_string`]
+/// for one-shot loads that should panic on missing files.
+pub fn path(rel: impl AsRef<Path>) -> PathBuf {
+    root().join(rel)
+}
+
+/// Reads the testdata file at `rel` as raw bytes.
+///
+/// # Panics
+///
+/// Panics if the file cannot be read. The panic message includes the
+/// resolved absolute path to aid debugging.
+pub fn read(rel: impl AsRef<Path>) -> Vec<u8> {
+    let p = path(rel.as_ref());
+    std::fs::read(&p)
+        .unwrap_or_else(|e| panic!("read testdata {}: {}", p.display(), e))
+}
+
+/// Reads the testdata file at `rel` as a UTF-8 string.
+///
+/// # Panics
+///
+/// Panics if the file cannot be read or is not valid UTF-8.
+pub fn read_to_string(rel: impl AsRef<Path>) -> String {
+    let p = path(rel.as_ref());
+    std::fs::read_to_string(&p)
+        .unwrap_or_else(|e| panic!("read testdata {}: {}", p.display(), e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `root()` resolves to a real directory under default workspace layout.
+    #[test]
+    fn root_resolves_to_workspace_testdata() {
+        // SAFETY: tests run with the workspace's testdata/ in place.
+        // Unset any user-side override to test the workspace-fallback path.
+        let saved = std::env::var(ENV_VAR).ok();
+        // SAFETY: tests in this module are run single-threaded via -j 1.
+        unsafe {
+            std::env::remove_var(ENV_VAR);
+        }
+
+        let r = root();
+        assert!(r.is_dir(), "expected testdata dir at {}", r.display());
+
+        // Restore prior value if any.
+        if let Some(v) = saved {
+            // SAFETY: see above.
+            unsafe {
+                std::env::set_var(ENV_VAR, v);
+            }
+        }
+    }
+
+    /// `EDGEFIRST_TESTDATA_DIR` override is honored.
+    #[test]
+    fn env_var_override_is_respected() {
+        let tmp = std::env::temp_dir();
+        let saved = std::env::var(ENV_VAR).ok();
+        // SAFETY: tests in this module are run single-threaded via -j 1.
+        unsafe {
+            std::env::set_var(ENV_VAR, &tmp);
+        }
+
+        let r = root();
+        assert_eq!(r, tmp);
+
+        // Restore.
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var(ENV_VAR, v),
+                None => std::env::remove_var(ENV_VAR),
+            }
+        }
+    }
+
+    /// `path()` joins relative segments onto the root.
+    #[test]
+    fn path_joins_relative_segments() {
+        let saved = std::env::var(ENV_VAR).ok();
+        // SAFETY: see above.
+        unsafe {
+            std::env::set_var(ENV_VAR, "/fake/root");
+        }
+
+        let p = path("per_scale/foo.json");
+        assert_eq!(p, PathBuf::from("/fake/root/per_scale/foo.json"));
+
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var(ENV_VAR, v),
+                None => std::env::remove_var(ENV_VAR),
+            }
+        }
+    }
+}

--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -37,3 +37,6 @@ log = { workspace = true }
 
 [build-dependencies]
 cbindgen = "0.29"
+
+[dev-dependencies]
+edgefirst-bench = { workspace = true }

--- a/crates/capi/src/decoder.rs
+++ b/crates/capi/src/decoder.rs
@@ -2817,10 +2817,7 @@ outputs:
 ";
         unsafe {
             // Load the yolov8s test data (i8 quantized, shape [1, 84, 8400])
-            let raw = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/yolov8s_80_classes.bin"
-            ));
+            let raw = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
             let quant_scale: f32 = 0.0040811873;
 
             // Build decoder from YAML config
@@ -2851,7 +2848,7 @@ outputs:
             assert!(!tensor.is_null());
 
             // Copy initial data
-            copy_data_to_tensor(tensor, raw);
+            copy_data_to_tensor(tensor, &raw);
 
             // --- Frame 0: initial decode ---
             let outputs = [tensor as *const HalTensor];
@@ -3577,10 +3574,7 @@ outputs:
 ";
         unsafe {
             // Load the yolov8s test data (i8 quantized, shape [1, 84, 8400])
-            let raw = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/yolov8s_80_classes.bin"
-            ));
+            let raw = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
             let raw = std::slice::from_raw_parts(raw.as_ptr() as *const i8, raw.len());
             let quant = (0.0040811873, -123);
 

--- a/crates/decoder/benches/decoder_benchmark.rs
+++ b/crates/decoder/benches/decoder_benchmark.rs
@@ -19,7 +19,7 @@ const WARMUP: usize = 10;
 const ITERATIONS: usize = 100;
 
 fn bench_yolo_quant(suite: &mut BenchSuite) {
-    let raw = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let raw = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let raw = unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const i8, raw.len()) };
     let tensor = TensorDyn::I8(Tensor::<i8>::from_slice(raw, &[1, 84, 8400]).unwrap());
 
@@ -53,7 +53,7 @@ fn bench_yolo_quant(suite: &mut BenchSuite) {
 
 fn bench_quant_decode_boxes(suite: &mut BenchSuite) {
     let score_threshold = 0.25;
-    let out = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
     let out = ndarray::Array2::from_shape_vec((84, 8400), out.to_vec()).unwrap();
     let quant = Quantization {
@@ -79,7 +79,7 @@ fn bench_quant_decode_boxes(suite: &mut BenchSuite) {
 fn bench_quant_nms(suite: &mut BenchSuite) {
     let score_threshold = 0.01;
     let iou_threshold = 0.70;
-    let out = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
     let out = out.to_vec();
     let quant = Quantization {
@@ -112,7 +112,7 @@ fn bench_yolo_f32(suite: &mut BenchSuite) {
     // Pre-dequantize once outside the timed loop. The bench measures
     // the float decode path; mixing dequant cost into each iteration
     // (as the legacy version did) inflated wall-time by the dequant.
-    let raw = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let raw = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let raw = unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const i8, raw.len()) };
     let quant = Quantization {
         scale: 0.0040811873,
@@ -152,7 +152,7 @@ fn bench_yolo_f32(suite: &mut BenchSuite) {
 }
 
 fn bench_dequantize_i8(suite: &mut BenchSuite) {
-    let out = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
     let out = out.to_vec();
     let quant = Quantization {
@@ -172,7 +172,7 @@ fn bench_dequantize_i8(suite: &mut BenchSuite) {
 }
 
 fn bench_dequantize_i8_chunked(suite: &mut BenchSuite) {
-    let out = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
     let out = out.to_vec();
     let quant = Quantization {
@@ -192,7 +192,7 @@ fn bench_dequantize_i8_chunked(suite: &mut BenchSuite) {
 }
 
 fn bench_dequantize_i16(suite: &mut BenchSuite) {
-    let out = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
     let out: Vec<_> = out.iter().map(|x| *x as i16).collect();
     let quant = Quantization {
@@ -212,7 +212,7 @@ fn bench_dequantize_i16(suite: &mut BenchSuite) {
 }
 
 fn bench_dequantize_i16_chunked(suite: &mut BenchSuite) {
-    let out = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
     let out: Vec<_> = out.iter().map(|x| *x as i16).collect();
     let quant = Quantization {
@@ -233,7 +233,7 @@ fn bench_dequantize_i16_chunked(suite: &mut BenchSuite) {
 
 fn bench_f32_decode_boxes(suite: &mut BenchSuite) {
     let score_threshold = 0.25;
-    let out = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
     let out = out.to_vec();
     let quant = Quantization {
@@ -259,7 +259,7 @@ fn bench_f32_decode_boxes(suite: &mut BenchSuite) {
 fn bench_f32_nms(suite: &mut BenchSuite) {
     let score_threshold = 0.01;
     let iou_threshold = 0.70;
-    let out = include_bytes!("../../../testdata/yolov8s_80_classes.bin");
+    let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
     let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
     let out = out.to_vec();
     let quant = Quantization {
@@ -292,11 +292,11 @@ fn bench_f32_nms(suite: &mut BenchSuite) {
 fn bench_modelpack_u8(suite: &mut BenchSuite) {
     let score_threshold = 0.45;
     let iou_threshold = 0.45;
-    let boxes = include_bytes!("../../../testdata/modelpack_boxes_1935x1x4.bin");
-    let boxes_tensor = TensorDyn::U8(Tensor::<u8>::from_slice(boxes, &[1, 1935, 1, 4]).unwrap());
+    let boxes = edgefirst_bench::testdata::read("modelpack_boxes_1935x1x4.bin");
+    let boxes_tensor = TensorDyn::U8(Tensor::<u8>::from_slice(&boxes, &[1, 1935, 1, 4]).unwrap());
 
-    let scores = include_bytes!("../../../testdata/modelpack_scores_1935x1.bin");
-    let scores_tensor = TensorDyn::U8(Tensor::<u8>::from_slice(scores, &[1, 1935, 1]).unwrap());
+    let scores = edgefirst_bench::testdata::read("modelpack_scores_1935x1.bin");
+    let scores_tensor = TensorDyn::U8(Tensor::<u8>::from_slice(&scores, &[1, 1935, 1]).unwrap());
 
     let quant_boxes: configs::QuantTuple = (0.004656755365431309, 21).into();
     let quant_scores: configs::QuantTuple = (0.0019603664986789227, 0).into();
@@ -349,12 +349,12 @@ fn bench_modelpack_split_u8(suite: &mut BenchSuite) {
     let score_threshold = 0.45;
     let iou_threshold = 0.45;
 
-    let detect0 = include_bytes!("../../../testdata/modelpack_split_9x15x18.bin");
-    let detect0_tensor = TensorDyn::U8(Tensor::<u8>::from_slice(detect0, &[1, 9, 15, 18]).unwrap());
+    let detect0 = edgefirst_bench::testdata::read("modelpack_split_9x15x18.bin");
+    let detect0_tensor = TensorDyn::U8(Tensor::<u8>::from_slice(&detect0, &[1, 9, 15, 18]).unwrap());
 
-    let detect1 = include_bytes!("../../../testdata/modelpack_split_17x30x18.bin");
+    let detect1 = edgefirst_bench::testdata::read("modelpack_split_17x30x18.bin");
     let detect1_tensor =
-        TensorDyn::U8(Tensor::<u8>::from_slice(detect1, &[1, 17, 30, 18]).unwrap());
+        TensorDyn::U8(Tensor::<u8>::from_slice(&detect1, &[1, 17, 30, 18]).unwrap());
 
     let detect_config0 = configs::Detection {
         decoder: configs::DecoderType::ModelPack,
@@ -417,7 +417,7 @@ fn bench_masks_f32(suite: &mut BenchSuite) {
     // Pre-dequantize boxes + protos once outside the timed loop. The bench
     // measures the float seg-det decode + mask materialization; the legacy
     // version dequantized each iteration which masked the actual decode time.
-    let boxes_raw = include_bytes!("../../../testdata/yolov8_boxes_116x8400.bin");
+    let boxes_raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
     let boxes_raw =
         unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
     let boxes_arr = ndarray::Array2::from_shape_vec((116, 8400), boxes_raw.to_vec()).unwrap();
@@ -430,7 +430,7 @@ fn bench_masks_f32(suite: &mut BenchSuite) {
         Tensor::<f32>::from_slice(boxes_f32.as_slice().unwrap(), &[1, 116, 8400]).unwrap(),
     );
 
-    let protos_raw = include_bytes!("../../../testdata/yolov8_protos_160x160x32.bin");
+    let protos_raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
     let protos_raw =
         unsafe { std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len()) };
     let protos_arr = ndarray::Array3::from_shape_vec((160, 160, 32), protos_raw.to_vec()).unwrap();
@@ -481,12 +481,12 @@ fn bench_masks_f32(suite: &mut BenchSuite) {
 }
 
 fn bench_masks_i8(suite: &mut BenchSuite) {
-    let boxes_raw = include_bytes!("../../../testdata/yolov8_boxes_116x8400.bin");
+    let boxes_raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
     let boxes_raw =
         unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
     let boxes_tensor = TensorDyn::I8(Tensor::<i8>::from_slice(boxes_raw, &[1, 116, 8400]).unwrap());
 
-    let protos_raw = include_bytes!("../../../testdata/yolov8_protos_160x160x32.bin");
+    let protos_raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
     let protos_raw =
         unsafe { std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len()) };
     let protos_tensor =

--- a/crates/decoder/benches/decoder_benchmark.rs
+++ b/crates/decoder/benches/decoder_benchmark.rs
@@ -350,7 +350,8 @@ fn bench_modelpack_split_u8(suite: &mut BenchSuite) {
     let iou_threshold = 0.45;
 
     let detect0 = edgefirst_bench::testdata::read("modelpack_split_9x15x18.bin");
-    let detect0_tensor = TensorDyn::U8(Tensor::<u8>::from_slice(&detect0, &[1, 9, 15, 18]).unwrap());
+    let detect0_tensor =
+        TensorDyn::U8(Tensor::<u8>::from_slice(&detect0, &[1, 9, 15, 18]).unwrap());
 
     let detect1 = edgefirst_bench::testdata::read("modelpack_split_17x30x18.bin");
     let detect1_tensor =

--- a/crates/decoder/src/decoder/builder.rs
+++ b/crates/decoder/src/decoder/builder.rs
@@ -171,7 +171,7 @@ impl Default for DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// #  let config_yaml = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.yaml")).to_string();
+    /// #  let config_yaml = edgefirst_bench::testdata::read_to_string("modelpack_split.yaml").to_string();
     /// let decoder = DecoderBuilder::default()
     ///     .with_config_yaml_str(config_yaml)
     ///     .build()?;
@@ -205,7 +205,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// #  let config_yaml = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.yaml")).to_string();
+    /// #  let config_yaml = edgefirst_bench::testdata::read_to_string("modelpack_split.yaml").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_yaml_str(config_yaml)
     ///     .build()?;
@@ -227,7 +227,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// let config_yaml = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.yaml")).to_string();
+    /// let config_yaml = edgefirst_bench::testdata::read_to_string("modelpack_split.yaml").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_yaml_str(config_yaml)
     ///     .build()?;
@@ -248,7 +248,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .build()?;
@@ -270,7 +270,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json"));
+    /// let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json");
     /// let config = serde_json::from_str(config_json)?;
     /// let decoder = DecoderBuilder::new().with_config(config).build()?;
     ///
@@ -861,7 +861,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// # let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .with_score_threshold(0.654)
@@ -882,7 +882,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// # let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .with_iou_threshold(0.654)
@@ -910,7 +910,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult, configs::Nms};
     /// # fn main() -> DecoderResult<()> {
-    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// # let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .with_nms(Some(Nms::ClassAware))
@@ -954,7 +954,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// # let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .with_score_threshold(0.25)
@@ -968,7 +968,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// # let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .with_score_threshold(0.001)
@@ -993,7 +993,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// # let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .with_max_det(100)
@@ -1023,7 +1023,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// # let config_yaml = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.yaml")).to_string();
+    /// # let config_yaml = edgefirst_bench::testdata::read_to_string("modelpack_split.yaml").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_yaml_str(config_yaml)
     ///     .with_input_dims(640, 640)
@@ -1045,7 +1045,7 @@ impl DecoderBuilder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// # let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json")).to_string();
+    /// # let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .with_score_threshold(0.654)

--- a/crates/decoder/src/decoder/builder.rs
+++ b/crates/decoder/src/decoder/builder.rs
@@ -224,10 +224,10 @@ impl DecoderBuilder {
     /// deserialize the YAML and parse the model configuration.
     ///
     /// # Examples
-    /// ```rust
-    /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
-    /// # fn main() -> DecoderResult<()> {
-    /// let config_yaml = edgefirst_bench::testdata::read_to_string("modelpack_split.yaml").to_string();
+    /// ```rust,no_run
+    /// # use edgefirst_decoder::DecoderBuilder;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let config_yaml = std::fs::read_to_string("modelpack_split.yaml")?;
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_yaml_str(config_yaml)
     ///     .build()?;
@@ -245,10 +245,10 @@ impl DecoderBuilder {
     /// deserialize the JSON and parse the model configuration.
     ///
     /// # Examples
-    /// ```rust
-    /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
-    /// # fn main() -> DecoderResult<()> {
-    /// let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json").to_string();
+    /// ```rust,no_run
+    /// # use edgefirst_decoder::DecoderBuilder;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let config_json = std::fs::read_to_string("modelpack_split.json")?;
     /// let decoder = DecoderBuilder::new()
     ///     .with_config_json_str(config_json)
     ///     .build()?;
@@ -267,11 +267,11 @@ impl DecoderBuilder {
     /// `DecoderBuilder.build()` to parse the model configuration.
     ///
     /// # Examples
-    /// ```rust
-    /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
-    /// # fn main() -> DecoderResult<()> {
-    /// let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json");
-    /// let config = serde_json::from_str(&config_json)?;
+    /// ```rust,no_run
+    /// # use edgefirst_decoder::{DecoderBuilder, ConfigOutputs};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let config_json = std::fs::read_to_string("modelpack_split.json")?;
+    /// let config: ConfigOutputs = serde_json::from_str(&config_json)?;
     /// let decoder = DecoderBuilder::new().with_config(config).build()?;
     ///
     /// # Ok(())

--- a/crates/decoder/src/decoder/builder.rs
+++ b/crates/decoder/src/decoder/builder.rs
@@ -271,7 +271,7 @@ impl DecoderBuilder {
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
     /// let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json");
-    /// let config = serde_json::from_str(config_json)?;
+    /// let config = serde_json::from_str(&config_json)?;
     /// let decoder = DecoderBuilder::new().with_config(config).build()?;
     ///
     /// # Ok(())

--- a/crates/decoder/src/decoder/config.rs
+++ b/crates/decoder/src/decoder/config.rs
@@ -6,10 +6,10 @@ use serde::{Deserialize, Serialize};
 
 /// Used to represent the outputs in the model configuration.
 /// # Examples
-/// ```rust
-/// # use edgefirst_decoder::{DecoderBuilder, DecoderResult, ConfigOutputs};
-/// # fn main() -> DecoderResult<()> {
-/// let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json");
+/// ```rust,no_run
+/// # use edgefirst_decoder::{DecoderBuilder, ConfigOutputs};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let config_json = std::fs::read_to_string("modelpack_split.json")?;
 /// let config: ConfigOutputs = serde_json::from_str(&config_json)?;
 /// let decoder = DecoderBuilder::new().with_config(config).build()?;
 ///

--- a/crates/decoder/src/decoder/config.rs
+++ b/crates/decoder/src/decoder/config.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// ```rust
 /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult, ConfigOutputs};
 /// # fn main() -> DecoderResult<()> {
-/// let config_json = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.json"));
+/// let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json");
 /// let config: ConfigOutputs = serde_json::from_str(config_json)?;
 /// let decoder = DecoderBuilder::new().with_config(config).build()?;
 ///

--- a/crates/decoder/src/decoder/config.rs
+++ b/crates/decoder/src/decoder/config.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult, ConfigOutputs};
 /// # fn main() -> DecoderResult<()> {
 /// let config_json = edgefirst_bench::testdata::read_to_string("modelpack_split.json");
-/// let config: ConfigOutputs = serde_json::from_str(config_json)?;
+/// let config: ConfigOutputs = serde_json::from_str(&config_json)?;
 /// let decoder = DecoderBuilder::new().with_config(config).build()?;
 ///
 /// # Ok(())

--- a/crates/decoder/src/decoder/mod.rs
+++ b/crates/decoder/src/decoder/mod.rs
@@ -275,7 +275,7 @@ impl Decoder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult, configs::ModelType};
     /// # fn main() -> DecoderResult<()> {
-    /// #    let config_yaml = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.yaml")).to_string();
+    /// #    let config_yaml = edgefirst_bench::testdata::read_to_string("modelpack_split.yaml").to_string();
     ///     let decoder = DecoderBuilder::default()
     ///         .with_config_yaml_str(config_yaml)
     ///         .build()?;
@@ -306,7 +306,7 @@ impl Decoder {
     /// ```rust
     /// # use edgefirst_decoder::{DecoderBuilder, DecoderResult};
     /// # fn main() -> DecoderResult<()> {
-    /// #    let config_yaml = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/modelpack_split.yaml")).to_string();
+    /// #    let config_yaml = edgefirst_bench::testdata::read_to_string("modelpack_split.yaml").to_string();
     ///     let decoder = DecoderBuilder::default()
     ///         .with_config_yaml_str(config_yaml)
     ///         .build()?;

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -241,9 +241,11 @@ mod decoder_builder_tests {
 
     #[test]
     fn builder_flat_schema_does_not_attach_per_scale_decoder() {
-        let schema_json = include_str!("../../../../testdata/per_scale/synthetic_flat_schema.json");
+        let schema_json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_flat_schema.json",
+        );
         let schema: crate::schema::SchemaV2 =
-            serde_json::from_str(schema_json).expect("flat fixture must parse");
+            serde_json::from_str(&schema_json).expect("flat fixture must parse");
 
         let decoder = DecoderBuilder::default()
             .with_schema(schema)

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -1721,10 +1721,7 @@ mod decoder_builder_tests {
         let score_threshold = 0.25;
         let iou_threshold = 0.7;
         let quant = (0.0040811873, -123);
-        let out = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8s_80_classes.bin"
-        ));
+        let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
         let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
         let out = Array3::from_shape_vec((1, 84, 8400), out.to_vec()).unwrap();
         let out_float: Array3<f32> = dequantize_ndarray(out.view(), quant.into());
@@ -3022,18 +3019,12 @@ outputs:
         use crate::{Nms, ProtoData, Quantization, XYWH};
 
         // Load cached YOLOv8 segmentation model outputs
-        let boxes_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let boxes_raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let boxes_i8 =
             unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
         let boxes = ndarray::Array2::from_shape_vec((116, 8400), boxes_i8.to_vec()).unwrap();
 
-        let protos_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let protos_raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let protos_i8 = unsafe {
             std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
         };
@@ -3123,18 +3114,12 @@ outputs:
         use crate::yolo::{impl_yolo_segdet_float_proto, impl_yolo_segdet_quant_proto};
         use crate::{Nms, ProtoData, Quantization, XYWH};
 
-        let boxes_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let boxes_raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let boxes_i8 =
             unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
         let boxes = ndarray::Array2::from_shape_vec((116, 8400), boxes_i8.to_vec()).unwrap();
 
-        let protos_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let protos_raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let protos_i8 = unsafe {
             std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
         };
@@ -3234,18 +3219,12 @@ outputs:
         use crate::yolo::{impl_yolo_segdet_float_proto, impl_yolo_segdet_quant_proto};
         use crate::{Nms, ProtoData, Quantization, XYWH};
 
-        let boxes_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let boxes_raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let boxes_i8 =
             unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
         let boxes = ndarray::Array2::from_shape_vec((116, 8400), boxes_i8.to_vec()).unwrap();
 
-        let protos_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let protos_raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let protos_i8 = unsafe {
             std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
         };
@@ -3575,10 +3554,7 @@ outputs:
 
         // Use the reference yolov8s detection output, but strip mask_coefs
         // (pretend they come from a separate tensor). Detection = [1,84,8400].
-        let out = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8s_80_classes.bin"
-        ));
+        let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
         let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
 
         // Dequantize the reference detection output
@@ -3654,11 +3630,8 @@ outputs:
         fn with_schema_v1_yaml_via_shim_builds() {
             // Legacy v1 testdata parsed through the v2 shim and fed to
             // the new builder should produce a working decoder.
-            let yaml = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/yolov8_seg.yaml"
-            ));
-            let schema = SchemaV2::parse_yaml(yaml).unwrap();
+            let yaml = edgefirst_bench::testdata::read_to_string("yolov8_seg.yaml");
+            let schema = SchemaV2::parse_yaml(&yaml).unwrap();
             let decoder = DecoderBuilder::new().with_schema(schema).build().unwrap();
             assert!(decoder.decode_program.is_none());
         }
@@ -3841,11 +3814,8 @@ outputs:
 
         #[test]
         fn with_schema_real_ara2_int8_dvm() {
-            let json = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/ara2_int8_edgefirst.json"
-            ));
-            let schema = SchemaV2::parse_json(json).unwrap();
+            let json = edgefirst_bench::testdata::read_to_string("ara2_int8_edgefirst.json");
+            let schema = SchemaV2::parse_json(&json).unwrap();
             schema.validate().unwrap();
             let decoder = DecoderBuilder::new()
                 .with_schema(schema)
@@ -3871,11 +3841,8 @@ outputs:
         #[test]
         fn with_schema_real_ara2_int8_dvm_decode_smoke() {
             use edgefirst_tensor::{Tensor, TensorDyn, TensorMemory, TensorTrait};
-            let json = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/ara2_int8_edgefirst.json"
-            ));
-            let schema = SchemaV2::parse_json(json).unwrap();
+            let json = edgefirst_bench::testdata::read_to_string("ara2_int8_edgefirst.json");
+            let schema = SchemaV2::parse_json(&json).unwrap();
             let decoder = DecoderBuilder::new()
                 .with_schema(schema)
                 .with_score_threshold(0.25)
@@ -3921,11 +3888,8 @@ outputs:
 
         #[test]
         fn with_schema_real_ara2_int16_dvm() {
-            let json = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/ara2_int16_edgefirst.json"
-            ));
-            let schema = SchemaV2::parse_json(json).unwrap();
+            let json = edgefirst_bench::testdata::read_to_string("ara2_int16_edgefirst.json");
+            let schema = SchemaV2::parse_json(&json).unwrap();
             schema.validate().unwrap();
             let decoder = DecoderBuilder::new()
                 .with_schema(schema)
@@ -3992,10 +3956,7 @@ outputs:
             // produces. This is the validator's target API: pass the raw
             // edgefirst.json string, get a decoder that handles the
             // xy/wh sub-split natively.
-            let json = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/ara2_int16_edgefirst.json"
-            ));
+            let json = edgefirst_bench::testdata::read_to_string("ara2_int16_edgefirst.json");
             let decoder = DecoderBuilder::new()
                 .with_config_json_str(json.to_string())
                 .with_score_threshold(0.25)
@@ -4010,10 +3971,7 @@ outputs:
 
         #[test]
         fn json_str_v2_ara2_int8_builds() {
-            let json = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/ara2_int8_edgefirst.json"
-            ));
+            let json = edgefirst_bench::testdata::read_to_string("ara2_int8_edgefirst.json");
             let decoder = DecoderBuilder::new()
                 .with_config_json_str(json.to_string())
                 .with_score_threshold(0.25)
@@ -4026,10 +3984,7 @@ outputs:
         fn json_str_v1_legacy_still_builds() {
             // Legacy v1 JSON must continue to build via the same path
             // (the auto-detect must not regress v1 callers).
-            let json = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/modelpack_split.json"
-            ));
+            let json = edgefirst_bench::testdata::read_to_string("modelpack_split.json");
             let decoder = DecoderBuilder::new()
                 .with_config_json_str(json.to_string())
                 .build()
@@ -4066,11 +4021,8 @@ outputs:
             //   * normalized == false (pixel coords per HAILORT spec)
             //   * the DFL reg_max extracted from the program == 16
             //     (= 64 feature channels ÷ 4)
-            let json = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/hailo_yolov8seg_edgefirst.json"
-            ));
-            let schema = SchemaV2::parse_json(json).unwrap();
+            let json = edgefirst_bench::testdata::read_to_string("hailo_yolov8seg_edgefirst.json");
+            let schema = SchemaV2::parse_json(&json).unwrap();
             schema.validate().unwrap();
             let decoder = DecoderBuilder::new()
                 .with_schema(schema)
@@ -4105,11 +4057,8 @@ outputs:
         #[ignore = "TODO HAL-Phase3: legacy PerScale arm to be removed; tests should be migrated to per_scale subsystem"]
         fn hailo_yolov8seg_uniform_uint8_128_dfl_decode_parity() {
             use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
-            let json = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/hailo_yolov8seg_edgefirst.json"
-            ));
-            let schema = SchemaV2::parse_json(json).unwrap();
+            let json = edgefirst_bench::testdata::read_to_string("hailo_yolov8seg_edgefirst.json");
+            let schema = SchemaV2::parse_json(&json).unwrap();
             let decoder = DecoderBuilder::new()
                 .with_schema(schema)
                 .with_score_threshold(0.25)
@@ -4243,20 +4192,14 @@ outputs:
         use crate::yolo::impl_yolo_segdet_quant_proto;
         use crate::{Nms, ProtoLayout, Quantization, XYWH};
 
-        let boxes_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let boxes_raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let boxes_i8 =
             unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
         let boxes = ndarray::Array2::from_shape_vec((116, 8400), boxes_i8.to_vec()).unwrap();
 
         // Create protos in physical NCHW layout [K, H, W] then view as [H, W, K].
         let (k, h, w) = (32, 160, 160);
-        let protos_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let protos_raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let protos_i8 = unsafe {
             std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
         };
@@ -4324,20 +4267,14 @@ outputs:
 
         // Use a very high score threshold so no detections survive NMS.
         // The proto layout should still be correctly detected as NCHW.
-        let boxes_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let boxes_raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let boxes_i8 =
             unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
         let boxes = ndarray::Array2::from_shape_vec((116, 8400), boxes_i8.to_vec()).unwrap();
 
         // Create NCHW protos (same as the non-zero-det test).
         let (k, h, w) = (32, 160, 160);
-        let protos_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let protos_raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let protos_i8 = unsafe {
             std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
         };

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -241,9 +241,8 @@ mod decoder_builder_tests {
 
     #[test]
     fn builder_flat_schema_does_not_attach_per_scale_decoder() {
-        let schema_json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_flat_schema.json",
-        );
+        let schema_json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_flat_schema.json");
         let schema: crate::schema::SchemaV2 =
             serde_json::from_str(&schema_json).expect("flat fixture must parse");
 

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -879,28 +879,19 @@ mod decoder_tests {
     // ─── Shared test data loaders ────────────────────────
 
     fn load_yolov8_boxes() -> Array3<i8> {
-        let raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let raw = unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const i8, raw.len()) };
         Array3::from_shape_vec((1, 116, 8400), raw.to_vec()).unwrap()
     }
 
     fn load_yolov8_protos() -> Array4<i8> {
-        let raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let raw = unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const i8, raw.len()) };
         Array4::from_shape_vec((1, 160, 160, 32), raw.to_vec()).unwrap()
     }
 
     fn load_yolov8s_det() -> Array3<i8> {
-        let raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8s_80_classes.bin"
-        ));
+        let raw = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
         let raw = unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const i8, raw.len()) };
         Array3::from_shape_vec((1, 84, 8400), raw.to_vec()).unwrap()
     }
@@ -909,16 +900,10 @@ mod decoder_tests {
     fn test_decoder_modelpack() {
         let score_threshold = 0.45;
         let iou_threshold = 0.45;
-        let boxes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_boxes_1935x1x4.bin"
-        ));
+        let boxes = edgefirst_bench::testdata::read("modelpack_boxes_1935x1x4.bin");
         let boxes = ndarray::Array4::from_shape_vec((1, 1935, 1, 4), boxes.to_vec()).unwrap();
 
-        let scores = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_scores_1935x1.bin"
-        ));
+        let scores = edgefirst_bench::testdata::read("modelpack_scores_1935x1.bin");
         let scores = ndarray::Array3::from_shape_vec((1, 1935, 1), scores.to_vec()).unwrap();
 
         let quant_boxes = (0.004656755365431309, 21).into();
@@ -1016,16 +1001,10 @@ mod decoder_tests {
     fn test_decoder_modelpack_split_u8() {
         let score_threshold = 0.45;
         let iou_threshold = 0.45;
-        let detect0 = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_split_9x15x18.bin"
-        ));
+        let detect0 = edgefirst_bench::testdata::read("modelpack_split_9x15x18.bin");
         let detect0 = ndarray::Array4::from_shape_vec((1, 9, 15, 18), detect0.to_vec()).unwrap();
 
-        let detect1 = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_split_17x30x18.bin"
-        ));
+        let detect1 = edgefirst_bench::testdata::read("modelpack_split_17x30x18.bin");
         let detect1 = ndarray::Array4::from_shape_vec((1, 17, 30, 18), detect1.to_vec()).unwrap();
 
         let quant0 = (0.08547406643629074, 174).into();
@@ -1142,24 +1121,15 @@ mod decoder_tests {
     fn test_decoder_parse_config_modelpack_split_u8() {
         let score_threshold = 0.45;
         let iou_threshold = 0.45;
-        let detect0 = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_split_9x15x18.bin"
-        ));
+        let detect0 = edgefirst_bench::testdata::read("modelpack_split_9x15x18.bin");
         let detect0 = ndarray::Array4::from_shape_vec((1, 9, 15, 18), detect0.to_vec()).unwrap();
 
-        let detect1 = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_split_17x30x18.bin"
-        ));
+        let detect1 = edgefirst_bench::testdata::read("modelpack_split_17x30x18.bin");
         let detect1 = ndarray::Array4::from_shape_vec((1, 17, 30, 18), detect1.to_vec()).unwrap();
 
         let decoder = DecoderBuilder::default()
             .with_config_yaml_str(
-                include_str!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/modelpack_split.yaml"
-                ))
+                edgefirst_bench::testdata::read_to_string("modelpack_split.yaml")
                 .to_string(),
             )
             .with_score_threshold(score_threshold)
@@ -1196,10 +1166,7 @@ mod decoder_tests {
 
     #[test]
     fn test_modelpack_seg() {
-        let out = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_seg_2x160x160.bin"
-        ));
+        let out = edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin");
         let out = ndarray::Array4::from_shape_vec((1, 2, 160, 160), out.to_vec()).unwrap();
         let quant = (1.0 / 255.0, 0).into();
 
@@ -1258,10 +1225,7 @@ mod decoder_tests {
     }
     #[test]
     fn test_modelpack_seg_quant() {
-        let out = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_seg_2x160x160.bin"
-        ));
+        let out = edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin");
         let out_u8 = ndarray::Array4::from_shape_vec((1, 2, 160, 160), out.to_vec()).unwrap();
         let out_i8 = out_u8.mapv(|x| (x as i16 - 128) as i8);
         let out_u16 = out_u8.mapv(|x| (x as u16) << 8);
@@ -1359,22 +1323,13 @@ mod decoder_tests {
         let score_threshold = 0.45;
         let iou_threshold = 0.45;
 
-        let boxes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_boxes_1935x1x4.bin"
-        ));
+        let boxes = edgefirst_bench::testdata::read("modelpack_boxes_1935x1x4.bin");
         let boxes = Array4::from_shape_vec((1, 1935, 1, 4), boxes.to_vec()).unwrap();
 
-        let scores = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_scores_1935x1.bin"
-        ));
+        let scores = edgefirst_bench::testdata::read("modelpack_scores_1935x1.bin");
         let scores = Array3::from_shape_vec((1, 1935, 1), scores.to_vec()).unwrap();
 
-        let seg = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_seg_2x160x160.bin"
-        ));
+        let seg = edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin");
         let seg = Array4::from_shape_vec((1, 2, 160, 160), seg.to_vec()).unwrap();
 
         let quant_boxes = (0.004656755365431309, 21).into();
@@ -1485,22 +1440,13 @@ mod decoder_tests {
         let score_threshold = 0.8;
         let iou_threshold = 0.5;
 
-        let seg = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_seg_2x160x160.bin"
-        ));
+        let seg = edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin");
         let seg = ndarray::Array4::from_shape_vec((1, 2, 160, 160), seg.to_vec()).unwrap();
 
-        let detect0 = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_split_9x15x18.bin"
-        ));
+        let detect0 = edgefirst_bench::testdata::read("modelpack_split_9x15x18.bin");
         let detect0 = ndarray::Array4::from_shape_vec((1, 9, 15, 18), detect0.to_vec()).unwrap();
 
-        let detect1 = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_split_17x30x18.bin"
-        ));
+        let detect1 = edgefirst_bench::testdata::read("modelpack_split_17x30x18.bin");
         let detect1 = ndarray::Array4::from_shape_vec((1, 17, 30, 18), detect1.to_vec()).unwrap();
 
         let quant0 = (0.08547406643629074, 174).into();
@@ -1857,10 +1803,7 @@ mod decoder_tests {
             1.0 / 160.0, // wider range because mask will expand the box
         ));
 
-        let full_mask = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_mask_results.bin"
-        ));
+        let full_mask = edgefirst_bench::testdata::read("yolov8_mask_results.bin");
         let full_mask = ndarray::Array2::from_shape_vec((160, 160), full_mask.to_vec()).unwrap();
 
         let cropped_mask = full_mask.slice(ndarray::s![
@@ -2323,10 +2266,7 @@ mod decoder_tests {
     }
 
     fn build_yolov8_seg_decoder(score_threshold: f32, iou_threshold: f32) -> crate::Decoder {
-        let config_yaml = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_seg.yaml"
-        ));
+        let config_yaml = edgefirst_bench::testdata::read_to_string("yolov8_seg.yaml");
         DecoderBuilder::default()
             .with_config_yaml_str(config_yaml.to_string())
             .with_score_threshold(score_threshold)
@@ -2470,23 +2410,14 @@ mod decoder_tests {
             let score_threshold = 0.8;
             let iou_threshold = 0.5;
 
-            let seg = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/modelpack_seg_2x160x160.bin"
-            ));
+            let seg = edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin");
             let seg = ndarray::Array4::from_shape_vec((1, 2, 160, 160), seg.to_vec()).unwrap();
 
-            let detect0 = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/modelpack_split_9x15x18.bin"
-            ));
+            let detect0 = edgefirst_bench::testdata::read("modelpack_split_9x15x18.bin");
             let detect0 =
                 ndarray::Array4::from_shape_vec((1, 9, 15, 18), detect0.to_vec()).unwrap();
 
-            let detect1 = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/modelpack_split_17x30x18.bin"
-            ));
+            let detect1 = edgefirst_bench::testdata::read("modelpack_split_17x30x18.bin");
             let detect1 =
                 ndarray::Array4::from_shape_vec((1, 17, 30, 18), detect1.to_vec()).unwrap();
 
@@ -2965,20 +2896,14 @@ mod decoder_tests {
                 let quant_boxes = (0.021287762_f32, 31_i32);
                 let quant_protos = (0.02491162_f32, -117_i32);
 
-                let raw_boxes = include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/yolov8_boxes_116x8400.bin"
-                ));
+                let raw_boxes = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
                 let raw_boxes = unsafe {
                     std::slice::from_raw_parts(raw_boxes.as_ptr() as *const i8, raw_boxes.len())
                 };
                 let boxes_i8 =
                     ndarray::Array3::from_shape_vec((1, 116, 8400), raw_boxes.to_vec()).unwrap();
 
-                let raw_protos = include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/yolov8_protos_160x160x32.bin"
-                ));
+                let raw_protos = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
                 let raw_protos = unsafe {
                     std::slice::from_raw_parts(raw_protos.as_ptr() as *const i8, raw_protos.len())
                 };
@@ -3035,10 +2960,7 @@ mod decoder_tests {
                 let quant_boxes = (0.021287762_f32, 31_i32);
                 let quant_protos = (0.02491162_f32, -117_i32);
 
-                let raw_boxes = include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/yolov8_boxes_116x8400.bin"
-                ));
+                let raw_boxes = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
                 let raw_boxes = unsafe {
                     std::slice::from_raw_parts(raw_boxes.as_ptr() as *const i8, raw_boxes.len())
                 };
@@ -3047,10 +2969,7 @@ mod decoder_tests {
                 let boxes_f32: Array3<f32> =
                     dequantize_ndarray(boxes_i8.view(), quant_boxes.into());
 
-                let raw_protos = include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/yolov8_protos_160x160x32.bin"
-                ));
+                let raw_protos = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
                 let raw_protos = unsafe {
                     std::slice::from_raw_parts(raw_protos.as_ptr() as *const i8, raw_protos.len())
                 };
@@ -3638,10 +3557,7 @@ outputs:
         let score_threshold = 0.45;
         let iou_threshold = 0.45;
 
-        let raw_boxes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let raw_boxes = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let raw_boxes =
             unsafe { std::slice::from_raw_parts(raw_boxes.as_ptr() as *const i8, raw_boxes.len()) };
         let boxes_i8: Tensor<i8> = Tensor::new(&[1, 116, 8400], None, None).unwrap();
@@ -3652,10 +3568,7 @@ outputs:
             .copy_from_slice(raw_boxes);
         let boxes_i8 = boxes_i8.into();
 
-        let raw_protos = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let raw_protos = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let raw_protos = unsafe {
             std::slice::from_raw_parts(raw_protos.as_ptr() as *const i8, raw_protos.len())
         };
@@ -3687,10 +3600,7 @@ outputs:
 
         let quant_boxes = (0.021287762_f32, 31_i32);
         let quant_protos = (0.02491162_f32, -117_i32);
-        let raw_boxes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let raw_boxes = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let raw_boxes =
             unsafe { std::slice::from_raw_parts(raw_boxes.as_ptr() as *const i8, raw_boxes.len()) };
         let mut raw_boxes_f32 = vec![0f32; raw_boxes.len()];
@@ -3703,10 +3613,7 @@ outputs:
             .copy_from_slice(&raw_boxes_f32);
         let boxes_f32 = boxes_f32.into();
 
-        let raw_protos = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let raw_protos = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let raw_protos = unsafe {
             std::slice::from_raw_parts(raw_protos.as_ptr() as *const i8, raw_protos.len())
         };
@@ -3745,10 +3652,7 @@ outputs:
 
         let quant_boxes = (0.021287762_f32, 31_i32);
         let quant_protos = (0.02491162_f32, -117_i32);
-        let raw_boxes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let raw_boxes = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let raw_boxes =
             unsafe { std::slice::from_raw_parts(raw_boxes.as_ptr() as *const i8, raw_boxes.len()) };
         let mut raw_boxes_f64 = vec![0f64; raw_boxes.len()];
@@ -3761,10 +3665,7 @@ outputs:
             .copy_from_slice(&raw_boxes_f64);
         let boxes_f64 = boxes_f64.into();
 
-        let raw_protos = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let raw_protos = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let raw_protos = unsafe {
             std::slice::from_raw_parts(raw_protos.as_ptr() as *const i8, raw_protos.len())
         };
@@ -3801,10 +3702,7 @@ outputs:
         let score_threshold = 0.45;
         let iou_threshold = 0.45;
 
-        let raw_boxes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let raw_boxes = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let raw_boxes =
             unsafe { std::slice::from_raw_parts(raw_boxes.as_ptr() as *const i8, raw_boxes.len()) };
         let boxes_i8: Tensor<i8> = Tensor::new(&[1, 116, 8400], None, None).unwrap();
@@ -3815,10 +3713,7 @@ outputs:
             .copy_from_slice(raw_boxes);
         let boxes_i8 = boxes_i8.into();
 
-        let raw_protos = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let raw_protos = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let raw_protos = unsafe {
             std::slice::from_raw_parts(raw_protos.as_ptr() as *const i8, raw_protos.len())
         };
@@ -4452,10 +4347,7 @@ mod decoder_tracked_tests {
 
         let score_threshold = 0.25;
         let iou_threshold = 0.1;
-        let out = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8s_80_classes.bin"
-        ));
+        let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
         let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
         let out = Array3::from_shape_vec((1, 84, 8400), out.to_vec()).unwrap();
         let quant = (0.0040811873, -123).into();
@@ -4681,10 +4573,7 @@ mod decoder_tracked_tests {
     }
 
     fn build_yolov8_seg_decoder(score_threshold: f32, iou_threshold: f32) -> crate::Decoder {
-        let config_yaml = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_seg.yaml"
-        ));
+        let config_yaml = edgefirst_bench::testdata::read_to_string("yolov8_seg.yaml");
         DecoderBuilder::default()
             .with_config_yaml_str(config_yaml.to_string())
             .with_score_threshold(score_threshold)
@@ -4711,20 +4600,14 @@ mod decoder_tracked_tests {
                 let quant_boxes = (0.021287762_f32, 31_i32);
                 let quant_protos = (0.02491162_f32, -117_i32);
 
-                let raw_boxes = include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/yolov8_boxes_116x8400.bin"
-                ));
+                let raw_boxes = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
                 let raw_boxes = unsafe {
                     std::slice::from_raw_parts(raw_boxes.as_ptr() as *const i8, raw_boxes.len())
                 };
                 let boxes_i8 =
                     ndarray::Array3::from_shape_vec((1, 116, 8400), raw_boxes.to_vec()).unwrap();
 
-                let raw_protos = include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/yolov8_protos_160x160x32.bin"
-                ));
+                let raw_protos = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
                 let raw_protos = unsafe {
                     std::slice::from_raw_parts(raw_protos.as_ptr() as *const i8, raw_protos.len())
                 };
@@ -4896,10 +4779,7 @@ mod decoder_tracked_tests {
                 let quant_boxes = (0.021287762_f32, 31_i32);
                 let quant_protos = (0.02491162_f32, -117_i32);
 
-                let raw_boxes = include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/yolov8_boxes_116x8400.bin"
-                ));
+                let raw_boxes = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
                 let raw_boxes = unsafe {
                     std::slice::from_raw_parts(raw_boxes.as_ptr() as *const i8, raw_boxes.len())
                 };
@@ -4907,10 +4787,7 @@ mod decoder_tracked_tests {
                     ndarray::Array3::from_shape_vec((1, 116, 8400), raw_boxes.to_vec()).unwrap();
                 let boxes_f32 = dequantize_ndarray(boxes_i8.view(), quant_boxes.into());
 
-                let raw_protos = include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/yolov8_protos_160x160x32.bin"
-                ));
+                let raw_protos = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
                 let raw_protos = unsafe {
                     std::slice::from_raw_parts(raw_protos.as_ptr() as *const i8, raw_protos.len())
                 };
@@ -6235,10 +6112,7 @@ outputs:
 
         let score_threshold = 0.25;
         let iou_threshold = 0.1;
-        let out = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8s_80_classes.bin"
-        ));
+        let out = edgefirst_bench::testdata::read("yolov8s_80_classes.bin");
         let out = unsafe { std::slice::from_raw_parts(out.as_ptr() as *const i8, out.len()) };
         let mut out = Array3::from_shape_vec((1, 84, 8400), out.to_vec()).unwrap();
         let quant = (0.0040811873, -123).into();

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -1129,8 +1129,7 @@ mod decoder_tests {
 
         let decoder = DecoderBuilder::default()
             .with_config_yaml_str(
-                edgefirst_bench::testdata::read_to_string("modelpack_split.yaml")
-                .to_string(),
+                edgefirst_bench::testdata::read_to_string("modelpack_split.yaml").to_string(),
             )
             .with_score_threshold(score_threshold)
             .with_iou_threshold(iou_threshold)

--- a/crates/decoder/src/per_scale/helper.rs
+++ b/crates/decoder/src/per_scale/helper.rs
@@ -103,9 +103,8 @@ mod tests {
     #[test]
     fn applies_quant_to_int8_by_shape() {
         // Build a tiny schema with one logical output `boxes` having an int8 child.
-        let json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolov8n_schema.json",
-        );
+        let json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolov8n_schema.json");
         let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
 
         // Build a tensor matching one box child's shape.
@@ -122,9 +121,8 @@ mod tests {
 
     #[test]
     fn applies_quant_to_full_yolov8_input_set() {
-        let json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolov8n_schema.json",
-        );
+        let json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolov8n_schema.json");
         let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
 
         // Build the full set of input tensors matching every schema child + protos.
@@ -187,9 +185,8 @@ mod tests {
 
     #[test]
     fn skips_float_tensors_silently() {
-        let json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolov8n_schema.json",
-        );
+        let json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolov8n_schema.json");
         let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
 
         // Build float tensors instead of int8.

--- a/crates/decoder/src/per_scale/helper.rs
+++ b/crates/decoder/src/per_scale/helper.rs
@@ -103,8 +103,10 @@ mod tests {
     #[test]
     fn applies_quant_to_int8_by_shape() {
         // Build a tiny schema with one logical output `boxes` having an int8 child.
-        let json = include_str!("../../../../testdata/per_scale/synthetic_yolov8n_schema.json");
-        let schema: SchemaV2 = serde_json::from_str(json).unwrap();
+        let json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolov8n_schema.json",
+        );
+        let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
 
         // Build a tensor matching one box child's shape.
         // The yolov8n schema's first box child has shape [1, 80, 80, 64].
@@ -120,8 +122,10 @@ mod tests {
 
     #[test]
     fn applies_quant_to_full_yolov8_input_set() {
-        let json = include_str!("../../../../testdata/per_scale/synthetic_yolov8n_schema.json");
-        let schema: SchemaV2 = serde_json::from_str(json).unwrap();
+        let json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolov8n_schema.json",
+        );
+        let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
 
         // Build the full set of input tensors matching every schema child + protos.
         let shapes_int8 = [
@@ -183,8 +187,10 @@ mod tests {
 
     #[test]
     fn skips_float_tensors_silently() {
-        let json = include_str!("../../../../testdata/per_scale/synthetic_yolov8n_schema.json");
-        let schema: SchemaV2 = serde_json::from_str(json).unwrap();
+        let json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolov8n_schema.json",
+        );
+        let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
 
         // Build float tensors instead of int8.
         let shape = vec![1, 80, 80, 64];

--- a/crates/decoder/src/per_scale/pipeline.rs
+++ b/crates/decoder/src/per_scale/pipeline.rs
@@ -904,8 +904,10 @@ mod tests {
         // Feeding f32 tensors would hit the dispatch's mismatched-arm path
         // → KernelDispatchUnreachable. End-to-end run() integration is
         // exercised separately via the int8-with-attached-quant test below.
-        let json = include_str!("../../../../testdata/per_scale/synthetic_yolov8n_schema.json");
-        let schema: SchemaV2 = serde_json::from_str(json).unwrap();
+        let json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolov8n_schema.json",
+        );
+        let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
         let plan = PerScalePlan::try_from_schema(&schema, DecodeDtype::F32)
             .unwrap()
             .unwrap();
@@ -927,8 +929,10 @@ mod tests {
         use edgefirst_tensor::Quantization as TQ;
         use edgefirst_tensor::{Tensor, TensorMemory};
 
-        let json = include_str!("../../../../testdata/per_scale/synthetic_yolov8n_schema.json");
-        let schema: SchemaV2 = serde_json::from_str(json).unwrap();
+        let json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolov8n_schema.json",
+        );
+        let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
         let plan = PerScalePlan::try_from_schema(&schema, DecodeDtype::F32)
             .unwrap()
             .unwrap();

--- a/crates/decoder/src/per_scale/pipeline.rs
+++ b/crates/decoder/src/per_scale/pipeline.rs
@@ -904,9 +904,8 @@ mod tests {
         // Feeding f32 tensors would hit the dispatch's mismatched-arm path
         // → KernelDispatchUnreachable. End-to-end run() integration is
         // exercised separately via the int8-with-attached-quant test below.
-        let json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolov8n_schema.json",
-        );
+        let json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolov8n_schema.json");
         let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
         let plan = PerScalePlan::try_from_schema(&schema, DecodeDtype::F32)
             .unwrap()
@@ -929,9 +928,8 @@ mod tests {
         use edgefirst_tensor::Quantization as TQ;
         use edgefirst_tensor::{Tensor, TensorMemory};
 
-        let json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolov8n_schema.json",
-        );
+        let json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolov8n_schema.json");
         let schema: SchemaV2 = serde_json::from_str(&json).unwrap();
         let plan = PerScalePlan::try_from_schema(&schema, DecodeDtype::F32)
             .unwrap()

--- a/crates/decoder/src/per_scale/plan.rs
+++ b/crates/decoder/src/per_scale/plan.rs
@@ -591,18 +591,24 @@ mod tests {
     use super::*;
 
     fn fixture_yolov8n_schema() -> SchemaV2 {
-        let json = include_str!("../../../../testdata/per_scale/synthetic_yolov8n_schema.json");
-        serde_json::from_str(json).expect("yolov8n fixture must parse")
+        let json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolov8n_schema.json",
+        );
+        serde_json::from_str(&json).expect("yolov8n fixture must parse")
     }
 
     fn fixture_yolo26n_schema() -> SchemaV2 {
-        let json = include_str!("../../../../testdata/per_scale/synthetic_yolo26n_schema.json");
-        serde_json::from_str(json).expect("yolo26n fixture must parse")
+        let json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolo26n_schema.json",
+        );
+        serde_json::from_str(&json).expect("yolo26n fixture must parse")
     }
 
     fn fixture_flat_schema() -> SchemaV2 {
-        let json = include_str!("../../../../testdata/per_scale/synthetic_flat_schema.json");
-        serde_json::from_str(json).expect("flat fixture must parse")
+        let json = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_flat_schema.json",
+        );
+        serde_json::from_str(&json).expect("flat fixture must parse")
     }
 
     #[test]

--- a/crates/decoder/src/per_scale/plan.rs
+++ b/crates/decoder/src/per_scale/plan.rs
@@ -591,23 +591,20 @@ mod tests {
     use super::*;
 
     fn fixture_yolov8n_schema() -> SchemaV2 {
-        let json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolov8n_schema.json",
-        );
+        let json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolov8n_schema.json");
         serde_json::from_str(&json).expect("yolov8n fixture must parse")
     }
 
     fn fixture_yolo26n_schema() -> SchemaV2 {
-        let json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolo26n_schema.json",
-        );
+        let json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolo26n_schema.json");
         serde_json::from_str(&json).expect("yolo26n fixture must parse")
     }
 
     fn fixture_flat_schema() -> SchemaV2 {
-        let json = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_flat_schema.json",
-        );
+        let json =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_flat_schema.json");
         serde_json::from_str(&json).expect("flat fixture must parse")
     }
 

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -1352,19 +1352,16 @@ mod tests {
 
     #[test]
     fn fixtures_round_trip_through_serde() {
-        let yolov8 = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolov8n_schema.json",
-        );
+        let yolov8 =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolov8n_schema.json");
         let _: super::SchemaV2 = serde_json::from_str(&yolov8).expect("yolov8n fixture must parse");
 
-        let yolo26 = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_yolo26n_schema.json",
-        );
+        let yolo26 =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_yolo26n_schema.json");
         let _: super::SchemaV2 = serde_json::from_str(&yolo26).expect("yolo26n fixture must parse");
 
-        let flat = edgefirst_bench::testdata::read_to_string(
-            "per_scale/synthetic_flat_schema.json",
-        );
+        let flat =
+            edgefirst_bench::testdata::read_to_string("per_scale/synthetic_flat_schema.json");
         let _: super::SchemaV2 = serde_json::from_str(&flat).expect("flat fixture must parse");
     }
 

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -1804,11 +1804,8 @@ mod tests {
 
     #[test]
     fn parse_v1_yaml_yolov8_seg_testdata() {
-        let yaml = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_seg.yaml"
-        ));
-        let schema = SchemaV2::parse_yaml(yaml).expect("parse v1 yaml");
+        let yaml = edgefirst_bench::testdata::read_to_string("yolov8_seg.yaml");
+        let schema = SchemaV2::parse_yaml(&yaml).expect("parse v1 yaml");
         assert_eq!(schema.schema_version, 2);
         assert_eq!(schema.outputs.len(), 2);
         // First output: Detection [1, 116, 8400]
@@ -1829,11 +1826,8 @@ mod tests {
 
     #[test]
     fn parse_v1_json_modelpack_split_testdata() {
-        let json = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_split.json"
-        ));
-        let schema = SchemaV2::parse_json(json).expect("parse v1 json");
+        let json = edgefirst_bench::testdata::read_to_string("modelpack_split.json");
+        let schema = SchemaV2::parse_json(&json).expect("parse v1 json");
         assert_eq!(schema.schema_version, 2);
         assert_eq!(schema.outputs.len(), 2);
         // Both are ModelPack anchor detection with anchors
@@ -2304,11 +2298,8 @@ mod tests {
 
     #[test]
     fn parse_real_ara2_int8_dvm_metadata() {
-        let json = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/ara2_int8_edgefirst.json"
-        ));
-        let schema = SchemaV2::parse_json(json).expect("ARA-2 int8 parse");
+        let json = edgefirst_bench::testdata::read_to_string("ara2_int8_edgefirst.json");
+        let schema = SchemaV2::parse_json(&json).expect("ARA-2 int8 parse");
         assert_eq!(schema.schema_version, 2);
         assert_eq!(schema.decoder_version, Some(DecoderVersion::Yolov8));
         assert_eq!(schema.nms, Some(NmsMode::ClassAgnostic));
@@ -2349,11 +2340,8 @@ mod tests {
 
     #[test]
     fn parse_real_ara2_int16_dvm_metadata() {
-        let json = include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/ara2_int16_edgefirst.json"
-        ));
-        let schema = SchemaV2::parse_json(json).expect("ARA-2 int16 parse");
+        let json = edgefirst_bench::testdata::read_to_string("ara2_int16_edgefirst.json");
+        let schema = SchemaV2::parse_json(&json).expect("ARA-2 int16 parse");
         assert_eq!(schema.schema_version, 2);
         assert_eq!(schema.outputs.len(), 4);
         let boxes = &schema.outputs[0];

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -1352,14 +1352,20 @@ mod tests {
 
     #[test]
     fn fixtures_round_trip_through_serde() {
-        let yolov8 = include_str!("../../../testdata/per_scale/synthetic_yolov8n_schema.json");
-        let _: super::SchemaV2 = serde_json::from_str(yolov8).expect("yolov8n fixture must parse");
+        let yolov8 = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolov8n_schema.json",
+        );
+        let _: super::SchemaV2 = serde_json::from_str(&yolov8).expect("yolov8n fixture must parse");
 
-        let yolo26 = include_str!("../../../testdata/per_scale/synthetic_yolo26n_schema.json");
-        let _: super::SchemaV2 = serde_json::from_str(yolo26).expect("yolo26n fixture must parse");
+        let yolo26 = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_yolo26n_schema.json",
+        );
+        let _: super::SchemaV2 = serde_json::from_str(&yolo26).expect("yolo26n fixture must parse");
 
-        let flat = include_str!("../../../testdata/per_scale/synthetic_flat_schema.json");
-        let _: super::SchemaV2 = serde_json::from_str(flat).expect("flat fixture must parse");
+        let flat = edgefirst_bench::testdata::read_to_string(
+            "per_scale/synthetic_flat_schema.json",
+        );
+        let _: super::SchemaV2 = serde_json::from_str(&flat).expect("flat fixture must parse");
     }
 
     #[test]

--- a/crates/image/benches/common.rs
+++ b/crates/image/benches/common.rs
@@ -214,21 +214,34 @@ impl BenchConfig {
 }
 
 // =============================================================================
-// Embedded Test Data
+// Test Data (loaded from testdata/ at first access; resolution via
+// EDGEFIRST_TESTDATA_DIR or workspace fallback — see edgefirst_bench::testdata)
 // =============================================================================
 
-pub const CAMERA_720P_YUYV: &[u8] = include_bytes!("../../../testdata/camera720p.yuyv");
-pub const CAMERA_720P_VYUY: &[u8] = include_bytes!("../../../testdata/camera720p.vyuy");
-pub const CAMERA_720P_NV12: &[u8] = include_bytes!("../../../testdata/camera720p.nv12");
-pub const CAMERA_720P_RGB: &[u8] = include_bytes!("../../../testdata/camera720p.rgb");
-pub const CAMERA_1080P_YUYV: &[u8] = include_bytes!("../../../testdata/camera1080p.yuyv");
-pub const CAMERA_1080P_NV12: &[u8] = include_bytes!("../../../testdata/camera1080p.nv12");
-pub const CAMERA_1080P_RGB: &[u8] = include_bytes!("../../../testdata/camera1080p.rgb");
-pub const CAMERA_1080P_VYUY: &[u8] = include_bytes!("../../../testdata/camera1080p.vyuy");
-pub const CAMERA_4K_YUYV: &[u8] = include_bytes!("../../../testdata/camera4k.yuyv");
-pub const CAMERA_4K_VYUY: &[u8] = include_bytes!("../../../testdata/camera4k.vyuy");
-pub const CAMERA_4K_NV12: &[u8] = include_bytes!("../../../testdata/camera4k.nv12");
-pub const CAMERA_4K_RGB: &[u8] = include_bytes!("../../../testdata/camera4k.rgb");
+pub static CAMERA_720P_YUYV: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera720p.yuyv"));
+pub static CAMERA_720P_VYUY: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera720p.vyuy"));
+pub static CAMERA_720P_NV12: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera720p.nv12"));
+pub static CAMERA_720P_RGB: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera720p.rgb"));
+pub static CAMERA_1080P_YUYV: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera1080p.yuyv"));
+pub static CAMERA_1080P_NV12: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera1080p.nv12"));
+pub static CAMERA_1080P_RGB: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera1080p.rgb"));
+pub static CAMERA_1080P_VYUY: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera1080p.vyuy"));
+pub static CAMERA_4K_YUYV: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera4k.yuyv"));
+pub static CAMERA_4K_VYUY: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera4k.vyuy"));
+pub static CAMERA_4K_NV12: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera4k.nv12"));
+pub static CAMERA_4K_RGB: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera4k.rgb"));
 
 // NV16 is 4:2:2 semi-planar: Y plane (W*H) + interleaved UV plane (W*H).
 // No real capture file available; synthetic mid-gray data is sufficient for
@@ -243,20 +256,20 @@ static CAMERA_1080P_RGBA: LazyLock<Vec<u8>> = LazyLock::new(|| vec![128u8; 1920 
 /// Get embedded test data for a given resolution and format.
 pub fn get_test_data(width: usize, height: usize, format: PixelFormat) -> &'static [u8] {
     match (width, height, format) {
-        (1280, 720, PixelFormat::Yuyv) => CAMERA_720P_YUYV,
-        (1280, 720, PixelFormat::Vyuy) => CAMERA_720P_VYUY,
-        (1280, 720, PixelFormat::Nv12) => CAMERA_720P_NV12,
-        (1280, 720, PixelFormat::Rgb) => CAMERA_720P_RGB,
-        (1920, 1080, PixelFormat::Yuyv) => CAMERA_1080P_YUYV,
-        (1920, 1080, PixelFormat::Vyuy) => CAMERA_1080P_VYUY,
-        (1920, 1080, PixelFormat::Nv12) => CAMERA_1080P_NV12,
+        (1280, 720, PixelFormat::Yuyv) => &CAMERA_720P_YUYV,
+        (1280, 720, PixelFormat::Vyuy) => &CAMERA_720P_VYUY,
+        (1280, 720, PixelFormat::Nv12) => &CAMERA_720P_NV12,
+        (1280, 720, PixelFormat::Rgb) => &CAMERA_720P_RGB,
+        (1920, 1080, PixelFormat::Yuyv) => &CAMERA_1080P_YUYV,
+        (1920, 1080, PixelFormat::Vyuy) => &CAMERA_1080P_VYUY,
+        (1920, 1080, PixelFormat::Nv12) => &CAMERA_1080P_NV12,
         (1920, 1080, PixelFormat::Nv16) => &CAMERA_1080P_NV16,
-        (1920, 1080, PixelFormat::Rgb) => CAMERA_1080P_RGB,
+        (1920, 1080, PixelFormat::Rgb) => &CAMERA_1080P_RGB,
         (1920, 1080, PixelFormat::Rgba) => &CAMERA_1080P_RGBA,
-        (3840, 2160, PixelFormat::Yuyv) => CAMERA_4K_YUYV,
-        (3840, 2160, PixelFormat::Vyuy) => CAMERA_4K_VYUY,
-        (3840, 2160, PixelFormat::Nv12) => CAMERA_4K_NV12,
-        (3840, 2160, PixelFormat::Rgb) => CAMERA_4K_RGB,
+        (3840, 2160, PixelFormat::Yuyv) => &CAMERA_4K_YUYV,
+        (3840, 2160, PixelFormat::Vyuy) => &CAMERA_4K_VYUY,
+        (3840, 2160, PixelFormat::Nv12) => &CAMERA_4K_NV12,
+        (3840, 2160, PixelFormat::Rgb) => &CAMERA_4K_RGB,
         _ => panic!("No test data for {}x{} {:?}", width, height, format),
     }
 }

--- a/crates/image/benches/image_benchmark.rs
+++ b/crates/image/benches/image_benchmark.rs
@@ -25,13 +25,16 @@ use edgefirst_bench::BenchSuite;
 
 use edgefirst_image::{Crop, Flip, ImageProcessor, ImageProcessorTrait, Rotation};
 use edgefirst_tensor::{DType, PixelFormat, TensorMapTrait, TensorMemory, TensorTrait};
+use std::sync::LazyLock;
 
 const WARMUP: usize = 10;
 const ITERATIONS: usize = 100;
 
-// Embedded test data — used in convert and hires sections
-const CAMERA_1080P_RGBA: &[u8] = include_bytes!("../../../testdata/camera1080p.rgba");
-const CAMERA_4K_RGBA: &[u8] = include_bytes!("../../../testdata/camera4k.rgba");
+// Test data loaded at first access from testdata/ (see edgefirst_bench::testdata)
+static CAMERA_1080P_RGBA: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera1080p.rgba"));
+static CAMERA_4K_RGBA: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("camera4k.rgba"));
 
 // =============================================================================
 // 1. Load Benchmarks — JPEG loading to different backends and formats
@@ -61,7 +64,8 @@ fn bench_load(suite: &mut BenchSuite) {
     // Load zidane to Shm and DMA backends
     #[cfg(target_os = "linux")]
     {
-        let zidane = include_bytes!("../../../testdata/zidane.jpg");
+        let zidane = edgefirst_bench::testdata::read("zidane.jpg");
+        let zidane = zidane.as_slice();
 
         {
             let name = "load/shm/RGBA/zidane";
@@ -98,7 +102,8 @@ fn bench_load(suite: &mut BenchSuite) {
 
     // Load zidane to different formats (Mem backend)
     println!("\n== Load: JPEG to Different Formats ==\n");
-    let zidane = include_bytes!("../../../testdata/zidane.jpg");
+    let zidane = edgefirst_bench::testdata::read("zidane.jpg");
+    let zidane = zidane.as_slice();
     for (fmt, fmt_name) in &[
         (PixelFormat::Rgba, "RGBA"),
         (PixelFormat::Rgb, "RGB"),
@@ -238,16 +243,36 @@ fn bench_convert(proc: &mut ImageProcessor, suite: &mut BenchSuite) {
             get_test_data(w, h, PixelFormat::Yuyv),
             2,
         ),
-        (PixelFormat::Rgba, PixelFormat::Yuyv, CAMERA_1080P_RGBA, 4),
-        (PixelFormat::Rgba, PixelFormat::Rgb, CAMERA_1080P_RGBA, 4),
-        (PixelFormat::Rgba, PixelFormat::Rgba, CAMERA_1080P_RGBA, 4),
+        (
+            PixelFormat::Rgba,
+            PixelFormat::Yuyv,
+            CAMERA_1080P_RGBA.as_slice(),
+            4,
+        ),
+        (
+            PixelFormat::Rgba,
+            PixelFormat::Rgb,
+            CAMERA_1080P_RGBA.as_slice(),
+            4,
+        ),
+        (
+            PixelFormat::Rgba,
+            PixelFormat::Rgba,
+            CAMERA_1080P_RGBA.as_slice(),
+            4,
+        ),
         (
             PixelFormat::Rgba,
             PixelFormat::PlanarRgb,
-            CAMERA_1080P_RGBA,
+            CAMERA_1080P_RGBA.as_slice(),
             4,
         ),
-        (PixelFormat::Rgba, PixelFormat::Nv16, CAMERA_1080P_RGBA, 4),
+        (
+            PixelFormat::Rgba,
+            PixelFormat::Nv16,
+            CAMERA_1080P_RGBA.as_slice(),
+            4,
+        ),
     ];
 
     for &(in_fmt, out_fmt, data, bpp) in configs {
@@ -290,7 +315,8 @@ fn bench_convert(proc: &mut ImageProcessor, suite: &mut BenchSuite) {
 fn bench_rotate(proc: &mut ImageProcessor, suite: &mut BenchSuite) {
     println!("\n== Rotate: 90/180/270 degree rotations ==\n");
 
-    let zidane = include_bytes!("../../../testdata/zidane.jpg");
+    let zidane = edgefirst_bench::testdata::read("zidane.jpg");
+    let zidane = zidane.as_slice();
     let src = edgefirst_image::load_image(zidane, Some(PixelFormat::Rgba), None)
         .expect("Failed to load zidane.jpg");
     let (w, h) = (src.width().unwrap(), src.height().unwrap());
@@ -432,9 +458,9 @@ fn run_hires_configs(
             return;
         };
         let data: &[u8] = if src_w == 1920 && src_h == 1080 {
-            CAMERA_1080P_RGBA
+            CAMERA_1080P_RGBA.as_slice()
         } else {
-            CAMERA_4K_RGBA
+            CAMERA_4K_RGBA.as_slice()
         };
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[..data.len()].copy_from_slice(data);
         src

--- a/crates/image/benches/mask_benchmark.rs
+++ b/crates/image/benches/mask_benchmark.rs
@@ -31,6 +31,7 @@ use edgefirst_image::{CPUProcessor, ImageProcessor, ImageProcessorTrait, MaskRes
 use edgefirst_tensor::{DType, PixelFormat, Tensor, TensorDyn, TensorMapTrait, TensorTrait};
 use half::f16;
 use ndarray::s;
+use std::sync::LazyLock;
 
 const WARMUP: usize = 10;
 const ITERATIONS: usize = 100;
@@ -50,9 +51,11 @@ const IOU_THRESHOLD: f32 = 0.45;
 const OUTPUT_W: usize = 640;
 const OUTPUT_H: usize = 640;
 
-/// Embedded test data: YOLOv8 segmentation model outputs.
-const BOXES_RAW: &[u8] = include_bytes!("../../../testdata/yolov8_boxes_116x8400.bin");
-const PROTOS_RAW: &[u8] = include_bytes!("../../../testdata/yolov8_protos_160x160x32.bin");
+/// YOLOv8 segmentation model outputs, loaded from testdata/ at first access.
+static BOXES_RAW: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin"));
+static PROTOS_RAW: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin"));
 
 /// Wrap the embedded int8 boxes fixture as a `[1, 116, 8400]` `TensorDyn::I8`.
 fn load_boxes_tensor() -> TensorDyn {

--- a/crates/image/benches/mask_decode_benchmark.rs
+++ b/crates/image/benches/mask_decode_benchmark.rs
@@ -41,6 +41,7 @@ use edgefirst_image::CPUProcessor;
 use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorTrait};
 
 use std::path::Path;
+use std::sync::LazyLock;
 
 const WARMUP: usize = 10;
 const ITERATIONS: usize = 100;
@@ -69,12 +70,14 @@ const LETTERBOX_640X480: [f32; 4] = [0.0, 80.0 / 640.0, 1.0, 560.0 / 640.0];
 
 /// Path to safetensors test data.
 fn safetensors_path() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../testdata/mask_decode_scaled.safetensors")
+    edgefirst_bench::testdata::path("mask_decode_scaled.safetensors")
 }
 
-/// Embedded test data: YOLOv8 segmentation model outputs (fallback).
-const BOXES_RAW: &[u8] = include_bytes!("../../../testdata/yolov8_boxes_116x8400.bin");
-const PROTOS_RAW: &[u8] = include_bytes!("../../../testdata/yolov8_protos_160x160x32.bin");
+/// YOLOv8 segmentation model outputs (fallback), loaded from testdata/.
+static BOXES_RAW: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin"));
+static PROTOS_RAW: LazyLock<Vec<u8>> =
+    LazyLock::new(|| edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin"));
 
 /// Wrap the embedded int8 boxes fixture as a `[1, 116, 8400]` `TensorDyn::I8`.
 fn load_boxes_tensor() -> TensorDyn {

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -165,11 +165,7 @@ mod cpu_tests {
                 720,
                 $src_fmt,
                 None,
-                include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/",
-                    $src_file
-                )),
+                &edgefirst_bench::testdata::read($src_file),
             )?;
 
             // Load destination reference
@@ -178,11 +174,7 @@ mod cpu_tests {
                 720,
                 $dst_fmt,
                 None,
-                include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/",
-                    $dst_file
-                )),
+                &edgefirst_bench::testdata::read($dst_file),
             )?;
 
             let mut converter = CPUProcessor::default();
@@ -219,11 +211,7 @@ mod cpu_tests {
                 720,
                 $src_fmt,
                 None,
-                include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/",
-                    $src_file
-                )),
+                &edgefirst_bench::testdata::read($src_file),
             )?;
 
             // Load destination reference
@@ -232,11 +220,7 @@ mod cpu_tests {
                 720,
                 $dst_fmt,
                 None,
-                include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/",
-                    $dst_file
-                )),
+                &edgefirst_bench::testdata::read($dst_file),
             )?;
 
             let mut converter = CPUProcessor::default();
@@ -1041,10 +1025,7 @@ mod cpu_tests {
         use ndarray::Array3;
 
         let image = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -1053,10 +1034,7 @@ mod cpu_tests {
 
         let mut segmentation = Array3::from_shape_vec(
             (2, 160, 160),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/modelpack_seg_2x160x160.bin"
-            ))
+            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin")
             .to_vec(),
         )
         .unwrap();
@@ -1093,10 +1071,7 @@ mod cpu_tests {
         // draw_decoded_masks fully writes dst: we must pass the camera
         // frame as a background via MaskOverlay, not as the dst canvas.
         let bg = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -1112,10 +1087,7 @@ mod cpu_tests {
 
         let segmentation = Array3::from_shape_vec(
             (76, 55, 1),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/yolov8_seg_crop_76x55.bin"
-            ))
+            edgefirst_bench::testdata::read("yolov8_seg_crop_76x55.bin")
             .to_vec(),
         )
         .unwrap();
@@ -1153,10 +1125,7 @@ mod cpu_tests {
             TensorDyn::from(__t)
         };
         let expected = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/output_render_cpu.jpg"
-            )),
+            &edgefirst_bench::testdata::read("output_render_cpu.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -1558,10 +1527,7 @@ mod cpu_tests {
             720,
             PixelFormat::Nv12,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -1602,10 +1568,7 @@ mod cpu_tests {
             720,
             PixelFormat::Yuyv,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -1645,10 +1608,7 @@ mod cpu_tests {
             720,
             PixelFormat::Vyuy,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.vyuy"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.vyuy"),
         )
         .unwrap();
 
@@ -1688,10 +1648,7 @@ mod cpu_tests {
             720,
             PixelFormat::Nv16,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv16"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.nv16"),
         )
         .unwrap();
 
@@ -2272,20 +2229,14 @@ mod cpu_tests {
         use edgefirst_decoder::{configs, ConfigOutput, DecoderBuilder, DetectBox, Nms, ProtoData};
         use edgefirst_tensor::{Tensor, TensorDyn};
 
-        let boxes_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let boxes_raw = edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let boxes_i8 =
             unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
         let boxes_tensor = TensorDyn::I8(
             Tensor::<i8>::from_slice(boxes_i8, &[1, 116, 8400]).expect("boxes tensor"),
         );
 
-        let protos_raw = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let protos_raw = edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let protos_i8 = unsafe {
             std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
         };
@@ -2952,17 +2903,14 @@ mod cpu_tests {
     #[test]
     fn test_multiplane_nv12_to_rgb_cpu() -> Result<()> {
         // Load PixelFormat::Nv12 test data as contiguous buffer
-        let nv12_bytes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes = edgefirst_bench::testdata::read("camera720p.nv12");
         let width = 1280usize;
         let height = 720usize;
         let y_size = width * height;
         let uv_size = width * (height / 2);
 
         // ── Contiguous path (baseline) ──────────────────────────────
-        let contiguous = load_bytes_to_tensor(width, height, PixelFormat::Nv12, None, nv12_bytes)?;
+        let contiguous = load_bytes_to_tensor(width, height, PixelFormat::Nv12, None, &nv12_bytes)?;
         let dst_contiguous = TensorDyn::image(width, height, PixelFormat::Rgb, DType::U8, None)?;
         let mut converter = CPUProcessor::default();
         let contiguous_dyn = contiguous;
@@ -3015,16 +2963,13 @@ mod cpu_tests {
 
     #[test]
     fn test_multiplane_nv12_to_rgba_cpu() -> Result<()> {
-        let nv12_bytes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes = edgefirst_bench::testdata::read("camera720p.nv12");
         let width = 1280usize;
         let height = 720usize;
         let y_size = width * height;
         let uv_size = width * (height / 2);
 
-        let contiguous = load_bytes_to_tensor(width, height, PixelFormat::Nv12, None, nv12_bytes)?;
+        let contiguous = load_bytes_to_tensor(width, height, PixelFormat::Nv12, None, &nv12_bytes)?;
         let dst_contiguous = TensorDyn::image(width, height, PixelFormat::Rgba, DType::U8, None)?;
         let mut converter = CPUProcessor::default();
         let contiguous_dyn = contiguous;
@@ -3074,16 +3019,13 @@ mod cpu_tests {
 
     #[test]
     fn test_multiplane_nv12_to_grey_cpu() -> Result<()> {
-        let nv12_bytes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes = edgefirst_bench::testdata::read("camera720p.nv12");
         let width = 1280usize;
         let height = 720usize;
         let y_size = width * height;
         let uv_size = width * (height / 2);
 
-        let contiguous = load_bytes_to_tensor(width, height, PixelFormat::Nv12, None, nv12_bytes)?;
+        let contiguous = load_bytes_to_tensor(width, height, PixelFormat::Nv12, None, &nv12_bytes)?;
         let dst_contiguous = TensorDyn::image(width, height, PixelFormat::Grey, DType::U8, None)?;
         let mut converter = CPUProcessor::default();
         let contiguous_dyn = contiguous;

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -1034,8 +1034,7 @@ mod cpu_tests {
 
         let mut segmentation = Array3::from_shape_vec(
             (2, 160, 160),
-            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin")
-            .to_vec(),
+            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin").to_vec(),
         )
         .unwrap();
         segmentation.swap_axes(0, 1);
@@ -1087,8 +1086,7 @@ mod cpu_tests {
 
         let segmentation = Array3::from_shape_vec(
             (76, 55, 1),
-            edgefirst_bench::testdata::read("yolov8_seg_crop_76x55.bin")
-            .to_vec(),
+            edgefirst_bench::testdata::read("yolov8_seg_crop_76x55.bin").to_vec(),
         )
         .unwrap();
 

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -488,10 +488,7 @@ mod g2d_tests {
     ) -> Result<(), crate::Error> {
         let dst_width = 1280;
         let dst_height = 720;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgb), None)?;
 
@@ -502,10 +499,7 @@ mod g2d_tests {
 
         // For PixelFormat::Nv12 input, load from file since CPU doesn't support PixelFormat::Rgb→PixelFormat::Nv12
         if g2d_in_fmt == PixelFormat::Nv12 {
-            let nv12_bytes = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.nv12"
-            ));
+            let nv12_bytes = edgefirst_bench::testdata::read("zidane.nv12");
             src2.as_u8()
                 .unwrap()
                 .map()?
@@ -615,10 +609,7 @@ mod g2d_tests {
     ) -> Result<(), crate::Error> {
         let dst_width = 600;
         let dst_height = 400;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgb), None)?;
 
@@ -644,10 +635,7 @@ mod g2d_tests {
 
         // For PixelFormat::Nv12 input, load from file since CPU doesn't support PixelFormat::Rgb→PixelFormat::Nv12
         if g2d_in_fmt == PixelFormat::Nv12 {
-            let nv12_bytes = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.nv12"
-            ));
+            let nv12_bytes = edgefirst_bench::testdata::read("zidane.nv12");
             src2.as_u8()
                 .unwrap()
                 .map()?
@@ -715,10 +703,7 @@ mod g2d_tests {
             }),
             dst_color: None,
         };
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgb), None)?;
 
@@ -745,10 +730,7 @@ mod g2d_tests {
 
         // For PixelFormat::Nv12 input, load from file since CPU doesn't support PixelFormat::Rgb→PixelFormat::Nv12
         if g2d_in_fmt == PixelFormat::Nv12 {
-            let nv12_bytes = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.nv12"
-            ));
+            let nv12_bytes = edgefirst_bench::testdata::read("zidane.nv12");
             src2.as_u8()
                 .unwrap()
                 .map()?
@@ -909,10 +891,7 @@ mod g2d_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )?;
 
         // Load PixelFormat::Rgba reference (ffmpeg-generated)
@@ -921,10 +900,7 @@ mod g2d_tests {
             720,
             PixelFormat::Rgba,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            edgefirst_bench::testdata::read("camera720p.rgba"),
         )?;
 
         // Convert using G2D
@@ -977,10 +953,7 @@ mod g2d_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )?;
 
         // Load PixelFormat::Rgb reference (ffmpeg-generated)
@@ -989,10 +962,7 @@ mod g2d_tests {
             720,
             PixelFormat::Rgb,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgb"
-            )),
+            edgefirst_bench::testdata::read("camera720p.rgb"),
         )?;
 
         // Convert using G2D
@@ -1045,10 +1015,7 @@ mod g2d_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            edgefirst_bench::testdata::read("camera720p.yuyv"),
         )?;
 
         // Load PixelFormat::Rgba reference (ffmpeg-generated)
@@ -1057,10 +1024,7 @@ mod g2d_tests {
             720,
             PixelFormat::Rgba,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            edgefirst_bench::testdata::read("camera720p.rgba"),
         )?;
 
         // Convert using G2D
@@ -1113,10 +1077,7 @@ mod g2d_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            edgefirst_bench::testdata::read("camera720p.yuyv"),
         )?;
 
         // Load PixelFormat::Rgb reference (ffmpeg-generated)
@@ -1125,10 +1086,7 @@ mod g2d_tests {
             720,
             PixelFormat::Rgb,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgb"
-            )),
+            edgefirst_bench::testdata::read("camera720p.rgb"),
         )?;
 
         // Convert using G2D
@@ -1187,10 +1145,7 @@ mod g2d_tests {
     }
 
     fn test_g2d_bgra_no_resize_(g2d_in_fmt: PixelFormat) -> Result<(), crate::Error> {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgb), None)?;
 
@@ -1199,10 +1154,7 @@ mod g2d_tests {
         let mut cpu_converter = CPUProcessor::new();
 
         if g2d_in_fmt == PixelFormat::Nv12 {
-            let nv12_bytes = include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.nv12"
-            ));
+            let nv12_bytes = edgefirst_bench::testdata::read("zidane.nv12");
             src2.as_u8()
                 .unwrap()
                 .map()?

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -488,8 +488,7 @@ mod g2d_tests {
     ) -> Result<(), crate::Error> {
         let dst_width = 1280;
         let dst_height = 720;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgb), None)?;
 
         // Create DMA buffer for G2D input
@@ -504,7 +503,7 @@ mod g2d_tests {
                 .unwrap()
                 .map()?
                 .as_mut_slice()
-                .copy_from_slice(nv12_bytes);
+                .copy_from_slice(&nv12_bytes);
         } else {
             cpu_converter.convert(&src, &mut src2, Rotation::None, Flip::None, Crop::no_crop())?;
         }
@@ -609,8 +608,7 @@ mod g2d_tests {
     ) -> Result<(), crate::Error> {
         let dst_width = 600;
         let dst_height = 400;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgb), None)?;
 
         let mut cpu_converter = CPUProcessor::new();
@@ -640,7 +638,7 @@ mod g2d_tests {
                 .unwrap()
                 .map()?
                 .as_mut_slice()
-                .copy_from_slice(nv12_bytes);
+                .copy_from_slice(&nv12_bytes);
         } else {
             cpu_converter.convert(&src, &mut src2, Rotation::None, Flip::None, Crop::no_crop())?;
         }
@@ -703,8 +701,7 @@ mod g2d_tests {
             }),
             dst_color: None,
         };
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgb), None)?;
 
         let mut cpu_converter = CPUProcessor::new();
@@ -735,7 +732,7 @@ mod g2d_tests {
                 .unwrap()
                 .map()?
                 .as_mut_slice()
-                .copy_from_slice(nv12_bytes);
+                .copy_from_slice(&nv12_bytes);
         } else {
             cpu_converter.convert(&src, &mut src2, Rotation::None, Flip::None, Crop::no_crop())?;
         }
@@ -891,7 +888,7 @@ mod g2d_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )?;
 
         // Load PixelFormat::Rgba reference (ffmpeg-generated)
@@ -900,7 +897,7 @@ mod g2d_tests {
             720,
             PixelFormat::Rgba,
             None,
-            edgefirst_bench::testdata::read("camera720p.rgba"),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )?;
 
         // Convert using G2D
@@ -953,7 +950,7 @@ mod g2d_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )?;
 
         // Load PixelFormat::Rgb reference (ffmpeg-generated)
@@ -962,7 +959,7 @@ mod g2d_tests {
             720,
             PixelFormat::Rgb,
             None,
-            edgefirst_bench::testdata::read("camera720p.rgb"),
+            &edgefirst_bench::testdata::read("camera720p.rgb"),
         )?;
 
         // Convert using G2D
@@ -1015,7 +1012,7 @@ mod g2d_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.yuyv"),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )?;
 
         // Load PixelFormat::Rgba reference (ffmpeg-generated)
@@ -1024,7 +1021,7 @@ mod g2d_tests {
             720,
             PixelFormat::Rgba,
             None,
-            edgefirst_bench::testdata::read("camera720p.rgba"),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )?;
 
         // Convert using G2D
@@ -1077,7 +1074,7 @@ mod g2d_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.yuyv"),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )?;
 
         // Load PixelFormat::Rgb reference (ffmpeg-generated)
@@ -1086,7 +1083,7 @@ mod g2d_tests {
             720,
             PixelFormat::Rgb,
             None,
-            edgefirst_bench::testdata::read("camera720p.rgb"),
+            &edgefirst_bench::testdata::read("camera720p.rgb"),
         )?;
 
         // Convert using G2D
@@ -1145,8 +1142,7 @@ mod g2d_tests {
     }
 
     fn test_g2d_bgra_no_resize_(g2d_in_fmt: PixelFormat) -> Result<(), crate::Error> {
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgb), None)?;
 
         // Create DMA buffer for G2D input
@@ -1159,7 +1155,7 @@ mod g2d_tests {
                 .unwrap()
                 .map()?
                 .as_mut_slice()
-                .copy_from_slice(nv12_bytes);
+                .copy_from_slice(&nv12_bytes);
         } else {
             cpu_converter.convert(&src, &mut src2, Rotation::None, Flip::None, Crop::no_crop())?;
         }

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -27,10 +27,7 @@ mod gl_tests {
         }
 
         let image = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -38,10 +35,7 @@ mod gl_tests {
 
         let mut segmentation = Array3::from_shape_vec(
             (2, 160, 160),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/modelpack_seg_2x160x160.bin"
-            ))
+            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin")
             .to_vec(),
         )
         .unwrap();
@@ -74,10 +68,7 @@ mod gl_tests {
         }
 
         let image = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             Some(edgefirst_tensor::TensorMemory::Mem),
         )
@@ -85,10 +76,7 @@ mod gl_tests {
 
         let mut segmentation = Array3::from_shape_vec(
             (2, 160, 160),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/modelpack_seg_2x160x160.bin"
-            ))
+            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin")
             .to_vec(),
         )
         .unwrap();
@@ -124,10 +112,7 @@ mod gl_tests {
         // draw_decoded_masks fully writes dst — pass the camera frame as
         // the MaskOverlay background, not as the dst canvas.
         let bg = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -143,10 +128,7 @@ mod gl_tests {
 
         let segmentation = Array3::from_shape_vec(
             (76, 55, 1),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/yolov8_seg_crop_76x55.bin"
-            ))
+            edgefirst_bench::testdata::read("yolov8_seg_crop_76x55.bin")
             .to_vec(),
         )
         .unwrap();
@@ -184,10 +166,7 @@ mod gl_tests {
             TensorDyn::from(__t)
         };
         let expected = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/output_render_gl.jpg"
-            )),
+            &edgefirst_bench::testdata::read("output_render_gl.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -208,10 +187,7 @@ mod gl_tests {
         }
 
         let image = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -391,10 +367,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -404,10 +377,7 @@ mod gl_tests {
             720,
             PixelFormat::Rgba,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            edgefirst_bench::testdata::read("camera720p.rgba"),
         )
         .unwrap();
 
@@ -458,10 +428,7 @@ mod gl_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -471,10 +438,7 @@ mod gl_tests {
             720,
             PixelFormat::Rgba,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            edgefirst_bench::testdata::read("camera720p.rgba"),
         )
         .unwrap();
 
@@ -660,10 +624,7 @@ mod gl_tests {
             // Smoke test: do a simple PixelFormat::Rgba → PixelFormat::Rgba conversion to verify the
             // GL context is fully functional.
             let src = crate::load_image(
-                include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/zidane.jpg"
-                )),
+                &edgefirst_bench::testdata::read("zidane.jpg"),
                 Some(PixelFormat::Rgba),
                 None,
             )
@@ -733,10 +694,7 @@ mod gl_tests {
 
         let mut gl = GLProcessorThreaded::new(None).expect("auto-detect should succeed");
         let src = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.jpg"
-            )),
+            &edgefirst_bench::testdata::read("zidane.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -854,10 +812,7 @@ mod gl_tests {
             1080,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera1080p.yuyv"
-            )),
+            edgefirst_bench::testdata::read("camera1080p.yuyv"),
         )
         .unwrap();
 
@@ -916,10 +871,7 @@ mod gl_tests {
             1080,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera1080p.yuyv"
-            )),
+            edgefirst_bench::testdata::read("camera1080p.yuyv"),
         )
         .unwrap();
 
@@ -990,10 +942,7 @@ mod gl_tests {
             1080,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera1080p.yuyv"
-            )),
+            edgefirst_bench::testdata::read("camera1080p.yuyv"),
         )
         .unwrap();
 
@@ -1061,10 +1010,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -1144,10 +1090,7 @@ mod gl_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -1220,10 +1163,7 @@ mod gl_tests {
             return;
         }
 
-        let seg_bytes = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/modelpack_seg_2x160x160.bin"
-        ))
+        let seg_bytes = edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin")
         .to_vec();
 
         // Build segmentation data (shared between both renders)
@@ -1245,10 +1185,7 @@ mod gl_tests {
 
         // Render to PixelFormat::Rgba
         let rgba_img = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -1259,10 +1196,7 @@ mod gl_tests {
 
         // Render to PixelFormat::Bgra (convert source to PixelFormat::Bgra first)
         let rgba_src = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -1332,10 +1266,7 @@ mod gl_tests {
 
         // Render boxes to PixelFormat::Rgba
         let rgba_img = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             Some(edgefirst_tensor::TensorMemory::Mem),
         )
@@ -1346,10 +1277,7 @@ mod gl_tests {
 
         // Render boxes to PixelFormat::Bgra
         let rgba_src = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/giraffe.jpg"
-            )),
+            &edgefirst_bench::testdata::read("giraffe.jpg"),
             Some(PixelFormat::Rgba),
             Some(edgefirst_tensor::TensorMemory::Mem),
         )
@@ -1483,10 +1411,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
 
         // Contiguous PixelFormat::Nv12 (single DMA-BUF)
         let src_contiguous = load_raw_image(
@@ -1574,10 +1499,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
         let width: usize = 1280;
         let height: usize = 720;
         let stride: usize = width; // NV12 Y plane: 1 byte per pixel
@@ -1690,10 +1612,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
 
         let src_contiguous = load_raw_image(
             1280,
@@ -1763,10 +1682,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
 
         let src_contiguous = load_raw_image(
             1280,
@@ -1847,10 +1763,7 @@ mod gl_tests {
         }
 
         // Load cached YOLOv8 seg model outputs as TensorDyn::I8 inputs.
-        let boxes_raw: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_boxes_116x8400.bin"
-        ));
+        let boxes_raw: &[u8] = &edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let boxes_i8 =
             unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
         let boxes_tensor = TensorDyn::I8(
@@ -1858,10 +1771,7 @@ mod gl_tests {
                 .expect("boxes tensor"),
         );
 
-        let protos_raw: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/yolov8_protos_160x160x32.bin"
-        ));
+        let protos_raw: &[u8] = &edgefirst_bench::testdata::read("yolov8_protos_160x160x32.bin");
         let protos_i8 = unsafe {
             std::slice::from_raw_parts(protos_raw.as_ptr() as *const i8, protos_raw.len())
         };
@@ -1967,10 +1877,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2057,10 +1964,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2118,10 +2022,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2212,10 +2113,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2314,10 +2212,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2375,10 +2270,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2479,10 +2371,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2585,10 +2474,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.nv12"
-            )),
+            edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2846,10 +2732,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
         let width: usize = 1280;
         let height: usize = 720;
         let stride: usize = width;
@@ -2969,10 +2852,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.nv12"
-        ));
+        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
         let width: usize = 1280;
         let height: usize = 720;
         let stride: usize = width;

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -35,8 +35,7 @@ mod gl_tests {
 
         let mut segmentation = Array3::from_shape_vec(
             (2, 160, 160),
-            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin")
-            .to_vec(),
+            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin").to_vec(),
         )
         .unwrap();
         segmentation.swap_axes(0, 1);
@@ -76,8 +75,7 @@ mod gl_tests {
 
         let mut segmentation = Array3::from_shape_vec(
             (2, 160, 160),
-            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin")
-            .to_vec(),
+            edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin").to_vec(),
         )
         .unwrap();
         segmentation.swap_axes(0, 1);
@@ -128,8 +126,7 @@ mod gl_tests {
 
         let segmentation = Array3::from_shape_vec(
             (76, 55, 1),
-            edgefirst_bench::testdata::read("yolov8_seg_crop_76x55.bin")
-            .to_vec(),
+            edgefirst_bench::testdata::read("yolov8_seg_crop_76x55.bin").to_vec(),
         )
         .unwrap();
 
@@ -367,7 +364,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -377,7 +374,7 @@ mod gl_tests {
             720,
             PixelFormat::Rgba,
             None,
-            edgefirst_bench::testdata::read("camera720p.rgba"),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )
         .unwrap();
 
@@ -428,7 +425,7 @@ mod gl_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.yuyv"),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -438,7 +435,7 @@ mod gl_tests {
             720,
             PixelFormat::Rgba,
             None,
-            edgefirst_bench::testdata::read("camera720p.rgba"),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )
         .unwrap();
 
@@ -812,7 +809,7 @@ mod gl_tests {
             1080,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera1080p.yuyv"),
+            &edgefirst_bench::testdata::read("camera1080p.yuyv"),
         )
         .unwrap();
 
@@ -871,7 +868,7 @@ mod gl_tests {
             1080,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera1080p.yuyv"),
+            &edgefirst_bench::testdata::read("camera1080p.yuyv"),
         )
         .unwrap();
 
@@ -942,7 +939,7 @@ mod gl_tests {
             1080,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera1080p.yuyv"),
+            &edgefirst_bench::testdata::read("camera1080p.yuyv"),
         )
         .unwrap();
 
@@ -1010,7 +1007,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -1090,7 +1087,7 @@ mod gl_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.yuyv"),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -1163,8 +1160,7 @@ mod gl_tests {
             return;
         }
 
-        let seg_bytes = edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin")
-        .to_vec();
+        let seg_bytes = edgefirst_bench::testdata::read("modelpack_seg_2x160x160.bin").to_vec();
 
         // Build segmentation data (shared between both renders)
         let make_seg = || {
@@ -1411,7 +1407,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
+        let nv12_bytes: &[u8] = &edgefirst_bench::testdata::read("camera720p.nv12");
 
         // Contiguous PixelFormat::Nv12 (single DMA-BUF)
         let src_contiguous = load_raw_image(
@@ -1499,7 +1495,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
+        let nv12_bytes: &[u8] = &edgefirst_bench::testdata::read("camera720p.nv12");
         let width: usize = 1280;
         let height: usize = 720;
         let stride: usize = width; // NV12 Y plane: 1 byte per pixel
@@ -1612,7 +1608,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
+        let nv12_bytes: &[u8] = &edgefirst_bench::testdata::read("camera720p.nv12");
 
         let src_contiguous = load_raw_image(
             1280,
@@ -1682,7 +1678,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
+        let nv12_bytes: &[u8] = &edgefirst_bench::testdata::read("camera720p.nv12");
 
         let src_contiguous = load_raw_image(
             1280,
@@ -1877,7 +1873,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -1964,7 +1960,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2022,7 +2018,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2113,7 +2109,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2212,7 +2208,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2270,7 +2266,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2371,7 +2367,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2474,7 +2470,7 @@ mod gl_tests {
             720,
             PixelFormat::Nv12,
             Some(TensorMemory::Dma),
-            edgefirst_bench::testdata::read("camera720p.nv12"),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
         )
         .unwrap();
 
@@ -2732,7 +2728,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
+        let nv12_bytes: &[u8] = &edgefirst_bench::testdata::read("camera720p.nv12");
         let width: usize = 1280;
         let height: usize = 720;
         let stride: usize = width;
@@ -2852,7 +2848,7 @@ mod gl_tests {
             return;
         }
 
-        let nv12_bytes: &[u8] = edgefirst_bench::testdata::read("camera720p.nv12");
+        let nv12_bytes: &[u8] = &edgefirst_bench::testdata::read("camera720p.nv12");
         let width: usize = 1280;
         let height: usize = 720;
         let stride: usize = width;

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -2974,7 +2974,9 @@ mod image_tests {
     #[test]
     fn test_from_tensor_planar() -> Result<(), Error> {
         let mut tensor = Tensor::new(&[3, 720, 1280], None, None)?;
-        tensor.map()?.copy_from_slice(&edgefirst_bench::testdata::read("camera720p.8bps"));
+        tensor
+            .map()?
+            .copy_from_slice(&edgefirst_bench::testdata::read("camera720p.8bps"));
         let planar = {
             tensor
                 .set_format(PixelFormat::PlanarRgb)
@@ -3196,8 +3198,7 @@ mod image_tests {
     fn test_new_image_converter() {
         let dst_width = 640;
         let dst_height = 360;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let mut converter = ImageProcessor::new().unwrap();
@@ -3251,8 +3252,7 @@ mod image_tests {
         assert_eq!(dst_u8.dtype(), DType::U8);
 
         // Convert into I8 dst should succeed
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
         let mut dst_i8 = converter
             .create_image(320, 240, PixelFormat::Rgb, DType::I8, None)
@@ -3317,8 +3317,7 @@ mod image_tests {
               // fallback triggers a GPU driver hang during SHM→texture upload (e.g.,
               // NVIDIA without /dev/dma_heap permissions). Works on embedded targets.
     fn test_crop_skip() {
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let mut converter = ImageProcessor::new().unwrap();
@@ -3390,15 +3389,13 @@ mod image_tests {
 
     #[test]
     fn test_load_jpeg_with_exif() {
-        let file = edgefirst_bench::testdata::read("zidane_rotated_exif.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane_rotated_exif.jpg").to_vec();
         let loaded = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         assert_eq!(loaded.height(), Some(1280));
         assert_eq!(loaded.width(), Some(720));
 
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let cpu_src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let (dst_width, dst_height) = (cpu_src.height().unwrap(), cpu_src.width().unwrap());
@@ -3422,15 +3419,13 @@ mod image_tests {
 
     #[test]
     fn test_load_png_with_exif() {
-        let file = edgefirst_bench::testdata::read("zidane_rotated_exif_180.png")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane_rotated_exif_180.png").to_vec();
         let loaded = crate::load_png(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         assert_eq!(loaded.height(), Some(720));
         assert_eq!(loaded.width(), Some(1280));
 
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let cpu_src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let cpu_dst = TensorDyn::image(1280, 720, PixelFormat::Rgba, DType::U8, None).unwrap();
@@ -3778,8 +3773,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 360;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src =
             crate::load_image(&file, Some(PixelFormat::Rgba), Some(TensorMemory::Dma)).unwrap();
 
@@ -3829,8 +3823,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 360;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let cpu_dst =
@@ -3953,8 +3946,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let cpu_dst =
@@ -4012,8 +4004,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let cpu_dst =
@@ -4066,8 +4057,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
         let src_dyn = src;
 
@@ -4146,8 +4136,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 360;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
         let crop = Crop {
             src_rect: Some(Rect {
@@ -4200,8 +4189,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let cpu_dst =
@@ -4249,8 +4237,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
 
         let mut cpu_converter = CPUProcessor::new();
 
@@ -4349,8 +4336,7 @@ mod image_tests {
         // This test rotates the image 4 times and checks that the image was returned to
         // be the same Currently doesn't check if rotations actually rotated in
         // right direction
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
 
         let unchanged_src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
@@ -4449,8 +4435,7 @@ mod image_tests {
             Rotation::Clockwise90 | Rotation::CounterClockwise90 => (size.1, size.0),
         };
 
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), tensor_memory).unwrap();
 
         let cpu_dst =
@@ -4523,8 +4508,7 @@ mod image_tests {
             Rotation::Clockwise90 | Rotation::CounterClockwise90 => (size.1, size.0),
         };
 
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src =
             crate::load_image(&file, Some(PixelFormat::Rgba), Some(TensorMemory::Dma)).unwrap();
 
@@ -4791,8 +4775,7 @@ mod image_tests {
 
     #[test]
     fn test_yuyv_to_rgba_cpu() {
-        let file = edgefirst_bench::testdata::read("camera720p.yuyv")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("camera720p.yuyv").to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Yuyv, DType::U8, None).unwrap();
         src.as_u8()
             .unwrap()
@@ -4828,8 +4811,7 @@ mod image_tests {
 
     #[test]
     fn test_yuyv_to_rgb_cpu() {
-        let file = edgefirst_bench::testdata::read("camera720p.yuyv")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("camera720p.yuyv").to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Yuyv, DType::U8, None).unwrap();
         src.as_u8()
             .unwrap()
@@ -4863,8 +4845,8 @@ mod image_tests {
             .iter_mut()
             .zip(
                 edgefirst_bench::testdata::read("camera720p.rgba")
-                .as_chunks::<4>()
-                .0,
+                    .as_chunks::<4>()
+                    .0,
             )
             .for_each(|(dst, src)| *dst = [src[0], src[1], src[2]]);
 
@@ -5315,8 +5297,7 @@ mod image_tests {
 
     #[test]
     fn test_vyuy_to_rgba_cpu() {
-        let file = edgefirst_bench::testdata::read("camera720p.vyuy")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("camera720p.vyuy").to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Vyuy, DType::U8, None).unwrap();
         src.as_u8()
             .unwrap()
@@ -5352,8 +5333,7 @@ mod image_tests {
 
     #[test]
     fn test_vyuy_to_rgb_cpu() {
-        let file = edgefirst_bench::testdata::read("camera720p.vyuy")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("camera720p.vyuy").to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Vyuy, DType::U8, None).unwrap();
         src.as_u8()
             .unwrap()
@@ -5387,8 +5367,8 @@ mod image_tests {
             .iter_mut()
             .zip(
                 edgefirst_bench::testdata::read("camera720p.rgba")
-                .as_chunks::<4>()
-                .0,
+                    .as_chunks::<4>()
+                    .0,
             )
             .for_each(|(dst, src)| *dst = [src[0], src[1], src[2]]);
 
@@ -5593,8 +5573,7 @@ mod image_tests {
 
     #[test]
     fn test_nv12_to_rgba_cpu() {
-        let file = edgefirst_bench::testdata::read("zidane.nv12")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.nv12").to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[0..(1280 * 720 * 3 / 2)]
             .copy_from_slice(&file);
@@ -5624,8 +5603,7 @@ mod image_tests {
 
     #[test]
     fn test_nv12_to_rgb_cpu() {
-        let file = edgefirst_bench::testdata::read("zidane.nv12")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.nv12").to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[0..(1280 * 720 * 3 / 2)]
             .copy_from_slice(&file);
@@ -5655,8 +5633,7 @@ mod image_tests {
 
     #[test]
     fn test_nv12_to_grey_cpu() {
-        let file = edgefirst_bench::testdata::read("zidane.nv12")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.nv12").to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[0..(1280 * 720 * 3 / 2)]
             .copy_from_slice(&file);
@@ -5686,8 +5663,7 @@ mod image_tests {
 
     #[test]
     fn test_nv12_to_yuyv_cpu() {
-        let file = edgefirst_bench::testdata::read("zidane.nv12")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.nv12").to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[0..(1280 * 720 * 3 / 2)]
             .copy_from_slice(&file);
@@ -5835,8 +5811,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = edgefirst_bench::testdata::read("test_image.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("test_image.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let cpu_dst = TensorDyn::image(
@@ -5899,8 +5874,7 @@ mod image_tests {
 
     #[test]
     fn test_cpu_resize_nv16() {
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         let cpu_nv16_dst = TensorDyn::image(640, 640, PixelFormat::Nv16, DType::U8, None).unwrap();
@@ -6320,8 +6294,7 @@ mod image_tests {
         );
 
         // Fill source PBO with test pattern: load JPEG then convert Mem→PBO
-        let file = edgefirst_bench::testdata::read("zidane.jpg")
-        .to_vec();
+        let file = edgefirst_bench::testdata::read("zidane.jpg").to_vec();
         let jpeg_src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         // Resize JPEG into a Mem temp of the right size, then copy into PBO

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -1011,11 +1011,11 @@ impl ImageProcessor {
     /// variables.
     ///
     /// # Examples
-    /// ```rust
+    /// ```rust,no_run
     /// # use edgefirst_image::{ImageProcessor, Rotation, Flip, Crop, ImageProcessorTrait, load_image};
     /// # use edgefirst_tensor::{PixelFormat, DType, TensorDyn};
     /// # fn main() -> Result<(), edgefirst_image::Error> {
-    /// let image = edgefirst_bench::testdata::read("zidane.jpg");
+    /// let image = std::fs::read("zidane.jpg")?;
     /// let src = load_image(&image, Some(PixelFormat::Rgba), None)?;
     /// let mut converter = ImageProcessor::new()?;
     /// let mut dst = converter.create_image(640, 480, PixelFormat::Rgb, DType::U8, None)?;
@@ -2556,11 +2556,11 @@ fn load_png(
 /// format of the file is used (typically RGB for JPEG).
 ///
 /// # Examples
-/// ```rust
+/// ```rust,no_run
 /// use edgefirst_image::load_image;
 /// use edgefirst_tensor::PixelFormat;
 /// # fn main() -> Result<(), edgefirst_image::Error> {
-/// let jpeg = edgefirst_bench::testdata::read("zidane.jpg");
+/// let jpeg = std::fs::read("zidane.jpg")?;
 /// let img = load_image(&jpeg, Some(PixelFormat::Rgb), None)?;
 /// assert_eq!(img.width(), Some(1280));
 /// assert_eq!(img.height(), Some(720));

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -2943,11 +2943,8 @@ mod image_tests {
 
     #[test]
     fn test_load_resize_save() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ));
-        let img = crate::load_image(file, Some(PixelFormat::Rgba), None).unwrap();
+        let file = edgefirst_bench::testdata::read("zidane.jpg");
+        let img = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
         assert_eq!(img.width(), Some(1280));
         assert_eq!(img.height(), Some(720));
 
@@ -2977,10 +2974,7 @@ mod image_tests {
     #[test]
     fn test_from_tensor_planar() -> Result<(), Error> {
         let mut tensor = Tensor::new(&[3, 720, 1280], None, None)?;
-        tensor.map()?.copy_from_slice(include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.8bps"
-        )));
+        tensor.map()?.copy_from_slice(&edgefirst_bench::testdata::read("camera720p.8bps"));
         let planar = {
             tensor
                 .set_format(PixelFormat::PlanarRgb)
@@ -2993,10 +2987,7 @@ mod image_tests {
             720,
             PixelFormat::Rgba,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )?;
         compare_images_convert_to_rgb(&planar, &rbga, 0.98, function!());
 
@@ -3018,10 +3009,7 @@ mod image_tests {
             720,
             PixelFormat::PlanarRgb,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.8bps"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.8bps"),
         )
         .unwrap();
 
@@ -3037,10 +3025,7 @@ mod image_tests {
             720,
             PixelFormat::Yuyv,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -3177,20 +3162,14 @@ mod image_tests {
     #[test]
     fn test_load_grey() {
         let grey_img = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/grey.jpg"
-            )),
+            &edgefirst_bench::testdata::read("grey.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
         .unwrap();
 
         let grey_but_rgb_img = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/grey-rgb.jpg"
-            )),
+            &edgefirst_bench::testdata::read("grey-rgb.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -3217,10 +3196,7 @@ mod image_tests {
     fn test_new_image_converter() {
         let dst_width = 640;
         let dst_height = 360;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -3275,10 +3251,7 @@ mod image_tests {
         assert_eq!(dst_u8.dtype(), DType::U8);
 
         // Convert into I8 dst should succeed
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
         let mut dst_i8 = converter
@@ -3344,10 +3317,7 @@ mod image_tests {
               // fallback triggers a GPU driver hang during SHM→texture upload (e.g.,
               // NVIDIA without /dev/dma_heap permissions). Works on embedded targets.
     fn test_crop_skip() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -3420,20 +3390,14 @@ mod image_tests {
 
     #[test]
     fn test_load_jpeg_with_exif() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane_rotated_exif.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane_rotated_exif.jpg")
         .to_vec();
         let loaded = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         assert_eq!(loaded.height(), Some(1280));
         assert_eq!(loaded.width(), Some(720));
 
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let cpu_src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -3458,20 +3422,14 @@ mod image_tests {
 
     #[test]
     fn test_load_png_with_exif() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane_rotated_exif_180.png"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane_rotated_exif_180.png")
         .to_vec();
         let loaded = crate::load_png(&file, Some(PixelFormat::Rgba), None).unwrap();
 
         assert_eq!(loaded.height(), Some(720));
         assert_eq!(loaded.width(), Some(1280));
 
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let cpu_src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -3820,10 +3778,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 360;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src =
             crate::load_image(&file, Some(PixelFormat::Rgba), Some(TensorMemory::Dma)).unwrap();
@@ -3874,10 +3829,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 360;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -3950,10 +3902,7 @@ mod image_tests {
         }
 
         let img = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/grey.jpg"
-            )),
+            &edgefirst_bench::testdata::read("grey.jpg"),
             Some(PixelFormat::Grey),
             None,
         )
@@ -4004,10 +3953,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -4066,10 +4012,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -4123,10 +4066,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
         let src_dyn = src;
@@ -4206,10 +4146,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 360;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
         let crop = Crop {
@@ -4263,10 +4200,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -4315,10 +4249,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
 
         let mut cpu_converter = CPUProcessor::new();
@@ -4418,10 +4349,7 @@ mod image_tests {
         // This test rotates the image 4 times and checks that the image was returned to
         // be the same Currently doesn't check if rotations actually rotated in
         // right direction
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
 
         let unchanged_src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
@@ -4521,10 +4449,7 @@ mod image_tests {
             Rotation::Clockwise90 | Rotation::CounterClockwise90 => (size.1, size.0),
         };
 
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), tensor_memory).unwrap();
 
@@ -4598,10 +4523,7 @@ mod image_tests {
             Rotation::Clockwise90 | Rotation::CounterClockwise90 => (size.1, size.0),
         };
 
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src =
             crate::load_image(&file, Some(PixelFormat::Rgba), Some(TensorMemory::Dma)).unwrap();
@@ -4650,10 +4572,7 @@ mod image_tests {
             720,
             PixelFormat::Rgba,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )
         .unwrap();
 
@@ -4725,10 +4644,7 @@ mod image_tests {
             720,
             PixelFormat::Rgba,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )
         .unwrap();
 
@@ -4804,10 +4720,7 @@ mod image_tests {
             720,
             PixelFormat::Rgba,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )
         .unwrap();
 
@@ -4878,10 +4791,7 @@ mod image_tests {
 
     #[test]
     fn test_yuyv_to_rgba_cpu() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.yuyv"
-        ))
+        let file = edgefirst_bench::testdata::read("camera720p.yuyv")
         .to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Yuyv, DType::U8, None).unwrap();
         src.as_u8()
@@ -4911,20 +4821,14 @@ mod image_tests {
             .map()
             .unwrap()
             .as_mut_slice()
-            .copy_from_slice(include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )));
+            .copy_from_slice(&edgefirst_bench::testdata::read("camera720p.rgba"));
 
         compare_images(&dst, &target_image, 0.98, function!());
     }
 
     #[test]
     fn test_yuyv_to_rgb_cpu() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.yuyv"
-        ))
+        let file = edgefirst_bench::testdata::read("camera720p.yuyv")
         .to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Yuyv, DType::U8, None).unwrap();
         src.as_u8()
@@ -4958,10 +4862,7 @@ mod image_tests {
             .0
             .iter_mut()
             .zip(
-                include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/camera720p.rgba"
-                ))
+                edgefirst_bench::testdata::read("camera720p.rgba")
                 .as_chunks::<4>()
                 .0,
             )
@@ -4989,10 +4890,7 @@ mod image_tests {
             720,
             PixelFormat::Yuyv,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -5023,10 +4921,7 @@ mod image_tests {
             .map()
             .unwrap()
             .as_mut_slice()
-            .copy_from_slice(include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )));
+            .copy_from_slice(&edgefirst_bench::testdata::read("camera720p.rgba"));
 
         compare_images(&dst, &target_image, 0.98, function!());
     }
@@ -5052,10 +4947,7 @@ mod image_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -5086,10 +4978,7 @@ mod image_tests {
             .map()
             .unwrap()
             .as_mut_slice()
-            .copy_from_slice(include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )));
+            .copy_from_slice(&edgefirst_bench::testdata::read("camera720p.rgba"));
 
         compare_images(&dst, &target_image, 0.98, function!());
     }
@@ -5113,10 +5002,7 @@ mod image_tests {
             720,
             PixelFormat::Yuyv,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -5177,10 +5063,7 @@ mod image_tests {
             720,
             PixelFormat::Yuyv,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -5228,10 +5111,7 @@ mod image_tests {
             720,
             PixelFormat::Yuyv,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -5258,10 +5138,7 @@ mod image_tests {
             720,
             PixelFormat::Rgba,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.rgba"),
         )
         .unwrap();
         let (result, _src_target, dst_target) = convert_img(
@@ -5298,10 +5175,7 @@ mod image_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -5381,10 +5255,7 @@ mod image_tests {
             720,
             PixelFormat::Yuyv,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.yuyv"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.yuyv"),
         )
         .unwrap();
 
@@ -5444,10 +5315,7 @@ mod image_tests {
 
     #[test]
     fn test_vyuy_to_rgba_cpu() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.vyuy"
-        ))
+        let file = edgefirst_bench::testdata::read("camera720p.vyuy")
         .to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Vyuy, DType::U8, None).unwrap();
         src.as_u8()
@@ -5477,20 +5345,14 @@ mod image_tests {
             .map()
             .unwrap()
             .as_mut_slice()
-            .copy_from_slice(include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )));
+            .copy_from_slice(&edgefirst_bench::testdata::read("camera720p.rgba"));
 
         compare_images(&dst, &target_image, 0.98, function!());
     }
 
     #[test]
     fn test_vyuy_to_rgb_cpu() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/camera720p.vyuy"
-        ))
+        let file = edgefirst_bench::testdata::read("camera720p.vyuy")
         .to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Vyuy, DType::U8, None).unwrap();
         src.as_u8()
@@ -5524,10 +5386,7 @@ mod image_tests {
             .0
             .iter_mut()
             .zip(
-                include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../../testdata/camera720p.rgba"
-                ))
+                edgefirst_bench::testdata::read("camera720p.rgba")
                 .as_chunks::<4>()
                 .0,
             )
@@ -5556,10 +5415,7 @@ mod image_tests {
             720,
             PixelFormat::Vyuy,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.vyuy"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.vyuy"),
         )
         .unwrap();
 
@@ -5596,10 +5452,7 @@ mod image_tests {
             .map()
             .unwrap()
             .as_mut_slice()
-            .copy_from_slice(include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )));
+            .copy_from_slice(&edgefirst_bench::testdata::read("camera720p.rgba"));
 
         compare_images(&dst, &target_image, 0.98, function!());
     }
@@ -5624,10 +5477,7 @@ mod image_tests {
             720,
             PixelFormat::Vyuy,
             None,
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.vyuy"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.vyuy"),
         )
         .unwrap();
 
@@ -5696,10 +5546,7 @@ mod image_tests {
             720,
             PixelFormat::Vyuy,
             Some(TensorMemory::Dma),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.vyuy"
-            )),
+            &edgefirst_bench::testdata::read("camera720p.vyuy"),
         )
         .unwrap();
 
@@ -5739,20 +5586,14 @@ mod image_tests {
             .map()
             .unwrap()
             .as_mut_slice()
-            .copy_from_slice(include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/camera720p.rgba"
-            )));
+            .copy_from_slice(&edgefirst_bench::testdata::read("camera720p.rgba"));
 
         compare_images(&dst, &target_image, 0.98, function!());
     }
 
     #[test]
     fn test_nv12_to_rgba_cpu() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.nv12"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.nv12")
         .to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[0..(1280 * 720 * 3 / 2)]
@@ -5772,10 +5613,7 @@ mod image_tests {
         result.unwrap();
 
         let target_image = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.jpg"
-            )),
+            &edgefirst_bench::testdata::read("zidane.jpg"),
             Some(PixelFormat::Rgba),
             None,
         )
@@ -5786,10 +5624,7 @@ mod image_tests {
 
     #[test]
     fn test_nv12_to_rgb_cpu() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.nv12"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.nv12")
         .to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[0..(1280 * 720 * 3 / 2)]
@@ -5809,10 +5644,7 @@ mod image_tests {
         result.unwrap();
 
         let target_image = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.jpg"
-            )),
+            &edgefirst_bench::testdata::read("zidane.jpg"),
             Some(PixelFormat::Rgb),
             None,
         )
@@ -5823,10 +5655,7 @@ mod image_tests {
 
     #[test]
     fn test_nv12_to_grey_cpu() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.nv12"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.nv12")
         .to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[0..(1280 * 720 * 3 / 2)]
@@ -5846,10 +5675,7 @@ mod image_tests {
         result.unwrap();
 
         let target_image = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.jpg"
-            )),
+            &edgefirst_bench::testdata::read("zidane.jpg"),
             Some(PixelFormat::Grey),
             None,
         )
@@ -5860,10 +5686,7 @@ mod image_tests {
 
     #[test]
     fn test_nv12_to_yuyv_cpu() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.nv12"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.nv12")
         .to_vec();
         let src = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         src.as_u8().unwrap().map().unwrap().as_mut_slice()[0..(1280 * 720 * 3 / 2)]
@@ -5883,10 +5706,7 @@ mod image_tests {
         result.unwrap();
 
         let target_image = crate::load_image(
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../testdata/zidane.jpg"
-            )),
+            &edgefirst_bench::testdata::read("zidane.jpg"),
             Some(PixelFormat::Rgb),
             None,
         )
@@ -6015,10 +5835,7 @@ mod image_tests {
 
         let dst_width = 640;
         let dst_height = 640;
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/test_image.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("test_image.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -6082,10 +5899,7 @@ mod image_tests {
 
     #[test]
     fn test_cpu_resize_nv16() {
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -6506,10 +6320,7 @@ mod image_tests {
         );
 
         // Fill source PBO with test pattern: load JPEG then convert Mem→PBO
-        let file = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ))
+        let file = edgefirst_bench::testdata::read("zidane.jpg")
         .to_vec();
         let jpeg_src = crate::load_image(&file, Some(PixelFormat::Rgba), None).unwrap();
 
@@ -7169,11 +6980,8 @@ mod image_tests {
         }
 
         // Load a source image
-        let image = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../testdata/zidane.jpg"
-        ));
-        let src = load_image(image, Some(PixelFormat::Rgba), None).unwrap();
+        let image = edgefirst_bench::testdata::read("zidane.jpg");
+        let src = load_image(&image, Some(PixelFormat::Rgba), None).unwrap();
 
         // Create a raw tensor, then attach format — simulating the from_fd workflow
         let mut dst =

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -28,8 +28,8 @@ the appropriate conversion method based on the available hardware.
 # use edgefirst_image::{ImageProcessor, Rotation, Flip, Crop, ImageProcessorTrait, load_image};
 # use edgefirst_tensor::{PixelFormat, DType, TensorDyn};
 # fn main() -> Result<(), edgefirst_image::Error> {
-let image = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/zidane.jpg"));
-let src = load_image(image, Some(PixelFormat::Rgba), None)?;
+let image = edgefirst_bench::testdata::read("zidane.jpg");
+let src = load_image(&image, Some(PixelFormat::Rgba), None)?;
 let mut converter = ImageProcessor::new()?;
 let mut dst = converter.create_image(640, 480, PixelFormat::Rgb, DType::U8, None)?;
 converter.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())?;
@@ -1015,8 +1015,8 @@ impl ImageProcessor {
     /// # use edgefirst_image::{ImageProcessor, Rotation, Flip, Crop, ImageProcessorTrait, load_image};
     /// # use edgefirst_tensor::{PixelFormat, DType, TensorDyn};
     /// # fn main() -> Result<(), edgefirst_image::Error> {
-    /// let image = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/zidane.jpg"));
-    /// let src = load_image(image, Some(PixelFormat::Rgba), None)?;
+    /// let image = edgefirst_bench::testdata::read("zidane.jpg");
+    /// let src = load_image(&image, Some(PixelFormat::Rgba), None)?;
     /// let mut converter = ImageProcessor::new()?;
     /// let mut dst = converter.create_image(640, 480, PixelFormat::Rgb, DType::U8, None)?;
     /// converter.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())?;
@@ -2560,8 +2560,8 @@ fn load_png(
 /// use edgefirst_image::load_image;
 /// use edgefirst_tensor::PixelFormat;
 /// # fn main() -> Result<(), edgefirst_image::Error> {
-/// let jpeg = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../testdata/zidane.jpg"));
-/// let img = load_image(jpeg, Some(PixelFormat::Rgb), None)?;
+/// let jpeg = edgefirst_bench::testdata::read("zidane.jpg");
+/// let img = load_image(&jpeg, Some(PixelFormat::Rgb), None)?;
 /// assert_eq!(img.width(), Some(1280));
 /// assert_eq!(img.height(), Some(720));
 /// # Ok(())


### PR DESCRIPTION
## Summary
Consolidated CI/CD cleanup PR. Absorbs the work originally split across PR #70 (xlarge runners) and PR #71 (testdata runtime reads + binary stripping) into a single coherent change.

Three streams are landed here:

### 1. GitHub Actions hash-pinned to latest upstream versions
12 actions bumped across all 4 workflow files (test, release, benchmark, sbom). Each pin keeps the SPS v2.1 form `uses: org/action@<sha>  # vX.Y.Z` so the hash is immutable and the trailing comment is human-readable / dependabot-resolvable.

| Action | Old | New |
|--------|-----|-----|
| actions/checkout | v4 | **v6.0.2** |
| actions/setup-python | v5 | **v6.2.0** |
| actions/upload-artifact | v4 | **v7.0.1** |
| actions/download-artifact | v4 | **v8.0.1** |
| dtolnay/rust-toolchain | stable | **v1** |
| Swatinem/rust-cache | v2.8.2 | **v2.9.1** |
| taiki-e/install-action | v2.71.2 | **v2.78.0** |
| SonarSource/sonarqube-scan-action | v6.0.0 | **v8.0.0** |
| EnricoMi/publish-unit-test-result-action | v2.21.0 | **v2.23.0** |
| softprops/action-gh-release | v2 | **v3.0.0** (Node 24) |
| pypa/gh-action-pypi-publish | — | **v1.14.0** |
| rust-lang/crates-io-auth-action | v1 | **v1.0.4** |

### 2. x86_64 CI runners upgraded to `ubuntu-22.04-xlarge`
- `Doc Tests` and `Build & Test (x86_64)` now run on 16-vCPU xlarge runners.
- Empirically dropped `Build & Test (x86_64)` from ~30 min → ~12 min on the xlarge tier (validated on PR #70 before consolidation).
- ARM64 builds were already on `ubuntu-22.04-arm-xlarge`; this brings x86_64 to parity.

### 3. Testdata runtime reads + binary stripping
- Introduced `edgefirst_bench::testdata` helper (root resolution, env override `EDGEFIRST_TESTDATA_DIR`, `path() / read() / read_to_string()` API).
- Migrated **224** `include_bytes!`/`include_str!` sites across `bench`, `image`, `decoder`, `capi` to runtime reads — ~160 LOC removed net.
- Added a strip step in CI that splits debug info: `strip --strip-debug` produces small on-target binaries while unstripped originals remain available for host-side coverage source-line attribution.
- Hardware-test artifacts shrank **525 MB → 191 MB** (compressed); on-target download time **~13 min → ~3 min**; total `Hardware Test (imx8mp)` dropped from >30 min to **10 min 54 s**.
- `Process Hardware Coverage` confirmed to still resolve source lines (validates the stripped/unstripped split).
- Wheel-pack/unpack used instead of zip/unzip on aarch64 runner (no `unzip` available; preserves PEP 376 RECORD SHA256 manifest correctly).

## Why consolidate
- All three streams touch CI/CD scope.
- They share the workflow files (especially `test.yml`), so landing them sequentially would force two rebase rounds; landing them together is a single review.
- Net effect on main: **`Build & Test (x86_64)` ~30 min → ~12 min, `Hardware Test (imx8mp)` >30 min → ~11 min, on-target download ~13 min → ~3 min.**

## Breaking changes worth watching
- **softprops/action-gh-release v3.0.0** — requires Node 24 runtime. Only exercised on release tags (not on PR runs).
- **SonarSource/sonarqube-scan-action v8.0.0** — changed default for `skipSignatureVerification`. We don't set this option, so behaviour is unchanged.
- **upload-artifact v4 → v7 / download-artifact v4 → v8** — major-version bumps. Artifact format unchanged; only internal upload concurrency/limits behaviour differs.

## Closes
- Closes #70 (xlarge runner upgrade — absorbed)
- Closes #71 (testdata runtime reads + binary stripping — absorbed)

## Test plan
- [ ] Full `test.yml` runs green: build-and-test-x86 (xlarge), doc-tests (xlarge), build-arm, hardware-test (with stripped artifacts), process-hardware-coverage (host-side source-line attribution still works), sonarcloud
- [ ] x86_64 runner timing confirmed near ~12 min (down from ~30 min)
- [ ] hardware-test-binaries artifact size near ~191 MB (down from ~525 MB)
- [ ] On-target download phase near ~3 min (down from ~13 min)
- [ ] Coverage processing on host produces source-line-mapped lcov for SonarCloud
- [ ] No CodeQL/scan-action warnings about deprecated inputs