### PR TITLE
Documentation refactor: per-crate hierarchy + root coordinators

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,11 +58,19 @@ Common operations cross backend boundaries via traits:
 
 ### 2. Enum dispatch
 
-Hot dispatch points use [`enum_dispatch`](https://docs.rs/enum_dispatch)
-to avoid dynamic dispatch overhead. The match-style code reads like
-trait-object dispatch but compiles to a direct call; the `TensorDyn`
-type-erased tensor and the tracker's per-detection dispatch both rely on
-this pattern.
+The hot `ImageProcessor` dispatch point uses the
+[`enum_dispatch`](https://docs.rs/enum_dispatch) crate
+(`#[enum_dispatch(ImageProcessor)]` in
+[`crates/image/src/lib.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/lib.rs))
+to avoid dynamic dispatch overhead on `convert()` and the `draw_*`
+APIs — the match-style code reads like trait-object dispatch but compiles
+to a direct call.
+
+`TensorDyn` is a hand-written `match` over a `DType` discriminant rather
+than an `enum_dispatch` macro, and the tracker is monomorphic over
+`DetectionBox`, so neither uses the `enum_dispatch` crate itself; the
+pattern (hot dispatch via an enum + compile-time fan-out) is shared, but
+the mechanism differs.
 
 ### 3. Builder pattern
 
@@ -83,13 +91,20 @@ Used pervasively to avoid per-frame allocations:
 
 ### 5. Hardware fallback chain
 
-`ImageProcessor::new()` probes the GPU once (DMA-BUF round-trip,
-GLES 3.1, PBO availability) and selects the active backend. All
-subsequent calls reuse the same backend; per-call dispatch never re-runs
-the probe. The `Tensor::new()` allocator chains DMA → SHM → Mem with
-the same one-time-probe philosophy. Both chains are defeatable via the
-`EDGEFIRST_DISABLE_*` and `EDGEFIRST_FORCE_*` environment variables for
-testing and benchmarking.
+`ImageProcessor::new()` runs the GPU probe once (DMA-BUF round-trip,
+GLES 3.1, PBO availability) and initializes every viable backend
+(`gl`, `g2d`, `cpu`). The probe never re-runs after construction. Each
+`convert()` / `draw_*()` call still walks the **OpenGL → G2D → CPU**
+chain at dispatch time, falling through when a backend cannot service
+the specific (src/dst format, memory type, operation) tuple — for
+example, GL declines NV12 → PlanarRgb on the GC7000UL two-pass cliff,
+and G2D declines anything that requires GPU compute. Use
+`EDGEFIRST_FORCE_BACKEND=...` to pin a single backend (still falls back
+to CPU only if the forced backend is missing). The `Tensor::new()`
+allocator chains DMA → SHM → Mem with the same probe-once philosophy
+but always uses the first viable backend per call. Both chains are
+defeatable via the `EDGEFIRST_DISABLE_*` and `EDGEFIRST_FORCE_*`
+environment variables for testing and benchmarking.
 
 ### 6. Type-safe foreign interfaces
 
@@ -120,10 +135,12 @@ The `Send + Sync` story across the workspace:
 ### 9. Error handling
 
 Each crate defines its own `Error` / `Result` pair (`DecoderError`,
-`edgefirst_image::Error`, `edgefirst_tensor::Error`). The `image` crate's
-`Error` implements `From<std::io::Error>` so `?` propagates cleanly from
-file I/O in user code; the others do not (rationale: those crates do not
-own file I/O).
+`edgefirst_image::Error`, `edgefirst_tensor::Error`). Both
+`edgefirst_image::Error` and `edgefirst_tensor::Error` implement
+`From<std::io::Error>` so `?` propagates cleanly from file I/O and from
+DMA-BUF / SHM syscalls. `DecoderError` does not, because the decoder
+crate never opens files or fds — its inputs are already-loaded tensors
+and JSON/YAML configuration strings.
 
 The C API translates all errors into POSIX `errno` codes; see
 [`crates/capi/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md#error-convention).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,8 +103,10 @@ GL handles tricky platform cases via in-backend workarounds (for
 example, NV12 → PlanarRgb on Vivante uses an automatic two-pass path
 within the GL backend rather than declining) — only true capability
 gaps cascade down the chain. Use `EDGEFIRST_FORCE_BACKEND=...` to pin
-a single backend (still falls back to CPU only if the forced backend
-is missing). The `Tensor::new()` allocator chains DMA → SHM → Mem with
+a single backend; this disables the fallback chain entirely — if the
+forced backend cannot service the requested operation, the call fails
+with `Error::ForcedBackendUnavailable` rather than dropping down to
+the next backend. The `Tensor::new()` allocator chains DMA → SHM → Mem with
 the same probe-once philosophy but always uses the first viable
 backend per call. Both chains are defeatable via the
 `EDGEFIRST_DISABLE_*` and `EDGEFIRST_FORCE_*` environment variables
@@ -350,7 +352,7 @@ hal/
 │   ├── python/             # edgefirst_hal (PyO3 bindings)
 │   ├── bench/              # edgefirst-bench (workspace dev-dep)
 │   └── gpu-probe/          # internal CLI for GPU capability probing
-├── tests/                  # Project-level Python and C integration tests
+├── tests/                  # Project-level Python tests (C integration tests live under crates/capi/tests/)
 ├── testdata/               # Git LFS-tracked fixtures (images, model outputs)
 ├── benchmarks/             # Per-platform benchmark JSON results
 ├── scripts/                # Build / audit / release tooling

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,15 +96,19 @@ GLES 3.1, PBO availability) and initializes every viable backend
 (`gl`, `g2d`, `cpu`). The probe never re-runs after construction. Each
 `convert()` / `draw_*()` call still walks the **OpenGL → G2D → CPU**
 chain at dispatch time, falling through when a backend cannot service
-the specific (src/dst format, memory type, operation) tuple — for
-example, GL declines NV12 → PlanarRgb on the GC7000UL two-pass cliff,
-and G2D declines anything that requires GPU compute. Use
-`EDGEFIRST_FORCE_BACKEND=...` to pin a single backend (still falls back
-to CPU only if the forced backend is missing). The `Tensor::new()`
-allocator chains DMA → SHM → Mem with the same probe-once philosophy
-but always uses the first viable backend per call. Both chains are
-defeatable via the `EDGEFIRST_DISABLE_*` and `EDGEFIRST_FORCE_*`
-environment variables for testing and benchmarking.
+the specific (src/dst format, memory type, operation) tuple — G2D
+declines anything that requires GPU compute (e.g. mask compositing,
+fused proto draws), and the CPU backend acts as the universal floor.
+GL handles tricky platform cases via in-backend workarounds (for
+example, NV12 → PlanarRgb on Vivante uses an automatic two-pass path
+within the GL backend rather than declining) — only true capability
+gaps cascade down the chain. Use `EDGEFIRST_FORCE_BACKEND=...` to pin
+a single backend (still falls back to CPU only if the forced backend
+is missing). The `Tensor::new()` allocator chains DMA → SHM → Mem with
+the same probe-once philosophy but always uses the first viable
+backend per call. Both chains are defeatable via the
+`EDGEFIRST_DISABLE_*` and `EDGEFIRST_FORCE_*` environment variables
+for testing and benchmarking.
 
 ### 6. Type-safe foreign interfaces
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,1080 +1,183 @@
-# EdgeFirst Hardware Abstraction Layer - Architecture
+# EdgeFirst HAL — Architecture
 
-**Version:** 3.1
-**Last Updated:** March 2026
-**Status:** Production
-**Audience:** Developers contributing to EdgeFirst HAL or integrating it into applications
+This document is the **cross-crate** architecture story for the EdgeFirst
+HAL workspace. It covers the design patterns shared across crates, the
+performance-tracing infrastructure, the cross-cutting story behind
+DMA-BUF identity and tensor caching, and the source-code organization.
+Per-crate architecture detail (class diagrams, internal layouts,
+backend-specific algorithms, lifecycle quirks) lives in each
+sub-crate's `ARCHITECTURE.md`:
+
+| Crate | Per-crate architecture |
+|-------|------------------------|
+| `tensor` | [crates/tensor/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md) — backend dispatch, multi-plane DMA-BUF, BufferIdentity |
+| `image` | [crates/image/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md) — GL/G2D/CPU, EGL image cache, GL_MUTEX, Vivante workaround, shutdown safety |
+| `decoder` | [crates/decoder/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md) — model-type selection, dshape contract, per-scale framework, fused proto path |
+| `tracker` | [crates/tracker/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/ARCHITECTURE.md) — ByteTrack two-pass association, Kalman state |
+| `hal` (umbrella) | [crates/hal/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/ARCHITECTURE.md) — re-export layer + tracing subscriber |
+| `capi` (C API) | [crates/capi/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md) — opaque-handle ABI, performance recommendations, Delegate DMA-BUF framework |
+| `python` | [crates/python/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/ARCHITECTURE.md) — PyO3 bindings, numpy 3-path copy strategy, abi3 wheels |
+
+The high-level system diagram lives at the top of
+[README.md § System Architecture](https://github.com/EdgeFirstAI/hal/blob/main/README.md#system-architecture);
+this document does not reproduce it.
 
 ---
 
-## Overview
+## Per-Crate Summary
 
-The EdgeFirst Hardware Abstraction Layer (HAL) is a Rust-based system that provides hardware-accelerated abstractions for computer vision and machine learning tasks on embedded Linux platforms. The HAL consists of multiple specialized crates that work together to provide high-performance image processing, tensor operations, model inference decoding, and object tracking.
+Each sub-crate has a single responsibility in the inference pipeline:
 
-## System Architecture
+- [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) — the foundation. Provides `Tensor<T>` and `TensorDyn` with four interchangeable backends (DMA / SHM / Mem / PBO), multi-plane composition for V4L2 NV12M, the `BufferIdentity` cache key, and the `PboOps` trait that lets the GL backend manage PBO lifetimes through a `WeakSender` channel.
+- [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) — the GPU/G2D/CPU image processor. Owns the GL thread, EGL image caches, and shutdown defense layers. Provides format conversion, geometric transforms, and three mask-rendering pipelines (materialized, fused proto, tracked).
+- [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) — model output post-processing. YOLOv5/v8/v11/v26 (incl. end-to-end) and ModelPack. NEON-optimized per-scale split-tensor framework. Validates `shape` / `dshape` declarations (EDGEAI-1288 contract) at builder time.
+- [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) — ByteTrack with Kalman-smoothed trajectories. Generic over the detection box type; the decoder's `DetectBox` plugs in via the `DetectionBox` trait.
+- [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) — umbrella crate. Re-exports the four functional crates and owns the optional Chrome JSON tracing subscriber.
+- [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) — C ABI layer with cbindgen-generated header. Defines the [Delegate DMA-BUF framework](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md#delegate-dma-buf-framework) ABI used by NXP Neutron, VxDelegate, and other TFLite delegates.
+- [`crates/python`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/) — PyO3 bindings, published as `edgefirst-hal` on PyPI. Contains the three-path numpy copy dispatcher.
 
-```mermaid
-graph TB
-    subgraph "EdgeFirst HAL"
-        Python["Python Bindings (edgefirst-hal)<br/>PyO3-based Python API"]
-        CAPI["C API Bindings (edgefirst-hal-capi)<br/>cbindgen-generated C headers"]
-        Main["Main HAL Crate (edgefirst)<br/>Re-exports tensor, image, decoder"]
+The internal dependency graph and external dependency list live in
+[README.md § Dependencies](https://github.com/EdgeFirstAI/hal/blob/main/README.md#dependencies).
 
-        Python --> Main
-        CAPI --> Main
-
-        Tensor["Tensor HAL<br/>Zero-copy memory buffers"]
-        Image["Image Converter HAL<br/>Format conversion & resize"]
-        Decoder["Decoder HAL<br/>Model output post-processing"]
-        Tracker["Tracker HAL<br/>Multi-object tracking"]
-
-        Main --> Tensor
-        Main --> Image
-        Main --> Decoder
-
-        Image --> Tensor
-        Image --> Decoder
-        Image --> G2D["G2D FFI (g2d-sys)<br/>NXP i.MX hardware acceleration"]
-        CAPI --> Tracker
-    end
-
-    Tensor -.-> DMA["Linux DMA-Heap<br/>Shared Memory"]
-    Decoder -.-> PostProc["Model Output<br/>Post-Processing"]
-
-    style Python fill:#e1f5ff
-    style CAPI fill:#e1f5ff
-    style Main fill:#fff4e1
-    style Tensor fill:#e8f5e9
-    style Image fill:#e8f5e9
-    style Decoder fill:#e8f5e9
-    style Tracker fill:#e8f5e9
-```
-
-## Core Components
-
-### 1. Tensor HAL (`edgefirst_tensor`)
-
-**Purpose**: Provides zero-copy memory buffers optimized for hardware accelerators.
-
-**Architecture**:
-```mermaid
-classDiagram
-    class TensorTrait~T~ {
-        <<trait>>
-        +shape() Vec~usize~
-        +size() usize
-        +map() TensorMap~T~
-        +clone_fd() Result~i32~
-    }
-    
-    class DmaTensor~T~ {
-        Linux DMA-Heap allocation
-    }
-    
-    class ShmTensor~T~ {
-        POSIX Shared Memory
-    }
-    
-    class MemTensor~T~ {
-        Standard heap allocation
-    }
-
-    class PboTensor~T~ {
-        OpenGL Pixel Buffer Object
-    }
-
-    TensorTrait <|.. DmaTensor
-    TensorTrait <|.. ShmTensor
-    TensorTrait <|.. MemTensor
-    TensorTrait <|.. PboTensor
-```
-
-**Key Features**:
-- Generic over numeric types (`T: Num + Clone + Debug + Send + Sync`) — commonly u8, i8, u16, i16, u32, i32, f32, f64
-- Automatic memory type selection with fallback chain: DMA → Shared Memory → Heap
-- PBO (Pixel Buffer Object) tensors for GPU-accelerated image processing
-- Memory mapping with `TensorMap<T>` for safe access (RAII map/unmap lifecycle)
-- `BufferIdentity` for cache keying and liveness tracking (monotonic ID + `Arc<()>` guard with weak reference detection)
-- File descriptor sharing for zero-copy IPC (DMA-buf and SHM both support fd cloning)
-- Cross-platform support (Linux optimized, macOS via SHM + heap, Windows via heap only)
-
-**Tensor Memory Mapping**:
-
-Each tensor backend provides a corresponding map type that implements `TensorMapTrait<T>`:
-
-| Tensor | Map | Mechanism |
-|--------|-----|-----------|
-| `DmaTensor<T>` | `DmaMap<T>` | `mmap` + `DMA_BUF_IOCTL_SYNC` for cache coherency |
-| `ShmTensor<T>` | `ShmMap<T>` | `mmap`/`munmap` on POSIX shared memory fd |
-| `MemTensor<T>` | `MemMap<T>` | Direct raw pointer into `Vec<T>` (no syscall) |
-| `PboTensor<T>` | `PboMap<T>` | GL thread `glMapBufferRange`/`glUnmapBuffer` via channel |
-
-`TensorMap<T>` implements `Deref<Target=[T]>` and `DerefMut`, providing slice access. When the `ndarray` feature is enabled, `TensorMapTrait` also provides `view()` and `view_mut()` for ndarray `ArrayView` access.
-
-**Memory Type Selection Logic**:
-```mermaid
-flowchart TD
-    Start[User Request] --> Explicit{Explicit type?}
-    Explicit -->|Yes| UseSpec[Use specified type]
-    Explicit -->|No| CheckEnv{EDGEFIRST_TENSOR_FORCE_MEM=1?}
-    CheckEnv -->|Yes| UseMem[MemTensor]
-    CheckEnv -->|No| TryDMA[Try DmaTensor]
-    TryDMA --> DMASuccess{Success?}
-    DMASuccess -->|Yes| UseDMA[DmaTensor]
-    DMASuccess -->|No| TryShm[Try ShmTensor]
-    TryShm --> ShmSuccess{Success?}
-    ShmSuccess -->|Yes| UseShm[ShmTensor]
-    ShmSuccess -->|No| UseMem
-    
-    style UseDMA fill:#90ee90
-    style UseShm fill:#87ceeb
-    style UseMem fill:#ffeb9c
-```
-
-**PBO Tensor Memory (`PboTensor<T>`)**:
-
-PBO tensors are a GPU-native memory type created by the OpenGL backend when
-`ImageProcessor::create_image()` is called and DMA-buf is not available. Unlike
-the other tensor types, PBO tensors are not allocated by the tensor crate
-directly — they are OpenGL Pixel Buffer Objects managed by the GL thread. The
-tensor crate provides the `PboTensor` wrapper and the `PboOps` trait that the
-GL backend implements to perform map/unmap/delete operations.
-
-PBO tensors use a `WeakSender` to communicate with the GL thread. This is a
-critical design choice: if `PboTensor` held a strong `Sender`, any surviving
-PBO tensor would keep the GL thread's message channel alive, preventing
-`GLProcessorThreaded::drop()` from joining the GL thread at shutdown. The
-`WeakSender` pattern allows the GL thread to exit cleanly when the
-`ImageProcessor` is dropped, even if PBO tensors still exist — subsequent
-PBO operations on orphaned tensors return `PboDisconnected`.
-
-### 2. Image HAL (`edgefirst_image`)
-
-**Purpose**: Hardware-accelerated image format conversion and resizing.
-
-**Architecture**:
-```mermaid
-classDiagram
-    class ImageProcessorTrait {
-        <<trait>>
-        +convert(src, dst, rotation, flip, crop)
-        +draw_decoded_masks(dst, detections, segmentations)
-        +draw_proto_masks(dst, detections, proto_data)
-        +set_class_colors(colors)
-    }
-
-    class ImageProcessor {
-        cpu: Option~CPUProcessor~
-        g2d: Option~G2DProcessor~
-        opengl: Option~GLProcessorThreaded~
-        +new() orchestrator with fallback chain
-        +create_image(w, h, PixelFormat, DType, Option~TensorMemory~) GPU-optimal alloc
-    }
-
-    class G2DProcessor {
-        NXP i.MX G2D hardware
-    }
-
-    class GLProcessorThreaded {
-        Threaded OpenGL ES wrapper
-        sends messages to GL thread
-    }
-
-    class GLProcessorST {
-        Single-threaded GL impl
-        owns EGL context + all GL state
-    }
-
-    class CPUProcessor {
-        fast_image_resize + rayon
-    }
-
-    ImageProcessorTrait <|.. ImageProcessor
-    ImageProcessorTrait <|.. G2DProcessor
-    ImageProcessorTrait <|.. GLProcessorThreaded
-    ImageProcessorTrait <|.. GLProcessorST
-    ImageProcessorTrait <|.. CPUProcessor
-    ImageProcessor o-- G2DProcessor
-    ImageProcessor o-- GLProcessorThreaded
-    ImageProcessor o-- CPUProcessor
-    GLProcessorThreaded *-- GLProcessorST : owns via thread
-```
-
-**`ImageProcessor` Dispatch Priority**: OpenGL (GPU-accelerated) → G2D (if supported for the format pair) → CPU (general fallback). Environment variables `EDGEFIRST_DISABLE_GL`, `EDGEFIRST_DISABLE_G2D`, `EDGEFIRST_DISABLE_CPU` can override this chain.
-
-**Supported Operations**:
-- Format conversion (YUYV, VYUY, NV12, NV16, RGB, RGBA, BGRA, GREY, Planar RGB, Planar RGBA, RGB int8, Planar RGB int8)
-- Resize with various interpolation methods
-- Rotation (0°, 90°, 180°, 270°)
-- Flip (horizontal, vertical)
-- Crop and region-of-interest
-- Instance segmentation mask rendering (draw and decode workflows)
-
-**TensorDyn (Image Representation)**:
-
-`TensorDyn` is the type-erased tensor enum that serves as the primary image type.
-It wraps `Tensor<T>` variants for different element types and carries an optional
-`PixelFormat` describing the spatial pixel layout. The format and element type are
-orthogonal: `PixelFormat` describes the spatial arrangement (e.g. packed RGB,
-semi-planar NV12) while `DType` describes the element storage (e.g. `U8`, `I8`,
-`F32`).
-
-```rust
-pub struct Tensor<T> {
-    storage: TensorStorage<T>,
-    format: Option<PixelFormat>,
-    /// Second plane for multiplane NV12/NV16 (separate DMA-BUF allocation).
-    chroma: Option<Box<Tensor<T>>>,
-}
-```
-
-The `chroma` field supports multi-plane DMA-BUF NV12/NV16 where Y and UV planes
-are in separate allocations (common with V4L2 `NV12M` format). Constructed via
-`Tensor::from_planes()`. See [Appendix A: Multi-Plane DMA-BUF](#appendix-a-multi-plane-dma-buf-limitation) for details.
-
-Image construction uses `TensorDyn::image(w, h, PixelFormat, DType, mem)` which
-allocates the appropriate tensor shape and sets the pixel format metadata.
-
-Width, height, channels, and stride are **not stored** — they are computed from the tensor shape and `PixelFormat` on every access. The tensor shape encoding depends on the pixel format:
-
-| Format | Tensor Shape | Notes |
-|--------|-------------|-------|
-| Rgb, Rgba, Bgra, Grey, Yuyv, Vyuy | `[H, W, C]` | Interleaved (channels-last) |
-| PlanarRgb, PlanarRgba | `[C, H, W]` | Channels-first |
-| Nv12 | `[H*3/2, W]` | 2D — Y plane (H rows) + UV plane (H/2 rows) |
-| Nv16 | `[H*2, W]` | 2D — Y plane (H rows) + UV plane (H rows) |
-
-**PixelFormat Enum**:
-
-Pixel formats are variants of the `PixelFormat` enum defined in the tensor crate.
-Int8 variants use `DType::I8` with any `PixelFormat` rather than separate format constants.
-
-| Variant | Display | Channels | Layout |
-|---------|---------|----------|--------|
-| `PixelFormat::Rgb` | RGB | 3 | Packed |
-| `PixelFormat::Rgba` | RGBA | 4 | Packed |
-| `PixelFormat::Bgra` | BGRA | 4 | Packed |
-| `PixelFormat::Grey` | Y800 | 1 | Packed |
-| `PixelFormat::Yuyv` | YUYV | 2 | Packed |
-| `PixelFormat::Vyuy` | VYUY | 2 | Packed |
-| `PixelFormat::Nv12` | NV12 | 1 | SemiPlanar |
-| `PixelFormat::Nv16` | NV16 | 1 | SemiPlanar |
-| `PixelFormat::PlanarRgb` | PlanarRgb | 3 | Planar |
-| `PixelFormat::PlanarRgba` | PlanarRgba | 4 | Planar |
-
-**Planar RGB Format**:
-Planar RGB (`PixelFormat::PlanarRgb`) stores color channels in separate planes rather than interleaved. This format is particularly useful for:
-- Neural network preprocessing where planar layout is required
-- Hardware accelerators that prefer planar data
-- Efficient SIMD operations on individual color channels
-- GPU texture operations via OpenGL with swizzled grayscale textures
-
-**Image Processing Flow**:
-```mermaid
-flowchart TD
-    Input[Input Image<br/>JPEG/PNG bytes or raw pixels]
-    TI[TensorDyn<br/>type-erased tensor + PixelFormat]
-    Conv{ImageProcessor::convert<br/>Backend selection}
-    G2D[G2D Acceleration<br/>NXP i.MX only]
-    GL[OpenGL Acceleration<br/>GPU accelerated]
-    CPU[CPU Fallback<br/>fast_image_resize]
-    Output[Output Image<br/>TensorDyn or numpy array]
-    
-    Input --> TI
-    TI --> Conv
-    Conv -->|Supported on i.MX| G2D
-    Conv -->|Linux with GPU| GL
-    Conv -->|Always available| CPU
-    G2D --> Output
-    GL --> Output
-    CPU --> Output
-    
-    style TI fill:#e1f5ff
-    style Conv fill:#fff4e1
-    style G2D fill:#90ee90
-    style GL fill:#87ceeb
-    style CPU fill:#ffeb9c
-    style Output fill:#e8f5e9
-```
-
-**GPU-Optimal Image Creation (`ImageProcessor::create_image()`)**:
-
-`create_image()` is the preferred way to allocate images for use with
-`ImageProcessor::convert()`. It probes the GPU at initialization time and
-selects the best available memory backend in priority order:
-
-```mermaid
-flowchart TD
-    Create["ImageProcessor::create_image(w, h, PixelFormat, DType, mem)"]
-    DMA{DMA-buf roundtrip<br/>verified at init?}
-    PBO{OpenGL PBO<br/>available?}
-    Mem[MemTensor<br/>heap fallback]
-
-    Create --> DMA
-    DMA -->|Yes| UseDMA["DmaTensor<br/>Zero-copy EGLImage import"]
-    DMA -->|No| PBO
-    PBO -->|Yes| UsePBO["PboTensor<br/>Zero-copy GL buffer binding"]
-    PBO -->|No| Mem
-
-    style UseDMA fill:#90ee90
-    style UsePBO fill:#87ceeb
-    style Mem fill:#ffeb9c
-```
-
-| Backend | When selected | GPU transfer method | Platforms |
-|---------|---------------|---------------------|-----------|
-| DMA-buf | GPU supports EGLImage import from DMA-buf FDs | Zero-copy: `EGL_EXT_image_dma_buf_import` — the GPU reads/writes the DMA buffer directly via EGLImage, no pixel copies | NXP i.MX 8M Plus (Vivante), NXP i.MX 95 (Mali/Panfrost) |
-| PBO | OpenGL ES 3.0 available but DMA-buf roundtrip fails | Zero-copy GL binding: `GL_PIXEL_UNPACK_BUFFER` for upload, `GL_PIXEL_PACK_BUFFER` for readback — data stays in GPU-accessible memory | NVIDIA desktop GPUs, systems without DMA-buf permissions |
-| Mem | No GPU or OpenGL not available | CPU `memcpy` via `glTexImage2D`/`glReadnPixels` with mapped host pointers | All platforms (fallback) |
-
-**GL Transfer Backend Selection**:
-
-The OpenGL processor selects a transfer backend at initialization time:
-
-| Backend | Detection | GPU Upload | GPU Readback |
-|---------|-----------|-----------|--------------|
-| `DmaBuf` | `verify_dma_buf_roundtrip()` passes | `EGL_EXT_image_dma_buf_import` (zero-copy) | EGLImage export (zero-copy) |
-| `Pbo` | OpenGL ES 3.0 available, DMA-buf fails | `GL_PIXEL_UNPACK_BUFFER` | `GL_PIXEL_PACK_BUFFER` |
-| `Sync` | Fallback | `glTexImage2D` with host pointer | `glReadnPixels` to host pointer |
-
-**GL Thread Architecture**:
-
-`GLProcessorThreaded` is the public thread-safe wrapper. It spawns a dedicated GL thread that owns the EGL context and all GL state (`GLProcessorST`). All operations are sent as `GLProcessorMessage` enum variants through a channel and block on a oneshot reply. This design is required because EGL contexts are thread-local — all GL calls must happen on the thread that created the context.
-
-The `PboOps` trait bridges the tensor crate and the GL thread: `PboTensor` holds a `WeakSender` to the GL thread channel. When the tensor needs to map/unmap/delete the PBO, it sends a message through this channel. The weak sender ensures PBO tensors don't prevent GL thread shutdown.
-
-**GLES 3.1 Context and Compute Shader Path**:
-
-At context creation time, the GL thread attempts to create a GLES 3.1 context
-first. If the driver does not support GLES 3.1, it falls back to GLES 3.0:
-
-```
-Try GLES 3.1  →  success: compute shaders available
-              →  failure: fall back to GLES 3.0 (no compute shaders)
-```
-
-When a GLES 3.1 context is active, an opt-in compute shader path is available for
-HWC→CHW proto tensor repack. Enable it by setting `EDGEFIRST_PROTO_COMPUTE=1`
-before launching the process:
-
-```sh
-EDGEFIRST_PROTO_COMPUTE=1 ./my_app
-```
-
-The compute shader performs the HWC→CHW layout transpose of the proto tensor on
-the GPU using an SSBO, avoiding a CPU-side copy. If compilation fails at runtime,
-the implementation logs a warning and falls back to the CPU repack path
-transparently — no API changes are required.
-
-**Why PBO matters**: On desktop Linux with NVIDIA GPUs, DMA-buf allocation
-succeeds (via `/dev/dma_heap/system`) but the NVIDIA EGL driver cannot import
-those buffers — the `verify_dma_buf_roundtrip()` check catches this at
-initialization. Without PBO, every `convert()` call would fall back to CPU
-`memcpy` for upload and readback. PBO keeps the data in GPU-accessible buffers,
-enabling the same zero-copy shader pipeline used on DMA platforms.
-
-**PBO Convert Dispatch**:
-
-When `convert()` is called with PBO-backed images, the GL thread must not call
-`tensor.map()` on those images — doing so would send a message back to itself
-and deadlock. Instead, the convert path dispatches to specialized methods:
-
-```
-┌─────────────────────────────┬──────────────────────────────────────────┐
-│ Source → Destination        │ Method                                    │
-├─────────────────────────────┼──────────────────────────────────────────┤
-│ DMA → DMA                   │ convert_dest_dma (EGLImage both sides)   │
-│ PBO → PBO                   │ convert_pbo_to_pbo (UNPACK + PACK)       │
-│ Mem/DMA → PBO               │ convert_any_to_pbo (texture + PACK)      │
-│ PBO → Mem                   │ convert_pbo_to_mem (UNPACK + ReadnPixels) │
-│ Mem/DMA → Mem/DMA           │ convert_dest_non_dma (texture + memcpy)  │
-└─────────────────────────────┴──────────────────────────────────────────┘
-```
-
-**EGL Image Cache**:
-
-The OpenGL backend maintains two independent LRU caches of EGLImages — one for
-source tensors (`src_egl_cache`) and one for destination tensors
-(`dst_egl_cache`). Each entry is keyed by `(BufferIdentity.id, chroma_id)`.
-
-`BufferIdentity` is a small struct that pairs a globally unique monotonic ID
-(allocated from an `AtomicU64` counter) with an `Arc<()>` liveness guard:
-
-```
-BufferIdentity {
-    id:    u64,     // unique per allocation — new value each time from_fd() is called
-    guard: Arc<()>, // cache entries hold Weak<()>; when tensor drops, weak dies
-}
-```
-
-When a tensor is freed, its `Arc<()>` guard drops. The cache holds only a
-`Weak<()>` reference, so `sweep()` detects dead entries without requiring an
-explicit removal call.
-
-| Pattern | Cache behavior | Performance |
-|---------|---------------|-------------|
-| Same tensor object reused across frames | Cache hit on every frame | Fast path — no EGLImage re-import |
-| New tensor created from same fd each frame | Cache miss on every frame | Slow path — EGLImage re-imported each call |
-| `dst` of call N reused as `src` of call N+1 | Hit in both caches | Two separate entries, no collision |
-
-**Key design implications**:
-
-- `hal_tensor_from_fd()` and `hal_import_image()` always allocate a new
-  `BufferIdentity`. Callers that re-wrap the same fd each frame will see a cache
-  miss on every `convert()` call. Hold the tensor object alive across frames.
-
-- Content written into a DMA-BUF between `convert()` calls (e.g., by a V4L2
-  decoder) is visible on the next call. EGLImage is a handle to live physical
-  memory — it is not a snapshot. The tensor wrapper does not need to be recreated
-  when the buffer contents change.
-
-- The `last_bound_src_egl` optimization skips the `glEGLImageTargetTexture2DOES`
-  rebind when the source EGLImage has not changed between consecutive calls. This
-  is safe because the texture already points at the correct DMA-BUF memory; skipping
-  the rebind does not prevent new frame data from being read.
-
-- A `glFinish()` is issued at the end of every `convert()` call. This guarantees
-  that all GPU reads of the source and writes to the destination are complete
-  before the function returns, making it safe to chain calls and to let the caller
-  write new data into a source buffer immediately after `convert()` returns.
-
-**Vivante NV12 to Planar RGB Two-Pass Workaround**:
-
-A single-pass NV12 → PlanarRgb shader causes a GPU hang on the Vivante GC7000UL
-(NXP i.MX 8M Plus). The workaround splits the conversion into two passes:
-
-```
-Pass 1:  NV12  →  RGBA  (intermediate)
-         All geometry operations here: resize, crop, rotation, flip, letterbox
-
-Pass 2:  RGBA  →  PlanarRgb  (at destination resolution)
-         Deinterleaves RGBA to three separate planes using sampler2D variants
-```
-
-Pass 1 reuses the existing `packed_rgb_intermediate_tex` GL texture — no new
-GPU resources are allocated. Pass 2 uses the same shader infrastructure as
-direct RGBA → PlanarRgb conversions. The two-pass path is selected automatically
-when `is_vivante && src_fmt == Nv12 && dst_fmt.layout() == Planar`. No API
-changes are required from callers.
-
-### 3. Decoder HAL (`edgefirst_decoder`)
-
-**Purpose**: Post-processing for object detection and segmentation model outputs.
-
-**Supported Decoders**:
-- **YOLO** (YOLOv5, YOLOv8, YOLOv11, YOLOv26)
-  - Object detection
-  - Instance segmentation
-  - Split output format support
-  - End-to-end models with embedded NMS (YOLOv26)
-  - Mixed data type support (different types per input tensor)
-- **ModelPack** (Au-Zone proprietary format)
-  - Detection with anchor-based decoding
-
-**`YoloSegDet2Way` Model Type**:
-
-TFLite INT8 segmentation models exported with 3 separate output tensors use the
-`YoloSegDet2Way` model type. The builder auto-selects this variant when 3 outputs
-are detected matching the expected shapes:
-
-| Tensor | Shape | Content |
-|--------|-------|---------|
-| detection | `[1, nc+4, N]` | Combined boxes and class scores |
-| mask_coeff | `[1, 32, N]` | Per-detection mask coefficients |
-| protos | `[1, H/4, W/4, 32]` | Prototype masks |
-
-This differs from the standard `YoloSegDet` variant (which combines boxes and
-mask coefficients into a single tensor). The builder auto-selects `YoloSegDet2Way`
-when the output count and shapes match the 3-tensor layout.
-
-**YOLO26 End-to-End Support**:
-
-YOLOv26 models can be exported with embedded NMS (one-to-one matching heads),
-eliminating external NMS post-processing. The `DecoderVersion::Yolo26` variant
-triggers end-to-end model type selection:
-
-| Config Field | Value | Effect |
-|-------------|-------|--------|
-| `decoder_version` | `"yolo26"` | Selects end-to-end model types, bypasses NMS |
-| `decoder_version` | `"yolov8"` | Uses traditional model types with external NMS |
-
-When `decoder_version` is `"yolo26"`, `DecoderVersion::is_end_to_end()` returns
-`true` and the decoder selects one of the end-to-end `ModelType` variants:
-
-| ModelType | Tensors | Format |
-|-----------|---------|--------|
-| `YoloEndToEndDet` | 1 | `[batch, N, 6+]` — xyxy, conf, class |
-| `YoloEndToEndSegDet` | 2 | `[batch, N, 6+num_protos]` + protos |
-| `YoloSplitEndToEndDet` | 3 | boxes `[B,N,4]` + scores `[B,N,1]` + classes `[B,N,1]` |
-| `YoloSplitEndToEndSegDet` | 5 | boxes + scores + classes + mask_coeff + protos |
-
-For non-end-to-end YOLO26 exports (`end2end=false`), use `decoder_version: "yolov8"`
-with an explicit `nms` field (`ClassAgnostic` or `ClassAware`).
-
-**NMS Modes** (`Option<Nms>`):
-- `Some(Nms::ClassAgnostic)` — suppress overlapping boxes regardless of class (default)
-- `Some(Nms::ClassAware)` — only suppress boxes sharing the same class label
-- `None` — bypass NMS entirely (auto-set for end-to-end models)
-
-**Output Tensor Physical-Order Contract** (EDGEAI-1288):
-
-Every output declared to the decoder — whether programmatically via
-`hal_decoder_params_add_output` / `DecoderBuilder`, or through YAML/JSON config
-— must have its `shape` and `dshape` fields listed in **physical memory order,
-outermost axis first, innermost axis last**. HAL derives C-contiguous strides
-from `shape` and wraps the raw buffer bytes with those strides; it never
-reorders bytes. When `dshape` is also supplied, HAL uses it to permute the
-stride tuple into the decoder's canonical logical order for the output role
-(e.g. `[batch, height, width, num_protos]` for protos); only the stride
-indices change, not the bytes.
-
-When `dshape` is omitted, HAL assumes `shape` is already in the decoder's
-canonical order for the role. This is appropriate for producers like
-Ultralytics ONNX/TFLite flat-detection, which emit outputs in the order the
-decoder kernels expect.
-
-Mis-declaring physical order (e.g. using NCHW dim names on an NHWC buffer)
-causes every element access to index the wrong byte. This was the root cause of
-two distinct production bugs: a vertical-stripe mask artifact on i.MX 8M Plus
-TFLite segmentation, and a coordinate mis-decode with Ara-2 anchor-first
-split-tensor boxes. HAL cannot detect the mismatch at runtime because it has no
-visibility into how the inference engine laid out the bytes.
-
-`DecoderBuilder::build` validates each output at construction time:
-- `dshape.len()` must equal `shape.len()` when `dshape` is present.
-- Each `dshape[i].size` must equal `shape[i]` — catches the common mistake of
-  declaring `dshape` in a different order than `shape`.
-- No axis name may appear twice within a single output's `dshape`.
-
-Common physical layouts by framework:
-
-| Framework | Typical proto layout | How to declare |
-|-----------|---------------------|----------------|
-| TFLite (NNStreamer) | `[1, H, W, C]` NHWC | `shape=[1,H,W,C]`, `dshape=[batch,height,width,num_protos]` |
-| ONNX / PyTorch | `[1, C, H, W]` NCHW | `shape=[1,C,H,W]`, `dshape=[batch,num_protos,height,width]` |
-| Ara-2 DVM | `[1, N, 1, 4]` anchor-first | `shape=[1,N,1,4]`, `dshape=[batch,num_boxes,padding,box_coords]` |
-| Ultralytics flat | already canonical | `shape=[1,C,N]`, `dshape` may be omitted |
-
-**Proto Mask API**:
-
-For segmentation models, `decode_quantized_proto()` and `decode_float_proto()`
-return raw proto data and mask coefficients without materializing pixel masks.
-These are the preferred entry point for fused GPU rendering via
-`ImageProcessor::draw_proto_masks()`.
-
-**Architecture**:
-```mermaid
-flowchart LR
-    Builder[DecoderBuilder]
-    Decoder[Decoder]
-    Det[decode_detection<br/>→ bboxes, scores, classes]
-    Seg[decode_segmentation<br/>→ bboxes, scores, classes, masks]
-    
-    Builder --> Decoder
-    Decoder --> Det
-    Decoder --> Seg
-    
-    style Builder fill:#e1f5ff
-    style Decoder fill:#fff4e1
-    style Det fill:#e8f5e9
-    style Seg fill:#e8f5e9
-```
-
-**Detection Pipeline**:
-```mermaid
-flowchart TD
-    Raw[Model Raw Output<br/>quantized or float]
-    E2E{End-to-end?<br/>decoder_version = yolo26}
-
-    Quant{Quantized?}
-    Dequant[Dequantization<br/>scale, zero_point]
-
-    Parse[Parse boxes & scores<br/>XYWH → XYXY conversion]
-    NMS[Non-Maximum Suppression<br/>IoU threshold filtering]
-    Filter[Filter by score threshold]
-
-    E2EParse[Parse post-NMS output<br/>XYXY + conf + class directly]
-    E2EFilter[Filter by score threshold]
-
-    Det[Detection boxes<br/>bbox, score, class]
-    Seg[Segmentation masks<br/>per-box mask matrices]
-
-    Raw --> E2E
-    E2E -->|Yes| E2EParse
-    E2EParse --> E2EFilter
-    E2EFilter --> Det
-    E2EFilter --> Seg
-
-    E2E -->|No| Quant
-    Quant -->|Yes| Dequant
-    Quant -->|No| Parse
-    Dequant --> Parse
-    Parse --> NMS
-    NMS --> Filter
-    Filter --> Det
-    Filter --> Seg
-
-    style Raw fill:#e1f5ff
-    style E2E fill:#fff4e1
-    style Dequant fill:#fff4e1
-    style NMS fill:#ffeb9c
-    style E2EParse fill:#87ceeb
-    style Det fill:#90ee90
-    style Seg fill:#90ee90
-```
-
-#### Instance Segmentation Mask Rendering
-
-YOLO segmentation models produce **proto masks** (shared basis masks at reduced
-resolution, typically 160x160) and **mask coefficients** (per-detection linear
-combination weights). The raw mask for detection `i` is:
-
-```
-mask_raw[i] = coefficients[i] @ protos    # shape: (proto_h, proto_w)
-```
-
-The HAL provides two workflows for consuming these masks:
-
-| Workflow | Python | Rust | C | CPU | OpenGL | G2D |
-|----------|--------|------|---|:---:|:------:|:---:|
-| **Draw** — fused overlay onto image | `processor.draw_masks()` | `draw_proto_masks()` | `hal_image_processor_draw_masks()` | Yes | Yes | No |
-| **Draw pre-decoded** — draw already-decoded masks | `processor.draw_decoded_masks()` | `draw_decoded_masks()` | `hal_image_processor_draw_decoded_masks()` | Yes | Yes | No |
-| **Draw with tracking** — decode, track, and draw in one call | `processor.draw_masks_tracked()` | `draw_masks_tracked()` | `hal_image_processor_draw_masks_tracked()` | Yes | Yes | No |
-
-**`MaskOverlay` Parameters**:
-
-The `draw_decoded_masks` and `draw_proto_masks` methods (and `draw_masks_tracked`)
-accept a `MaskOverlay<'_>` struct controlling compositing behaviour:
-
-```rust
-pub struct MaskOverlay<'a> {
-    pub background: Option<&'a TensorDyn>,  // blit this image into dst before drawing masks
-    pub opacity: f32,                        // scale mask alpha; 1.0 = fully opaque
-}
-```
-
-Use the builder API to construct it:
-
-```rust
-// Default: no background blit, full opacity
-let overlay = MaskOverlay::default();
-
-// With a background frame and reduced opacity
-let overlay = MaskOverlay::new()
-    .with_background(&bg_tensor)
-    .with_opacity(0.7);
-```
-
-`draw_masks_tracked` combines decoding, tracking, and mask rendering in a single
-call, returning `(Vec<DetectBox>, Vec<TrackInfo>)`:
-
-```rust
-let (boxes, tracks) = processor.draw_masks_tracked(
-    &decoder, &mut tracker, timestamp, &outputs, &mut dst, overlay)?;
-```
-
-> **G2D limitation:** The NXP G2D hardware accelerator does not support mask
-> rendering. On platforms where G2D is the primary image processor (e.g.
-> i.MX 8M Plus without EGL), all mask methods return `NotImplemented`. Use
-> an OpenGL-capable `ImageProcessor` (pass an `egl_display`) or fall back
-> to CPU rendering.
-
-**Choosing between `draw_masks` workflows:**
-
-| Use case | Recommended API | Why |
-|----------|----------------|-----|
-| Overlay colored masks onto a display frame | `processor.draw_masks()` | Fused path — masks never leave Rust/GPU, lowest latency |
-| Draw masks you already have (e.g. from a previous `decode()` call) | `processor.draw_decoded_masks()` | Accepts pre-decoded `(H, W, C)` mask arrays |
-
-**Format requirements:**
-
-- **CPU backend:** destination image must be `RGBA` or `RGB`.
-- **OpenGL backend:** destination image must be `RGBA`, `BGRA`, or `RGB`.
-
-> These are representative ranges for typical COCO-class detections. Actual
-> timings depend on detection count, bounding box sizes, and proto tensor
-> quantization format. Use `mask_benchmark` for precise on-target measurements:
-> `cargo bench -p edgefirst-image --bench mask_benchmark`
-
-**Fused proto→pixel algorithm (`draw_proto_masks`)**
-
-Instead of computing the matmul at proto resolution and upsampling the result,
-the fused path upsamples the proto field itself and evaluates the dot product at
-every output pixel:
-
-```
-For each output pixel (x, y) in bbox at 640×640:
-    bilinear_sample(protos, proto_coords(x, y))  →  32 interpolated values
-    dot(coefficients, interpolated_protos)        →  raw logit
-    sigmoid(raw)                                  →  mask value [0, 1]
-    threshold at 0.5 → blend color onto pixel
-```
-
-This is algebraically equivalent to bilinear upsampling after matmul (because
-both bilinear interpolation and the dot product are linear), but avoids
-materializing intermediate tensors. Key design choices:
-
-- **No proto-resolution crop** — the full 160×160 proto field is sampled,
-  avoiding the boundary erosion artifact of crop-before-upsample approaches.
-- **Sigmoid after interpolation** — sigmoid is nonlinear, so applying it after
-  spatial operations preserves the full dynamic range through interpolation.
-- The draw path uses the sigmoid value for alpha-blend weighting.
-
-This approach is mathematically equivalent to Ultralytics' `retina_masks=True`
-(`process_mask_native`) for binary mask output. Empirical validation across 26
-matched detections on COCO val2017 images confirms **0.993 mean mask IoU**
-between the two methods.
-
-**GPU implementation (OpenGL)**
-
-*Draw path (`draw_proto_masks`) — sigmoid shaders with alpha blending:*
-
-The fragment shader computes sigmoid(logit) and blends the detection color onto
-the framebuffer using `GL_SRC_ALPHA / GL_ONE_MINUS_SRC_ALPHA`.
-
-The GPU renders a quad per detection, and the fragment shader evaluates the mask
-at every output pixel.
-
-### 4. Tracker HAL (`edgefirst_tracker`)
-
-**Purpose**: Multi-object tracking across video frames.
-
-**Implementation**: ByteTrack algorithm with Kalman filtering
-
-**Architecture**:
-```mermaid
-classDiagram
-    class ByteTrack {
-        +update(detections) TrackInfo[]
-    }
-    
-    class Tracklet {
-        +UUID uuid
-        +KalmanFilter filter
-        +int track_count
-        +Timestamps timestamps
-    }
-    
-    ByteTrack *-- Tracklet : manages
-```
-
-**Tracking Flow**:
-```mermaid
-flowchart TD
-    NewFrame[New Frame Detections]
-    Predict[Predict tracklet positions<br/>Kalman filter forward step]
-    Cost[Compute cost matrix<br/>IoU between predictions and detections]
-    Hungarian[Hungarian Algorithm LAPJV<br/>optimal assignment]
-    
-    Matched[Matched:<br/>Update tracklet]
-    UnmatchedDet[Unmatched detection:<br/>Create new tracklet]
-    UnmatchedTrack[Unmatched tracklet:<br/>Increment lost count]
-    
-    CheckLost{Lost > threshold?}
-    Delete[Delete tracklet]
-    Keep[Keep tracklet]
-    
-    NewFrame --> Predict
-    Predict --> Cost
-    Cost --> Hungarian
-    Hungarian --> Matched
-    Hungarian --> UnmatchedDet
-    Hungarian --> UnmatchedTrack
-    UnmatchedTrack --> CheckLost
-    CheckLost -->|Yes| Delete
-    CheckLost -->|No| Keep
-    
-    style Matched fill:#90ee90
-    style UnmatchedDet fill:#87ceeb
-    style Delete fill:#ffcccb
-```
-
-### 5. Python Bindings (`edgefirst-hal`)
-
-**Purpose**: Expose HAL functionality to Python via PyO3.
-
-**Exposed Classes**:
-- `Tensor`: Unified tensor with image support and numpy buffer protocol
-- `ImageProcessor`: Image processing operations
-- `Decoder`: Model output decoding
-- `PixelFormat`, `Normalization`, `Rect`, `Rotation`, `Flip`: Configuration types
-
-**Python Integration**:
-```mermaid
-flowchart LR
-    Py[Python Code]
-    PyO3[PyO3 Bindings]
-    Rust[Rust Core HAL]
-    HW[Hardware Accelerators / CPU]
-
-    Py --> PyO3
-    PyO3 --> Rust
-    Rust --> HW
-
-    style Py fill:#3776ab,color:#fff
-    style PyO3 fill:#ce422b
-    style Rust fill:#dea584
-    style HW fill:#90ee90
-```
-
-**NumPy → Tensor Copy Strategy** (`crates/python/src/tensor.rs`,
-`copy_numpy_to_tensor_dyn`): the binding inspects the source array's
-strides and dispatches to one of three paths to balance copy cost
-against allocation overhead:
-
-| Path | Source layout | Strategy | Cost |
-|---|---|---|---|
-| 1 | Fully contiguous | `copy_from_slice` (memcpy), rayon-parallel ≥ 256 KiB | Lower bound — no allocation |
-| 2 | Strided with contiguous inner rows (column slice, sub-volume, negative stride) | Per-row memcpy, iterate outer dimensions | Within ≈ 5 % of Path 1 for typical row sizes |
-| 3 | Fully strided (transposed view, every-other-element) | Internal `np.ascontiguousarray()` (numpy's vectorised C strided→contig pass), then Path 1 memcpy | ≈ 4× Path 1 — but ≈ 4× faster than the legacy element-wise iteration the binding used to do here |
-
-Path 3 is the case that bit early users: a HailoRT output naturally
-arrives as `arr.transpose(0, 2, 1)` over a `(1, anchors, channels)`
-buffer, which has no contiguous inner row. The legacy element-wise
-loop incurred stride arithmetic and broke vectorisation. PR #58
-replaced it with the `np.ascontiguousarray` materialisation path.
-Callers therefore no longer need to maintain a manual
-`np.ascontiguousarray()` workaround above HAL — see
-[README § Rule 7](README.md#rule-7--numpy-interop-pass-arrays-straight-to-from_numpy)
-for the user-facing rule.
-
-### Cross-Crate Dependencies
-
-The `edgefirst_image` crate depends on `edgefirst_decoder` for the `DetectBox`, `ProtoData`, and `Segmentation` types used in the mask rendering APIs (`draw_decoded_masks`, `draw_proto_masks`). This means the image crate imports decoder types but does not import the `Decoder` itself — it only needs the output data structures that describe detections and masks.
-
-### 6. C API Bindings (`edgefirst-hal-capi`)
-
-**Purpose**: Expose HAL functionality to C/C++ consumers via cbindgen-generated headers.
-
-**Architecture**:
-- Builds as both `staticlib` and `cdylib`
-- cbindgen generates C headers from Rust source annotations
-- Opaque handle pattern: C code operates on `HalTensor*`, `HalImageProcessor*`, etc.
-- All functions return error codes; error messages retrieved via `hal_error_message()`
-- Covers tensor, image, decoder, and tracker APIs
-
-**Source files** (`crates/capi/src/`):
-
-| File | Lines | Scope |
-|------|------:|-------|
-| `tensor.rs` | ~1,200 | Tensor create, map, reshape, fd sharing |
-| `image.rs` | ~2,600 | ImageProcessor, convert, draw |
-| `decoder.rs` | ~3,200 | Decoder create, decode detection/segmentation |
-| `tracker.rs` | ~300 | ByteTrack create, update |
-| `error.rs` | ~120 | Error handling utilities |
-| `delegate.rs` | ~200 | Delegate DMA-BUF ABI types and camera adaptor format info |
-| `log.rs` | ~50 | C-side logging configuration |
-
-### 7. G2D FFI (`g2d-sys`)
-
-**Purpose**: Foreign Function Interface to NXP i.MX G2D library.
-
-**Architecture**:
-- Raw FFI bindings via bindgen
-- Safe Rust wrapper types
-- IOCTL interface for DMA buffer operations
-- Version detection and capability queries
-
-### 8. GPU Probe (`gpu-probe`)
-
-**Purpose**: Standalone binary for probing GPU capabilities and benchmarking transfer methods.
-
-Used during development and CI to verify EGL/OpenGL support, benchmark RGB packing strategies, test DMA-buf roundtrip, and measure pipeline throughput on target hardware.
-
-## Common API Usage Patterns
-
-### Pattern 1: Basic Image Conversion
-
-```rust
-use edgefirst_image::{load_image, ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
-use edgefirst_tensor::{PixelFormat, DType, TensorDyn};
-
-// Load image from JPEG
-let bytes = std::fs::read("testdata/zidane.jpg")?;
-let input = load_image(&bytes, Some(PixelFormat::Rgb), None)?;
-
-// Create converter (auto-selects best backend: OpenGL, G2D, CPU)
-let mut converter = ImageProcessor::new()?;
-
-// Create output buffer with optimal GPU memory (DMA > PBO > Mem)
-let mut output = converter.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
-
-// Convert and resize — zero-copy if DMA or PBO backend is active
-converter.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default())?;
-```
-
-### Pattern 2: Detection Decoding
-
-```rust
-use edgefirst_decoder::{Decoder, DetectBox, Segmentation};
-use edgefirst_tensor::TensorDyn;
-
-// Build decoder from JSON configuration
-let decoder = DecoderBuilder::new()
-    .with_config_json_str(&config_json)?
-    .with_score_threshold(0.5)
-    .with_iou_threshold(0.45)
-    .build()?;
-
-// Decode model outputs into pre-allocated output vectors
-let mut output_boxes: Vec<DetectBox> = Vec::new();
-let mut output_masks: Vec<Segmentation> = Vec::new();
-let outputs: Vec<&TensorDyn> = vec![&boxes_tensor, &scores_tensor];
-decoder.decode(&outputs, &mut output_boxes, &mut output_masks)?;
-```
-
-**Python Example**:
-```python
-import edgefirst_hal
-import numpy as np
-
-# Create decoder from config dict or YAML
-decoder = edgefirst_hal.Decoder(config_dict, 0.5, 0.45)
-
-# Decode outputs (automatically handles quantization)
-boxes, scores, classes = decoder.decode([output0, output1])
-```
-
-### Pattern 3: Multi-Frame Tracking
-
-```rust
-use edgefirst_hal::tracker::{ByteTrack, Tracker, DetectionBox};
-
-let mut tracker = ByteTrack::default();
-
-for frame in video_frames {
-    let detections = run_detection(frame)?;
-    let track_infos = tracker.update(&detections, frame.timestamp);
-    
-    for track_info in track_infos {
-        println!("Object {}: {:?}", track_info.uuid, track_info.tracked_location);
-    }
-}
-```
-
-### Pattern 4: Zero-Copy Tensor Sharing
-
-```rust
-use edgefirst_hal::tensor::{Tensor, TensorTrait};
-
-// Create tensor in process A
-let tensor = Tensor::<u8>::new(&[1920, 1080, 3], None, Some("frame1"))?;
-let fd = tensor.clone_fd()?;
-
-// Send fd to process B (via Unix domain socket, etc.)
-// ...
-
-// Process B recreates tensor from fd
-let shared_tensor = Tensor::<u8>::from_fd(fd, &[1920, 1080, 3], None)?;
-```
-
-### Pattern 5: Python API Usage
-
-```python
-import edgefirst_hal as ef
-import numpy as np
-
-# Load image from file
-tensor_img = ef.Tensor.load("testdata/zidane.jpg", ef.PixelFormat.Rgb)
-
-# Create converter
-converter = ef.ImageProcessor()
-
-# Create output image with optimal GPU memory (DMA > PBO > Mem)
-output = converter.create_image(640, 640, ef.PixelFormat.Rgb)
-
-# Resize with hardware acceleration
-converter.convert(tensor_img, output)
-
-# Convert to numpy for processing
-output_array = np.zeros((640, 640, 3), dtype=np.uint8)
-output.normalize_to_numpy(output_array)
-```
+---
 
 ## Design Patterns
 
-### 1. Trait-Based Polymorphism
+The workspace consistently applies a small set of Rust idioms across all
+crates. Knowing which pattern is in play makes individual files much
+easier to read.
 
-The HAL uses Rust traits extensively to provide polymorphic behavior:
-- `TensorTrait<T>`: Common interface for all tensor types
-- `ImageProcessorTrait`: Common interface for all image converters
-- `DetectionBox`: Trait for objects with bounding boxes
+### 1. Trait-based polymorphism
 
-### 2. Enum Dispatch
+Common operations cross backend boundaries via traits:
 
-Uses `enum_dispatch` crate for zero-cost polymorphism without dynamic dispatch overhead.
+- `TensorTrait<T>` — every tensor backend implements this; `shape`, `size`, `map`, `clone_fd`, `buffer_identity` are uniform across DMA / SHM / Mem / PBO.
+- `ImageProcessorTrait` — `convert`, `draw_decoded_masks`, `draw_proto_masks`, `set_class_colors` work the same way against `ImageProcessor`, `G2DProcessor`, `GLProcessorThreaded`, `GLProcessorST`, `CPUProcessor`.
+- `DetectionBox` — the decoder's `DetectBox` and any third-party detection type implement this so the tracker can read XYXY boxes, scores, and labels without copying.
+- `PboOps` — the GL backend implements this trait (defined in `tensor`) so PBO tensors can route map/unmap/delete operations back to the GL thread without making `tensor` depend on `image`.
 
-### 3. Builder Pattern
+### 2. Enum dispatch
 
-Complex objects use the builder pattern (e.g., `DecoderBuilder`) for flexible construction.
+Hot dispatch points use [`enum_dispatch`](https://docs.rs/enum_dispatch)
+to avoid dynamic dispatch overhead. The match-style code reads like
+trait-object dispatch but compiles to a direct call; the `TensorDyn`
+type-erased tensor and the tracker's per-detection dispatch both rely on
+this pattern.
 
-### 4. Zero-Copy Operations
+### 3. Builder pattern
 
-Extensive use of:
-- Memory-mapped file descriptors
-- Slice views into tensors
-- ndarray views for array operations
+Complex multi-parameter constructors use a fluent builder:
+[`DecoderBuilder`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.DecoderBuilder.html),
+[`ByteTrackBuilder`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/bytetrack/struct.ByteTrackBuilder.html),
+and the in-progress `hal_decoder_params` C type. Builders enforce
+invariants in `.build()` rather than scattering checks across setters.
 
-### 5. Hardware Fallback Chain
+### 4. Zero-copy operations
 
-Operations try hardware accelerators first, falling back to CPU implementations gracefully.
+Used pervasively to avoid per-frame allocations:
 
-### 6. Type-Safe Foreign Interfaces
+- Memory-mapped file descriptors (DMA-BUF, SHM)
+- `&[T]` slice views into tensor maps
+- ndarray `ArrayView` for math operations
+- `WeakSender<T>` for cross-thread channels that should not extend lifetime
 
-Raw FFI bindings are wrapped in safe Rust types that enforce correct usage at compile time.
+### 5. Hardware fallback chain
 
-### 7. Python Wrapper Naming Convention
+`ImageProcessor::new()` probes the GPU once (DMA-BUF round-trip,
+GLES 3.1, PBO availability) and selects the active backend. All
+subsequent calls reuse the same backend; per-call dispatch never re-runs
+the probe. The `Tensor::new()` allocator chains DMA → SHM → Mem with
+the same one-time-probe philosophy. Both chains are defeatable via the
+`EDGEFIRST_DISABLE_*` and `EDGEFIRST_FORCE_*` environment variables for
+testing and benchmarking.
 
-Python wrapper types use a `Py` prefix (e.g., `PyTensor`, `PyPixelFormat`) to clearly distinguish them from their Rust counterparts. The Python `Tensor` class wraps `TensorDyn` internally. This convention makes it explicit which types are Python-facing and which are internal Rust types.
+### 6. Type-safe foreign interfaces
+
+Raw FFI bindings (`dma-heap`, `g2d-sys`, `khronos-egl`) are wrapped in
+safe Rust types that enforce correct usage at compile time. The unsafe
+boundary is concentrated in `crates/tensor/src/dma.rs`,
+`crates/image/src/g2d.rs`, and `crates/image/src/gl/`; nothing
+downstream sees `unsafe` blocks.
+
+### 7. Python wrapper naming convention
+
+PyO3 wrapper types use a `Py` prefix internally (e.g. `PyTensor`,
+`PyPixelFormat`) to distinguish them from their Rust counterparts. The
+Python-facing `Tensor` class wraps `TensorDyn` internally; users see
+the unprefixed name. This convention makes it explicit which types are
+Python-facing and which are internal Rust types — important when a
+class needs both a `#[pyclass]` impl and an internal Rust impl.
+
+### 8. Thread safety
+
+The `Send + Sync` story across the workspace:
+
+- `Tensor<T>` / `TensorDyn` — `Send + Sync`. Safe to share across threads.
+- `Decoder` — `Send + Sync` for read operations (decoding). The builder consumes itself on `.build()`.
+- `ImageProcessor` — `Send + Sync`, but concurrent use serializes on the global `GL_MUTEX` (see [`crates/image/ARCHITECTURE.md#gl-command-serialization-gl_mutex`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#gl-command-serialization-gl_mutex)). For best performance: one `ImageProcessor` per worker thread.
+- `ByteTrack<T>` — `Send + Sync`. Mutable methods take `&mut self`, so concurrent updates require external synchronization.
+
+### 9. Error handling
+
+Each crate defines its own `Error` / `Result` pair (`DecoderError`,
+`edgefirst_image::Error`, `edgefirst_tensor::Error`). The `image` crate's
+`Error` implements `From<std::io::Error>` so `?` propagates cleanly from
+file I/O in user code; the others do not (rationale: those crates do not
+own file I/O).
+
+The C API translates all errors into POSIX `errno` codes; see
+[`crates/capi/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md#error-convention).
+
+---
 
 ## Performance Tracing Architecture
 
-### Overview
+This section is the **architecture rationale** for the tracing
+infrastructure. The user-facing how-to-use-it lives in
+[README.md § Performance Tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing).
 
-The HAL provides built-in instrumentation for performance analysis using the
-[`tracing`](https://docs.rs/tracing) ecosystem. All library crates emit
-structured span events on hot paths, which can be captured to Chrome JSON trace
-files for visualization in [Perfetto UI](https://ui.perfetto.dev/).
+### Design goals
 
-### Design Goals
+1. **Near-zero cost when disabled** — no heap allocations, no
+   formatting, no function calls on the hot path when no subscriber is
+   active.
+2. **Always compiled in** — span sites are present in all builds; only
+   the capture infrastructure (subscriber + file writer) is
+   feature-gated.
+3. **Language-agnostic capture API** — Rust, Python, and C callers all
+   use the same underlying mechanism.
+4. **One process, one session** — simplifies the subscriber model and
+   avoids runtime complexity from dynamic subscriber management.
 
-1. **Near-zero cost when disabled** — no heap allocations, no formatting, no
-   function calls on the hot path when no subscriber is active.
-2. **Always compiled in** — span sites are present in all builds; only the
-   capture infrastructure (subscriber + file writer) is feature-gated.
-3. **Language-agnostic capture API** — Rust, Python, and C callers all use
-   the same underlying mechanism.
-4. **One process, one session** — simplifies the subscriber model and avoids
-   runtime complexity from dynamic subscriber management.
+### Zero-cost implementation
 
-### Zero-Cost Implementation
-
-The `tracing` crate's `trace_span!` macro compiles each span site to:
+The [`tracing`](https://docs.rs/tracing) crate's `trace_span!` macro
+compiles each span site to:
 
 ```text
-static CALLSITE: DefaultCallsite = ...;  // registered once at first use
-if INTEREST.load(Relaxed) != NEVER {     // single atomic load — the "hot path"
+static CALLSITE: DefaultCallsite = ...;       // registered once at first use
+if INTEREST.load(Relaxed) != NEVER {           // single atomic load — the hot path
     // subscriber is interested → create span, record fields
 } else {
-    Span::none()                         // disabled span — no work done
+    Span::none()                               // disabled — no work done
 }
 ```
 
-When no subscriber is installed (the default state), the interest cache is
-`NEVER` and the entire span creation is skipped. Key properties:
+When no subscriber is installed (the default), the interest cache is
+`NEVER` and the entire span creation is skipped. Properties:
 
-- **No heap allocation**: Field values use `tracing::field::debug(&val)` which
-  stores a reference; actual `Debug` formatting is deferred to the subscriber's
-  record method and only executes when actively tracing.
-- **No string formatting**: The `?field` syntax in `trace_span!` wraps values
-  lazily — the `Display`/`Debug` impl is never called when disabled.
-- **No function calls**: The macro inlines to a single `Relaxed` atomic load
-  followed by a branch-not-taken.
-- **Span.record() guard**: For fields recorded after span creation (e.g.,
-  detection counts computed mid-function), `Span::record()` checks
+- **No heap allocation** — field values use `tracing::field::debug(&val)`
+  which stores a reference; actual `Debug` formatting is deferred to the
+  subscriber's record method and only executes when actively tracing.
+- **No string formatting** — the `?field` syntax wraps values lazily;
+  the `Display` / `Debug` impl is never called when disabled.
+- **No function calls** — the macro inlines to a single `Relaxed` atomic
+  load followed by a branch-not-taken.
+- **`Span::record()` guard** — for fields recorded after span creation
+  (e.g. detection counts computed mid-function), `record()` checks
   `is_disabled()` and returns immediately when no subscriber cares.
 
-### Span Naming Conventions
+### Span naming conventions
 
 | Prefix | Meaning | Example |
 |--------|---------|---------|
@@ -1083,1263 +186,210 @@ When no subscriber is installed (the default state), the interest cache is
 | `gl_` | OpenGL backend operation | `gl_convert`, `gl_pass1_to_rgba` |
 | `g2d_` | G2D hardware backend | `g2d_convert` |
 | `py_` | Python binding entry point | `py_decode`, `py_convert` |
-| `gl_pass1_`/`gl_pass2_` | Multi-pass GL sub-operation | `gl_pass1_to_rgba`, `gl_pass2_pack_rgb` |
+| `gl_pass1_` / `gl_pass2_` | Multi-pass GL sub-operation | `gl_pass1_to_rgba`, `gl_pass2_pack_rgb` |
 
 Field conventions:
+
 - `n` or `n_*` — counts (detections, candidates, tracks)
-- `mode` — algorithm variant (float/quant, proto/scaled)
+- `mode` — algorithm variant (float / quant, proto / scaled)
 - `*_fmt` — pixel format enum value
-- `*_memory` — tensor memory backend (Dma/Shm/Mem)
-- `layout` — data layout (nhwc/nchw)
-- `pass` — multi-pass identifier (pre_resize/post_resize/direct)
+- `*_memory` — tensor memory backend (`Dma` / `Shm` / `Mem`)
+- `layout` — data layout (`nhwc` / `nchw`)
+- `pass` — multi-pass identifier (`pre_resize` / `post_resize` / `direct`)
 
-### Crate Layering
+Each per-crate `ARCHITECTURE.md` documents the spans that crate emits.
 
-```
+### Crate layering
+
+```text
 ┌─────────────────────────────────────────────────────────┐
-│                  Application Code                         │
+│                    Application Code                      │
 ├─────────────────────────────────────────────────────────┤
 │  edgefirst-hal (subscriber install, start/stop API)      │
-│  ┌─ tracing-chrome (Chrome JSON writer)                  │
+│  ├─ tracing-chrome (Chrome JSON writer)                  │
 │  └─ tracing-subscriber (subscriber registry)             │
 ├─────────────────────────────────────────────────────────┤
-│  edgefirst-decoder   │ edgefirst-image  │ edgefirst-     │
-│  (decode spans)      │ (convert spans)  │ tracker        │
-│                      │                  │ (update spans) │
-├──────────────────────┴──────────────────┴────────────────┤
-│  edgefirst-tensor (alloc/map spans)                      │
+│  edgefirst-decoder │ edgefirst-image   │ edgefirst-      │
+│  (decode spans)    │ (convert spans)   │ tracker         │
+│                    │                   │ (update spans)  │
+├────────────────────┴───────────────────┴────────────────┤
+│  edgefirst-tensor  (alloc / map spans)                   │
 ├─────────────────────────────────────────────────────────┤
 │  tracing crate (span macros, callsite interest cache)    │
 └─────────────────────────────────────────────────────────┘
 ```
 
-- **Inner crates** (tensor, image, decoder, tracker) depend on `tracing` as a
-  **required** (non-optional) dependency. The span macros are always compiled.
-  Cost when disabled: one `Relaxed` atomic load per span site.
-- **Top-level crate** (`edgefirst-hal`) gates `tracing-chrome` and
+- **Inner crates** (`tensor`, `image`, `decoder`, `tracker`) depend on
+  `tracing` as a **required** (non-optional) dependency. The span
+  macros are always compiled. Cost when disabled: one `Relaxed` atomic
+  load per span site.
+- **Umbrella crate** (`edgefirst-hal`) gates `tracing-chrome` and
   `tracing-subscriber` behind the `tracing` feature (default on). These
-  provide the capture infrastructure — the subscriber that actually writes
-  the Chrome JSON file.
-- **Binding crates** (Python, C API) forward the feature flag and provide
-  language-appropriate start/stop APIs.
+  provide the capture infrastructure — the subscriber that actually
+  writes the Chrome JSON file.
+- **Binding crates** (Python, C API) forward the feature flag and
+  provide language-appropriate start/stop APIs.
 
-### Subscriber Model
+### Subscriber model
 
-The HAL uses Rust's **global subscriber** model (`set_global_default`):
+The HAL uses Rust's **global subscriber** model
+(`set_global_default`):
 
-- Only one subscriber per process lifetime (Rust's `tracing` design constraint).
+- Only one subscriber per process lifetime (Rust's `tracing` design
+  constraint).
 - `start_tracing(path)` installs a Chrome JSON subscriber on first call.
 - `stop_tracing()` drops the `FlushGuard`, flushing buffered spans to disk.
-- After stop, the subscriber remains installed but the guard is gone — a second
-  `start_tracing()` returns `TracingError::SessionExhausted`.
-- If user code installs its own subscriber before calling `start_tracing()`,
-  the HAL returns `TracingError::SubscriberInstallFailed`.
+- After stop, the subscriber remains installed but the guard is gone — a
+  second `start_tracing()` returns `TracingError::SessionExhausted`.
+- If user code installs its own subscriber before calling
+  `start_tracing()`, the HAL returns `TracingError::SubscriberInstallFailed`.
 
-This single-session model is acceptable for profiling workflows where one trace
-per process run is the norm. Applications needing multiple trace files should
-run separate processes.
+This single-session model is acceptable for profiling workflows where
+one trace per process run is the norm. Applications needing multiple
+trace files run separate processes.
 
-### Error Handling
+### Error handling
 
 The tracing API uses poison-resistant mutex access
-(`unwrap_or_else(|e| e.into_inner())`) to ensure that a panic in one thread
-doesn't permanently poison the tracing state and crash the entire process.
+(`unwrap_or_else(|e| e.into_inner())`) so a panic in one thread does not
+permanently poison the tracing state and crash the process.
 
 Error variants:
+
 - `AlreadyActive` — a session is currently capturing
 - `SessionExhausted` — a session was previously started and stopped
 - `SubscriberInstallFailed` — another subscriber was already installed
 
-### Multi-Pass Pipeline Visibility
+### Multi-pass pipeline visibility
 
-Image conversion operations that use multiple internal passes emit per-pass
-spans to reveal the breakdown:
+Image conversion operations that use multiple internal passes emit
+per-pass spans to reveal the breakdown:
 
-**CPU 3-pass pipeline** (format → resize → format):
-```
+CPU 3-pass (format → resize → format):
+
+```text
 image_convert
 └─ cpu_format_convert (pass="pre_resize", from=Nv12, to=Rgb)
 └─ cpu_resize
 └─ cpu_format_convert (pass="post_resize", from=Rgb, to=Rgba)
 ```
 
-**OpenGL 2-pass packed RGB**:
-```
+OpenGL 2-pass packed RGB:
+
+```text
 gl_convert
 └─ gl_pass1_to_rgba (dst_w=640, dst_h=480)
 └─ gl_pass2_pack_rgb (render_w=640, render_h=480)
 ```
 
-**OpenGL 2-pass Vivante workaround** (NV12→Planar):
-```
+OpenGL 2-pass Vivante NV12 → Planar workaround:
+
+```text
 gl_convert
 └─ gl_pass1_to_rgba (dst_w=640, dst_h=480)
 └─ gl_pass2_to_planar (dst_w=640, dst_h=480)
 ```
 
-Spans within a multi-pass sequence are non-overlapping — the first pass guard
-is explicitly dropped before the second pass span is entered, producing clean
-sequential slices in the Perfetto timeline.
+Spans within a multi-pass sequence are non-overlapping — the first
+pass guard is explicitly dropped before the second pass span is
+entered, producing clean sequential slices in the Perfetto timeline.
 
-### Relationship to perf and Benchmarks
+### Relationship to perf and benchmarks
 
-The trace instrumentation complements (but does not replace) hardware
-performance counters and microbenchmarks:
-
-| Tool | What It Shows | When to Use |
+| Tool | What it shows | When to use |
 |------|---------------|-------------|
-| HAL Tracing | Span-level timing, pipeline structure, per-call metadata | Understanding pipeline structure, finding which stage is slow |
-| `perf record` | Instruction-level CPU hotspots, cache misses, branch mispredictions | Optimizing within a single span (e.g., mask matmul kernel) |
-| HAL Benchmarks | Statistical timing (mean/p95/p99) across many iterations | Measuring improvement from optimizations |
-
-**Recommended workflow** for performance analysis:
-1. Run with HAL tracing to identify the slow span(s)
-2. Use `perf record` targeting the specific operation to find CPU hotspots
-3. Optimize the hotspot
-4. Re-run benchmarks to quantify the improvement
-5. Re-run tracing to confirm the span duration decreased
-
-See [BENCHMARKS.md](BENCHMARKS.md) for benchmark infrastructure details and
-[README.md § Performance Tracing](README.md#performance-tracing) for the
-complete span reference table.
-
-## EGL/GL Resource Cleanup at Process Shutdown
-
-### Problem
-
-The OpenGL headless renderer (`crates/image/src/opengl_headless.rs`) uses EGL and
-OpenGL ES via dynamically loaded shared libraries (`libEGL.so.1`, `libGLESv2.so`).
-When the process exits — particularly from a Python interpreter running PyO3
-extensions — EGL resource cleanup can crash with heap corruption, segfaults, or
-panics. This is a well-documented, industry-wide problem with no clean solution.
-
-The crash occurs due to a fundamental conflict between four systems during
-process shutdown:
-
-1. **Python finalization order is non-deterministic.** During `Py_FinalizeEx()`,
-   Python destroys modules and objects in random order. A PyO3 `#[pyclass]`
-   wrapping `GlContext` may have its Rust `Drop` invoked after dependent state
-   has already been torn down.
-
-2. **Linux `atexit` handler ordering is unreliable.** The glibc `__cxa_finalize`
-   mechanism interacts with `dlclose` in ways that produce non-deterministic
-   ordering between atexit handlers registered by different shared libraries.
-   A known glibc bug ([glibc #21032](https://sourceware.org/bugzilla/show_bug.cgi?id=21032))
-   prevents proper cleanup of TLS destructors from unloaded libraries.
-
-3. **Mesa's `_eglAtExit` use-after-free.** Mesa registers an atexit handler
-   that frees per-thread EGL state (`_EGLThreadInfo`). If our `Drop` calls
-   `eglReleaseThread()` after this handler has already run, it dereferences
-   freed memory ([Ubuntu Bug #1946621](https://bugs.launchpad.net/ubuntu/+source/mesa/+bug/1946621)).
-
-4. **Vendor EGL driver bugs.** Some vendor EGL drivers (e.g. Qualcomm Adreno,
-   older NVIDIA) may misbehave during cleanup. On NXP Vivante, earlier
-   observations suggested a double-free in `gcoOS_FreeMemo` when both
-   `eglDestroyContext` and `eglTerminate` are called, but this was not
-   conclusively confirmed. The `catch_unwind` guard (Layer 3) absorbs any
-   driver-side panics during cleanup.
-
-### Solution
-
-The implementation uses a defense-in-depth strategy with four layers, each
-addressing a different failure mode:
-
-```
-┌─────────────────────────────────────────────────────────┐
-│ Layer 1: Box::leak — EGL library handle                 │
-│   Prevents dlclose from unmapping shared library code   │
-├─────────────────────────────────────────────────────────┤
-│ Layer 2: ManuallyDrop<Rc<Egl>> — EGL instance           │
-│   Prevents khronos-egl Drop from calling                │
-│   eglReleaseThread() into freed Mesa state              │
-├─────────────────────────────────────────────────────────┤
-│ Layer 3: catch_unwind — EGL cleanup calls               │
-│   Catches panics from eglDestroyContext/eglMakeCurrent  │
-│   if function pointers are invalidated                  │
-├─────────────────────────────────────────────────────────┤
-│ Layer 4: eglTerminate inside catch_unwind               │
-│   Releases ref-counted display; catch_unwind absorbs    │
-│   any driver-side misbehaviour                          │
-└─────────────────────────────────────────────────────────┘
-```
-
-The `GlContext::drop` implementation performs explicit EGL resource cleanup
-(destroy context, destroy surface, terminate display) inside `catch_unwind`,
-then intentionally skips dropping the `Rc<Egl>` wrapper. The EGL library
-handle is leaked via `Box::leak` at load time so it is never `dlclose`'d.
-`eglTerminate` is ref-counted per the EGL spec: each `eglInitialize`
-increments a reference count and each `eglTerminate` decrements it, so the
-display is only truly torn down when the last reference is released.
-
-### Industry Precedent
-
-This approach is consistent with how other major graphics projects handle the
-same problem:
-
-- **Chromium/ANGLE** skips full EGL teardown on GPU process exit, treating
-  cleanup as more dangerous than no cleanup during shutdown.
-
-- **wgpu** (the Rust WebGPU implementation used by Firefox) wraps its
-  `glow::Context` in `ManuallyDrop` and loads EGL with `RTLD_NODELETE` to
-  prevent library unloading. The `khronos-egl` crate itself adopted
-  `RTLD_NOW | RTLD_NODELETE` on Linux after
-  [khronos-egl #14](https://github.com/timothee-haudebourg/khronos-egl/issues/14),
-  referencing the same glibc root cause.
-
-- **Smithay** (Wayland compositor toolkit) supports skipping `eglTerminate`
-  via a feature flag for the same class of driver bugs.
-
-### Limitations
-
-`catch_unwind` catches Rust panics but cannot catch fatal signals (`SIGABRT`,
-`SIGSEGV`, `SIGBUS`) that originate from heap corruption inside the C driver.
-The `Box::leak` layer prevents `dlclose` from unmapping driver code, and the
-`ManuallyDrop<Rc<Egl>>` layer avoids `eglReleaseThread` calls into freed
-Mesa state. If a driver causes a fatal signal during `eglTerminate`, the
-process will crash — but this has not been observed in practice on any
-supported platform (NXP i.MX8 Vivante, NXP i.MX95 Mali/Panfrost, Mesa x86_64).
-
-### References
-
-- Mesa atexit use-after-free: [Ubuntu Bug #1946621](https://bugs.launchpad.net/ubuntu/+source/mesa/+bug/1946621)
-- glibc TLS destructor bug: [glibc #21032](https://sourceware.org/bugzilla/show_bug.cgi?id=21032)
-- khronos-egl RTLD_NODELETE fix: [khronos-egl #14](https://github.com/timothee-haudebourg/khronos-egl/issues/14)
-- wgpu SIGSEGV on library unload: [wgpu #246](https://github.com/gfx-rs/wgpu/issues/246)
-- PyO3 Drop after finalization: [PyO3 #4632](https://github.com/PyO3/pyo3/issues/4632)
-- Python finalization order: [CPython docs — Py_FinalizeEx](https://docs.python.org/3/c-api/init.html)
-
-## G2D Resource Cleanup
-
-### Problem
-
-On NXP i.MX platforms, the G2D hardware accelerator (`libg2d.so.2`) and the EGL
-library (`libEGL.so.1`) share kernel driver state through the Vivante `galcore`
-device (`/dev/galcore`). When both libraries are loaded, calling `dlclose` on
-either one can trigger heap corruption (`corrupted double-linked list`) during
-process exit because the atexit handlers registered by the shared `galcore`
-driver become inconsistent.
-
-### Solution
-
-For production code, `G2DProcessor` is used normally and dropped by Rust's
-ownership system. The `Box::leak` of the EGL library handle (Layer 1 in the
-EGL cleanup strategy above) prevents `dlclose` from unmapping `libEGL.so.1`,
-which keeps the shared `galcore` state intact during process shutdown.
-
-For benchmark code (where `G2DProcessor` instances are created and destroyed
-many times within a single process), use `ManuallyDrop<G2DProcessor>` to
-prevent repeated `g2d_close` + `dlclose` cycles that can exhaust driver
-resources. The benchmark harness (`crates/bench`) wraps G2D processor
-instances in `ManuallyDrop` to avoid this pattern.
-
-### Resource Leak Prevention Policy
-
-All GPU and DMA resources must be properly released. Specifically:
-
-- **EGL displays**: `eglTerminate` must be called in `GlContext::drop`. The
-  EGL spec ref-counts display connections, so each `eglTerminate` decrements
-  the count and only tears down state when it reaches zero.
-- **EGL contexts**: `eglDestroyContext` must be called before `eglTerminate`.
-  No EGL surfaces are created — the HAL uses surfaceless contexts
-  (`EGL_KHR_surfaceless_context` + `EGL_KHR_no_config_context`) and renders
-  exclusively through FBOs backed by EGLImages imported from DMA-buf.
-- **DMA buffers**: Closed via file descriptor `close()` in `Drop`.
-- **G2D contexts**: `g2d_close` via `G2DProcessor::drop`.
-
-Intentional leaks are limited to the EGL **library handle** (`Box::leak` to
-prevent `dlclose`) and the `Rc<Egl>` wrapper (`ManuallyDrop` to prevent
-`eglReleaseThread`). These are lightweight Rust-side objects; the actual
-GPU/display resources are released by the explicit cleanup calls above.
-
-## GL Command Serialization (GL_MUTEX)
-
-### Problem
-
-Multiple `ImageProcessor` instances can coexist in the same process, each
-backed by a `GLProcessorThreaded` that spawns a dedicated OS thread with
-its own EGL display and GL context. While EGL and OpenGL ES specify that
-independent contexts on separate threads should not interfere, several
-embedded GPU drivers violate this assumption:
-
-- **Vivante `galcore` (i.MX8M Plus)**: Concurrent `eglInitialize`,
-  `eglCreateContext`, DMA-BUF import ioctls, and `eglTerminate` from
-  multiple threads corrupt driver-internal state, causing SIGSEGV
-  (null pointer dereference at offset 0x18 inside `galcore` ioctl) and
-  futex-based deadlocks. This affects both initialization and runtime
-  operations.
-
-- **Broadcom V3D 7.1.10.2 (Raspberry Pi 5)**: Concurrent `eglTerminate`
-  calls break the spec-required ref-counting, causing `EGL(NotInitialized)`
-  errors on surviving contexts. Subsequent GL operations (DMA-BUF roundtrip
-  verification) fail with GL error 0x502 (`GL_INVALID_OPERATION`).
-
-- **ARM Mali-G310 (i.MX95)**: No issues observed. The Panfrost driver
-  handles concurrent EGL/GL operations correctly.
-
-### Solution
-
-A global `GL_MUTEX` (`std::sync::Mutex<()>` in `crates/image/src/gl/context.rs`)
-serializes **all** EGL and GL operations across every `GLProcessorST` instance.
-The mutex is acquired in `GLProcessorThreaded`'s GL thread message loop at
-three points:
-
-1. **Initialization**: Wraps `GLProcessorST::new()` — EGL display creation,
-   context setup, shader compilation, and DMA-BUF roundtrip verification.
-2. **Message dispatch**: Wraps every incoming message (convert, draw masks,
-   PBO create/download, etc.) so that only one GL thread executes driver
-   calls at any time.
-3. **Teardown**: Wraps `GLProcessorST::drop()` → `GlContext::drop()` so
-   that `eglDestroyContext`/`eglTerminate` are serialized.
-
-The mutex uses `unwrap_or_else(|e| e.into_inner())` to recover from
-poisoning: if a prior GL operation panicked, subsequent operations on
-other instances can still proceed rather than propagating a poison error.
-
-### Performance Implications
-
-All GL operations are serialized — there is no concurrent GPU execution
-across `ImageProcessor` instances. This is acceptable because:
-
-- The primary use case (edge AI inference pipelines) typically uses a
-  single `ImageProcessor` per pipeline. Multiple instances exist mainly
-  in test scenarios or when multiple independent pipelines share a process.
-- GPU operations are already I/O-bound on embedded targets; the mutex
-  overhead (microseconds) is negligible compared to DMA transfers and
-  shader execution (milliseconds).
-- The alternative (concurrent GPU access) crashes on Vivante hardware,
-  which is a primary deployment target.
-
-Future work could relax this to init/teardown-only serialization if a
-driver is known to be safe for concurrent runtime operations (e.g., Mali),
-but the current approach prioritizes correctness across all targets.
-
-## Testing with GPU Resources
-
-### Single-Threaded Test Execution
-
-All test execution must use single-threaded mode (`--test-threads=1` for
-`cargo test`, `-j 1` for `cargo nextest`). This is required because:
-
-1. **EGL display sharing**: When multiple tests run in parallel threads within
-   one process, `eglTerminate` on one thread can tear down a shared EGL display
-   while other threads still reference it. This causes intermittent test failures
-   that are difficult to reproduce.
-
-2. **G2D driver state**: The `galcore` kernel driver maintains per-process state
-   that is not safe to access from concurrent threads creating and destroying
-   G2D contexts.
-
-3. **DMA-heap allocation**: Concurrent DMA-heap allocations from multiple test
-   threads can exhaust the CMA pool on memory-constrained embedded targets.
-
-This constraint applies to CI (`test.yml`), the Makefile, and local development.
-The `cargo nextest` runner already provides per-test process isolation, but
-`-j 1` is still specified to prevent DMA/GPU contention across test processes.
-
-### Mask Rendering Benchmarks
-
-The mask rendering benchmarks use a custom in-process harness (`edgefirst-bench`)
-instead of Criterion to avoid GPU driver crashes from fork-based benchmarking
-on i.MX8/i.MX95 targets.
-
-**Rust benchmark** (`crates/image/benches/mask_benchmark.rs`):
-- `decode_masks/proto` — NMS + extract mask coefficients (no mask materialization)
-- `decode_masks/materialize` — NMS + extract proto data + materialize pixel masks on CPU
-- `draw_masks/{cpu,opengl}` — pre-decoded mask overlay
-- `draw_proto_masks/{cpu,opengl}` — fused proto→overlay
-
-Run: `cargo bench -p edgefirst-image --bench mask_benchmark`
-
-**Python benchmarks** (`tests/bench_decode_render.py`):
-- `decode() + draw_decoded_masks()` — 2-step path (decode to proto-res masks, then draw)
-- `draw_masks() [fused]` — single-call fused decode+draw path
-
-Run: `python tests/bench_decode_render.py [--iterations N] [--json results.json]`
-
-**Python profiling** (`tests/profile_decode_render.py`):
-Isolated hot-loop profiling designed for `perf record`. Separates setup (model
-load, EGL init) from the measured loop.
-
-Run: `perf record -F 997 --call-graph dwarf -- python tests/profile_decode_render.py fused`
-
-## Performance Considerations
-
-This section is the **architecture-level reference** for the
-[Optimization Guide in README.md][readme-opt]. The README states the rules;
-this section explains why each rule exists and what fails when it is broken.
-
-| Rule (from README) | Why it matters at the architecture level |
-|--------------------|------------------------------------------|
-| Reuse tensors across frames | Each new tensor allocates a fresh `BufferIdentity` (monotonic atomic counter, see `crates/tensor/src/lib.rs::BufferIdentity`). The EGL image cache is keyed by `(BufferIdentity.id, chroma_id)` (see `crates/image/src/gl/cache.rs::EglCacheKey`). New ID → cache miss → full `eglCreateImageKHR` import. See [§ C API Performance Recommendations](#c-api-performance-recommendations-dma-buf--egl-path) below. |
-| Allocate via `ImageProcessor::create_image()` | The processor selects DMA-buf, PBO, or heap based on a runtime GPU probe at `ImageProcessor::new()` time. Bypassing this with `Tensor::new(memory=...)` forces a slow transfer path on every `convert()`. See [§ Memory Allocation Strategy](#memory-allocation-strategy). |
-| Cache imported camera tensors by inode | DMA-BUF fd numbers are recycled across V4L2 / libcamera buffer pools. The inode is the only stable identifier for the underlying `dma_buf` kernel object. See [§ Appendix C — DMA-BUF Identity and Tensor Caching](#appendix-c-dma-buf-identity-and-tensor-caching). |
-| Build the decoder once | `DecoderBuilder` parses the model output schema, resolves quantization parameters, and allocates internal working buffers. See [§ Decoder Optimization](#decoder-optimization). |
-| One `ImageProcessor` per pipeline | Each instance owns an EGL display, a GL thread, and per-thread caches. Multiple instances serialize on the global `GL_MUTEX`. See [§ GL Command Serialization (GL_MUTEX)](#gl-command-serialization-gl_mutex). |
-| Native CPU feature builds (Rule 6) | Not an architectural pattern — a build-time concern. `RUSTFLAGS` controls whether the f16 mask kernel at `crates/image/src/cpu/masks.rs` compiles to native widening instructions or to the soft-float `__extendhfsf2` helper. Distributed binaries stay on the target triple's baseline ISA so a single binary runs on every CPU within that triple; benchmark hosts opt in via `RUSTFLAGS` overrides. See [README.md § Rule 6][readme-rule6]. |
-
-[readme-opt]: README.md#optimization-guide
-[readme-rule6]: README.md#rule-6--local-fp16--avx-build-overrides
-
-### Memory Allocation Strategy
-
-The choice of memory type significantly impacts performance depending on the workload:
-
-1. **Heap Memory** (`MemTensor<T>`): Fastest for pure CPU algorithms (image resizing, filtering, format conversion). Standard heap allocation has minimal overhead and is optimized by the OS. Recommended when no hardware acceleration is required.
-
-2. **DMA Memory** (`DmaTensor<T>`): Introduces CPU-level overhead for allocation and memory mapping, but provides substantial benefits when interfacing with hardware accelerators:
-   - Zero-copy access from G2D (NXP i.MX graphics processor)
-   - Zero-copy access from OpenGL/GPU
-   - Zero-copy access from V4L2 video capture and codec engines
-   - Hardware DMA operations benefit from DMA-capable memory alignment and page locking
-   - Best for workloads that combine CPU processing with hardware acceleration
-
-3. **Shared Memory** (`ShmTensor<T>`): Slowest option with CPU overhead from POSIX shared memory operations. Does not support hardware DMA operations. Use only for cross-process buffer sharing when dma-buf is unavailable due to insufficient permissions, non-Linux platforms, or when persistent memory that survives process termination is required.
-
-**Memory Selection Guidance**:
-- Pure CPU workloads (algorithms only): Use `MemTensor` (Heap)
-- Hardware-accelerated operations (G2D, OpenGL, V4L2, codec): Use `DmaTensor`
-- Cross-process buffer sharing: Use `ShmTensor` (when dma memory cannot be used)
-
-### Image Processing Strategy
-
-The HAL supports multiple image processing backends that are selected automatically based on hardware availability:
-- **G2D**: NXP i.MX graphics processor acceleration
-- **OpenGL**: GPU-accelerated image processing
-- **CPU**: Fallback using vectorized operations and parallelization with Rayon
-
-**BGRA destination format**: BGRA (byte order B, G, R, A) is supported as a
-destination-only format for Cairo/Wayland compositing, where the native pixel
-format is ARGB32 (big-endian), which is BGRA in memory on little-endian AArch64.
-OpenGL renders natively via `GL_BGRA` (`GL_EXT_texture_format_BGRA8888`), G2D
-uses the native `G2D_BGRA8888` format, and the CPU backend converts to RGBA
-then swizzles R↔B channels in-place.
-
-### C API Performance Recommendations (DMA-BUF / EGL Path)
-
-The following patterns apply when using the DMA-BUF tensor APIs
-(`hal_import_image()`, `hal_tensor_from_fd()`)
-together with `hal_image_processor_convert()` from C or C++.
-
-> **Reference implementation**: The `bench_preproc` C benchmark
-> (`crates/capi/tests/bench_preproc.c`) demonstrates every pattern described
-> below in a complete, runnable program. Build it with `make bench` from
-> `crates/capi/tests/`. Use it as a starting point for new integrations.
-
-#### Core Principle: Allocate Once, Reuse Every Frame, Free on Exit
-
-Every call to the tensor-from-fd family of functions allocates a new
-`BufferIdentity` with a globally unique ID. The OpenGL EGL image cache is
-keyed by this ID (see the "EGL Image Cache" section above). A new
-`BufferIdentity` means a cache miss, which means a full `eglCreateImageKHR`
-import on the next `convert()` call. On the i.MX 8M Plus this costs roughly
-0.5--1.5 ms per import — enough to drop below real-time at 30 fps when source
-and destination are both re-imported every frame.
-
-The correct lifecycle follows three phases:
-
-```
- INIT                         LOOP                         TEARDOWN
- ──────────────────────────   ──────────────────────────   ─────────────
- Allocate processor           Reuse same tensors           Free tensors
- Allocate src/dst tensors     Call convert()               Free processor
- (from fd or create_image)    (EGL cache hits)
-```
-
-#### Phase 1 — Initialization
-
-Allocate all tensors before entering the processing loop. When the source
-dimensions are not known until the first frame arrives (e.g., V4L2 resolution
-negotiation), allocate on first use and keep the tensors for all subsequent
-frames.
-
-> **Important**: When using `hal_image_processor_convert()`, all
-> internally-allocated tensors (intermediate buffers, output buffers) **must**
-> be created via `hal_image_processor_create_image()`, **not** via
-> `hal_tensor_new()` or `hal_tensor_from_fd()`. The processor's
-> `create_image` method selects the optimal memory backend for the active
-> GPU: DMA-BUF when the GPU uses EGLImage imports (Vivante, Mali), PBO when
-> it uses pixel buffer transfers (NVIDIA desktop), and heap as fallback.
-> Using `hal_tensor_new()` with a hardcoded memory type bypasses this
-> selection and can force a slow transfer path.
->
-> **`hal_import_image` is NOT the same as `create_image`.** Despite
-> living on the processor object, `hal_import_image()` does not use the
-> processor's backend intelligence — it simply wraps an external DMA-BUF
-> fd as a DMA tensor. It exists only for importing buffers that are
-> **externally allocated** by V4L2, GStreamer, or codec output. Do not
-> use it to create intermediate or destination buffers; use
-> `hal_image_processor_create_image()` for those.
->
-> | Function | Use for | Memory selection |
-> |----------|---------|-----------------|
-> | `hal_image_processor_create_image()` | Intermediate and output buffers | **Auto** (DMA / PBO / Mem based on GPU) |
-> | `hal_import_image()` | External DMA-BUF import only | Always DMA (wraps caller's fd) |
-> | `hal_tensor_new()` / `hal_tensor_from_fd()` | Low-level tensor creation | Caller-specified (no GPU awareness) |
-
-```c
-// --- Initialization (once) ------------------------------------------------
-
-struct hal_image_processor *proc = hal_image_processor_new();
-
-// Source: external DMA-BUF from a V4L2 capture buffer.
-// hal_plane_descriptor_new dups the fd — caller keeps its copy.
-struct hal_plane_descriptor *pd = hal_plane_descriptor_new(v4l2_buf.m.fd);
-struct hal_tensor *src = hal_import_image(
-    proc, pd, NULL, width, height, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
-// pd is consumed by hal_import_image — do NOT free
-
-// Intermediate: processor-allocated RGBA for chained conversion.
-// MUST use create_image (not hal_tensor_new) for optimal memory backend.
-struct hal_tensor *mid = hal_image_processor_create_image(
-    proc, model_w, model_h, HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8);
-
-// Destination: PlanarRgb for model input, also processor-allocated.
-// MUST use create_image (not hal_tensor_new) for optimal memory backend.
-struct hal_tensor *dst = hal_image_processor_create_image(
-    proc, model_w, model_h, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
-```
-
-When the external buffer has row padding (stride > width * bytes_per_pixel),
-set the stride on the plane descriptor:
-
-```c
-struct hal_plane_descriptor *pd = hal_plane_descriptor_new(v4l2_buf.m.fd);
-hal_plane_descriptor_set_stride(pd, v4l2_fmt.fmt.pix.bytesperline);
-struct hal_tensor *src = hal_import_image(
-    proc, pd, NULL, width, height, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
-// pd is consumed — do NOT free
-```
-
-#### Phase 2 — Main Processing Loop
-
-Reuse the same tensor objects on every frame. The EGL image cache hits on
-the second and all subsequent iterations because the `BufferIdentity.id` has
-not changed.
-
-```c
-// --- Main loop (every frame) ----------------------------------------------
-
-while (running) {
-    // Upstream writes new pixel data into the DMA-BUF (V4L2 DQBUF, decoder
-    // output, etc.). The tensor and its cached EGLImage remain valid — no
-    // need to recreate anything. EGLImage is a handle to live physical memory.
-
-    // Two-pass conversion: NV12 → RGBA → PlanarRgb
-    hal_image_processor_convert(proc, src, mid,
-                                HAL_ROTATION_NONE, HAL_FLIP_NONE, &crop);
-    hal_image_processor_convert(proc, mid, dst,
-                                HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
-
-    // Feed dst to the model ...
-}
-```
-
-Both `mid` entries (as destination in pass 1 and as source in pass 2) live in
-independent EGL image caches (`dst_egl_cache` and `src_egl_cache`), so both
-sides achieve cache hits after the first frame.
-
-The `glFinish()` issued at the end of each `convert()` call guarantees
-coherency, making chained calls safe without explicit synchronization.
-
-#### Phase 3 — Teardown
-
-Free tensors only when the pipeline is torn down — typically at program exit
-or when a pipeline is reconfigured (e.g., resolution change).
-
-```c
-// --- Teardown (once) ------------------------------------------------------
-
-hal_tensor_free(dst);
-hal_tensor_free(mid);
-hal_tensor_free(src);
-hal_image_processor_free(proc);
-```
-
-#### Buffer Pool Integration (V4L2 / GStreamer)
-
-When upstream provides DMA-BUF fds from a buffer pool (V4L2 MMAP, GStreamer
-allocator, codec output ring), a small number of physical buffers are cycled
-through a queue. The correct pattern maps each pool slot to a HAL tensor that
-is created once and reused whenever that slot is dequeued.
-
-```c
-// Pool integration example (V4L2 MMAP with N_BUFS buffers)
-
-#define N_BUFS 4
-struct hal_tensor *pool_tensors[N_BUFS] = { NULL };
-
-// At DQBUF time, lazily create or reuse the tensor for this buffer index.
-int buf_index = v4l2_buf.index;  // 0..N_BUFS-1
-
-if (pool_tensors[buf_index] == NULL) {
-    // First time this pool slot is seen — create the HAL tensor.
-    // hal_plane_descriptor_new dups the fd, so V4L2 keeps its copy.
-    struct hal_plane_descriptor *pd = hal_plane_descriptor_new(v4l2_buf.m.fd);
-    pool_tensors[buf_index] = hal_import_image(
-        proc, pd, NULL, width, height,
-        HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
-    // pd is consumed — do NOT free
-}
-
-// Reuse the existing tensor — cache hit on every subsequent dequeue.
-hal_image_processor_convert(proc, pool_tensors[buf_index], dst, ...);
-
-// QBUF returns the buffer to the driver; the tensor stays alive.
-ioctl(fd, VIDIOC_QBUF, &v4l2_buf);
-
-// --- Teardown (when stopping capture) ---
-for (int i = 0; i < N_BUFS; i++) {
-    hal_tensor_free(pool_tensors[i]);  // NULL-safe
-    pool_tensors[i] = NULL;
-}
-```
-
-With `hal_tensor_from_fd()` the pattern is similar. The function dups
-the fd internally — the caller retains ownership of the original:
-
-```c
-// When using hal_tensor_from_fd (dups fd, caller retains original):
-if (pool_tensors[buf_index] == NULL) {
-    size_t shape[] = { height, width, 1 };    // NV12 luma plane
-    pool_tensors[buf_index] = hal_tensor_from_fd(
-        HAL_DTYPE_U8, v4l2_buf.m.fd, shape, 3, "v4l2_src");
-    hal_tensor_set_format(pool_tensors[buf_index], HAL_PIXEL_FORMAT_NV12);
-}
-```
-
-#### fd Ownership Summary
-
-| Function | fd ownership | When to `dup()` |
-|----------|-------------|-----------------|
-| `hal_plane_descriptor_new()` | Dups eagerly — caller retains original fd | Never — caller keeps its fd |
-| `hal_import_image()` | Consumes both descriptors (success or fail) | Never — descriptors already duped the fd |
-| `hal_tensor_from_fd()` | Dups internally — caller retains original fd | Never — caller keeps its fd |
-
-#### Anti-Patterns
-
-The following patterns cause severe performance regressions. Each is explained
-with the underlying cost so that the reason is clear, not just the rule.
-
-**1. Creating a tensor from fd every frame**
-
-```c
-// BAD: ~1-3 ms overhead per frame from EGLImage re-import
-while (running) {
-    struct hal_plane_descriptor *pd = hal_plane_descriptor_new(v4l2_buf.m.fd);
-    struct hal_tensor *src = hal_import_image(
-        proc, pd, NULL, width, height, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
-    hal_image_processor_convert(proc, src, dst, ...);
-    hal_tensor_free(src);
-}
-```
-
-*Why it is slow*: Every call allocates a new `BufferIdentity` with a fresh ID.
-The EGL image cache keys on `(BufferIdentity.id, chroma_id)`, so the cache
-never hits. Each `convert()` call must call `eglCreateImageKHR` to re-import
-the DMA-BUF as a GL texture. On the Vivante GC7000UL this takes 0.5--1.5 ms.
-When both source and destination are re-imported, the cost doubles.
-
-**2. Freeing and reallocating tensors between frames**
-
-```c
-// BAD: same cost as #1, plus heap allocation overhead
-while (running) {
-    struct hal_tensor *dst = hal_image_processor_create_image(
-        proc, model_w, model_h, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
-    hal_image_processor_convert(proc, src, dst, ...);
-    // ... use dst ...
-    hal_tensor_free(dst);
-}
-```
-
-*Why it is slow*: In addition to EGL image cache misses, every iteration
-allocates and frees a DMA-BUF (or PBO), which involves kernel calls
-(`dma-heap ioctl` or `glBufferData`). On memory-constrained embedded
-targets, CMA pool fragmentation can also cause allocation failures
-after sustained operation.
-
-**3. Using the same tensor as both src and dst**
-
-```c
-// BAD: undefined behavior
-hal_image_processor_convert(proc, tensor, tensor, ...);
-```
-
-*Why it fails*: The OpenGL backend binds `src` as a texture and `dst` as a
-framebuffer attachment. Sampling from and rendering to the same image in a
-single draw call is undefined behavior per the OpenGL ES specification.
-Results range from correct output (by accident) to GPU hangs.
-
-**4. Using `hal_tensor_new()` instead of `hal_image_processor_create_image()`**
-
-```c
-// BAD: bypasses processor's memory backend selection
-size_t shape[] = { 640, 640, 3 };
-struct hal_tensor *dst = hal_tensor_new(HAL_DTYPE_U8, shape, 3,
-                                         HAL_TENSOR_MEMORY_DMA, "output");
-hal_image_processor_convert(proc, src, dst, ...);
-```
-
-*Why it is slow*: `hal_image_processor_create_image()` inspects the active GPU
-backend and selects the optimal memory type — DMA-BUF for EGLImage-capable
-GPUs (Vivante, Mali), PBO for desktop GPUs (NVIDIA), heap for CPU-only.
-Calling `hal_tensor_new()` with a hardcoded memory type skips this selection.
-On a PBO-preferred system, a DMA tensor forces a slow `glTexSubImage2D`
-upload; on a DMA-preferred system, a heap tensor forces a full CPU readback.
-Always use `create_image` for tensors that will be passed to `convert()`.
-
-**5. Ignoring row stride for padded buffers**
-
-```c
-// BAD: corrupted output (skewed image)
-struct hal_plane_descriptor *pd = hal_plane_descriptor_new(padded_fd);
-struct hal_tensor *src = hal_import_image(
-    proc, pd, NULL, width, height, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
-```
-
-*Why it fails*: Many V4L2 drivers and GStreamer allocators pad rows to
-alignment boundaries (e.g., 128-byte or 256-byte alignment). If the
-stride is not communicated to HAL, the GPU interprets rows at `width *
-bpp` spacing while the actual data is at `stride` spacing, producing a
-skewed or corrupted image. Set the stride on the plane descriptor via
-`hal_plane_descriptor_set_stride()` when
-`bytesperline > width * bytes_per_pixel`.
-
-#### Live-Memory Semantics
-
-After a V4L2 decoder, camera ISP, or codec writes new pixel data into a
-DMA-BUF, the existing tensor and its cached EGLImage remain valid. Do not
-free and recreate the tensor. Simply call `convert()` again. The GPU reads
-the updated content because EGLImage is a handle to physical memory, not a
-snapshot of its contents at import time. This is the key property that makes
-the allocate-once / reuse-every-frame pattern work.
-
-### Decoder Optimization
-
-Decoder implementations use:
-- Quantized integer math where applicable
-- Vectorized operations via ndarray
-- Parallel processing with Rayon
-- Early termination in NMS loops
-
-## Thread Safety
-
-All major types implement `Send + Sync`:
-- `Tensor<T>`: Safe to share across threads
-- `TensorDyn`: Thread-safe
-- `ImageProcessor`: Thread-local (create per thread)
-- `Decoder`: Thread-safe for read operations
-
-## Error Handling
-
-Consistent error handling throughout:
-- Custom `Result<T, Error>` types per crate following the standard Rust pattern
-- Each crate defines its own `Error` enum (e.g., `tensor::Error`, `image::Error`, `decoder::Error`)
-- Errors are enums with context
-- Conversion to PyErr for Python bindings
-- All public APIs return `Result<T, Error>` for fallible operations
-
-## Platform Support
-
-| Feature | Linux (i.MX) | Linux (Generic) | macOS | Windows |
-|---------|--------------|-----------------|-------|---------|
-| DMA Tensors | ✅ | ✅ | ❌ | ❌ |
-| PBO Tensors (GPU) | ✅ | ✅ | ❌ | ❌ |
-| Shared Memory Tensors | ✅ | ✅ | ✅ | ❌ |
-| Heap Tensors | ✅ | ✅ | ✅ | ✅ |
-| G2D Acceleration | ✅ | ❌ | ❌ | ❌ |
-| OpenGL Acceleration | ✅ (optional) | ✅ (optional) | ❌ | ❌ |
-| CPU Fallback | ✅ | ✅ | ✅ | ✅ |
-
-> **Note**: Shared Memory uses POSIX `shm_open` and is available on Unix platforms only (`#[cfg(unix)]`). Windows is not supported for SHM tensors.
-
-## Dependencies
-
-### Key External Dependencies
-
-- **PyO3**: Python bindings
-- **ndarray**: N-dimensional arrays
-- **rayon**: Data parallelism
-- **fast_image_resize**: CPU image operations
-- **zune-jpeg/zune-png**: Image decoding
-- **dma-heap**: Linux DMA allocation
-- **nix**: Unix system calls
-
-### Internal Dependency Graph
-
-```mermaid
-graph TD
-    EF[edgefirst<br/>top-level re-export]
-    Tensor[edgefirst_tensor]
-    Image[edgefirst_image]
-    Decoder[edgefirst_decoder]
-    Tracker[edgefirst_tracker]
-    G2D[g2d-sys<br/>optional, Linux only]
-
-    EF --> Tensor
-    EF --> Image
-    EF --> Decoder
-    Image --> Tensor
-    Image --> Decoder
-    Image -.optional.-> G2D
-
-    Python[edgefirst-hal<br/>Python bindings]
-    PyO3[pyo3]
-    Numpy[numpy]
-
-    Python --> EF
-    Python --> PyO3
-    Python --> Numpy
-
-    CAPI[edgefirst-hal-capi<br/>C API bindings]
-    CAPI --> EF
-    CAPI --> Tracker
-
-    GpuProbe[gpu-probe<br/>binary]
-    GpuProbe --> Image
-
-    style EF fill:#fff4e1
-    style Python fill:#e1f5ff
-    style CAPI fill:#e1f5ff
-    style Tracker fill:#e8f5e9
-    style GpuProbe fill:#f5f5f5
-```
-
-## Source Code Organization
-
-### Repository Structure
-```
-hal/
-├── .github/
-│   └── workflows/          # CI/CD automation
-│       ├── test.yml        # Rust + Python testing
-│       ├── release.yml     # PyPI + crates.io publishing
-│       └── nightly.yml     # Nightly builds
-├── crates/
-│   ├── hal/                # Top-level re-export crate (edgefirst)
-│   ├── tensor/             # Zero-copy tensor abstraction
-│   ├── image/              # Image processing HAL
-│   │   └── src/
-│   │       ├── lib.rs      # load_image, save_jpeg, ImageProcessor
-│   │       ├── cpu/        # CPU format conversion, resize, masks
-│   │       ├── g2d.rs      # NXP G2D hardware accelerator
-│   │       ├── gl/         # EGL/OpenGL headless renderer
-│   │       │   ├── mod.rs      # Public types, Int8InterpolationMode
-│   │       │   ├── processor.rs # GPU rendering pipelines
-│   │       │   ├── shaders.rs  # GLSL shader generators
-│   │       │   ├── context.rs  # EGL context management
-│   │       │   ├── threaded.rs # Thread-safe wrapper
-│   │       │   ├── resources.rs # GL resource management
-│   │       │   └── cache.rs    # Shader/texture caching
-│   │       └── error.rs
-│   ├── decoder/            # Model output decoding
-│   │   └── src/
-│   │       ├── lib.rs      # Public API
-│   │       └── decoder/    # Core decode logic
-│   │           ├── mod.rs      # Decoder struct, decode methods
-│   │           ├── builder.rs  # DecoderBuilder, model type resolution
-│   │           ├── configs.rs  # ModelType, DecoderVersion, Nms enums
-│   │           ├── postprocess.rs # NMS, dequantization, box parsing
-│   │           └── helpers.rs  # Shared utilities
-│   ├── tracker/            # Object tracking (ByteTrack)
-│   ├── capi/               # C API bindings (cbindgen, staticlib/cdylib)
-│   ├── gpu-probe/          # GPU capability probing binary
-│   ├── bench/              # Benchmark harness (avoids Criterion fork issues)
-│   └── python/             # PyO3 Python bindings
-├── tests/                  # Python integration tests
-├── testdata/               # Test data (Git LFS)
-├── README.md
-├── ARCHITECTURE.md         # This document
-├── CONTRIBUTING.md
-├── SECURITY.md
-├── CODE_OF_CONDUCT.md
-├── CHANGELOG.md
-├── LICENSE                 # Apache-2.0
-└── NOTICE                  # Third-party attributions
-```
-
-### Crate Dependency Graph
-```
-python (edgefirst-hal) → edgefirst → tensor, image, decoder
-capi → edgefirst → tensor, image, decoder, tracker
-image → tensor, decoder (for DetectBox/ProtoData/Segmentation types), g2d-sys
-decoder → (standalone — no internal crate deps)
-tracker → (standalone — no internal crate deps)
-```
-
-### Notable File Sizes
-
-Several modules are significantly larger than typical Rust modules:
-
-| File / Module | Lines | Content |
-|---------------|------:|---------|
-| `image/src/gl/` (total) | ~8,600 | EGL context, GL processors, shaders, caching, tests |
-| `image/src/gl/processor.rs` | ~4,600 | GPU rendering pipelines (convert, masks, atlas) |
-| `decoder/src/decoder/` (total) | ~7,000 | Config parsing, decode logic, postprocessing, tests |
-| `image/src/lib.rs` | ~5,500 | load_image, save_jpeg, ImageProcessor |
-| `capi/src/decoder.rs` | ~3,200 | C API decoder bindings |
+| HAL tracing | Span-level timing, pipeline structure, per-call metadata | Understanding pipeline structure, finding which stage is slow |
+| `perf record` | Instruction-level CPU hotspots, cache misses, branch mispredictions | Optimizing within a single span |
+| HAL benchmarks | Statistical timing (mean / p95 / p99) across many iterations | Measuring improvement from optimizations |
+
+Recommended workflow:
+
+1. Run with HAL tracing to identify the slow span(s).
+2. Use `perf record` targeting the specific operation to find CPU hotspots.
+3. Optimize the hotspot.
+4. Re-run benchmarks to quantify the improvement.
+5. Re-run tracing to confirm the span duration decreased.
+
+See [BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md)
+for benchmark infrastructure.
 
 ---
 
-## Appendix A: Multi-Plane DMA-BUF Limitation
+## Source Code Organization
 
-### Current State
-
-The HAL's DMA-BUF integration assumes a **single file descriptor per buffer**
-with all planes stored contiguously. This is baked into multiple layers:
-
-| Layer | Assumption | Code Location |
-|-------|-----------|---------------|
-| `DmaTensor<T>` | Single `fd: OwnedFd` field | `crates/tensor/src/dma.rs:31` |
-| `TensorTrait::from_fd()` | Takes one `OwnedFd` | `crates/tensor/src/dma.rs:88` |
-| `hal_tensor_from_fd()` C API | Takes one `int fd` | `crates/capi/include/edgefirst/hal.h` |
-| `TensorDyn` NV12 shape | `[H*3/2, W]` — contiguous Y+UV | `crates/tensor/src/lib.rs` |
-| EGL NV12 import | Same fd for both planes, UV offset = `W*H` | `crates/image/src/opengl_headless.rs:4492–4501` |
-
-This works correctly when the kernel allocates NV12 from a single CMA/system
-DMA-heap buffer (e.g. `hal_tensor_new()`, `hal_image_processor_create_image()`).
-The Y and UV planes are contiguous in physical memory and share one fd.
-
-### The Problem: Multi-Planar Formats
-
-Video hardware on NXP i.MX platforms frequently produces **multi-planar**
-NV12 buffers where Y and UV reside in separate DMA-BUF allocations, each
-with its own file descriptor:
-
-| Source | V4L2 Format | Planes | Behavior |
-|--------|-------------|--------|----------|
-| VPU (Hantro/Amphion) via `v4l2h264dec` | `V4L2_PIX_FMT_NV12M` (NM12) | 2 fds | Y and UV in separate DMA-BUFs |
-| NeoISP via `libcamerasrc` | `V4L2_PIX_FMT_NV12M` (NM12) | 2 fds | Y and UV in separate DMA-BUFs |
-| MIPI-CSI direct capture | `V4L2_PIX_FMT_NV12` (NV12) | 1 fd | Contiguous — works today |
-
-When GStreamer negotiates `video/x-raw(memory:DMABuf), format=DMA_DRM,
-drm-format=NV12`, the upstream element may deliver buffers with 2 `GstMemory`
-blocks (one per plane).
-
-### Multi-Plane Support (Implemented)
-
-The HAL supports multi-plane DMA-BUF NV12/NV16 via a two-tensor approach
-rather than extending `DmaTensor` with multiple fds:
-
-**C API**: `hal_import_image(proc, y_pd, uv_pd, width, height, format, dtype)`
-takes separate Y and UV plane descriptors, wraps each into its own
-`Tensor<u8>` via `from_fd()`, and combines them with `Tensor::from_planes()`.
-Per-plane stride and offset can be set on each descriptor before import.
-
-**Tensor crate**: `Tensor::from_planes(luma, chroma, PixelFormat::Nv12)` stores the
-two tensors as separate planes inside the `Tensor`, preserving their
-independent DMA-BUF allocations for zero-copy GPU import.
-
-**OpenGL path**: `create_image_from_dma2()` uses per-plane fds in EGL
-attributes (`DMA_BUF_PLANE0_FD → y_fd`, `DMA_BUF_PLANE1_FD → uv_fd`),
-with per-plane stride and offset from `PlaneDescriptor` metadata.
-
-| Scenario | Zero-Copy | Notes |
-|----------|-----------|-------|
-| Single-fd NV12 DMA-BUF | Yes | V4L2 single-planar capture, HAL-allocated buffers |
-| Single-fd YUYV/RGB/RGBA DMA-BUF | Yes | Always single-plane |
-| System memory input | N/A | Copied into HAL tensor regardless |
-| Multi-fd NV12/NV16 DMA-BUF | Yes | Via `hal_import_image()` with two plane descriptors |
-
-### GStreamer Integration (External)
-
-The `edgefirstcameraadaptor` element detects multi-plane buffers
-(`gst_buffer_n_memory() > 1`) and extracts per-plane fds via
-`gst_dmabuf_memory_get_fd()` on each `GstMemory` block, passing them to
-`hal_import_image()` via separate plane descriptors for zero-copy import.
-
-### Tracking
-
-This work was implemented under **EDGEAI-1107**.
-
-## Appendix B: Delegate DMA-BUF Framework
-
-### Purpose
-
-The Delegate DMA-BUF Framework defines an ABI contract for querying DMA-BUF
-tensor information from external TFLite delegates (e.g., NXP Neutron NPU,
-VxDelegate). The HAL owns the type definitions; function implementations
-live in delegate shared libraries.
-
-The API is **query-only by design**: delegates own all DMA-BUF allocations
-internally. Consumers query tensor metadata (fd, shape, dtype) and
-synchronize caches — they never register, allocate, bind, or release
-buffers through this API.
-
-Each delegate ships a self-contained `hal_dmabuf.h` header with all type
-definitions and function declarations. Consumers do **not** need the full
-`edgefirst/hal.h` — they either include the delegate's header or load
-symbols via `dlsym`.
-
-### Zero-Copy Data Flow
-
-```
-Camera DMA-BUF
-  → hal_plane_descriptor (wraps camera_fd, stride, offset)
-  → hal_import_image(proc, camera_pd, NULL, width, height, format, dtype)
-  → HAL Tensor with image attributes (camera source)
-
-NPU input DMA-BUF (fd/shape from hal_dmabuf_get_tensor_info)
-  → hal_plane_descriptor (wraps npu_input_fd, stride, offset)
-  → hal_import_image(proc, npu_pd, NULL, model_width, model_height, format, dtype)
-  → HAL Tensor with image attributes (NPU destination)
-
-ImageProcessor::convert(camera_tensor, npu_tensor)
-  → DMA→DMA convert (resize, colorspace, letterbox)
-
-hal_dmabuf_sync_for_device(delegate, input_tensor_index)
-  → flush CPU caches so NPU can read
-
-NPU inference
-
-hal_dmabuf_sync_for_cpu(delegate, output_tensor_index) [optional]
-  → invalidate CPU caches so CPU sees NPU writes
+```text
+hal/
+├── crates/
+│   ├── tensor/             # edgefirst-tensor
+│   ├── image/              # edgefirst-image
+│   ├── decoder/            # edgefirst-decoder
+│   ├── tracker/            # edgefirst-tracker
+│   ├── hal/                # edgefirst-hal (umbrella)
+│   ├── capi/               # edgefirst-hal-capi (C ABI)
+│   ├── python/             # edgefirst_hal (PyO3 bindings)
+│   ├── bench/              # edgefirst-bench (workspace dev-dep)
+│   └── gpu-probe/          # internal CLI for GPU capability probing
+├── tests/                  # Project-level Python and C integration tests
+├── testdata/               # Git LFS-tracked fixtures (images, model outputs)
+├── benchmarks/             # Per-platform benchmark JSON results
+├── scripts/                # Build / audit / release tooling
+├── .github/workflows/      # CI: test.yml, release.yml, benchmark.yml, sbom.yml
+├── README.md               # Cross-cutting overview + Optimization Guide
+├── ARCHITECTURE.md         # This file
+├── TESTING.md              # Cross-cutting testing guide
+├── BENCHMARKS.md           # Empirical performance reference
+├── CHANGELOG.md            # Release history
+└── Makefile                # Common workflow wrappers
 ```
 
-Both camera and NPU input tensors are imported via `hal_import_image()` so
-that `convert()` has the pixel format, dimensions, stride, and plane metadata
-it requires. `hal_tensor_from_fd()` creates raw tensors without image
-attributes; to use such tensors as a `convert()` source or destination you
-must either import them as images (via `hal_import_image()`) or attach the
-required image metadata (for example with `hal_tensor_set_format()`).
+Each `crates/<name>/` directory carries its own `README.md`,
+`ARCHITECTURE.md`, and `TESTING.md` with the crate-specific story.
 
-Output DMA-BUF access via `hal_dmabuf_get_tensor_info()` is optional and
-depends on the use case: useful when feeding outputs to GPU (e.g., mask
-rendering via OpenGL), but for CPU-side post-processing (YOLO decode, NMS)
-it is simpler to read tensor data directly since the decode will memcpy
-anyway.
-
-### Type Definitions
-
-**`hal_delegate_t`** — opaque handle for any delegate, defined as `void*`.
-Implementations receive this as a parameter and cast it internally to their
-concrete delegate type. The delegate lifetime is managed by the caller; the
-HAL never creates or destroys delegates.
-
-> **Important:** Exported function signatures **must** use `hal_delegate_t`
-> (`void*`), not `TfLiteDelegate*` or any other concrete type. This ensures
-> ABI compatibility across different delegate implementations.
-
-**`hal_dmabuf_tensor_info`** — describes a single delegate tensor's DMA-BUF:
-
-| Field   | Type                          | Description |
-|---------|-------------------------------|-------------|
-| `size`  | `size_t`                      | Buffer size in bytes (may exceed logical tensor size for padded buffers) |
-| `offset`| `size_t`                      | Byte offset within the DMA-BUF (for sub-allocated buffers) |
-| `shape` | `size_t[HAL_DMABUF_MAX_NDIM]` | Tensor dimensions (max 8) |
-| `ndim`  | `size_t`                      | Number of valid entries in `shape` |
-| `fd`    | `int`                         | DMA-BUF file descriptor (**borrowed** — do not close) |
-| `dtype` | `hal_dtype`                   | Element data type |
-
-Fields are ordered to eliminate padding on LP64 (`size_t` fields first,
-then smaller 4-byte fields). Total struct size: 96 bytes on LP64.
-
-All fields are **mandatory**. Implementations must populate `shape`, `ndim`,
-and `dtype` in addition to `fd`, `offset`, and `size`. An implementation
-that cannot determine the shape should set `ndim = 0`.
-
-**`hal_camera_adaptor_format_info`** — describes a camera format adaptor:
-
-| Field             | Type                       | Description |
-|-------------------|----------------------------|-------------|
-| `input_channels`  | `int`                      | Number of input channels (e.g., 4 for RGBA) |
-| `output_channels` | `int`                      | Number of output channels (e.g., 3 for RGB) |
-| `fourcc`          | `char[HAL_FOURCC_MAX_LEN]` | V4L2 FourCC string, NUL-terminated (ASCII, at most 4 bytes + NUL) |
-
-### DMA-BUF Functions
-
-These functions are **not implemented in the HAL**. They document the exact
-ABI that delegate shared libraries must export and that consumers probe via
-`dlsym`. All exported symbols must use
-`__attribute__((visibility("default")))`.
-
-```c
-/* Get the delegate's internal handle.
- *
- * When TFLite creates a delegate via TfLiteExternalDelegateCreate(), it
- * wraps the real delegate in an opaque adapter. This function returns the
- * inner delegate pointer that the hal_dmabuf_* functions expect.
- *
- * Returns the inner delegate handle, or NULL if no delegate has been
- * created. */
-hal_delegate_t hal_dmabuf_get_instance(void);
-
-/* Query whether the delegate supports DMA-BUF tensor access.
- * Returns 1 if supported, 0 otherwise (including NULL delegate or error).
- * This function does not set errno. */
-int hal_dmabuf_is_supported(hal_delegate_t delegate);
-
-/* Get DMA-BUF tensor info for a given tensor index.
- * Returns 0 on success, -1 on error (sets errno).
- *
- * info_size enables forward-compatible versioning: pass
- * sizeof(hal_dmabuf_tensor_info). Implementations must:
- * 1. memset(info, 0, info_size) before populating
- * 2. Only write fields whose offsetof + sizeof fits within info_size
- *
- * Errno: EINVAL (NULL info, negative tensor_index, info_size too small),
- *        ENOTSUP (DMA-BUF not supported),
- *        ERANGE (tensor_index out of range),
- *        EIO (DMA-BUF ioctl or internal failure) */
-int hal_dmabuf_get_tensor_info(hal_delegate_t delegate,
-                               int tensor_index,
-                               hal_dmabuf_tensor_info *info,
-                               size_t info_size);
-
-/* Flush CPU caches → device can read.
- * Call after writing to an input tensor (e.g., via
- * ImageProcessor::convert()), before invoking NPU inference.
- * Returns 0 on success, -1 on error (sets errno).
- * Errno: EINVAL (NULL delegate, negative tensor_index),
- *        ERANGE (tensor_index out of range),
- *        EIO (DMA-BUF ioctl failure) */
-int hal_dmabuf_sync_for_device(hal_delegate_t delegate, int tensor_index);
-
-/* Invalidate CPU caches → CPU sees device writes.
- * Call after NPU inference completes, before reading output tensor data.
- * Returns 0 on success, -1 on error (sets errno).
- * Errno: EINVAL (NULL delegate, negative tensor_index),
- *        ERANGE (tensor_index out of range),
- *        EIO (DMA-BUF ioctl failure) */
-int hal_dmabuf_sync_for_cpu(hal_delegate_t delegate, int tensor_index);
-```
-
-`tensor_index` must be non-negative; negative values return -1 with
-`errno` set to `EINVAL`.
-
-### Camera Adaptor Functions
-
-Some delegates support NPU-accelerated format conversion (e.g., RGBA→RGB
-channel slicing, uint8→int8 quantization) that runs as part of the
-inference graph. These functions allow consumers to query format support
-without vendor-specific symbols.
-
-Format conversion is configured **before** graph compilation via delegate
-options (e.g., `DelegateOptions::option("camera_adaptor", "rgba")`), not
-through this query API.
-
-```c
-/* Check if the delegate supports a camera format adaptor.
- * Returns 1 if the given format is supported, 0 otherwise.
- * This function does not set errno.
- *
- * Delegates without camera adaptor support always return 0. */
-int hal_camera_adaptor_is_supported(hal_delegate_t delegate,
-                                    const char *format);
-
-/* Query camera adaptor format information.
- * Returns 0 on success, -1 on error (sets errno).
- *
- * info_size enables forward-compatible versioning (same pattern as
- * hal_dmabuf_get_tensor_info).
- *
- * Errno: EINVAL (NULL format or info),
- *        ENOTSUP (format not supported by this delegate) */
-int hal_camera_adaptor_get_format_info(hal_delegate_t delegate,
-                                       const char *format,
-                                       hal_camera_adaptor_format_info *info,
-                                       size_t info_size);
-```
-
-### errno Requirements
-
-Implementations **must** set `errno` before returning -1. The following
-table specifies which errno values apply to each function:
-
-| Function | EINVAL | ENOTSUP | ERANGE | EIO |
-|----------|--------|---------|--------|-----|
-| `hal_dmabuf_get_tensor_info` | NULL info, negative index, info_size too small | DMA-BUF not supported | tensor_index out of range | ioctl or internal failure |
-| `hal_dmabuf_sync_for_device` | NULL delegate, negative index | — | tensor_index out of range | ioctl failure |
-| `hal_dmabuf_sync_for_cpu` | NULL delegate, negative index | — | tensor_index out of range | ioctl failure |
-| `hal_camera_adaptor_get_format_info` | NULL format or info | format not supported | — | — |
-
-Functions that return 1/0 (`hal_dmabuf_is_supported`,
-`hal_camera_adaptor_is_supported`) do **not** set errno.
-
-### Integration Pattern
-
-1. The delegate shared library (e.g., `libvx_delegate.so`,
-   `libneutron_delegate.so`) implements the functions above and exports
-   them as public C symbols with default visibility.
-2. Consumers probe for the symbols at runtime via `dlsym` on the delegate's
-   shared library.
-3. Consumers call `hal_dmabuf_get_instance()` to obtain the inner delegate
-   handle (needed when the delegate was created via
-   `TfLiteExternalDelegateCreate()`).
-4. If `hal_dmabuf_is_supported()` returns 1, consumers call
-   `hal_dmabuf_get_tensor_info()` to obtain the DMA-BUF fd and shape for
-   each tensor of interest.
-5. The fd and metadata are passed to `hal_import_image()` to create a
-   HAL tensor with full image attributes for use with
-   `ImageProcessor::convert()`.
-
-### Lifecycle and Ownership
-
-- The **delegate** owns all DMA-BUF allocations. File descriptors returned
-  by `hal_dmabuf_get_tensor_info()` are borrowed — callers must not close
-  them.
-- Sync functions (`sync_for_device`, `sync_for_cpu`) wrap
-  `DMA_BUF_IOCTL_SYNC` and bracket hardware access. They must be called
-  at the correct points in the pipeline (see data flow above).
-- The delegate instance itself is created and destroyed by the caller
-  (e.g., via the TFLite C API). The HAL never manages delegate lifetime.
-
-### Symbol Visibility
-
-All exported `hal_dmabuf_*` and `hal_camera_adaptor_*` functions must be
-annotated with `__attribute__((visibility("default")))` to ensure they
-remain visible even when the delegate is compiled with
-`-fvisibility=hidden`.
-
-### Thread Safety
-
-Delegate functions are not required to be thread-safe for concurrent calls
-on the same delegate instance. Callers must serialize access per delegate.
-Different delegate instances may be used concurrently from different threads.
-
-### Tracking
-
-- **Epic:** [EDGEAI-1185](https://au-zone.atlassian.net/browse/EDGEAI-1185) — NXP Neutron DMABUF Zero-Copy Support
-- **Type definitions:** [EDGEAI-1189](https://au-zone.atlassian.net/browse/EDGEAI-1189) — EdgeFirst HAL: formalize hal_dmabuf_* interface
-- **Implementation:** [EDGEAI-1190](https://au-zone.atlassian.net/browse/EDGEAI-1190) — edgefirst-tflite: update probing for hal_dmabuf_* symbols
+---
 
 ## Appendix C: DMA-BUF Identity and Tensor Caching
 
-### The Problem: fd Numbers Are Not Stable Buffer Identifiers
+This is a cross-cutting story spanning the `tensor`, `image`, and `capi`
+crates plus downstream integrators (V4L2 / GStreamer / libcamera). It
+deserves a single canonical home, hence its place at the workspace root
+rather than in any single per-crate doc.
+
+### The problem: fd numbers are not stable buffer identifiers
 
 A DMA-BUF is exported from the kernel as a file descriptor. Many callers
-assume that the same fd number means the same buffer, and use fd as the key
-for caching imported tensors (`hal_import_image`, EGL image creation, etc.).
-This assumption is **wrong** and leads to cache misses or incorrect cache
+assume the same fd number means the same buffer and use fd as the cache
+key for imported tensors (`hal_import_image`, EGL image creation, etc.).
+**This assumption is wrong** and leads to cache misses or incorrect
 hits.
 
 The lifecycle of a DMA-BUF fd in a typical GStreamer pipeline:
 
 1. A V4L2 decoder or libcamera source creates a buffer pool at startup,
-   exporting each DMA-BUF once (`VIDIOC_EXPBUF`). The fd numbers are stable
-   as long as the buffer pool exists.
-2. A GStreamer `GstBuffer` wraps the DMA-BUF fd in a `GstMemory` object.
-3. When the downstream element finishes with the buffer and unrefs it, the
-   `GstMemory` refcount may drop to zero, **closing the fd**.
-4. The upstream driver re-exports the buffer for the next frame, potentially
-   receiving a **different fd number** even though the underlying physical
-   buffer is the same.
-5. Any cache keyed by fd number will see a miss even though the buffer
-   content, EGL image, and GPU mapping are all identical to a previous frame.
+   exporting each DMA-BUF once (`VIDIOC_EXPBUF`). The fd numbers are
+   stable as long as the buffer pool exists.
+2. A GStreamer `GstBuffer` wraps the DMA-BUF fd in a `GstMemory`
+   object.
+3. When the downstream element finishes with the buffer and unrefs it,
+   the `GstMemory` refcount may drop to zero, **closing the fd**.
+4. The upstream driver re-exports the buffer for the next frame,
+   potentially receiving a **different fd number** even though the
+   underlying physical buffer is the same.
+5. Any cache keyed by fd number sees a miss even though the buffer
+   content, EGL image, and GPU mapping are identical to a previous
+   frame.
 
-This fd recycling happens in practice with `v4l2h264dec`, `v4l2src`, and
-`libcamerasrc`. Pool sizes are bounded (typically 4–16 buffers), so fd
-numbers cycle through a small set, but there is no guarantee that a
-particular fd number always refers to the same physical buffer.
+This fd recycling happens in practice with `v4l2h264dec`, `v4l2src`,
+and `libcamerasrc`. Pool sizes are bounded (typically 4–16 buffers),
+so fd numbers cycle through a small set, but there is no guarantee
+that a particular fd number always refers to the same physical buffer.
 
-### The Solution: DMA-BUF Inode as Stable Identity
+### The solution: DMA-BUF inode as stable identity
 
-The Linux kernel identifies each `dma_buf` object with a unique inode in the
-anonymous inode filesystem. The inode is assigned when the DMA-BUF is
-created and remains constant for its lifetime, regardless of how many
-times it is exported or what fd numbers are assigned to it.
-
-Obtaining the inode:
+The Linux kernel identifies each `dma_buf` object with a unique inode
+in the anonymous inode filesystem. The inode is assigned when the
+DMA-BUF is created and remains constant for its lifetime, regardless
+of how many times it is exported or what fd numbers are assigned to
+it.
 
 ```c
 struct stat st;
@@ -2347,67 +397,78 @@ fstat(fd, &st);
 ino_t inode = st.st_ino;
 ```
 
-This is a single cheap syscall on cache miss. For a 16-buffer pool, `fstat`
-is called exactly 16 times over the lifetime of the pipeline (once per
-unique buffer at first import). All subsequent frames are cache hits.
+This is a single cheap syscall on cache miss. For a 16-buffer pool,
+`fstat` is called exactly 16 times over the lifetime of the pipeline
+(once per unique buffer at first import). All subsequent frames are
+cache hits.
 
 Cache key design for multi-plane buffers:
 
 ```c
 typedef struct {
-    ino_t inode;   /* identifies the dma_buf kernel object */
-    gsize offset;  /* byte offset within the DMA-BUF (NV12 planar) */
+    ino_t inode;   // identifies the dma_buf kernel object
+    gsize offset;  // byte offset within the DMA-BUF (NV12 planar)
 } DmaBufCacheKey;
 ```
 
-The `offset` is needed because a single DMA-BUF may contain multiple planes
-at different byte offsets (e.g., NV12 luma at offset 0, chroma at
-`stride * height`). The (inode, offset) pair uniquely identifies a plane.
+The `offset` is needed because a single DMA-BUF may contain multiple
+planes at different byte offsets (NV12 luma at offset 0, chroma at
+`stride * height`). The `(inode, offset)` pair uniquely identifies a
+plane.
 
-### Cache Warm-Up and Steady State
+### Cache warm-up and steady state
 
 Pool behaviour in practice:
 
-| Phase          | Frames      | EGL import | Preprocessing time (i.MX 95) |
-|----------------|-------------|------------|------------------------------|
-| Warm-up        | 1 – N       | Yes        | ~5–6 ms (import + GL)        |
-| Steady state   | N+1 onwards | No         | ~5–6 ms (GL only)            |
+| Phase | Frames | EGL import | Preprocessing time (i.MX 95) |
+|-------|--------|------------|------------------------------|
+| Warm-up | 1 – N | Yes | ~5–6 ms (import + GL) |
+| Steady state | N+1 onwards | No | ~5–6 ms (GL only) |
 
-Where N is the buffer pool depth (typically 9 for `v4l2h264dec` at 1080p
-with the NXP Amphion Wave5 VPU).
+Where N is the buffer pool depth (typically 9 for `v4l2h264dec` at
+1080p with the NXP Amphion Wave5 VPU).
 
-The preprocessing time in steady state is dominated by the GL computation
-(resize + letterbox + colorspace + quantization on Mali-G310: ~5–6 ms at
-1920×1080 → 640×640 INT8), not the EGL import. However, the EGL import
-overhead does matter in low-latency or short-clip scenarios where the
-pipeline never fully warms up.
+The preprocessing time in steady state is dominated by GL computation
+(resize + letterbox + colorspace + quantization on Mali-G310: ~5–6 ms
+at 1920×1080 → 640×640 INT8), not the EGL import. However, the EGL
+import overhead does matter in low-latency or short-clip scenarios
+where the pipeline never fully warms up.
 
-### EGL Image Cache Inside HAL
+### EGL image cache inside HAL
 
-`hal_import_image()` internally maintains an EGL image cache keyed by DMA-BUF
-fd. When called with the same fd, it returns the cached EGL image without
-re-creating it.
+`hal_import_image()` internally maintains an EGL image cache keyed by
+DMA-BUF fd (more precisely, by the new `BufferIdentity.id` allocated
+on each import). When called with the same fd, it returns the cached
+EGL image without re-creating it.
 
-However, this HAL-internal cache **also suffers from fd recycling**: if the
-calling code frees the `hal_tensor*` and later calls `hal_import_image` with
-a different fd that refers to the same physical buffer, HAL creates a new EGL
-image — incurring the full import cost again and leaving a "swept dead entry"
-in the EGL cache log.
+However, this HAL-internal cache **also suffers from fd recycling**:
+if the calling code frees the `hal_tensor *` and later calls
+`hal_import_image` with a different fd that refers to the same
+physical buffer, HAL creates a new EGL image — incurring the full
+import cost again and leaving a "swept dead entry" in the EGL cache
+log.
 
-The fix is at the **calling layer** (e.g., `edgefirstcameraadaptor`): maintain
-a cache of `hal_tensor*` objects keyed by (inode, offset), and never free
-them between frames. This ensures that `hal_import_image` is called exactly
-once per unique DMA-BUF over the lifetime of the pipeline.
+**The fix is at the calling layer** (e.g. `edgefirstcameraadaptor`):
+maintain a cache of `hal_tensor *` objects keyed by `(inode, offset)`,
+and never free them between frames. This ensures `hal_import_image` is
+called exactly once per unique DMA-BUF over the lifetime of the
+pipeline.
+
+For the per-tensor `BufferIdentity` mechanism that the EGL cache uses
+internally, see
+[`crates/tensor/ARCHITECTURE.md#bufferidentity-and-egl-image-caching`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md#bufferidentity-and-egl-image-caching)
+and
+[`crates/image/ARCHITECTURE.md#egl-image-cache`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#egl-image-cache).
 
 ### Implementation in edgefirstcameraadaptor
 
-`edgefirstcameraadaptor` (EdgeFirst GStreamer plug-in) implements the
-inode-based cache as follows:
+`edgefirstcameraadaptor` (the EdgeFirst GStreamer plug-in) implements
+the inode-based cache as follows:
 
 ```c
 typedef struct { ino_t inode; gsize offset; } InputCacheKey;
 
-/* On each input frame: */
+// On each input frame:
 int fd = gst_dmabuf_memory_get_fd(mem);
 gsize offset = 0;
 gst_memory_get_sizes(mem, &offset, NULL);
@@ -2418,30 +479,34 @@ InputCacheKey key = { .inode = st.st_ino, .offset = offset };
 
 hal_tensor *tensor = g_hash_table_lookup(input_cache, &key);
 if (!tensor) {
-    /* First time seeing this buffer — import and cache */
-    tensor = hal_import_image(processor, pd, chroma, ...);
-    g_hash_table_insert(input_cache, g_memdup2(&key, sizeof key), tensor);
+    // First time seeing this buffer — import and cache
+    tensor = hal_import_image(processor, pd, chroma, /* ... */);
+    g_hash_table_insert(input_cache,
+                        g_memdup2(&key, sizeof key),
+                        tensor);
 }
-/* tensor is valid for the lifetime of the pipeline */
+// tensor is valid for the lifetime of the pipeline
 ```
 
-The cache is invalidated on `set_caps` (resolution or format change) and
-`stop` (pipeline teardown). It is never invalidated per-frame.
+The cache is invalidated on `set_caps` (resolution or format change)
+and on `stop` (pipeline teardown). It is **never** invalidated
+per-frame.
+
+This pattern, applied above HAL, is what makes the steady-state
+behaviour in the table above achievable. Without it, the warm-up row
+applies on every frame.
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for:
-- Development environment setup
-- Build instructions
-- Testing guidelines
-- Code style standards
-- Pull request process
+See
+[CONTRIBUTING.md](https://github.com/EdgeFirstAI/hal/blob/main/CONTRIBUTING.md)
+for development environment setup, build instructions, testing
+guidelines, code-style standards, and the pull-request process.
 
 ## Support
 
-For questions, issues, or contributions:
-- **Documentation**: https://doc.edgefirst.ai
-- **GitHub Issues**: https://github.com/EdgeFirstAI/hal/issues
-- **Email**: support@au-zone.com
+- Documentation: <https://doc.edgefirst.ai>
+- GitHub Issues: <https://github.com/EdgeFirstAI/hal/issues>
+- Email: <support@au-zone.com>

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Each sub-crate has a single responsibility in the inference pipeline:
 
 - [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) — the foundation. Provides `Tensor<T>` and `TensorDyn` with four interchangeable backends (DMA / SHM / Mem / PBO), multi-plane composition for V4L2 NV12M, the `BufferIdentity` cache key, and the `PboOps` trait that lets the GL backend manage PBO lifetimes through a `WeakSender` channel.
 - [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) — the GPU/G2D/CPU image processor. Owns the GL thread, EGL image caches, and shutdown defense layers. Provides format conversion, geometric transforms, and three mask-rendering pipelines (materialized, fused proto, tracked).
-- [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) — model output post-processing. YOLOv5/v8/v11/v26 (incl. end-to-end) and ModelPack. NEON-optimized per-scale split-tensor framework. Validates `shape` / `dshape` declarations (EDGEAI-1288 contract) at builder time.
+- [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) — model output post-processing. YOLOv5/v8/v11/v26 (incl. end-to-end) and ModelPack. NEON-optimized per-scale split-tensor framework. Validates `shape` / `dshape` declarations against the physical-memory-order contract at builder time.
 - [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) — ByteTrack with Kalman-smoothed trajectories. Generic over the detection box type; the decoder's `DetectBox` plugs in via the `DetectionBox` trait.
 - [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) — umbrella crate. Re-exports the four functional crates and owns the optional Chrome JSON tracing subscriber.
 - [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) — C ABI layer with cbindgen-generated header. Defines the [Delegate DMA-BUF framework](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md#delegate-dma-buf-framework) ABI used by NXP Neutron, VxDelegate, and other TFLite delegates.
@@ -397,10 +397,15 @@ fstat(fd, &st);
 ino_t inode = st.st_ino;
 ```
 
-This is a single cheap syscall on cache miss. For a 16-buffer pool,
-`fstat` is called exactly 16 times over the lifetime of the pipeline
-(once per unique buffer at first import). All subsequent frames are
-cache hits.
+`fstat` is a cheap syscall (microseconds), but it does run on **every
+buffer handoff** because the inode is the lookup key — it must be
+computed before the cache table is consulted. The cache lookup itself
+is a hash-table probe; only the import path (`hal_import_image`) is
+skipped on hits. If the per-frame `fstat` is undesirable on a
+particular pipeline, layer an fd-to-inode memoization above the cache
+(invalidated whenever an fd is closed). For a typical 4–16 buffer
+pool, the steady-state cost is one `fstat` per frame and zero EGL
+re-imports.
 
 Cache key design for multi-plane buffers:
 
@@ -436,23 +441,28 @@ where the pipeline never fully warms up.
 
 ### EGL image cache inside HAL
 
-`hal_import_image()` internally maintains an EGL image cache keyed by
-DMA-BUF fd (more precisely, by the new `BufferIdentity.id` allocated
-on each import). When called with the same fd, it returns the cached
-EGL image without re-creating it.
+The image backend maintains an EGL image cache keyed by the
+**tensor's** `BufferIdentity.id` — not by the DMA-BUF fd. Every call
+to `hal_import_image()` / `hal_tensor_from_fd()` allocates a fresh
+`BufferIdentity`, so calling those functions repeatedly with the same
+fd produces a new key each time and misses the cache on every call.
+The cache only hits when the **same tensor object** is reused across
+frames.
 
-However, this HAL-internal cache **also suffers from fd recycling**:
-if the calling code frees the `hal_tensor *` and later calls
-`hal_import_image` with a different fd that refers to the same
-physical buffer, HAL creates a new EGL image — incurring the full
-import cost again and leaving a "swept dead entry" in the EGL cache
-log.
+This means the cache cannot rescue a pipeline that re-imports its
+camera buffers every frame: each import is a brand-new identity.
+HAL emits a "swept dead entry" log line when a tensor is dropped
+while its EGL image is still in the cache; a steady stream of these
+in a running pipeline is a sign that the calling code is churning
+tensors.
 
-**The fix is at the calling layer** (e.g. `edgefirstcameraadaptor`):
-maintain a cache of `hal_tensor *` objects keyed by `(inode, offset)`,
-and never free them between frames. This ensures `hal_import_image` is
-called exactly once per unique DMA-BUF over the lifetime of the
-pipeline.
+**The fix is at the calling layer** (the GStreamer / V4L2 / libcamera
+adaptor that hands buffers to the HAL): maintain a cache of
+`hal_tensor *` objects keyed by `(inode, offset)`, and never free them
+between frames. Holding the tensor alive keeps its `BufferIdentity`
+stable, which keeps the in-HAL EGL image cache hitting. This ensures
+`hal_import_image` is called exactly once per unique DMA-BUF over the
+lifetime of the pipeline.
 
 For the per-tensor `BufferIdentity` mechanism that the EGL cache uses
 internally, see
@@ -460,10 +470,10 @@ internally, see
 and
 [`crates/image/ARCHITECTURE.md#egl-image-cache`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#egl-image-cache).
 
-### Implementation in edgefirstcameraadaptor
+### Reference implementation pattern (GStreamer adaptor)
 
-`edgefirstcameraadaptor` (the EdgeFirst GStreamer plug-in) implements
-the inode-based cache as follows:
+A representative GStreamer source/transform element that hands camera
+buffers to the HAL implements the inode-based cache as follows:
 
 ```c
 typedef struct { ino_t inode; gsize offset; } InputCacheKey;

--- a/README.md
+++ b/README.md
@@ -5,103 +5,120 @@
 [![Crates.io](https://img.shields.io/crates/v/edgefirst-hal.svg)](https://crates.io/crates/edgefirst-hal)
 [![PyPI](https://img.shields.io/pypi/v/edgefirst-hal.svg)](https://pypi.org/project/edgefirst-hal/)
 
-The EdgeFirst Hardware Abstraction Layer (HAL) is a Rust-based system that provides hardware-accelerated abstractions for computer vision and machine learning tasks on embedded Linux platforms. The HAL consists of multiple specialized crates that work together to provide high-performance image processing, tensor operations, model inference decoding, and object tracking.
+The EdgeFirst Hardware Abstraction Layer (HAL) is a Rust workspace that
+provides hardware-accelerated tensor management, image processing, ML model
+output decoding, and multi-object tracking for edge AI inference pipelines.
+It ships as a Rust crate, a Python package, and a C library — same code,
+three language surfaces — with Linux DMA-BUF, OpenGL ES, and NXP G2D
+acceleration where the platform supports them, and a portable CPU fallback
+everywhere else.
 
 ## Features
 
-- ✨ **Zero-Copy Memory Management** - DMA-heap optimized tensors with automatic fallback
-- 🚀 **Hardware-Accelerated Image Processing** - G2D, OpenGL, and optimized CPU paths
-- 🎯 **YOLO Decoder** - YOLOv5/v8/v11/v26 detection and segmentation support (including end-to-end models)
-- 🔌 **Python Bindings** - PyO3-based API with numpy integration
-- ⚡ **Multi-Object Tracking** - ByteTrack algorithm with Kalman filtering
-- 🔧 **Cross-Platform** - Linux (i.MX optimized), macOS, Windows support
-- 📊 **Mixed Precision** - Support for quantized and float models
-- 🏭 **Production Ready** - The EdgeFirst suite of components for production AI deployments at the edge.
-- 🖥️ **Hardware Optimized** - Accelerated on NXP i.MX platforms with NPU/GPU support
+- **Zero-copy memory management** — DMA-BUF, POSIX shared memory, OpenGL PBO, and heap with automatic backend selection
+- **Hardware-accelerated image processing** — OpenGL → G2D → CPU dispatch with shared cache infrastructure
+- **YOLO + ModelPack decoding** — YOLOv5 / v8 / v11 / v26 (incl. end-to-end) and ModelPack post-processing
+- **Multi-object tracking** — ByteTrack with Kalman filtering and stable per-track UUIDs
+- **Cross-platform** — Linux (i.MX 8M Plus / i.MX 95 / desktop), macOS, with three CPU/GPU/DMA tiers
+- **Production-ready** — used in the Au-Zone EdgeFirst suite for edge AI deployments
 
 ## Quick Start
 
 ### Installation
 
-#### Python
+Python:
+
 ```bash
 pip install edgefirst-hal
 ```
 
-#### Rust
+Rust:
+
 ```toml
 [dependencies]
-edgefirst-hal = "0.18"
+edgefirst-hal = "0.22"
 ```
 
-### Basic Usage
+C: download a release archive from
+[GitHub Releases](https://github.com/EdgeFirstAI/hal/releases) and link
+against `libedgefirst_hal.so` (or `.a`); see
+[`crates/capi/README.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/README.md)
+for full instructions.
 
-#### Python
+### Basic usage
+
+**Python:**
+
 ```python
 import edgefirst_hal as ef
 
-# Load and process image
 img = ef.Tensor.load("image.jpg", ef.PixelFormat.Rgb)
-converter = ef.ImageProcessor()
-output = converter.create_image(640, 640, ef.PixelFormat.Rgb)
-converter.convert(img, output)
+processor = ef.ImageProcessor()
+output = processor.create_image(640, 640, ef.PixelFormat.Rgb)
+processor.convert(img, output)
 
-# Decode YOLO outputs (outputs are ef.Tensor objects, not np.ndarray)
 decoder = ef.Decoder(config, 0.5, 0.45)
 boxes, scores, classes, masks = decoder.decode([output0, output1])
 
-# Draw segmentation masks directly onto the destination image
-result = converter.create_image(640, 640, ef.PixelFormat.Rgb)
-converter.draw_masks(decoder, [output0, output1], result)
+# Fused decode + draw — masks never leave Rust
+processor.draw_masks(decoder, [output0, output1], output)
 ```
 
-#### Rust
+**Rust:**
+
 ```rust
 use edgefirst_image::{load_image, ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
-use edgefirst_tensor::{PixelFormat, DType, TensorDyn};
+use edgefirst_tensor::{PixelFormat, DType};
 
-// Load and process image
 let bytes = std::fs::read("image.jpg")?;
 let input = load_image(&bytes, Some(PixelFormat::Rgb), None)?;
-let mut converter = ImageProcessor::new()?;
-let mut output = converter.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
-converter.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default())?;
+let mut processor = ImageProcessor::new()?;
+let mut output = processor.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
+processor.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default())?;
 ```
 
-#### C
+**C:**
+
 ```c
 #include <edgefirst/hal.h>
 
 struct hal_image_processor *proc = hal_image_processor_new();
-struct hal_tensor *dst = hal_image_processor_create_image(proc, 640, 640, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
+struct hal_tensor *dst = hal_image_processor_create_image(
+    proc, 640, 640, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
 hal_image_processor_convert(proc, src, dst, HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
 ```
+
+Per-language quick-starts and richer examples live in each crate's README:
+[Rust (`edgefirst-hal`)](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/README.md),
+[C API](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/README.md),
+[Python](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/README.md).
 
 ## System Architecture
 
 ```mermaid
 graph TB
     subgraph "EdgeFirst HAL Ecosystem"
-        Python["Python Bindings (edgefirst-hal)<br/>PyO3-based Python API exposing core functionality"]
-        CAPI["C API Bindings (edgefirst-hal-capi)<br/>cbindgen-generated C headers"]
-        Main["Main HAL Crate (edgefirst)<br/>Re-exports tensor, image, decoder"]
+        Python["Python Bindings (edgefirst-hal)<br/>PyO3"]
+        CAPI["C API (edgefirst-hal-capi)<br/>cbindgen"]
+        Main["Umbrella crate (edgefirst-hal)<br/>Re-exports"]
 
         Python --> Main
         CAPI --> Main
 
-        Tensor["Tensor HAL<br/>Zero-copy memory buffers"]
-        Image["Image Converter HAL<br/>Format conversion & resize"]
-        Decoder["Decoder HAL<br/>Model output post-processing"]
-        Tracker["Tracker HAL<br/>Multi-object tracking"]
+        Tensor["edgefirst-tensor<br/>Zero-copy buffers"]
+        Image["edgefirst-image<br/>Format conv + draw"]
+        Decoder["edgefirst-decoder<br/>Model output decode"]
+        Tracker["edgefirst-tracker<br/>ByteTrack"]
 
         Main --> Tensor
         Main --> Image
         Main --> Decoder
+        Main -.->|tracker feature| Tracker
         CAPI --> Tracker
 
         Image --> Tensor
         Image --> Decoder
-        Image --> G2D["G2D FFI (g2d-sys)<br/>NXP i.MX hardware acceleration"]
+        Image -.optional.-> G2D["g2d-sys<br/>NXP i.MX"]
     end
 
     Tensor -.-> DMA["Linux DMA-Heap<br/>Shared Memory"]
@@ -118,1220 +135,428 @@ graph TB
 
 ## Core Components
 
-### 1. Tensor HAL (`edgefirst_tensor`)
+| Crate | Role | Architecture | Testing |
+|-------|------|--------------|---------|
+| [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) | Zero-copy multi-dim buffers (DMA / SHM / Mem / PBO) | [ARCH](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md) | [TEST](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/TESTING.md) |
+| [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) | OpenGL / G2D / CPU image processor + mask rendering | [ARCH](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md) | [TEST](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md) |
+| [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) | YOLO + ModelPack post-processing, NMS, proto-mask APIs | [ARCH](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md) | [TEST](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/TESTING.md) |
+| [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) | ByteTrack multi-object tracking | [ARCH](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/ARCHITECTURE.md) | [TEST](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/TESTING.md) |
+| [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) | Umbrella + tracing subscriber | [ARCH](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/ARCHITECTURE.md) | [TEST](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/TESTING.md) |
+| [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) | C ABI + Delegate DMA-BUF framework | [ARCH](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md) | [TEST](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/TESTING.md) |
+| `crates/python/` (PyPI: `edgefirst-hal`) | PyO3 bindings, numpy buffer protocol | [ARCH](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/ARCHITECTURE.md) | [TEST](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/TESTING.md) |
 
-**Purpose**: Provides zero-copy memory buffers optimized for hardware accelerators.
-
-**Architecture**:
-```mermaid
-classDiagram
-    class TensorTrait~T~ {
-        <<trait>>
-        +shape() Vec~usize~
-        +size() usize
-        +map() TensorMap~T~
-        +clone_fd() Result~i32~
-    }
-    
-    class DmaTensor~T~ {
-        Linux DMA-Heap allocation
-    }
-    
-    class ShmTensor~T~ {
-        POSIX Shared Memory
-    }
-    
-    class MemTensor~T~ {
-        Standard heap allocation
-    }
-    
-    class PboTensor~T~ {
-        OpenGL Pixel Buffer Object
-    }
-
-    TensorTrait <|.. DmaTensor
-    TensorTrait <|.. ShmTensor
-    TensorTrait <|.. MemTensor
-    TensorTrait <|.. PboTensor
-```
-
-**Key Features**:
-- Generic over numeric types (u8, i8, u16, i16, u32, i32, u64, i64, f32, f64)
-- Automatic memory type selection with fallback chain: DMA → Shared Memory → Heap
-- Memory mapping with `TensorMap<T>` for safe access
-- File descriptor sharing for zero-copy IPC
-- Cross-platform support (Linux optimized, macOS/Windows via heap memory)
-
-**Memory Type Selection Logic**:
-```mermaid
-flowchart TD
-    Start[User Request] --> Explicit{Explicit type?}
-    Explicit -->|Yes| UseSpec[Use specified type]
-    Explicit -->|No| CheckEnv{EDGEFIRST_TENSOR_FORCE_MEM=1?}
-    CheckEnv -->|Yes| UseMem[MemTensor]
-    CheckEnv -->|No| TryDMA[Try DmaTensor]
-    TryDMA --> DMASuccess{Success?}
-    DMASuccess -->|Yes| UseDMA[DmaTensor]
-    DMASuccess -->|No| TryShm[Try ShmTensor]
-    TryShm --> ShmSuccess{Success?}
-    ShmSuccess -->|Yes| UseShm[ShmTensor]
-    ShmSuccess -->|No| UseMem
-    
-    style UseDMA fill:#90ee90
-    style UseShm fill:#87ceeb
-    style UseMem fill:#ffeb9c
-```
-
-### 2. Image HAL (`edgefirst_image`)
-
-**Purpose**: Hardware-accelerated image format conversion and resizing.
-
-**Architecture**:
-```mermaid
-classDiagram
-    class ImageProcessorTrait {
-        <<trait>>
-        +convert(src, dst, options)
-    }
-    
-    class G2DConverter {
-        NXP i.MX G2D hardware
-    }
-    
-    class GLConverterThreaded {
-        OpenGL GPU acceleration
-    }
-    
-    class CPUConverter {
-        fast_image_resize fallback
-    }
-    
-    ImageProcessorTrait <|.. G2DConverter
-    ImageProcessorTrait <|.. GLConverterThreaded
-    ImageProcessorTrait <|.. CPUConverter
-```
-
-**Supported Operations**:
-- Format conversion (YUYV, VYUY, NV12, NV16, RGB, RGBA, BGRA, GREY, Planar RGB, Planar RGBA, RGB int8, Planar RGB int8)
-- Resize with various interpolation methods
-- Rotation (0°, 90°, 180°, 270°)
-- Flip (horizontal, vertical)
-- Crop and region-of-interest
-- Normalization (signed, unsigned, raw)
-
-**Planar RGB Format**:
-Planar RGB (`PixelFormat::PlanarRgb`) stores color channels in separate planes rather than interleaved. This format is particularly useful for:
-- Neural network preprocessing where planar layout is required
-- Hardware accelerators that prefer planar data
-- Efficient SIMD operations on individual color channels
-- GPU texture operations via OpenGL with swizzled grayscale textures
-
-**Image Processing Flow**:
-```mermaid
-flowchart TD
-    Input[Input Image<br/>JPEG/PNG bytes or raw pixels]
-    TI[TensorDyn<br/>type-erased tensor + PixelFormat]
-    Conv{ImageProcessor::convert<br/>Backend selection}
-    G2D[G2D Acceleration<br/>NXP i.MX only]
-    GL[OpenGL Acceleration<br/>GPU accelerated]
-    CPU[CPU Fallback<br/>fast_image_resize]
-    Output[Output Image<br/>TensorDyn or numpy array]
-
-    Input --> TI
-    TI --> Conv
-    Conv -->|Supported on i.MX| G2D
-    Conv -->|Linux with GPU| GL
-    Conv -->|Always available| CPU
-    G2D --> Output
-    GL --> Output
-    CPU --> Output
-
-    style TI fill:#e1f5ff
-    style Conv fill:#fff4e1
-    style G2D fill:#90ee90
-    style GL fill:#87ceeb
-    style CPU fill:#ffeb9c
-    style Output fill:#e8f5e9
-```
-
-### 3. Decoder HAL (`edgefirst_decoder`)
-
-**Purpose**: Post-processing for object detection and segmentation model outputs.
-
-**Supported Decoders**:
-- **YOLO** (YOLOv5, YOLOv8, YOLOv11, YOLOv26)
-  - Object detection
-  - Instance segmentation
-  - Split output format support
-  - End-to-end models (embedded NMS)
-  - Mixed data type support (different types per input tensor)
-- **ModelPack** (Au-Zone proprietary format)
-  - Detection with anchor-based decoding
-
-**Architecture**:
-```mermaid
-flowchart LR
-    Builder[DecoderBuilder]
-    Decoder[Decoder]
-    Det[decode_detection<br/>→ bboxes, scores, classes]
-    Seg[decode_segmentation<br/>→ bboxes, scores, classes, masks]
-    
-    Builder --> Decoder
-    Decoder --> Det
-    Decoder --> Seg
-    
-    style Builder fill:#e1f5ff
-    style Decoder fill:#fff4e1
-    style Det fill:#e8f5e9
-    style Seg fill:#e8f5e9
-```
-
-**Detection Pipeline**:
-```mermaid
-flowchart TD
-    Raw[Model Raw Output<br/>quantized or float]
-    
-    Quant{Quantized?}
-    Dequant[Dequantization<br/>scale, zero_point]
-    
-    Parse[Parse boxes & scores<br/>XYWH → XYXY conversion]
-    NMS[Non-Maximum Suppression<br/>IoU threshold filtering]
-    Filter[Filter by score threshold]
-    
-    Det[Detection boxes<br/>bbox, score, class]
-    Seg[Segmentation masks<br/>per-box mask matrices]
-    
-    Raw --> Quant
-    Quant -->|Yes| Dequant
-    Quant -->|No| Parse
-    Dequant --> Parse
-    Parse --> NMS
-    NMS --> Filter
-    Filter --> Det
-    Filter --> Seg
-    
-    style Raw fill:#e1f5ff
-    style Dequant fill:#fff4e1
-    style NMS fill:#ffeb9c
-    style Det fill:#90ee90
-    style Seg fill:#90ee90
-```
-
-### 4. Tracker HAL (`edgefirst_tracker`)
-
-**Purpose**: Multi-object tracking across video frames.
-
-**Implementation**: ByteTrack algorithm with Kalman filtering
-
-**Architecture**:
-```mermaid
-classDiagram
-    class ByteTrack {
-        +update(detections) TrackInfo[]
-    }
-    
-    class Tracklet {
-        +UUID uuid
-        +KalmanFilter filter
-        +int track_count
-        +Timestamps timestamps
-    }
-    
-    ByteTrack *-- Tracklet : manages
-```
-
-**Tracking Flow**:
-```mermaid
-flowchart TD
-    NewFrame[New Frame Detections]
-    Predict[Predict tracklet positions<br/>Kalman filter forward step]
-    Cost[Compute cost matrix<br/>IoU between predictions and detections]
-    Hungarian[Hungarian Algorithm LAPJV<br/>optimal assignment]
-    
-    Matched[Matched:<br/>Update tracklet]
-    UnmatchedDet[Unmatched detection:<br/>Create new tracklet]
-    UnmatchedTrack[Unmatched tracklet:<br/>Increment lost count]
-    
-    CheckLost{Lost > threshold?}
-    Delete[Delete tracklet]
-    Keep[Keep tracklet]
-    
-    NewFrame --> Predict
-    Predict --> Cost
-    Cost --> Hungarian
-    Hungarian --> Matched
-    Hungarian --> UnmatchedDet
-    Hungarian --> UnmatchedTrack
-    UnmatchedTrack --> CheckLost
-    CheckLost -->|Yes| Delete
-    CheckLost -->|No| Keep
-    
-    style Matched fill:#90ee90
-    style UnmatchedDet fill:#87ceeb
-    style Delete fill:#ffcccb
-```
-
-### 5. Python Bindings (`edgefirst-hal`)
-
-**Purpose**: Expose HAL functionality to Python via PyO3.
-
-**Exposed Classes**:
-- `Tensor`: Unified tensor with image support and numpy buffer protocol
-- `ImageProcessor`: Image processing operations
-- `Decoder`: Model output decoding
-- `PixelFormat`, `Normalization`, `Rect`, `Rotation`, `Flip`: Configuration types
-
-**Python Integration**:
-```mermaid
-flowchart LR
-    Py[Python Code]
-    PyO3[PyO3 Bindings]
-    Rust[Rust Core HAL]
-    HW[Hardware Accelerators / CPU]
-    
-    Py --> PyO3
-    PyO3 --> Rust
-    Rust --> HW
-    
-    style Py fill:#3776ab,color:#fff
-    style PyO3 fill:#ce422b
-    style Rust fill:#dea584
-    style HW fill:#90ee90
-```
-
-### 6. G2D FFI (`g2d-sys`)
-
-**Purpose**: Foreign Function Interface to NXP i.MX G2D library.
-
-**Architecture**:
-- Raw FFI bindings via bindgen
-- Safe Rust wrapper types
-- IOCTL interface for DMA buffer operations
-- Version detection and capability queries
+The deep dive on each component (class diagrams, supported operations,
+backend dispatch, performance considerations) lives in the per-crate
+`ARCHITECTURE.md`. The cross-cutting story (DMA-BUF identity, performance
+tracing internals, design patterns) lives in the project
+[ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md).
 
 ## Optimization Guide
 
-This section establishes the core rules for getting the best performance from
-the HAL. Each rule below has a measurable cost when broken; see [BENCHMARKS.md]
-for the empirical penalty on each platform, [ARCHITECTURE.md] for *why* the
-rule exists, and [TESTING.md] for how to verify your integration follows it.
+This section is the **rules** part of the cross-language performance
+contract. Each rule has a measurable cost when broken; see
+[BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md)
+for empirical penalties per platform,
+[ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
+for *why* the rule exists, and
+[TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations)
+for how to verify your integration follows it.
 
 | Rule | Why it matters | Measured penalty when broken |
 |------|----------------|------------------------------|
-| Reuse tensors across frames | Each new tensor mints a fresh `BufferIdentity`; the EGL image cache misses on every frame | 1.7–3.3× slower preprocessing on Vivante / Mali |
-| Allocate output tensors via `ImageProcessor::create_image()` | Auto-selects DMA-buf / PBO / heap based on the active GPU; bypassing this forces a slow transfer path | Forced `glTexSubImage2D` upload or full CPU readback |
-| Cache imported camera tensors by **inode**, not by fd | v4l2 / libcamera recycle fd numbers across a small buffer pool; an fd-keyed cache misses on every frame even when the physical buffer is the same | Full EGL re-import per frame (≈0.5–1.5 ms on Vivante, multiplied by source + chroma planes) |
+| Reuse tensors across frames | Each new tensor mints a fresh `BufferIdentity`; the EGL image cache misses every frame | 1.7–3.3× slower preprocessing on Vivante / Mali |
+| Allocate via `ImageProcessor::create_image()` | Auto-selects DMA-buf / PBO / heap based on the active GPU; bypassing forces a slow transfer path | Forced `glTexSubImage2D` upload or full CPU readback |
+| Cache imported camera tensors by **inode**, not by fd | V4L2 / libcamera recycle fd numbers across a small buffer pool; an fd-keyed cache misses on every frame even when the physical buffer is the same | Full EGL re-import per frame (≈0.5–1.5 ms on Vivante, doubled with chroma planes) |
 | Build `Decoder` once, decode many | Decoder construction parses model metadata and allocates working buffers | Parse + alloc cost per frame |
-| Construct one `ImageProcessor` per pipeline | Each instance owns its own GL context and EGL display | Multiple GL contexts contend on `GL_MUTEX`; see ARCHITECTURE.md |
-| Use native fp16 / AVX build overrides only on CPUs that support them | These flags unlock native widening/vector paths for local perf testing | Unsupported targets may fail to build or hit illegal instructions; portability loss |
-| Pass numpy arrays straight to `Tensor.from_numpy()` — do not pre-`ascontiguousarray()` | HAL detects strided sources and materialises via numpy's vectorized C strided→contig pass; a manual workaround above HAL adds a redundant copy | A redundant `np.ascontiguousarray` pre-copy on every call (size-dependent; e.g. ≈1.5 ms per call on a `(1, 116, 8400)` f32 view on rpi5-hailo) |
-| For COCO/IoU evaluation use `MaskResolution::Scaled(orig_w, orig_h)`, not `Proto` | `Scaled` upsamples the proto plane *before* thresholding at full output resolution (clean sub-pixel edges); `Proto` thresholds at proto resolution (160×160) then callers typically nearest-upsample, producing blocky edges | Mask mAP regression of up to 0.04–0.05 absolute (model- and dataset-dependent) when `Proto` is nearest-upsampled |
+| One `ImageProcessor` per pipeline | Each instance owns its own GL context, EGL display, and per-thread caches | Multiple GL contexts contend on the global `GL_MUTEX` |
+| Use native fp16 / AVX build overrides only on supporting CPUs | These flags unlock native widening / vector paths for local perf testing | Unsupported targets may SIGILL or fail to build; portability loss |
+| Pass numpy arrays straight to `Tensor.from_numpy()` — do not pre-`ascontiguousarray()` | HAL detects strided sources and materializes via numpy's vectorized C strided→contig pass; a manual workaround above HAL adds a redundant copy | Redundant pre-copy on every call (≈ 1.5 ms on a `(1, 116, 8400)` f32 view, rpi5-hailo) |
+| For COCO/IoU evaluation use `MaskResolution::Scaled(orig_w, orig_h)`, not `Proto` | `Scaled` upsamples the proto plane *before* thresholding (clean sub-pixel edges); `Proto` thresholds at proto resolution and callers typically nearest-upsample (blocky) | Mask mAP regression of up to 0.04–0.05 absolute when `Proto` is nearest-upsampled |
 
 > [!IMPORTANT]
-> The single most common performance bug is calling
-> `Tensor::from_fd()` (or `import_image()`) on every frame from a v4l2 /
-> libcamera buffer pool. The HAL's internal EGL image cache cannot rescue
-> you here — the cache key includes a per-tensor monotonic ID that is fresh
-> on every import. The fix lives in the **calling code**, not in HAL.
+> The single most common performance bug is calling `Tensor::from_fd()`
+> (or `import_image()`) on every frame from a V4L2 / libcamera buffer
+> pool. The HAL's internal EGL image cache cannot rescue you — the cache
+> key includes a per-tensor monotonic ID that is fresh on every import.
+> The fix lives in the **calling code**, not in HAL.
 
-### Rule 1 — Reuse Tensors Across Frames
+### Rule 1 — Reuse tensors across frames
 
 Allocate input and output tensors once at pipeline startup; reuse the same
 objects on every frame. The DMA memory backing a tensor is live: when an
-upstream producer (V4L2 DQBUF, codec output, ISP) writes new pixels into it,
-the existing tensor and its cached EGLImage remain valid. No re-import, no
-re-allocation.
+upstream producer (V4L2 DQBUF, codec output, ISP) writes new pixels into
+it, the existing tensor and its cached EGLImage remain valid. No
+re-import, no re-allocation.
 
 ```rust
-use edgefirst_image::{ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
-use edgefirst_tensor::{PixelFormat, DType};
-
 let mut proc = ImageProcessor::new()?;
 let mut dst = proc.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
 
 for frame in camera_frames {
     proc.convert(&frame, &mut dst, Rotation::None, Flip::None, Crop::default())?;
-    run_inference(&dst)?;  // run_inference() is a stand-in — replace with your model call
+    run_inference(&dst)?;
 }
 ```
 
 ```python
-import edgefirst_hal as ef
-
 proc = ef.ImageProcessor()
 dst = proc.create_image(640, 640, ef.PixelFormat.Rgb)
-
 for frame in camera_frames:
     proc.convert(frame, dst)
-    run_inference(dst)  # run_inference() is a stand-in — replace with your model call
+    run_inference(dst)
 ```
 
 ### Rule 2 — Allocate via `ImageProcessor::create_image()`
 
-`ImageProcessor::create_image()` is the **preferred** way to allocate images
-for use with `convert()`. It automatically selects the fastest memory
-backend for the active GPU:
+`create_image()` selects the fastest memory backend for the active GPU at
+construction time:
 
-| Priority | Backend | Transfer Method | Platforms |
-|----------|---------|-----------------|-----------|
+| Priority | Backend | Transfer | Platforms |
+|----------|---------|----------|-----------|
 | 1st | **DMA-buf** | Zero-copy EGLImage import | NXP i.MX 8M Plus, i.MX 95 |
-| 2nd | **PBO** (Pixel Buffer Object) | Zero-copy GL buffer binding | NVIDIA desktop GPUs |
+| 2nd | **PBO** | Zero-copy GL buffer binding | NVIDIA desktop |
 | 3rd | **Mem** (heap) | CPU memcpy fallback | All platforms |
 
-The backend is selected once at `ImageProcessor::new()` time based on a
-runtime GPU capability probe. All subsequent `create_image()` calls use the
-same backend.
+The probe runs once at `ImageProcessor::new()` time. All subsequent
+`create_image()` calls reuse the same backend. Use `create_image()` for
+every destination passed to `convert()`; direct `Tensor::new(memory=...)`
+bypasses the probe.
 
-**Best practice**: Create your output images once and reuse them across your
-pipeline loop. Creating images is relatively expensive (GPU buffer allocation,
-format negotiation); reusing them amortizes that cost over thousands of frames.
+For DMA-buf access, the process needs `/dev/dma_heap/{linux,cma|system}`
+and `/dev/dri/renderD128`. On embedded Linux, add the user to `video` and
+`render` groups, or set udev rules. If DMA-buf fails, `create_image()`
+transparently falls back to PBO or heap.
 
-**Rust** (same imports as Rule 1):
-
-```rust
-let mut converter = ImageProcessor::new()?;
-
-// Create reusable output buffer — allocated once
-let mut output = converter.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
-
-for frame in camera_frames {
-    // Reuse output buffer each iteration — no allocation
-    converter.convert(&frame, &mut output, Rotation::None, Flip::None, Crop::default())?;
-    run_inference(&output)?;  // your model inference call
-}
-```
-
-**Python:**
-
-```python
-converter = ef.ImageProcessor()
-
-# Create reusable output buffer — allocated once
-output = converter.create_image(640, 640, ef.PixelFormat.Rgb)
-
-for frame in camera_frames:
-    # Reuse output buffer each iteration — no allocation
-    converter.convert(frame, output)
-    run_inference(output)  # your model inference call
-```
-
-**C:**
-
-```c
-struct hal_image_processor *proc = hal_image_processor_new();
-
-/* Create reusable output buffer — allocated once */
-struct hal_tensor *output = hal_image_processor_create_image(
-    proc, 640, 640, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
-
-for (;;) {
-    /* Reuse output buffer each iteration — no allocation */
-    hal_image_processor_convert(proc, frame, output,
-        HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
-    run_inference(output);  /* your model inference call */
-}
-
-hal_tensor_free(output);
-hal_image_processor_free(proc);
-```
-
-#### DMA-buf Permissions
-
-For the DMA-buf backend to be selected, the process needs access to
-`/dev/dma_heap/linux,cma` (or `/dev/dma_heap/system` on some kernels) and a
-DRM render node (`/dev/dri/renderD128`). On embedded Linux systems, this
-typically requires one of:
-
-- Running as root
-- Adding the user to the `video` and `render` groups:
-  ```bash
-  sudo usermod -aG video,render $USER
-  ```
-- Setting appropriate udev rules for the DMA heap and DRI devices
-
-If DMA-buf allocation fails (insufficient permissions, no CMA region, or the
-GPU driver cannot import the resulting buffers), `create_image()` transparently
-falls back to PBO or heap memory with no API change required.
-
-#### Platform GPU Support
-
-| Platform | GPU | `create_image()` backend | Notes |
-|----------|-----|--------------------------|-------|
-| NXP i.MX 8M Plus | Vivante GC7000UL | DMA-buf | Full zero-copy via EGLImage + G2D |
-| NXP i.MX 95 | Mali G310 (Panfrost) | DMA-buf | Full zero-copy via EGLImage |
-| NVIDIA Desktop | GeForce (proprietary) | PBO | DMA-buf alloc works but EGL import fails; PBO provides GPU-native buffers |
-| Generic x86_64 | Mesa (llvmpipe/iris) | DMA-buf or PBO | Depends on driver DMA-buf support |
-| No GPU / macOS | N/A | Mem | CPU fallback, still functional |
-
-### Rule 3 — Cache Imported Camera Tensors by Inode, Not by fd
+### Rule 3 — Cache imported camera tensors by inode, not by fd
 
 V4L2, libcamera, and codec output all surface frames as DMA-BUF file
 descriptors drawn from a small fixed pool (typically 4–16 buffers). The fd
-*number* is recycled: the same fd value can refer to a different physical
+**number** is recycled: the same fd can refer to a different physical
 buffer between frames, and the same physical buffer can be exported with a
-different fd value over time. **A cache keyed by fd will produce false hits
-or false misses.**
+different fd over time. **A cache keyed by fd will produce false hits or
+false misses.**
 
 The kernel assigns each `dma_buf` object a unique inode in the anonymous
-inode filesystem. The inode is constant for the lifetime of the buffer
-regardless of how many times it is exported. Cache imported HAL tensors by
-`(inode, plane_offset)`.
-
-In C, retrieve the inode via [`fstat(2)`][fstat] on the dma_buf fd; the
-`st_ino` field is the stable identifier. The pattern below shows the
-lookup-or-import flow on every dequeued frame:
-
-[fstat]: https://man7.org/linux/man-pages/man2/fstat.2.html
+inode filesystem. The inode is constant for the buffer's lifetime
+regardless of how many times it is exported. Cache imported HAL tensors
+by `(inode, plane_offset)`:
 
 ```c
 #include <sys/stat.h>
-#include <stdio.h>
 
-typedef struct {
-    ino_t inode;
-    size_t offset;   /* per-plane offset within the dma_buf (NV12 etc.) */
-} BufferKey;
+typedef struct { ino_t inode; size_t offset; } BufferKey;
 
-/* On each input frame: */
 struct stat st;
-if (fstat(fd, &st) != 0) {
-    perror("fstat");
-    continue;  /* skip this frame */
-}
+if (fstat(fd, &st) != 0) continue;
 BufferKey key = { .inode = st.st_ino, .offset = plane_offset };
 
 struct hal_tensor *tensor = lookup_tensor(cache, &key);
 if (!tensor) {
-    /* First time seeing this physical buffer — import once. */
     struct hal_plane_descriptor *pd = hal_plane_descriptor_new(fd);
-    if (!pd) {
-        perror("hal_plane_descriptor_new");
-        continue;
-    }
     tensor = hal_import_image(proc, pd, NULL, w, h,
                               HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
-    /* pd is consumed by hal_import_image(), even on failure. */
-    if (!tensor) {
-        fprintf(stderr, "hal_import_image failed\n");
-        continue;
-    }
-    insert_tensor(cache, &key, tensor);
+    insert_tensor(cache, &key, tensor);  // pd is consumed
 }
-/* Reuse `tensor` for this frame; do NOT free it between frames. */
 hal_image_processor_convert(proc, tensor, dst, /* ... */);
 ```
 
 ```python
 import os
-from typing import Dict, Tuple
-import edgefirst_hal as ef
-
-# (inode, offset) -> ef.Tensor
-buffer_cache: Dict[Tuple[int, int], ef.Tensor] = {}
+buffer_cache: dict[tuple[int, int], ef.Tensor] = {}
 
 def get_or_import(proc, fd, offset, width, height, fmt):
     key = (os.fstat(fd).st_ino, offset)
-    tensor = buffer_cache.get(key)
-    if tensor is None:
-        tensor = proc.import_image(fd, width, height, fmt, "uint8",
-                                   offset=offset)
-        buffer_cache[key] = tensor
-    return tensor
+    t = buffer_cache.get(key)
+    if t is None:
+        t = proc.import_image(fd, width, height, fmt, "uint8", offset=offset)
+        buffer_cache[key] = t
+    return t
 ```
 
-The cache is invalidated on resolution / format change and on pipeline
-teardown — never per frame. Pool sizes are bounded so the cache reaches
-steady state after the first N frames and never grows.
+EdgeFirst's GStreamer elements implement this as a reference. For other
+pipelines (libcamera direct, custom V4L2, RTSP decoder) you are
+responsible for the equivalent layer above HAL. See
+[ARCHITECTURE.md § Appendix C](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
+for the full identity-and-caching story.
 
-> [!NOTE]
-> EdgeFirst's GStreamer elements implement this inode-keyed cache as a
-> reference. If you are integrating the HAL into a different pipeline
-> (libcamera direct, custom V4L2 capture, RTSP decoder), you are
-> responsible for adding the equivalent cache layer above HAL.
+### Rule 4 — Build the decoder once
 
-The HAL's *internal* EGL image cache is keyed by a per-tensor
-`BufferIdentity.id` and is correctly invalidated when a tensor is dropped.
-The internal cache only hits when you hand it the *same* tensor object on
-each call — which is what the inode-keyed application cache guarantees.
-See [ARCHITECTURE.md] Appendix C for the full cache hierarchy.
-
-### Rule 4 — Build the Decoder Once
-
-`Decoder` parses the model's output schema, resolves quantization parameters,
-and allocates working buffers at construction time. Build it once outside
-the inference loop:
+`Decoder` parses the model output schema, resolves quantization, and
+allocates working buffers at construction time. Build it once outside the
+loop; the decoder clears its output vectors per call:
 
 ```rust
-use edgefirst_hal::decoder::{DecoderBuilder, DetectBox, Segmentation};
-use edgefirst_hal::tensor::TensorDyn;
-
-// Build once, outside the inference loop. The builder parses the model's
-// output schema and allocates internal working buffers at .build() time.
 let decoder = DecoderBuilder::default()
-    .with_config_yaml_str(config_yaml.to_string())
+    .with_config_yaml_str(config_yaml)
     .with_score_threshold(0.5)
     .with_iou_threshold(0.45)
     .build()?;
 
-// Reusable output buffers — decoder.decode() clears them on each call.
-let mut boxes: Vec<DetectBox> = Vec::new();
-let mut masks: Vec<Segmentation> = Vec::new();
-
 for frame in frames {
-    let outputs: Vec<TensorDyn> = run_inference(frame)?;
-    let output_refs: Vec<&TensorDyn> = outputs.iter().collect();
-    decoder.decode(&output_refs, &mut boxes, &mut masks)?;
-    // Use `boxes` (and `masks`, if the model emits segmentation) here.
+    let outputs = run_inference(frame)?;
+    let refs: Vec<&TensorDyn> = outputs.iter().collect();
+    decoder.decode(&refs, &mut boxes, &mut masks)?;
 }
 ```
 
-```python
-decoder = ef.Decoder(config, 0.5, 0.45)  # construct once
+The same applies to `ByteTrack`: construct once, call `update()` per
+frame.
 
-for frame in frames:
-    outputs = run_inference(frame)  # your model call, returns list[ef.Tensor]
-    boxes, scores, classes, masks = decoder.decode(outputs)
-```
-
-The same applies to `ByteTrack`: construct once, call `update()` per frame.
-
-### Rule 5 — One `ImageProcessor` per Pipeline Thread
+### Rule 5 — One `ImageProcessor` per pipeline
 
 `ImageProcessor` owns its EGL display, OpenGL context, GL thread, and EGL
 image cache. Two instances do not share caches and serialize on a global
-GL mutex. Construct one per pipeline (or one per worker thread for parallel
-pipelines) and share it across all `convert()`, `draw_*()`, and
+`GL_MUTEX`. Construct one per pipeline (or one per worker thread for
+parallel pipelines) and share it across all `convert()`, `draw_*()`, and
 `create_image()` calls.
 
 `ImageProcessor` is `Send + Sync`, so it can be moved or shared across
-threads. Concurrent use of a single shared instance is still discouraged:
-operations can serialize on `GL_MUTEX`, and per-worker ownership gives more
-predictable cache behavior. For parallel inference workers, give each worker
-its own `ImageProcessor` and its own output tensor.
+threads. Concurrent use of a single shared instance still serializes on
+`GL_MUTEX`; per-worker ownership gives more predictable cache behavior.
 
 ### Rule 6 — Local fp16 / AVX build overrides
 
 The default HAL binary is built to the target triple's guaranteed
-baseline ISA so that a single distributed binary runs on every CPU
-within that triple. Richer ISAs (ARMv8.2-FP16, x86_64 F16C/FMA/AVX2)
-are **not** enabled by default; until the HAL gains runtime
-CPU-feature detection with dynamic dispatch, baking them in would
-SIGILL on older CPUs.
+baseline ISA so a single distributed binary runs on every CPU within that
+triple. Richer ISAs (ARMv8.2-FP16, x86_64 F16C / FMA / AVX2) are **not**
+enabled by default; until HAL gains runtime CPU-feature detection with
+dynamic dispatch, baking them in would SIGILL on older CPUs.
 
-Developers benchmarking on hosts that do support these features can
-enable them ad-hoc via `RUSTFLAGS`. Example incantations:
+For local benchmarking on supporting hosts, enable them via `RUSTFLAGS`:
 
 ```bash
-# Orin Nano (Cortex-A78AE — ARMv8.2-FP16 + dotprod + lse):
+# Orin Nano (Cortex-A78AE)
 RUSTFLAGS="-C target-cpu=cortex-a78ae" cargo build --release \
-    --target aarch64-unknown-linux-gnu --workspace
+  --target aarch64-unknown-linux-gnu --workspace
 
-# Generic aarch64 with FEAT_FP16 (do NOT use on Cortex-A53 / imx8mp):
+# Generic aarch64 with FEAT_FP16 (do NOT use on Cortex-A53 / imx8mp)
 RUSTFLAGS="-C target-feature=+fp16" cargo build --release \
-    --target aarch64-unknown-linux-gnu -p edgefirst-image
+  --target aarch64-unknown-linux-gnu -p edgefirst-image
 
-# x86_64 Haswell+ (F16C + FMA + AVX2):
+# x86_64 Haswell+ (F16C + FMA + AVX2)
 RUSTFLAGS="-C target-feature=+f16c,+fma,+avx2" cargo build --release \
-    -p edgefirst-image
+  -p edgefirst-image
 ```
 
-When these flags are active, the f16 mask kernel at
-`crates/image/src/cpu/masks.rs` compiles to native widening
-instructions (`fcvt` on aarch64, `vcvtph2ps` on x86_64) and — on
-x86_64 with `+f16c,+fma` — an explicit 8-lane `_mm256_cvtph_ps +
-_mm256_fmadd_ps` intrinsic path is also enabled via cfg gate. The
-helper `scripts/audit_f16_codegen.sh` disassembles a release build
-of the kernel and confirms native instructions are emitted.
+When active, the f16 mask kernel at
+[`crates/image/src/cpu/masks.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/cpu/masks.rs)
+compiles to native widening (`fcvt` on aarch64, `vcvtph2ps` on x86_64),
+and on x86_64 with `+f16c,+fma` an explicit 8-lane `_mm256_cvtph_ps +
+_mm256_fmadd_ps` intrinsic path is enabled via cfg gate. Verify with
+[`scripts/audit_f16_codegen.sh`](https://github.com/EdgeFirstAI/hal/blob/main/scripts/audit_f16_codegen.sh).
 
 ### Rule 7 — NumPy interop: pass arrays straight to `from_numpy()`
 
-`Tensor.from_numpy()` (and the implicit copy from numpy arrays passed
-to `Decoder.decode_proto()` etc.) handles strided / non-contiguous
-sources internally. Callers should **not** maintain a manual
-`np.ascontiguousarray()` workaround — it wastes a copy.
+`Tensor.from_numpy()` (and the implicit copy from numpy arrays passed to
+`Decoder.decode_proto()`) handles strided / non-contiguous sources
+internally. Do **not** maintain a manual `np.ascontiguousarray()`
+workaround — it wastes a copy.
 
 The Python binding's `copy_numpy_to_tensor_dyn` selects one of three
 paths based on the source array's layout:
 
 | Source layout | Path | Cost |
 |---|---|---|
-| **Fully contiguous** | Single `copy_from_slice` (memcpy), rayon-parallel ≥ 256 KiB | Lower bound |
-| **Strided with contiguous inner rows** (e.g. column slice, sub-volume, negative stride) | Per-row memcpy iterating outer dimensions | ≈ same as fully contiguous |
-| **Fully strided** (e.g. transposed view, every-other-element) | Internal `np.ascontiguousarray()` materialisation, then Path 1 memcpy | ≈ 4× the contiguous cost |
+| Fully contiguous | Single `copy_from_slice` (memcpy), rayon-parallel ≥ 256 KiB | Lower bound |
+| Strided with contiguous inner rows (column slice, sub-volume, negative stride) | Per-row memcpy iterating outer dimensions | ≈ same as contiguous |
+| Fully strided (transposed view, every-other-element) | Internal `np.ascontiguousarray()` materialisation, then Path 1 memcpy | ≈ 4× contiguous |
 
-The fully-strided case is the one that bites users in practice — it
-matches the layout HailoRT returns natively (a `(1, channels, anchors)`
-f32 view obtained by `arr.transpose(0, 2, 1)` over a `(1, anchors,
-channels)` backing buffer). On `rpi5-hailo` with `(1, 116, 8400)` f32,
-the legacy element-wise iteration ran ≈ 27 ms / call; the current
-fast path runs ≈ 6.5 ms / call — close to the manual
-`np.ascontiguousarray + from_numpy(contig)` workaround that callers
-used to maintain.
+The fully-strided case is the one that bites users in practice: HailoRT's
+natural output is `arr.transpose(0, 2, 1)` over a `(1, anchors,
+channels)` buffer. PR #58 replaced the legacy element-wise loop with
+internal `np.ascontiguousarray` materialization (≈ 4× faster than the
+legacy loop, within ≈ 1.5× of the manual workaround).
 
 ```python
 # Wrong (post-PR #58): adds an extra copy above HAL.
-arr_contig = np.ascontiguousarray(arr_strided)
-tensor.from_numpy(arr_contig)
+tensor.from_numpy(np.ascontiguousarray(arr_strided))
 
-# Right: HAL detects the strided layout and materialises internally.
+# Right: HAL detects the strided layout and materializes internally.
 tensor.from_numpy(arr_strided)
 ```
 
-**Narrow case where pre-materialising still helps:** if the same
-strided view is fed into HAL many times in a tight loop (e.g. reusing
-a transposed numpy intermediary across frames), pre-`ascontiguousarray`
-*once outside the loop* amortises the strided→contig cost. Inside the
-loop, just call `from_numpy()` on the cached contiguous array. This
-is rare in practice.
+The regression tests in
+[`tests/test_tensor.py`](https://github.com/EdgeFirstAI/hal/blob/main/tests/test_tensor.py)
+(`test_from_numpy_hailort_shape`,
+`test_from_numpy_hailort_shape_perf_sanity`) pin the behaviour and the
+≤ 1.5× perf bound.
 
-This was previously a footgun because the legacy Path 3 iterated
-element-by-element over the strided view, which broke vectorisation
-and incurred stride arithmetic per load. The fix landed in PR #58.
-The regression tests in `tests/test_tensor.py` (`test_from_numpy_hailort_shape`,
-`test_from_numpy_hailort_shape_perf_sanity`) pin the behaviour and
-the perf bound (≤ 1.5× slower than the manual workaround).
-
-### Rule 8 — Choose the correct `MaskResolution` for your evaluation
+### Rule 8 — Choose the correct `MaskResolution`
 
 `ImageProcessor.materialize_masks()` accepts a `MaskResolution`
-parameter that controls the output resolution and pipeline:
+parameter:
 
 | Mode | Output | Pipeline | When to use |
-|---|---|---|---|
-| `MaskResolution::Proto` (default) | `(roi_h, roi_w, 1)` u8 — **binary** {0, 255} at 160×160 proto resolution | dot → sign threshold → emit | Real-time visualisation, rendering, or when proto-resolution binary masks suffice |
-| `MaskResolution::Scaled { width, height }` | `(roi_h, roi_w, 1)` u8 — **binary** {0, 255} at the requested resolution | dot → sigmoid → upsample to `(width, height)` → threshold (`>127`) | All COCO / IoU / mAP evaluation. Upsample-then-threshold preserves sub-proto-cell precision; the alternative (threshold-at-160 then upsample the binary mask) produces blocky 4-pixel-aligned edges and a measurable mAP regression |
+|------|--------|----------|-------------|
+| `MaskResolution::Proto` (default) | `(roi_h, roi_w, 1)` u8 binary at 160×160 proto resolution | dot → sign threshold → emit | Real-time visualisation, when proto-resolution binary suffices |
+| `MaskResolution::Scaled { width, height }` | `(roi_h, roi_w, 1)` u8 binary at requested resolution | dot → sigmoid → upsample to `(W, H)` → threshold (`>127`) | All COCO / IoU / mAP evaluation |
 
 ```python
-# Wrong: threshold then upsample → lossy edges, mAP regression.
-tiles_proto = proc.materialize_masks(boxes, scores, classes, proto_data,
-                                     letterbox=letterbox_norm)  # default = Proto
-for tile, box in zip(tiles_proto, boxes):
-    binary_proto = (tile[:, :, 0] > 127).astype(np.uint8)         # threshold first
-    canvas[y:y+h, x:x+w] = cv2.resize(binary_proto, (W, H),
-                                       interpolation=cv2.INTER_NEAREST)  # upsample binary
+# Wrong: threshold then upsample → blocky edges, mAP regression.
+tiles = proc.materialize_masks(boxes, scores, classes, proto_data, letterbox=lb)
+for tile, box in zip(tiles, boxes):
+    binary = (tile[:, :, 0] > 127).astype(np.uint8)
+    canvas[y:y+h, x:x+w] = cv2.resize(binary, (W, H), cv2.INTER_NEAREST)
 
 # Right: HAL upsamples-then-thresholds inside its batched-GEMM kernel.
-tiles_scaled = proc.materialize_masks(boxes, scores, classes, proto_data,
-                                       letterbox=letterbox_norm,
-                                       resolution=hal.MaskResolution.Scaled(W, H))
-for tile, box in zip(tiles_scaled, boxes):
-    canvas[y:y+h, x:x+w] = (tile[:, :, 0] > 127).astype(np.uint8)  # already at orig res
+tiles = proc.materialize_masks(boxes, scores, classes, proto_data,
+                               letterbox=lb,
+                               resolution=hal.MaskResolution.Scaled(W, H))
+for tile, box in zip(tiles, boxes):
+    canvas[y:y+h, x:x+w] = (tile[:, :, 0] > 127).astype(np.uint8)
 ```
 
-The `Scaled` path goes through the batched-GEMM materialiser added in
-0.18.0 (PR #54). At N ≥ 16 detections it amortises a single GEMM at
-proto resolution across all detections, then upsamples per-detection
-in rayon-parallel — so it is *both* more accurate than threshold-then-
-resize and faster than per-detection scalar work in caller code.
+The `Scaled` path uses the batched-GEMM materializer (PR #54). At N ≥ 16
+detections it amortizes a single GEMM at proto resolution and upsamples
+per-detection in rayon-parallel — both more accurate than
+threshold-then-resize *and* faster than per-detection scalar work in
+caller code.
 
 > [!TIP]
-> If you are seeing a mask-mAP gap between your HAL-based validator
-> and a reference (ONNX / numpy) implementation, this rule is almost
-> always the first thing to check.
+> If you see a mask-mAP gap between your HAL validator and a reference
+> (ONNX / numpy) implementation, this rule is almost always the first
+> thing to check.
 
-### Where to Go Next
+### Where to go next
 
 | Document | Level | Use it for |
-|----------|-------|-----------|
-| [ARCHITECTURE.md] § Performance Considerations | Architecture | Why the rules exist: `BufferIdentity`, EGL image cache, fd ownership, GL serialization, fd-vs-inode lifecycle |
-| [ARCHITECTURE.md] § Appendix C — DMA-BUF Identity and Tensor Caching | Architecture | The full v4l2 / GStreamer fd-recycling story and the inode-keyed cache pattern |
-| [TESTING.md] § Validating Optimizations | Testing | Confirming your integration follows the rules: cache hit logs, allocation counters, backend isolation |
-| [BENCHMARKS.md] § Optimization Performance Reference | Benchmarks | Empirical cost of breaking each rule, per platform |
-
-[ARCHITECTURE.md]: ARCHITECTURE.md
-[TESTING.md]: TESTING.md
-[BENCHMARKS.md]: BENCHMARKS.md
-
-## Advanced Examples
-
-> [!NOTE]
-> The snippets below use stand-in helpers (`run_inference()`, `run_detection()`,
-> `config_yaml`, `config_dict`, etc.) to keep each example focused on the HAL
-> API. Replace these with your own model invocation, configuration loader, or
-> data-source code.
-
-<details>
-<summary><b>Rust Examples</b></summary>
-
-### Image Conversion
-
-```rust
-use edgefirst_image::{load_image, ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
-use edgefirst_tensor::{PixelFormat, DType, TensorDyn};
-
-// Load image from JPEG
-let bytes = std::fs::read("testdata/zidane.jpg")?;
-let input = load_image(&bytes, Some(PixelFormat::Rgb), None)?;
-
-// Create converter (auto-selects best backend: OpenGL, G2D, CPU)
-let mut converter = ImageProcessor::new()?;
-
-// Create output buffer with optimal GPU memory (DMA > PBO > Mem)
-let mut output = converter.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
-
-// Convert and resize
-converter.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default())?;
-```
-
-### Detection Decoding
-
-```rust
-use edgefirst_hal::decoder::{DecoderBuilder, DetectBox, Segmentation};
-use edgefirst_hal::tensor::TensorDyn;
-
-// Build decoder from a YAML config string (or use other with_config_*
-// methods to build from a parsed schema).
-let decoder = DecoderBuilder::default()
-    .with_config_yaml_str(config_yaml.to_string())
-    .with_score_threshold(0.5)
-    .with_iou_threshold(0.45)
-    .build()?;
-
-// Decode model outputs (supports mixed types per tensor). The decoder
-// uses out-parameters: `boxes` and `masks` are cleared on each call.
-let outputs: Vec<&TensorDyn> = vec![&boxes_tensor, &scores_tensor];
-let mut boxes: Vec<DetectBox> = Vec::new();
-let mut masks: Vec<Segmentation> = Vec::new();
-decoder.decode(&outputs, &mut boxes, &mut masks)?;
-```
-
-### Multi-Frame Tracking
-
-```rust
-// Requires: edgefirst-hal = { version = "0.18", features = ["tracker"] }
-use edgefirst_hal::tracker::{ByteTrack, Tracker, DetectionBox};
-
-let mut tracker = ByteTrack::default();
-
-for frame in video_frames {
-    let detections = run_detection(frame)?;
-    // update() returns Vec<Option<TrackInfo>> — one slot per input detection;
-    // None means the detection was not associated with an existing track this
-    // frame (e.g., low-confidence track in the matching cascade).
-    let track_infos = tracker.update(&detections, frame.timestamp);
-
-    for track_info in track_infos.into_iter().flatten() {
-        println!("Object {}: {:?}", track_info.uuid, track_info.tracked_location);
-    }
-}
-```
-
-### Zero-Copy Tensor Sharing
-
-```rust
-use edgefirst_hal::tensor::{Tensor, TensorTrait};
-
-// Create tensor in process A
-let tensor = Tensor::<u8>::new(&[1920, 1080, 3], None, Some("frame1"))?;
-let fd = tensor.clone_fd()?;
-
-// Send fd to process B (via Unix domain socket, etc.)
-// ...
-
-// Process B recreates tensor from fd
-let shared_tensor = Tensor::<u8>::from_fd(fd, &[1920, 1080, 3], None)?;
-```
-
-### Zero-Copy Import of External DMA-BUF
-
-```rust
-use edgefirst_image::{ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
-use edgefirst_tensor::{PixelFormat, DType, PlaneDescriptor};
-
-// Render directly into a DMA-BUF buffer owned by the NPU delegate.
-// No memcpy between HAL output and the delegate's input buffer.
-let mut processor = ImageProcessor::new()?;
-let pd = PlaneDescriptor::new(vx_fd.as_fd())?;  // dups fd — caller keeps ownership
-let mut dst = processor.import_image(pd, None, 640, 640, PixelFormat::Rgb, DType::U8)?;
-processor.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())?;
-// dst's backing memory IS vx_fd — no memcpy needed
-```
-
-</details>
-
-<details>
-<summary><b>Python Examples</b></summary>
-
-### Image Processing
-
-```python
-import edgefirst_hal as ef
-import numpy as np
-
-# Load image from file
-tensor_img = ef.Tensor.load("testdata/zidane.jpg", ef.PixelFormat.Rgb)
-
-# Create converter
-converter = ef.ImageProcessor()
-
-# Create output image with optimal GPU memory (DMA > PBO > Mem)
-output = converter.create_image(640, 640, ef.PixelFormat.Rgb)
-
-# Resize with hardware acceleration
-converter.convert(tensor_img, output)
-
-# Convert to numpy for processing
-output_array = np.zeros((640, 640, 3), dtype=np.uint8)
-output.normalize_to_numpy(output_array)
-```
-
-### Object Detection
-
-```python
-import edgefirst_hal
-
-# Create decoder from config dict or YAML
-decoder = edgefirst_hal.Decoder(config_dict, 0.5, 0.45)
-
-# Decode outputs (accepts List[Tensor]; automatically handles quantization)
-boxes, scores, classes, masks = decoder.decode([output0, output1])
-```
-
-### Tracked Segmentation
-
-```python
-import time
-import edgefirst_hal as ef
-
-converter = ef.ImageProcessor()
-decoder = ef.Decoder(config_dict, 0.5, 0.45)
-tracker = ef.ByteTrack()
-
-dst = converter.create_image(640, 640, ef.PixelFormat.Rgb)
-
-for frame in video_frames:
-    converter.convert(frame, dst)
-    outputs = run_inference(dst)
-
-    # Draw segmentation masks with stable per-track colours.
-    # timestamp must be monotonic nanoseconds for correct track expiry.
-    converter.draw_masks(
-        decoder, outputs, dst,
-        tracker=tracker, timestamp=time.monotonic_ns()
-    )
-```
-
-</details>
-
-## Design Patterns
-
-### 1. Trait-Based Polymorphism
-
-The HAL uses Rust traits extensively to provide polymorphic behavior:
-- `TensorTrait<T>`: Common interface for all tensor types
-- `ImageProcessorTrait`: Common interface for all image converters
-- `DetectionBox`: Trait for objects with bounding boxes
-
-### 2. Enum Dispatch
-
-Uses `enum_dispatch` crate for zero-cost polymorphism without dynamic dispatch overhead.
-
-### 3. Builder Pattern
-
-Complex objects use the builder pattern (e.g., `DecoderBuilder`) for flexible construction.
-
-### 4. Zero-Copy Operations
-
-Extensive use of:
-- Memory-mapped file descriptors
-- Slice views into tensors
-- ndarray views for array operations
-
-### 5. Hardware Fallback Chain
-
-Operations try hardware accelerators first, falling back to CPU implementations gracefully.
-
-### 6. Type-Safe Foreign Interfaces
-
-Raw FFI bindings are wrapped in safe Rust types that enforce correct usage at compile time.
-
-### 7. Python Wrapper Naming Convention
-
-Python wrapper types use a `Py` prefix (e.g., `PyTensor`, `PyPixelFormat`) to clearly distinguish them from their Rust counterparts. The Python `Tensor` class wraps `TensorDyn` internally. This convention makes it explicit which types are Python-facing and which are internal Rust types.
-
-## Performance Considerations
-
-The rules for getting the best performance are summarized in the
-[Optimization Guide](#optimization-guide) above. The architectural
-rationale (memory backends, image processing strategy, decoder internals)
-is documented in [ARCHITECTURE.md] § Performance Considerations.
-
-Use [Performance Tracing](#performance-tracing) to capture Perfetto traces
-and identify bottlenecks in your pipeline. The trace spans directly correspond
-to the operations described in the optimization rules.
-
-## Thread Safety
-
-Thread safety of major types:
-- `Tensor<T>`: `Send + Sync` — safe to share across threads
-- `TensorDyn`: `Send + Sync` — thread-safe
-- `ImageProcessor`: `Send + Sync` — thread-safe to move/share, but per-thread ownership is still recommended for predictable performance
-- `Decoder`: `Send + Sync` — thread-safe for read operations
-
-## Error Handling
-
-Consistent error handling throughout:
-- Custom `Result<T, Error>` types per crate following the standard Rust pattern
-- Each crate defines its own `Error` enum (e.g., `tensor::Error`, `image::Error`, `decoder::Error`)
-- Errors are enums with context
-- Conversion to PyErr for Python bindings
-- All public APIs return `Result<T, Error>` for fallible operations
+|----------|-------|------------|
+| [ARCHITECTURE.md § Performance Considerations](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#performance-considerations) | Architecture | Why the rules exist: `BufferIdentity`, EGL image cache, GL serialization |
+| [ARCHITECTURE.md § Appendix C](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching) | Architecture | The full v4l2 / GStreamer fd-recycling story and the inode-keyed cache pattern |
+| [TESTING.md § Validating Optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations) | Testing | Confirming your integration follows the rules |
+| [BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md) | Benchmarks | Empirical cost of breaking each rule, per platform |
 
 ## Platform Support
 
-| Feature | Linux (i.MX) | Linux (Generic) | macOS | Windows |
-|---------|--------------|-----------------|-------|---------|
-| DMA Tensors | ✅ | ✅ | ❌ | ❌ |
-| PBO Tensors (GPU) | ✅ | ✅ | ❌ | ❌ |
-| Shared Memory Tensors | ✅ | ✅ | ✅ | ✅ |
-| Heap Tensors | ✅ | ✅ | ✅ | ✅ |
-| G2D Acceleration | ✅ | ❌ | ❌ | ❌ |
-| OpenGL Acceleration | ✅ (optional) | ✅ (optional) | ❌ | ❌ |
-| CPU Fallback | ✅ | ✅ | ✅ | ✅ |
+| Feature | Linux (i.MX) | Linux (other) | macOS | Windows |
+|---------|--------------|---------------|-------|---------|
+| DMA tensors | Yes | Yes | No | No |
+| PBO tensors (GPU) | Yes | Yes | No | No |
+| Shared memory tensors | Yes | Yes | Yes | Yes |
+| Heap tensors | Yes | Yes | Yes | Yes |
+| G2D acceleration | Yes | No | No | No |
+| OpenGL acceleration | Yes (optional) | Yes (optional) | No | No |
+| CPU fallback | Yes | Yes | Yes | Yes |
 
 ## Build System
 
-- **Workspace**: Cargo workspace with 9 crates (tensor, image, decoder, tracker, hal, capi, python, bench, gpu-probe)
-- **Build Scripts**: Custom build.rs for PyO3 configuration
-- **Features**: Conditional compilation for hardware features
-- **Profiles**: Release, profiling, and debug profiles
+The workspace builds with standard `cargo`. The
+[`Makefile`](https://github.com/EdgeFirstAI/hal/blob/main/Makefile) wraps
+the common workflows (`make test`, `make bench`, `make build`,
+`make format lint check`) with the right flags and gates.
 
-### Building Python Bindings
-
-The Python bindings are built using `maturin`, which is the standard build tool for PyO3-based Python packages:
-
-```bash
-# Development build (editable install)
-maturin develop -m crates/python/Cargo.toml
-
-# Production build
-maturin build -m crates/python/Cargo.toml --release
-
-# Install from wheel
-pip install target/wheels/edgefirst_hal-*.whl
-```
-
-**Note**: `maturin` is the recommended and standard way to build PyO3 Python extensions. It handles the complex linking requirements between Python and Rust automatically.
+For Python wheels, see
+[`crates/python/README.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/README.md)
+and
+[`crates/python/TESTING.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/TESTING.md).
+For the C library and consumer linking, see
+[`crates/capi/README.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/README.md).
 
 ## Environment Variables
 
-The HAL respects the following environment variables at runtime:
-
 | Variable | Description |
 |----------|-------------|
-| `EDGEFIRST_TENSOR_FORCE_MEM` | Set to `1` to force heap memory (disables DMA/SHM) |
+| `EDGEFIRST_TENSOR_FORCE_MEM` | `1` forces heap memory (disables DMA / SHM) |
 | `EDGEFIRST_DISABLE_G2D` | Disable G2D backend |
 | `EDGEFIRST_DISABLE_GL` | Disable OpenGL backend |
 | `EDGEFIRST_DISABLE_CPU` | Disable CPU backend |
-| `EDGEFIRST_FORCE_BACKEND` | Force a single backend: `cpu`, `g2d`, or `opengl`. Disables fallback chain. |
-| `EDGEFIRST_FORCE_TRANSFER` | Force GPU transfer method: `pbo`, `dmabuf`, or `sync` (`sync` falls back to `glTexImage2D` / `glReadnPixels` memcpy — useful for measuring the non-zero-copy baseline) |
-| `EDGEFIRST_OPENGL_RENDERSURFACE` | Set to `1` to enable EGL renderbuffer path for non-dma_heap DMA-BUF buffers (i.MX 95 Neutron NPU) |
-| `EDGEFIRST_PROTO_COMPUTE` | Set to `1` to enable GLES 3.1 compute shader for HWC-to-CHW proto repack |
+| `EDGEFIRST_FORCE_BACKEND` | Force one backend: `cpu`, `g2d`, or `opengl` (disables fallback) |
+| `EDGEFIRST_FORCE_TRANSFER` | Force GL transfer: `pbo`, `dmabuf`, or `sync` |
+| `EDGEFIRST_OPENGL_RENDERSURFACE` | `1` enables EGL renderbuffer path for non-`dma_heap` DMA-BUF (i.MX 95 Neutron NPU) |
+| `EDGEFIRST_PROTO_COMPUTE` | `1` enables GLES 3.1 compute shader for HWC→CHW proto repack |
+| `EDGEFIRST_TESTDATA_DIR` | Override testdata location (used by benches and CI) |
+| `RUST_LOG` | Standard `env_logger` filter — `RUST_LOG=edgefirst_image=debug` for backend dispatch + cache stats |
+
+Per-crate variables and additional detail live in each crate's README.
 
 ## Testing
 
-The HAL includes comprehensive test coverage across Rust and Python:
-
-### Rust Tests
-```bash
-# Run all Rust tests
-cargo test --workspace
-
-# Run tests for specific crate
-cargo test -p edgefirst_image
-cargo test -p edgefirst_decoder
-cargo test -p edgefirst_tensor
-```
-
-### Python Tests
-Python tests are located in the `tests/` directory and use the pytest framework:
-
-```bash
-# First, build the Python bindings
-maturin develop -m crates/python/Cargo.toml
-
-# Run all Python tests
-python -m pytest tests/
-
-# Run specific test modules
-python -m pytest tests/image/
-python -m pytest tests/decoder/
-python -m pytest tests/test_tensor.py
-```
-
-Python tests require the `pytest-benchmark` plugin for benchmarks, and the Pillow library for the image tests, these can be installed using:
-```bash
-python -m pip install pytest-benchmark
-python -m pip install pillow
-```
-
-**Note**: Python tests require the Python bindings to be built via `maturin develop` first, as they test the PyO3 interface.
+See [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md)
+for the cross-cutting testing guide (single-threaded rule, on-target
+gating, cross-compilation, CI matrix, optimization validation). Per-crate
+testing detail lives in each crate's `TESTING.md` — links in the
+[Core Components](#core-components) table.
 
 ## Benchmarking
 
-The HAL includes dedicated benchmark binaries for measuring performance across platforms and compute backends.
+| Binary | Crate | What it measures |
+|--------|-------|------------------|
+| `tensor_benchmark` | `edgefirst-tensor` | Tensor allocation and map/unmap latency across buffer types |
+| `image_benchmark` | `edgefirst-image` | Crop, flip, rotate, resize, draw |
+| `pipeline_benchmark` | `edgefirst-image` | Letterbox pipeline + format conversion |
+| `mask_benchmark` | `edgefirst-image` | `draw_decoded_masks`, `draw_proto_masks`, hybrid path |
+| `opencv_benchmark` | `edgefirst-image` | OpenCV baseline comparison |
+| `decoder_benchmark` | `edgefirst-decoder` | YOLO post-processing, NMS, dequant |
+| `tracker_benchmark` | `edgefirst-tracker` | ByteTrack throughput vs. simultaneous tracks |
 
-### Benchmark Binaries
-
-| Binary | Crate | What It Measures |
-|--------|-------|-----------------|
-| `tensor_benchmark` | `edgefirst-tensor` | Tensor allocation and map/unmap latency across buffer types (Heap, SHM, DMA) |
-| `image_benchmark` | `edgefirst-image` | Low-level image operations: crop, flip, rotate, resize, draw |
-| `pipeline_benchmark` | `edgefirst-image` | Letterbox pipeline and format conversion (camera→model input) |
-| `mask_benchmark` | `edgefirst-image` | Mask rendering: draw_decoded_masks, draw_proto_masks, hybrid path |
-| `opencv_benchmark` | `edgefirst-image` | OpenCV baseline comparison for same operations |
-| `decoder_benchmark` | `edgefirst-decoder` | YOLO detection/segmentation post-processing, NMS, dequantization |
-
-### Running Locally
+Run on host:
 
 ```bash
-# Auto backend selection (default)
 cargo bench -p edgefirst-image --bench pipeline_benchmark -- --bench
 
-# Force a specific compute backend
+# Force a backend
 EDGEFIRST_FORCE_BACKEND=cpu cargo bench -p edgefirst-image --bench pipeline_benchmark -- --bench
-EDGEFIRST_FORCE_BACKEND=opengl cargo bench -p edgefirst-image --bench pipeline_benchmark -- --bench
-EDGEFIRST_FORCE_BACKEND=g2d cargo bench -p edgefirst-image --bench pipeline_benchmark -- --bench
-
-# Force PBO buffer transfer strategy (even when DMA-buf is available)
-EDGEFIRST_FORCE_TRANSFER=pbo cargo bench -p edgefirst-image --bench pipeline_benchmark -- --bench
 ```
 
-### Cross-Compiling for aarch64
+Cross-compile + deploy to a target (SSH hostnames in `~/.ssh/config`:
+`imx8mp-frdm`, `imx95-frdm`, `rpi5-hailo`, `jetson-orin-nano`,
+`maivin`):
 
 ```bash
 cargo-zigbuild build --target aarch64-unknown-linux-gnu --release \
-    -p edgefirst-image --features opengl --bench pipeline_benchmark
+  -p edgefirst-image --features opengl --bench pipeline_benchmark
 
-cargo-zigbuild build --target aarch64-unknown-linux-gnu --release \
-    -p edgefirst-tensor --bench tensor_benchmark
-
-cargo-zigbuild build --target aarch64-unknown-linux-gnu --release \
-    -p edgefirst-decoder --bench decoder_benchmark
-```
-
-### Deploying to Targets
-
-SSH hostnames are configured in `~/.ssh/config`: `imx8mp-frdm`, `imx95-frdm`, `rpi5-hailo`, `jetson-orin-nano`, `maivin`
-
-```bash
-# Copy benchmark binary to target
 scp target/aarch64-unknown-linux-gnu/release/deps/pipeline_benchmark-* imx8mp-frdm:/tmp/
-
-# Run on target with JSON output
-ssh imx8mp-frdm '/tmp/pipeline_benchmark-* --bench --json /tmp/pipeline-cpu.json'
+ssh imx8mp-frdm '/tmp/pipeline_benchmark-* --bench --json /tmp/pipeline.json'
 ```
 
-### JSON Output Convention
-
-All benchmarks accept `--bench --json <path>` to write structured JSON results. Store results in `benchmarks/<platform>/<name>.json`:
-- `benchmarks/imx8mp-frdm/mask-opengl.json`
-- `benchmarks/x86-desktop/pipeline-cpu.json`
-
-### Updating BENCHMARKS.md
+All benchmarks accept `--bench --json <path>` for structured output.
+Store results under `benchmarks/<platform>/<name>.json`. Update
+[BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md)
+via:
 
 ```bash
 python3 .github/scripts/generate_benchmark_tables.py --data-dir benchmarks/
 ```
 
-This prints markdown tables to stdout. Copy the relevant sections into [BENCHMARKS.md](BENCHMARKS.md), which contains the full results and analysis.
-
 ## Performance Tracing
 
-The HAL includes built-in instrumentation for capturing detailed performance
-traces across all processing stages. Traces are written in Chrome JSON format
-and can be viewed in [Perfetto UI](https://ui.perfetto.dev/).
+The HAL ships with built-in tracing for capturing detailed performance
+traces across all processing stages. Traces use the Chrome JSON format
+and view in [Perfetto UI](https://ui.perfetto.dev/).
 
-### How It Works
+### How it works
 
-All HAL library crates (`edgefirst-decoder`, `edgefirst-image`,
-`edgefirst-tensor`, `edgefirst-tracker`) emit `tracing` spans on hot paths.
-These spans have **near-zero overhead** when tracing is not active — each span
-site compiles to a single relaxed atomic load that short-circuits when no
-subscriber is installed. No heap allocations, no string formatting, and no
-function calls occur on the hot path when tracing is disabled.
+Every HAL library crate emits `tracing` spans on hot paths. These spans
+have **near-zero overhead** when no subscriber is active — each site
+compiles to a single relaxed atomic load. No heap allocations, no string
+formatting, no function calls on the hot path.
 
-When a trace session is started via the API, a Chrome JSON subscriber records
+When a session is started via the API, a Chrome JSON subscriber records
 all span enter/exit events with high-resolution timestamps and structured
-metadata (detection counts, proto dimensions, format conversions, memory types,
-etc.) to a file. The resulting trace can be loaded into
-[ui.perfetto.dev](https://ui.perfetto.dev/) for interactive timeline analysis.
+metadata (detection counts, proto dimensions, format conversions, memory
+types, etc.) to a file.
 
-### Instrumented Spans
+### Span coverage
 
-The following spans provide full visibility into HAL processing pipelines:
+The tracing surface covers decode, image conversion, GL multi-pass, mask
+materialization, tensor lifecycle, tracker association, and the Python
+entry points. Each span carries structured fields — see the per-crate
+ARCHITECTURE.md files for the authoritative list of spans and fields per
+component.
 
-#### Decode Pipeline
+### Enabling tracing
 
-| Span | Component | Fields |
-|------|-----------|--------|
-| `decode` | decoder | `mode` (quant_det/float_det/split_quant_det/split_float_det) |
-| `score_filter` | decoder | — |
-| `top_k` | decoder | `k` |
-| `nms` | decoder | — |
-| `box_dequant` | decoder | `n` |
-| `extract_proto` | decoder | `n`, `num_protos`, `layout` |
-| `process_masks` | decoder | `n`, `mode` (float/quant) |
-
-#### Image Processing
-
-| Span | Component | Fields |
-|------|-----------|--------|
-| `image_convert` | image | `src_fmt`, `dst_fmt`, `src_memory`, `dst_memory`, `rotation`, `flip` |
-| `cpu_format_convert` | image | `from`, `to`, `pass` (pre_resize/post_resize/direct) |
-| `cpu_resize` | image | — |
-| `gl_convert` | image | `src_fmt`, `dst_fmt`, `is_int8`, `src_memory`, `dst_memory` |
-| `gl_pass1_to_rgba` | image | `dst_w`, `dst_h` |
-| `gl_pass2_pack_rgb` | image | `render_w`, `render_h` |
-| `gl_pass2_to_planar` | image | `dst_w`, `dst_h` |
-| `g2d_convert` | image | `src_fmt`, `dst_fmt` |
-| `draw_masks` | image | `n_detections`, `n_segmentations` |
-| `materialize_masks` | image | `mode`, `n_detections`, `width`, `height` |
-| `mask_i8_fastpath` | image | `n`, `proto_h`, `proto_w`, `num_protos`, `layout` |
-
-#### Tensor & Tracker
-
-| Span | Component | Fields |
-|------|-----------|--------|
-| `tensor_alloc` | tensor | `shape`, `memory`, `dtype` |
-| `tensor_map` | tensor | `memory` |
-| `tracker_update` | tracker | `n_detections`, `n_tracks` |
-| `predict` | tracker | — |
-| `match_high_conf` | tracker | — |
-| `match_low_conf` | tracker | — |
-
-#### Python Entry Points
-
-| Span | Component | Fields |
-|------|-----------|--------|
-| `py_decode` | python | `n_tensors`, `max_boxes` |
-| `py_decode_tracked` | python | `n_tensors`, `max_boxes` |
-| `py_decode_proto` | python | `n_tensors`, `max_boxes` |
-| `py_convert` | python | — |
-| `py_materialize_masks` | python | — |
-| `py_draw_masks` | python | — |
-
-### Enabling Tracing
-
-The tracing infrastructure is included by default in all crate builds
-(`edgefirst-hal`, `edgefirst-hal-capi`, `edgefirst_hal` Python). No traces are
-captured until the application explicitly starts a session via the API — the
-runtime overhead is near-zero until then. The `tracing` Cargo feature can be
-disabled with `--no-default-features` to remove the capture infrastructure
-entirely (the span sites remain compiled but become true no-ops).
-
-#### Python
+Python:
 
 ```python
 import edgefirst_hal as hal
-
 with hal.Tracing("/tmp/trace.json"):
     # ... run inference pipeline ...
     pass
-# Trace file is ready — open in https://ui.perfetto.dev/
 ```
 
-#### Rust
+Rust:
 
 ```rust
 use edgefirst_hal::trace::{start_tracing, stop_tracing};
@@ -1341,168 +566,137 @@ start_tracing("/tmp/trace.json").expect("start tracing");
 stop_tracing(); // flushes and closes the trace file
 ```
 
-#### C
+C:
 
 ```c
 #include <edgefirst/hal.h>
-
 hal_start_tracing("/tmp/trace.json");
-// ... inference pipeline ...
+/* ... inference pipeline ... */
 hal_stop_tracing();
 ```
 
-### Viewing Traces
+### Viewing traces
 
-1. Open [ui.perfetto.dev](https://ui.perfetto.dev/)
+1. Open <https://ui.perfetto.dev/>
 2. Drag the generated `.json` file onto the page
-3. Navigate the timeline to see decode and mask spans with timing and metadata
+3. Click slices to see structured fields in the *Current Selection* panel
 
-Each span appears as a slice on the timeline. Click a slice to see its
-structured fields (detection counts, proto layout, etc.) in the "Current
-Selection" panel.
+### Using traces for optimization
 
-### Using Traces for Optimization
+The tracing infrastructure complements the rules in the
+[Optimization Guide](#optimization-guide) and the data in
+[BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md):
 
-The trace instrumentation is designed to complement the optimization rules in
-the [Optimization Guide](#optimization-guide) above and the benchmark data in
-[BENCHMARKS.md]:
-
-1. **Identify bottlenecks**: Run your pipeline with tracing enabled to see
-   which spans dominate. Common findings:
-   - `extract_proto` taking >3 ms → model outputs NCHW protos but HAL is
-     transposing (check `layout` field)
-   - `cpu_format_convert` appearing twice → intermediate format conversion
-     steps (consider matching src/dst formats)
-   - `tensor_alloc` appearing per-frame → tensors not being reused (Rule 1)
-
-2. **Validate optimization rules**: After applying a rule from the guide,
-   re-run with tracing to confirm the expected spans disappear or shrink.
-
-3. **Cross-reference with perf**: For CPU-bound spans (mask materialization,
-   NMS), combine trace data with `perf record` to identify instruction-level
-   hotspots within each span. See
-   [BENCHMARKS.md § Measurement Methodology](BENCHMARKS.md#measurement-methodology)
-   for the recommended workflow.
-
-4. **Multi-pass pipeline visibility**: The per-pass spans (`cpu_format_convert`
-   with `pass` field, `gl_pass1_*`/`gl_pass2_*`) reveal the internal breakdown
-   of image conversion operations that would otherwise appear as a single block.
+1. **Identify bottlenecks** — common findings:
+   - `extract_proto > 3 ms` → model emits NCHW protos but HAL is transposing (check the `layout` field)
+   - `cpu_format_convert` appearing twice → intermediate format conversion (consider matching src/dst formats)
+   - `tensor_alloc` per-frame → tensors not being reused (Rule 1)
+2. **Validate rules** — re-run with tracing after applying a rule to confirm the expected spans disappear or shrink.
+3. **Cross-reference with `perf`** — for CPU-bound spans, combine trace data with `perf record` for instruction-level hotspots.
 
 ### Limitations
 
-- Only one trace session per process lifetime (Rust global subscriber model)
-- Rayon worker thread spans are not automatically parented to the calling span
-- The `log::*` output (via `env_logger` / C callback logger) operates
-  independently from trace capture — both can be active simultaneously
+- Only one trace session per process lifetime (Rust global subscriber model).
+- Rayon worker spans are not automatically parented to the calling span.
+- The `log::*` output (via `env_logger` / C callback logger) operates independently from trace capture; both can be active simultaneously.
 
 ## Dependencies
 
-### Key External Dependencies
+### Key external dependencies
 
-- **PyO3**: Python bindings
-- **ndarray**: N-dimensional arrays
-- **rayon**: Data parallelism
-- **fast_image_resize**: CPU image operations
-- **zune-jpeg/zune-png**: Image decoding
-- **dma-heap**: Linux DMA allocation
-- **nix**: Unix system calls
+- [PyO3](https://pyo3.rs) — Python bindings
+- [ndarray](https://docs.rs/ndarray) — N-dimensional arrays
+- [rayon](https://docs.rs/rayon) — Data parallelism
+- [fast_image_resize](https://docs.rs/fast_image_resize) — CPU image operations
+- [zune-jpeg](https://docs.rs/zune-jpeg) / [zune-png](https://docs.rs/zune-png) — Image decoding
+- [dma-heap](https://docs.rs/dma-heap) — Linux DMA allocation
+- [nix](https://docs.rs/nix) — Unix system calls
 
-### Internal Dependency Graph
+### Internal dependency graph
 
 ```mermaid
 graph TD
-    EF[edgefirst<br/>top-level]
-    Tensor[edgefirst_tensor]
-    Image[edgefirst_image]
-    Decoder[edgefirst_decoder]
+    EF[edgefirst-hal<br/>umbrella]
+    Tensor[edgefirst-tensor]
+    Image[edgefirst-image]
+    Decoder[edgefirst-decoder]
+    Tracker[edgefirst-tracker<br/>optional]
     G2D[g2d-sys<br/>optional]
-    
+
     EF --> Tensor
     EF --> Image
     EF --> Decoder
     Image --> Tensor
+    Image --> Decoder
     Image -.optional.-> G2D
-    
-    Python[edgefirst-hal<br/>Python bindings]
-    PyO3[pyo3]
-    Numpy[numpy]
-    
-    Python --> EF
-    Python --> PyO3
-    Python --> Numpy
-    
-    Tracker[tracker<br/>optional]
-
     Image -.->|tracker feature| Tracker
     Decoder -.->|tracker feature| Tracker
 
+    Python[edgefirst_hal<br/>PyO3]
+    CAPI[edgefirst-hal-capi]
+
+    Python --> EF
+    CAPI --> EF
+
     style EF fill:#fff4e1
     style Python fill:#e1f5ff
+    style CAPI fill:#e1f5ff
     style Tracker fill:#e8f5e9
 ```
 
 ## Future Considerations
 
-1. **Model HAL**: Planned abstraction for inference engines (ONNX, TFLite, Kinara)
-2. **VPI Integration**: Support for NVIDIA Vision Programming Interface
-3. **Additional Trackers**: SORT, Deep SORT implementations
-4. **Async I/O**: Non-blocking image loading and processing
-5. **GPU Compute**: Vulkan/CUDA backends for custom operations
+1. **Model HAL** — planned abstraction for inference engines (ONNX, TFLite, Kinara)
+2. **VPI integration** — support for NVIDIA Vision Programming Interface
+3. **Additional trackers** — SORT, Deep SORT
+4. **Async I/O** — non-blocking image loading and processing
+5. **GPU compute** — Vulkan / CUDA backends for custom operations
 
 ## Support
 
-### Community Resources
+### Community resources
 
-- 📚 [Documentation](docs/) - Comprehensive guides and tutorials
-- 💬 [GitHub Discussions](https://github.com/EdgeFirstAI/hal/discussions) - Ask questions and share ideas
-- 🐛 [Issue Tracker](https://github.com/EdgeFirstAI/hal/issues) - Report bugs and request features
+- [GitHub Discussions](https://github.com/EdgeFirstAI/hal/discussions) — questions and ideas
+- [Issue Tracker](https://github.com/EdgeFirstAI/hal/issues) — bug reports and feature requests
 
-### EdgeFirst Ecosystem
+### EdgeFirst ecosystem
 
 This project is part of the EdgeFirst Perception stack:
 
-- **[EdgeFirst Studio](https://edgefirst.studio?utm_source=github&utm_medium=readme&utm_campaign=hal)** - Complete MLOps Platform
-  - Deploy and manage edge AI models at scale
-  - Real-time performance monitoring and analytics
-  - Model optimization for edge devices
-  - Free tier available for development
+- [**EdgeFirst Studio**](https://edgefirst.studio?utm_source=github&utm_medium=readme&utm_campaign=hal) — complete MLOps platform
+- [**EdgeFirst Hardware Platforms**](https://au-zone.com/hardware?utm_source=github&utm_medium=readme&utm_campaign=hal) — NPU/GPU acceleration on NXP i.MX
 
-- **[EdgeFirst Hardware Platforms](https://au-zone.com/hardware?utm_source=github&utm_medium=readme&utm_campaign=hal)** - Optimized Platforms
-  - NPU/GPU acceleration support on NXP i.MX platforms
-  - Reference designs available
-  - Custom hardware development services
+### Professional services
 
-### Professional Services
+Au-Zone Technologies offers comprehensive support for production
+deployments: training & workshops, custom development, integration
+services, enterprise SLAs, and hardware reference designs.
 
-Au-Zone Technologies offers comprehensive support for production deployments:
-
-- **Training & Workshops** - Get your team up to speed quickly with expert-led sessions
-- **Custom Development** - Extend HAL capabilities for your specific use case
-- **Integration Services** - Seamless integration with your existing systems and workflows
-- **Enterprise Support** - SLAs, priority fixes, and dedicated engineering support
-- **Hardware Platforms** - Reference designs, customization, and production services
-
-📧 Contact: support@au-zone.com | 🌐 Learn more: [au-zone.com](https://au-zone.com?utm_source=github&utm_medium=readme&utm_campaign=hal)
+Contact: <support@au-zone.com> · [au-zone.com](https://au-zone.com?utm_source=github&utm_medium=readme&utm_campaign=hal)
 
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
-
-This project follows our [Code of Conduct](CODE_OF_CONDUCT.md).
+We welcome contributions! Please see
+[CONTRIBUTING.md](https://github.com/EdgeFirstAI/hal/blob/main/CONTRIBUTING.md)
+for development setup and guidelines. This project follows our
+[Code of Conduct](https://github.com/EdgeFirstAI/hal/blob/main/CODE_OF_CONDUCT.md).
 
 ## Security
 
-For security vulnerabilities, please see [SECURITY.md](SECURITY.md) or email support@au-zone.com with subject "Security Vulnerability".
+For security vulnerabilities, see
+[SECURITY.md](https://github.com/EdgeFirstAI/hal/blob/main/SECURITY.md)
+or email <support@au-zone.com> with subject "Security Vulnerability".
 
 ## Documentation
 
-- [User Guide](docs/) - Comprehensive usage documentation
-- [API Reference](docs/api/) - Detailed API documentation
-- [Examples](examples/) - Sample code and tutorials
-- [CHANGELOG.md](CHANGELOG.md) - Version history and release notes
+- [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md) — cross-crate architecture story
+- [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md) — workspace testing rules and CI matrix
+- [BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md) — empirical performance reference
+- [CHANGELOG.md](https://github.com/EdgeFirstAI/hal/blob/main/CHANGELOG.md) — release history
+- Per-crate docs (README + ARCHITECTURE + TESTING) — see [Core Components](#core-components) table
 
 ## License
 
-Apache License 2.0 - see [LICENSE](LICENSE) for details.
+Apache License 2.0 — see [LICENSE](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE) for details.
 
 Copyright 2025-2026 Au-Zone Technologies

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ processor.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default
 #include <edgefirst/hal.h>
 
 struct hal_image_processor *proc = hal_image_processor_new();
+/* `src` is loaded from disk or imported from a DMA-BUF fd —
+ * see the C API README for hal_tensor_load_file / hal_import_image. */
+struct hal_tensor *src = /* ... */;
 struct hal_tensor *dst = hal_image_processor_create_image(
     proc, 640, 640, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
 hal_image_processor_convert(proc, src, dst, HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
@@ -253,9 +256,12 @@ BufferKey key = { .inode = st.st_ino, .offset = plane_offset };
 struct hal_tensor *tensor = lookup_tensor(cache, &key);
 if (!tensor) {
     struct hal_plane_descriptor *pd = hal_plane_descriptor_new(fd);
+    if (!pd) { perror("hal_plane_descriptor_new"); continue; }
     tensor = hal_import_image(proc, pd, NULL, w, h,
                               HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
-    insert_tensor(cache, &key, tensor);  // pd is consumed
+    // pd is consumed by hal_import_image (success or failure)
+    if (!tensor) { perror("hal_import_image"); continue; }
+    insert_tensor(cache, &key, tensor);
 }
 hal_image_processor_convert(proc, tensor, dst, /* ... */);
 ```
@@ -392,6 +398,8 @@ parameter:
 | `MaskResolution::Scaled { width, height }` | `(roi_h, roi_w, 1)` u8 binary at requested resolution | dot → sigmoid → upsample to `(W, H)` → threshold (`>127`) | All COCO / IoU / mAP evaluation |
 
 ```python
+import edgefirst_hal as hal
+
 # Wrong: threshold then upsample → blocky edges, mAP regression.
 tiles = proc.materialize_masks(boxes, scores, classes, proto_data, letterbox=lb)
 for tile, box in zip(tiles, boxes):
@@ -432,7 +440,7 @@ caller code.
 |---------|--------------|---------------|-------|---------|
 | DMA tensors | Yes | Yes | No | No |
 | PBO tensors (GPU) | Yes | Yes | No | No |
-| Shared memory tensors | Yes | Yes | Yes | Yes |
+| Shared memory tensors | Yes | Yes | Yes | No |
 | Heap tensors | Yes | Yes | Yes | Yes |
 | G2D acceleration | Yes | No | No | No |
 | OpenGL acceleration | Yes (optional) | Yes (optional) | No | No |
@@ -503,7 +511,7 @@ Cross-compile + deploy to a target (SSH hostnames in `~/.ssh/config`:
 `maivin`):
 
 ```bash
-cargo-zigbuild build --target aarch64-unknown-linux-gnu --release \
+cargo-zigbuild zigbuild --target aarch64-unknown-linux-gnu --release \
   -p edgefirst-image --features opengl --bench pipeline_benchmark
 
 scp target/aarch64-unknown-linux-gnu/release/deps/pipeline_benchmark-* imx8mp-frdm:/tmp/

--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ processor.draw_masks(decoder, [output0, output1], output)
 
 **Rust:**
 
+The umbrella `edgefirst-hal` crate re-exports its sub-crates as modules,
+so a single `edgefirst-hal = "0.22"` dependency is enough — no need to
+list `edgefirst-image` / `edgefirst-tensor` separately in `Cargo.toml`.
+
 ```rust
-use edgefirst_image::{load_image, ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
-use edgefirst_tensor::{PixelFormat, DType};
+use edgefirst_hal::image::{load_image, ImageProcessor, ImageProcessorTrait, Rotation, Flip, Crop};
+use edgefirst_hal::tensor::{PixelFormat, DType};
 
 let bytes = std::fs::read("image.jpg")?;
 let input = load_image(&bytes, Some(PixelFormat::Rgb), None)?;
@@ -76,6 +80,12 @@ let mut processor = ImageProcessor::new()?;
 let mut output = processor.create_image(640, 640, PixelFormat::Rgb, DType::U8, None)?;
 processor.convert(&input, &mut output, Rotation::None, Flip::None, Crop::default())?;
 ```
+
+If you prefer to depend on the sub-crates directly (e.g. to opt out of
+features or to track them at independent versions), add the relevant
+`edgefirst-image`, `edgefirst-tensor`, `edgefirst-decoder`, and
+`edgefirst-tracker` entries to your `Cargo.toml` and use the
+unprefixed `edgefirst_image::*` / `edgefirst_tensor::*` paths above.
 
 **C:**
 
@@ -310,11 +320,14 @@ frame.
 
 ### Rule 5 — One `ImageProcessor` per pipeline
 
-`ImageProcessor` owns its EGL display, OpenGL context, GL thread, and EGL
-image cache. Two instances do not share caches and serialize on a global
-`GL_MUTEX`. Construct one per pipeline (or one per worker thread for
-parallel pipelines) and share it across all `convert()`, `draw_*()`, and
-`create_image()` calls.
+`ImageProcessor` owns its OpenGL context, dedicated GL thread, and EGL
+image cache. The EGL **display** itself is process-global (a shared
+`SharedEglDisplay` initialized once and never terminated), so additional
+processors don't pay the display-creation cost — but each one still
+creates a fresh context and per-instance caches, and all GL operations
+across every processor serialize on a global `GL_MUTEX`. Construct one
+per pipeline (or one per worker thread for parallel pipelines) and share
+it across all `convert()`, `draw_*()`, and `create_image()` calls.
 
 `ImageProcessor` is `Send + Sync`, so it can be moved or shared across
 threads. Concurrent use of a single shared instance still serializes on
@@ -429,7 +442,8 @@ caller code.
 
 | Document | Level | Use it for |
 |----------|-------|------------|
-| [ARCHITECTURE.md § Performance Considerations](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#performance-considerations) | Architecture | Why the rules exist: `BufferIdentity`, EGL image cache, GL serialization |
+| [ARCHITECTURE.md § Appendix C: DMA-BUF Identity and Tensor Caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching) | Architecture | Why the rules exist: `BufferIdentity`, EGL image cache, fd-recycling, downstream cache keying |
+| [image/ARCHITECTURE.md § Performance Considerations](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#performance-considerations) | Architecture | GL serialization (`GL_MUTEX`), backend dispatch, per-instance caches |
 | [ARCHITECTURE.md § Appendix C](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching) | Architecture | The full v4l2 / GStreamer fd-recycling story and the inode-keyed cache pattern |
 | [TESTING.md § Validating Optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations) | Testing | Confirming your integration follows the rules |
 | [BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md) | Benchmarks | Empirical cost of breaking each rule, per platform |

--- a/README.md
+++ b/README.md
@@ -236,9 +236,11 @@ every destination passed to `convert()`; direct `Tensor::new(memory=...)`
 bypasses the probe.
 
 For DMA-buf access, the process needs `/dev/dma_heap/{linux,cma|system}`
-and `/dev/dri/renderD128`. On embedded Linux, add the user to `video` and
-`render` groups, or set udev rules. If DMA-buf fails, `create_image()`
-transparently falls back to PBO or heap.
+and a DRM render/card node — the GL backend probes
+`/dev/dri/renderD128`, then `/dev/dri/card0`, then `/dev/dri/card1` and
+uses the first one that opens. On embedded Linux, add the user to
+`video` and `render` groups, or set udev rules. If DMA-buf fails,
+`create_image()` transparently falls back to PBO or heap.
 
 ### Rule 3 — Cache imported camera tensors by inode, not by fd
 
@@ -344,9 +346,9 @@ dynamic dispatch, baking them in would SIGILL on older CPUs.
 For local benchmarking on supporting hosts, enable them via `RUSTFLAGS`:
 
 ```bash
-# Orin Nano (Cortex-A78AE)
+# Orin Nano (Cortex-A78AE) — exclude the PyO3 binding (cross-Python toolchain not configured)
 RUSTFLAGS="-C target-cpu=cortex-a78ae" cargo build --release \
-  --target aarch64-unknown-linux-gnu --workspace
+  --target aarch64-unknown-linux-gnu --workspace --exclude edgefirst_hal
 
 # Generic aarch64 with FEAT_FP16 (do NOT use on Cortex-A53 / imx8mp)
 RUSTFLAGS="-C target-feature=+fp16" cargo build --release \
@@ -442,9 +444,8 @@ caller code.
 
 | Document | Level | Use it for |
 |----------|-------|------------|
-| [ARCHITECTURE.md § Appendix C: DMA-BUF Identity and Tensor Caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching) | Architecture | Why the rules exist: `BufferIdentity`, EGL image cache, fd-recycling, downstream cache keying |
+| [ARCHITECTURE.md § Appendix C: DMA-BUF Identity and Tensor Caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching) | Architecture | Why the rules exist: `BufferIdentity`, EGL image cache, the v4l2 / GStreamer fd-recycling story, and the inode-keyed downstream cache pattern |
 | [image/ARCHITECTURE.md § Performance Considerations](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#performance-considerations) | Architecture | GL serialization (`GL_MUTEX`), backend dispatch, per-instance caches |
-| [ARCHITECTURE.md § Appendix C](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching) | Architecture | The full v4l2 / GStreamer fd-recycling story and the inode-keyed cache pattern |
 | [TESTING.md § Validating Optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations) | Testing | Confirming your integration follows the rules |
 | [BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md) | Benchmarks | Empirical cost of breaking each rule, per platform |
 

--- a/README.md
+++ b/README.md
@@ -645,6 +645,10 @@ graph TD
 
     Python --> EF
     CAPI --> EF
+    CAPI --> Tensor
+    CAPI --> Image
+    CAPI --> Decoder
+    CAPI --> Tracker
 
     style EF fill:#fff4e1
     style Python fill:#e1f5ff

--- a/TESTING.md
+++ b/TESTING.md
@@ -320,6 +320,41 @@ environment variable from the table below and re-run with
 | `EDGEFIRST_FORCE_TRANSFER=sync` | Memcpy upload/readback via `glTexImage2D` / `glReadnPixels` | Non-zero-copy baseline; useful for measuring fast-path cost |
 | `EDGEFIRST_TENSOR_FORCE_MEM=1` | Forces heap tensors; disables DMA / SHM | Pure-CPU regression baseline |
 
+### Warm up before measuring
+
+The first few frames through a pipeline pay one-time costs that do not
+recur in steady state: the EGL image cache populates from cold, GPU
+shaders are JIT-compiled and cached by the driver, and any DMA-BUF
+import that succeeds at the API level still pays its first
+`eglCreateImageKHR` round trip. If a benchmark starts timing on frame
+0, the first measurement is biased upward by these one-time costs and
+the distribution's tail is dominated by them.
+
+The canonical pattern is to run a small warm-up loop on the same
+fixtures used by the measurement loop, with the **same tensors**, the
+**same decoder**, and the **same `ImageProcessor`** that the measurement
+will use:
+
+```rust
+// Warm-up — same objects, results discarded
+for path in fixture_paths.iter().take(WARMUP_FRAMES) {
+    backend.process_one_image(path)?;
+}
+
+// Measurement — caches are now warm, GL shaders JIT-cached
+for path in fixture_paths {
+    let t0 = Instant::now();
+    backend.process_one_image(path)?;
+    record_latency(t0.elapsed());
+}
+```
+
+A typical warm-up depth is 3–5 frames for the cache itself plus enough
+frames to span one full buffer-pool rotation (e.g. 9 for the i.MX 8M
+Plus VPU's 1080p pool). Allocate any new tensor objects **before** the
+warm-up phase, not between warm-up and measurement, or the measurement
+will see a fresh `BufferIdentity` and miss its own warmed cache.
+
 ### Regression testing for tensor reuse
 
 To catch regressions where a caller starts allocating a tensor per
@@ -404,6 +439,8 @@ not the default `Proto`. Downstream validators should pin this with a
 small assertion at the materialize call site:
 
 ```python
+import edgefirst_hal as hal
+
 masks = proc.materialize_masks(
     boxes, scores, classes, proto_data,
     letterbox=letterbox_norm,
@@ -481,10 +518,11 @@ because the gate is an explicit probe, not a `#[ignore]` attribute.
 
 The x86_64 build steps moved to `ubuntu-22.04-xlarge` (16 vCPU) in the
 v0.22 → v0.23 cycle, cutting build time roughly 30 min → ~12 min.
-Hardware-test binaries are stripped on the build host before upload
-(`hardware-test-binaries-stripped` artifact); unstripped originals are
-preserved as `coverage-binaries-aarch64` so source-line attribution
-still works during the post-target coverage merge.
+Hardware-test binaries are stripped on the build host into a
+`hardware-test-binaries-stripped/` directory and uploaded under the
+artifact name `hardware-test-binaries`; unstripped originals are
+preserved as the `coverage-binaries-aarch64` artifact so source-line
+attribution still works during the post-target coverage merge.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,7 +29,7 @@ lives in each sub-crate's `TESTING.md`:
 | `make test-rust` | Run Rust tests only with `cargo-llvm-cov nextest` |
 | `make test-python` | Run Python tests with pytest (and slipcover if available) |
 | `make test-capi` | Build the C library and run C API integration tests |
-| `make bench` | Run Rust criterion benchmarks |
+| `make bench` | Run the workspace Rust benchmarks (custom `harness = false` binaries backed by [`crates/bench`](https://github.com/EdgeFirstAI/hal/tree/main/crates/bench); not Criterion) |
 | `make build` | Build with coverage instrumentation (profiling profile) |
 | `make format lint check` | Pre-commit gate — required before every commit |
 
@@ -127,11 +127,19 @@ enforces this automatically via `cargo llvm-cov nextest ... -j 1`.
 
 Three independent constraints each require it:
 
-1. **EGL display sharing** — when multiple tests run in parallel threads
-   within one process, `eglTerminate` on one thread can tear down a
-   shared EGL display while other threads still reference it. This
-   causes intermittent failures that are difficult to reproduce and
-   platform-dependent.
+1. **GL driver concurrency bugs** — the HAL uses a process-global EGL
+   display (`SharedEglDisplay`) that is intentionally never terminated,
+   but the embedded GPU drivers it sits on top of still corrupt
+   driver-internal state under concurrent operations on that shared
+   display. Vivante `galcore` (i.MX 8M Plus) hits SIGSEGV at offset
+   `0x18` in its ioctl path and futex deadlocks when context creation,
+   DMA-BUF import, or draw commands overlap across threads; Broadcom
+   V3D 7.1.10.2 (Raspberry Pi 5) drops affected contexts into
+   `EGL(NotInitialized)` under similar pressure. The HAL's `GL_MUTEX`
+   serializes every GL/EGL call at runtime to keep this safe;
+   `--test-threads=1` extends the same discipline to test harness
+   processes, since `cargo nextest` runs each test in its own process
+   but multiple test processes still share the GPU driver state.
 2. **G2D driver state** — the `galcore` kernel driver maintains
    per-process state that is unsafe to access from concurrent threads
    creating and destroying G2D contexts.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,36 +1,45 @@
-# EdgeFirst HAL - Testing Guide
+# EdgeFirst HAL — Testing Guide
 
-**Version:** 1.0
-**Last Updated:** March 2026
-**Status:** Production
-**Audience:** Developers contributing to EdgeFirst HAL or running tests on target hardware
+**Audience:** developers contributing to EdgeFirst HAL or running tests on
+target hardware.
 
----
+This guide is the **cross-crate** testing reference. It covers the rules
+and patterns that apply across the whole workspace — single-threaded
+execution, on-target hardware gating, cross-compilation, optimization
+validation, coverage, and the CI matrix. Crate-specific testing detail
+lives in each sub-crate's `TESTING.md`:
 
-## Overview
-
-This guide consolidates all testing information for the EdgeFirst HAL project. Testing spans five categories: Rust unit tests, Python integration tests, C API integration tests, GL hardware-gated tests, and on-target tests. All categories share a single constraint: tests must run single-threaded.
+| Crate | Per-crate testing guide |
+|-------|------------------------|
+| `tensor` | [crates/tensor/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/TESTING.md) |
+| `image` | [crates/image/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md) — GL gating, fp16 benches |
+| `decoder` | [crates/decoder/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/TESTING.md) |
+| `tracker` | [crates/tracker/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/TESTING.md) |
+| `hal` (umbrella) | [crates/hal/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/TESTING.md) |
+| `capi` (C API) | [crates/capi/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/TESTING.md) — C suite, header parity check |
+| `python` | [crates/python/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/TESTING.md) — maturin develop, slipcover |
 
 ---
 
 ## Quick Reference
 
-| Makefile Target  | What It Does                                              |
-|------------------|-----------------------------------------------------------|
-| `make test`        | Run all tests (Rust + Python + C API) with coverage       |
-| `make test-rust`   | Run Rust tests only with `cargo-llvm-cov nextest`         |
-| `make test-python` | Run Python tests only with pytest (and slipcover if available) |
-| `make test-capi`   | Build the C library and run C API integration tests       |
-| `make bench`       | Run Rust criterion benchmarks                             |
-| `make build`       | Build with coverage instrumentation (profiling profile)   |
+| Makefile target | What it does |
+|-----------------|--------------|
+| `make test` | Run all tests (Rust + Python + C API) with coverage |
+| `make test-rust` | Run Rust tests only with `cargo-llvm-cov nextest` |
+| `make test-python` | Run Python tests with pytest (and slipcover if available) |
+| `make test-capi` | Build the C library and run C API integration tests |
+| `make bench` | Run Rust criterion benchmarks |
+| `make build` | Build with coverage instrumentation (profiling profile) |
+| `make format lint check` | Pre-commit gate — required before every commit |
 
-C API tests are also available individually from `crates/capi/tests/` using their own Makefile.
+C API tests are also available individually from
+[`crates/capi/tests/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/capi/tests)
+using their own Makefile.
 
 ---
 
 ## Required Toolchain
-
-The following tools must be installed before running tests:
 
 | Tool | Required | Purpose |
 |------|----------|---------|
@@ -48,7 +57,7 @@ cargo install cargo-llvm-cov --locked
 pip install maturin
 ```
 
-Install `slipcover` into the local virtual environment for coverage reports:
+Install `slipcover` into the local virtual environment for coverage:
 
 ```bash
 source venv/bin/activate
@@ -57,9 +66,7 @@ pip install slipcover
 
 ---
 
-## Test Categories
-
-### Rust Unit Tests
+## Rust Unit Tests
 
 Rust tests are co-located with source code in `#[cfg(test)]` modules:
 
@@ -75,162 +82,107 @@ mod tests {
 }
 ```
 
-Tests live in every crate under `crates/`: `tensor`, `image`, `decoder`, `tracker`, `hal`, `capi`, `gpu-probe`. The `edgefirst_hal` Python crate is excluded from most test runs because it requires a live Python interpreter.
+Every crate under `crates/` carries its own tests: `tensor`, `image`,
+`decoder`, `tracker`, `hal`, `capi`, `gpu-probe`. The `edgefirst_hal`
+Python crate is excluded from most workspace runs because it requires a
+live Python interpreter — see
+[`crates/python/TESTING.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/TESTING.md).
 
-### Python Integration Tests
+Cross-crate integration suites live in each crate's `tests/` directory;
+see the relevant per-crate `TESTING.md` for what each suite covers.
 
-Python tests are located in `tests/` and use pytest:
+---
 
-```
-tests/
-├── test_tensor.py
-├── image/
-│   ├── test_image.py
-│   └── test_image_perf.py
-└── decoder/
-    └── test_decoder.py
-```
+## On-Target Tests
 
-Python tests require the bindings to be built with `maturin develop` before running. Some tests use `pytest.mark.skipif` to gate platform-specific paths (e.g., DMA-BUF tests require `sys.platform == "linux"`). Benchmark tests use `pytest.mark.benchmark` with `warmup_iterations=3`.
+Tests that exercise DMA-heap or G2D acceleration require target hardware.
+They skip themselves on development machines when the required device
+nodes are absent.
 
-### C API Integration Tests
-
-C integration tests live in `crates/capi/tests/` and are built by their own Makefile. The test suite covers tensor, image, decoder, and tracker APIs:
-
-| Source File | Coverage Area |
-|-------------|---------------|
-| `test_tensor.c` | Tensor allocation, DMA-BUF, memory types |
-| `test_image.c` | Image loading, format conversion |
-| `test_decoder.c` | YOLO decoder, post-processing |
-| `test_tracker.c` | Object tracking API |
-| `test_neutron_dmabuf.c` | On-target Neutron NPU DMA-BUF regression |
-| `bench_preproc.c` | C preprocessing benchmark |
-
-Build and run:
-
-```bash
-# First build the C library
-cargo build --release -p edgefirst-hal-capi
-
-# Then build and run the C tests
-cd crates/capi/tests
-make test
-
-# Individual test suites
-make test_tensor
-make test_image
-make test_decoder
-make test_tracker
-
-# Memory check
-make valgrind
-```
-
-The Neutron DMA-BUF regression test (`test_neutron_dmabuf`) requires a live TFLite delegate and model; it must be run on target hardware with `NEUTRON_ENABLE_ZERO_COPY=1`.
-
-### GL Hardware-Gated Tests
-
-OpenGL and G2D tests inside `crates/image/src/gl/tests.rs` use `OnceLock<bool>` to probe hardware availability once and skip if the hardware is absent:
-
-```rust
-static GL_AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-
-fn is_opengl_available() -> bool {
-    *GL_AVAILABLE.get_or_init(|| GLProcessorThreaded::new(None).is_ok())
-}
-```
-
-A test that requires OpenGL calls `is_opengl_available()` at the start and returns early when it returns `false`. This keeps the test suite green on developer machines without GPU hardware, while exercising the full hardware path on target boards and CI runners with GPU access.
-
-The Neutron-scenario tests gate on `/dev/neutron0` as a platform discriminator for i.MX 95 with Mali GPU. This device node indicates that large-offset DMA-BUF EGLImage imports are supported — these fail with `EGL(BadAccess)` on Vivante (i.MX 8MP) even without the NPU driver:
-
-```rust
-fn is_neutron_available() -> bool {
-    *NEUTRON_AVAILABLE.get_or_init(|| std::path::Path::new("/dev/neutron0").exists())
-}
-```
-
-### On-Target Tests
-
-Tests that exercise DMA-heap or G2D acceleration require target hardware. They are automatically skipped on development machines when the required devices are absent.
-
-| Device Node | What It Gates |
+| Device node | What it gates |
 |-------------|---------------|
 | `/dev/dma_heap/linux,cma` or `/dev/dma_heap/system` | DMA-BUF tensor allocation tests |
 | `/dev/galcore` | G2D hardware acceleration tests |
 | `/dev/neutron0` | Neutron NPU DMA-BUF EGLImage tests |
 | `/dev/dri/renderD128` | DRM render node; required for DMA-buf backend |
 
+The hardware-gated test pattern (a single `OnceLock<bool>` probe that
+short-circuits on missing devices) is documented in
+[`crates/image/TESTING.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md#gl-hardware-gated-tests).
+
 ---
 
 ## Single-Threaded Execution
 
-**All tests must run single-threaded.** This is a hard requirement, not a recommendation.
+**All tests must run single-threaded.** This is a hard requirement, not a
+recommendation.
 
-Use `--test-threads=1` with `cargo test` and `-j 1` with `cargo nextest`. The Makefile enforces this automatically via `cargo llvm-cov nextest ... -j 1`.
+Use `--test-threads=1` with `cargo test` and `-j 1` with `cargo nextest`.
+The [`Makefile`](https://github.com/EdgeFirstAI/hal/blob/main/Makefile)
+enforces this automatically via `cargo llvm-cov nextest ... -j 1`.
 
-### Why Single-Threaded
+### Why single-threaded
 
-Three independent constraints each independently require single-threaded execution:
+Three independent constraints each require it:
 
-1. **EGL display sharing**: When multiple tests run in parallel threads within one process, `eglTerminate` on one thread can tear down a shared EGL display while other threads still reference it. This causes intermittent failures that are difficult to reproduce and platform-dependent.
+1. **EGL display sharing** — when multiple tests run in parallel threads
+   within one process, `eglTerminate` on one thread can tear down a
+   shared EGL display while other threads still reference it. This
+   causes intermittent failures that are difficult to reproduce and
+   platform-dependent.
+2. **G2D driver state** — the `galcore` kernel driver maintains
+   per-process state that is unsafe to access from concurrent threads
+   creating and destroying G2D contexts.
+3. **DMA-heap CMA pool exhaustion** — concurrent DMA-heap allocations
+   from multiple test threads can exhaust the CMA pool on
+   memory-constrained embedded targets, masking the real failures.
 
-2. **G2D driver state**: The `galcore` kernel driver maintains per-process state that is not safe to access from concurrent threads creating and destroying G2D contexts.
+`cargo nextest` already provides per-test process isolation, but `-j 1`
+is still required to prevent DMA and GPU contention across test
+processes.
 
-3. **DMA-heap CMA pool exhaustion**: Concurrent DMA-heap allocations from multiple test threads can exhaust the CMA pool on memory-constrained embedded targets, causing allocation failures that mask the real test failures.
-
-`cargo nextest` already provides per-test process isolation, but `-j 1` is still required to prevent DMA and GPU contention across test processes.
-
-This constraint applies to CI (`test.yml`), the Makefile, and local development. See ARCHITECTURE.md section "Testing with GPU Resources" for the full technical rationale.
+This constraint applies to CI, the Makefile, and local development.
+[`crates/image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#gl-command-serialization-gl_mutex)
+documents the GL_MUTEX implementation that makes the single-threaded rule
+load-bearing.
 
 ---
 
 ## Running Tests Locally
 
-### Native Development (x86_64)
+### Native development (x86_64)
 
 ```bash
 # 1. Run the full test suite (Rust + Python + C API) with coverage
 make test
 
-# 2. Run Rust tests only
+# 2. Rust tests only
 make test-rust
 
-# 3. Run Python tests only
+# 3. Python tests only
 make test-python
 
-# 4. Run Rust tests manually with nextest
+# 4. Rust tests manually with nextest
 cargo nextest run --workspace --exclude edgefirst_hal -j 1
 
-# 5. Run tests for a specific crate
-cargo test -p edgefirst_image -- --test-threads=1
-cargo test -p edgefirst_decoder -- --test-threads=1
-cargo test -p edgefirst_tensor -- --test-threads=1
+# 5. Tests for a specific crate
+cargo test -p edgefirst-image -- --test-threads=1
+cargo test -p edgefirst-decoder -- --test-threads=1
+cargo test -p edgefirst-tensor -- --test-threads=1
 ```
 
-### Python Test Setup
+### Per-language workflows
 
-Python tests require the native bindings to be installed into the virtual environment:
+Python: see
+[`crates/python/TESTING.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/TESTING.md)
+for the `maturin develop` + `pytest` + `slipcover` workflow.
 
-```bash
-# 1. Activate the virtual environment
-source venv/bin/activate
+C API: see
+[`crates/capi/TESTING.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/TESTING.md)
+for the Makefile-based C test suite, valgrind integration, and the
+cbindgen header parity check.
 
-# 2. Build and install the Python bindings in development mode
-maturin develop -m crates/python/Cargo.toml
-
-# 3. Run tests
-python -m pytest tests/
-
-# 4. Run a specific test module
-python -m pytest tests/image/test_image.py
-python -m pytest tests/decoder/test_decoder.py
-
-# 5. Run with coverage (if slipcover is installed)
-python -m slipcover --xml --out target/python-coverage.xml -m pytest tests/
-```
-
-### Disabling Hardware Backends
+### Disabling hardware backends
 
 Use environment variables to isolate tests to specific backends:
 
@@ -242,97 +194,80 @@ Use environment variables to isolate tests to specific backends:
 | `EDGEFIRST_FORCE_BACKEND=g2d` | Force G2D backend |
 | `EDGEFIRST_DISABLE_GL=1` | Disable OpenGL even when hardware is present |
 | `EDGEFIRST_DISABLE_G2D=1` | Disable G2D even when hardware is present |
+| `EDGEFIRST_FORCE_TRANSFER=pbo` / `=dmabuf` / `=sync` | Force GL transfer backend |
 
 Example — run tests without any GPU backend:
 
 ```bash
-EDGEFIRST_DISABLE_GL=1 EDGEFIRST_DISABLE_G2D=1 cargo test --workspace -- --test-threads=1
+EDGEFIRST_DISABLE_GL=1 EDGEFIRST_DISABLE_G2D=1 \
+  cargo test --workspace -- --test-threads=1
 ```
-
-### Benchmarking native fp16 paths (local only)
-
-The default build does **not** enable `+fp16` (aarch64) or `+f16c`
-(x86_64) — distributed HAL binaries stay on each target triple's
-baseline ISA so they run on older CPUs within the same triple.
-Benchmarks that need to exercise the native f16 mask kernel
-(`fused_dot_sigmoid_f16_slice`) must set `RUSTFLAGS` explicitly on
-the host that supports the extension.
-
-```bash
-# Orin Nano (Cortex-A78AE):
-RUSTFLAGS="-C target-cpu=cortex-a78ae" \
-    cargo bench -p edgefirst-image --bench mask_benchmark
-
-# Generic aarch64 with FEAT_FP16 (verify the host first —
-# imx8mp / Cortex-A53 will SIGILL):
-RUSTFLAGS="-C target-feature=+fp16" \
-    cargo bench -p edgefirst-image --bench mask_benchmark
-
-# x86_64 Haswell+ (enables the explicit _mm256_cvtph_ps intrinsic
-# kernel in addition to the scalar path):
-RUSTFLAGS="-C target-feature=+f16c,+fma,+avx2" \
-    cargo bench -p edgefirst-image --bench mask_benchmark
-```
-
-Verify the release build actually compiled to native instructions
-(not the soft-float `__extendhfsf2` helper) via
-`scripts/audit_f16_codegen.sh <target-triple>`. Requires
-`cargo install cargo-show-asm`.
 
 ---
 
 ## Cross-Compilation and On-Target Testing
 
-The project primarily targets ARM64 embedded Linux (NXP i.MX 8M Plus, i.MX 95). Tests that exercise DMA or GPU acceleration must run on physical hardware.
+The project primarily targets ARM64 embedded Linux (NXP i.MX 8M Plus,
+i.MX 95). Tests that exercise DMA or GPU acceleration must run on
+physical hardware.
 
-### Step 1: Cross-Compile Tests
+### Step 1 — Cross-compile tests
 
-Use `cargo-zigbuild` to produce test binaries without running them. Exclude the Python crate because PyO3 requires a target Python installation:
+Use `cargo-zigbuild` to produce test binaries without running them.
+Exclude the Python crate (PyO3 requires a target Python installation):
 
 ```bash
 cargo-zigbuild test --target aarch64-unknown-linux-gnu --release --no-run \
-    --workspace --exclude edgefirst_hal
+  --workspace --exclude edgefirst_hal
 ```
 
-Test binaries are written to `target/aarch64-unknown-linux-gnu/release/deps/`.
+Test binaries land in `target/aarch64-unknown-linux-gnu/release/deps/`.
 
-### Step 2: Copy Binaries to Target
+### Step 2 — Copy binaries to target
 
 ```bash
-# Copy test binaries (the hash suffix varies per build)
 scp target/aarch64-unknown-linux-gnu/release/deps/edgefirst_image-* user@target:/tmp/hal-tests/
 scp target/aarch64-unknown-linux-gnu/release/deps/edgefirst_tensor-* user@target:/tmp/hal-tests/
 scp target/aarch64-unknown-linux-gnu/release/deps/edgefirst_decoder-* user@target:/tmp/hal-tests/
 
-# Also copy test data
+# Also copy testdata
 scp -r testdata/ user@target:/tmp/hal-tests/
 ```
 
-### Step 3: Run Tests on Target
+### Step 3 — Run on target
 
 ```bash
-ssh user@target 'cd /tmp/hal-tests && ./edgefirst_image-<hash> --test-threads=1'
+ssh user@target 'cd /tmp/hal-tests && EDGEFIRST_TESTDATA_DIR=$(pwd)/testdata ./edgefirst_image-<hash> --test-threads=1'
 ```
 
-The `--test-threads=1` flag is mandatory on target hardware for the same reasons as local development — the CMA pool exhaustion risk is higher on embedded boards with limited memory.
+The `--test-threads=1` flag is mandatory on target for the same reasons
+as local development — CMA pool exhaustion risk is higher on embedded
+boards with limited memory.
+
+CI automates this flow in
+[`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml).
+Binaries are stripped on the build host (split debuginfo preserved for
+coverage attribution) and uploaded as the `hardware-test-binaries`
+artifact for the hardware runner to download.
 
 ---
 
 ## Validating Optimizations
 
 This section is the **testing-level reference** for the
-[Optimization Guide in README.md](README.md#optimization-guide). Each rule
-in that guide has a corresponding way to verify your integration follows
-it; this section documents those verification techniques.
+[Optimization Guide in README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide).
+Each rule in that guide has a corresponding way to verify your
+integration follows it; this section documents those techniques.
 
-### Verifying EGL Image Cache Hits
+### Verifying EGL image cache hits
 
 The OpenGL backend's EGL image cache emits a summary log line at process
-shutdown. Run any test or benchmark with `RUST_LOG=edgefirst_image=debug`:
+shutdown. Run any test or benchmark with
+`RUST_LOG=edgefirst_image=debug`:
 
 ```bash
 RUST_LOG=edgefirst_image=debug \
-    cargo test -p edgefirst-image --test ... -- --test-threads=1 2>&1 | tee cache.log
+  cargo test -p edgefirst-image --test ... -- --test-threads=1 2>&1 | tee cache.log
 ```
 
 Look for the final line:
@@ -341,29 +276,31 @@ Look for the final line:
 EglImageCache stats: 999 hits, 1 misses, 1 entries remaining
 ```
 
-A correctly-tuned camera pipeline reaches steady state with **misses ≈ pool
-depth** (one miss per unique physical buffer) and **hits ≈ frame count**.
-If `misses` grows linearly with frame count, the calling code is creating
-new tensor objects per frame — review the cache key (Rule 3 in the
-Optimization Guide).
+A correctly-tuned camera pipeline reaches steady state with **misses ≈
+pool depth** (one miss per unique physical buffer) and **hits ≈ frame
+count**. If `misses` grows linearly with frame count, the calling code
+is creating new tensor objects per frame — review the cache key (Rule 3
+in the Optimization Guide).
 
-The cache also logs `EglImageCache: swept N dead entries` when tensors are
-dropped while their entries are still in the cache. Frequent sweeps in a
-steady-state pipeline are a sign of leaked or churned tensor objects.
+The cache also logs `EglImageCache: swept N dead entries` when tensors
+are dropped while their entries are still in the cache. Frequent sweeps
+in a steady-state pipeline are a sign of leaked or churned tensor
+objects.
 
-### Verifying Backend Selection
+### Verifying backend selection
 
-The active backend is logged at `info` level when `ImageProcessor::new()`
-succeeds:
+The active backend is logged at `info` level when
+`ImageProcessor::new()` succeeds:
 
 ```text
 Shared EGL display initialized: kind=Wayland, transfer=DmaBuf
 ```
 
-This `transfer=` field is the **initial EGL display capability probe** and
-reports only `DmaBuf` or `Sync`. The effective transfer backend used for
-conversions (after `Sync -> Pbo` upgrade and any `EDGEFIRST_FORCE_TRANSFER`
-override) is logged when the GL converter is created:
+This `transfer=` field is the **initial EGL display capability probe**
+and reports only `DmaBuf` or `Sync`. The effective transfer backend used
+for conversions (after `Sync -> Pbo` upgrade and any
+`EDGEFIRST_FORCE_TRANSFER` override) is logged when the GL converter is
+created:
 
 ```text
 GLConverter created (transfer=Pbo)
@@ -380,17 +317,17 @@ environment variable from the table below and re-run with
 | `EDGEFIRST_FORCE_BACKEND=g2d` | G2D only — fails on non-i.MX | G2D-specific format pairs |
 | `EDGEFIRST_FORCE_TRANSFER=pbo` | PBO transfers even when DMA-buf is available | PBO path on Linux with DMA-buf hardware |
 | `EDGEFIRST_FORCE_TRANSFER=dmabuf` | DMA-buf transfers; fails if EGLImage import fails | DMA-buf path on systems where it normally falls back |
-| `EDGEFIRST_FORCE_TRANSFER=sync` | Memcpy upload/readback via `glTexImage2D` / `glReadnPixels` | Non-zero-copy baseline; useful for measuring the cost of the fast paths |
+| `EDGEFIRST_FORCE_TRANSFER=sync` | Memcpy upload/readback via `glTexImage2D` / `glReadnPixels` | Non-zero-copy baseline; useful for measuring fast-path cost |
 | `EDGEFIRST_TENSOR_FORCE_MEM=1` | Forces heap tensors; disables DMA / SHM | Pure-CPU regression baseline |
 
-### Regression Testing for Tensor Reuse
+### Regression testing for tensor reuse
 
-To catch regressions where a caller starts allocating a tensor per frame,
-gate the test on the cache miss count reported in the `EglImageCache stats`
-log line. The pattern below is illustrative — the `alloc_count()` accessor
-is **not** a stable public API. In practice, capture the log output and
-parse the `H hits, M misses` summary, or use the `bench_preproc` reuse
-variant (see below) as the regression baseline.
+To catch regressions where a caller starts allocating a tensor per
+frame, gate the test on the cache miss count reported in the
+`EglImageCache stats` log line. The pattern below is illustrative — the
+`alloc_count()` accessor is **not** a stable public API. In practice,
+capture the log output and parse the `H hits, M misses` summary, or use
+the `bench_preproc` reuse variant as the regression baseline.
 
 ```rust
 // Illustrative — alloc_count() is shown for clarity, not as a real API.
@@ -404,61 +341,64 @@ fn test_steady_state_no_realloc() {
     let src = load_image(&fixture_bytes(), Some(PixelFormat::Rgb), None).unwrap();
 
     // Warm-up
-    proc.convert(&src, &mut dst,
-                 Rotation::None, Flip::None, Crop::default()).unwrap();
+    proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default()).unwrap();
 
     // Steady state — every iteration must hit the EGL image cache.
     for _ in 0..100 {
-        proc.convert(&src, &mut dst,
-                     Rotation::None, Flip::None, Crop::default()).unwrap();
+        proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default()).unwrap();
     }
-    // Drop `proc` to flush the EglImageCache stats log line. Assert in the
-    // test harness that misses == 1 (the warm-up) by parsing the log.
+    // Drop `proc` to flush the EglImageCache stats log line. Assert in
+    // the test harness that misses == 1 (the warm-up) by parsing the log.
 }
 ```
 
-For the C API, `bench_preproc` (in `crates/capi/tests/bench_preproc.c`) is
-the reference reproduction of the allocate-once / reuse-every-frame pattern
-and serves as both a benchmark and a regression test.
+For the C API,
+[`bench_preproc`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/bench_preproc.c)
+is the reference reproduction of the allocate-once / reuse-every-frame
+pattern and serves as both a benchmark and a regression test.
 
-### Verifying the Inode-Keyed Cache (V4L2 / libcamera Integrations)
+### Verifying the inode-keyed cache (V4L2 / libcamera integrations)
 
 When integrating the HAL into a pipeline that consumes V4L2 or libcamera
 buffers, write an integration test that simulates fd recycling:
 
-1. Open a single `dma_buf` and obtain two distinct fd numbers via `dup()`.
+1. Open a single `dma_buf` and obtain two distinct fd numbers via
+   `dup()`.
 2. Import the first fd into HAL, run a `convert()`, and capture the EGL
    cache miss count.
 3. Close the first fd, then import the *second* fd (which refers to the
    same physical buffer).
-4. Run `convert()` again. If the calling code uses an inode-keyed cache,
-   it returns the existing tensor and the miss count does not increase.
-   If it uses an fd-keyed cache or skips caching entirely, the miss count
-   grows by one.
+4. Run `convert()` again. If the calling code uses an inode-keyed
+   cache, it returns the existing tensor and the miss count does not
+   increase. If it uses an fd-keyed cache or skips caching entirely,
+   the miss count grows by one.
 
 The Au-Zone GStreamer elements ship with this regression test in their
 own test suite; downstream integrators should write the equivalent for
-their pipeline.
+their pipeline. See
+[Appendix C in ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
+for the full identity-and-caching story.
 
-### Verifying the `from_numpy` Strided Fast-Path
+### Verifying the `from_numpy` strided fast-path
 
-Rule 7 in the [Optimization Guide](README.md#rule-7--numpy-interop-pass-arrays-straight-to-from_numpy)
-asserts that callers should not pre-apply `np.ascontiguousarray()` —
-HAL handles strided sources internally. Two regression tests in
-`tests/test_tensor.py` pin this:
+Rule 7 in the [Optimization Guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)
+asserts that callers should not pre-apply `np.ascontiguousarray()` — HAL
+handles strided sources internally. Two regression tests in
+[`tests/test_tensor.py`](https://github.com/EdgeFirstAI/hal/blob/main/tests/test_tensor.py)
+pin this:
 
 | Test | What it verifies |
-|---|---|
-| `test_from_numpy_hailort_shape` | Correctness on the HailoRT-shaped `(1, 116, 8400)` f32 transposed view (Path 3 of `copy_numpy_to_tensor_dyn`). The destination tensor matches the source values element-by-element. |
-| `test_from_numpy_hailort_shape_perf_sanity` | Perf bound: the automatic fast path runs no more than 1.5× the manual `np.ascontiguousarray + from_numpy(contig)` workaround. Prior to PR #58 the ratio was ≈ 10×. |
+|------|------------------|
+| `test_from_numpy_hailort_shape` | Correctness on the HailoRT-shaped `(1, 116, 8400)` f32 transposed view (Path 3 of `copy_numpy_to_tensor_dyn`). Destination matches source element-by-element. |
+| `test_from_numpy_hailort_shape_perf_sanity` | Perf bound: automatic fast path runs no more than 1.5× the manual `np.ascontiguousarray + from_numpy(contig)` workaround. Prior to PR #58 the ratio was ≈ 10×. |
 
-Both tests are in the standard Python suite and run in CI. If the
-perf-sanity test fails, suspect a regression in `numpy.ascontiguousarray`
-behaviour or in the Path-3 dispatch logic in `crates/python/src/tensor.rs`.
+Both run in CI. If the perf-sanity test fails, suspect a regression in
+`numpy.ascontiguousarray` behaviour or in the Path-3 dispatch logic in
+[`crates/python/src/tensor.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/src/tensor.rs).
 
-### Verifying `MaskResolution` Selection in COCO Validators
+### Verifying `MaskResolution` selection in COCO validators
 
-Rule 8 in the [Optimization Guide](README.md#rule-8--choose-the-correct-maskresolution-for-your-evaluation)
+Rule 8 in the [Optimization Guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)
 asserts that COCO / IoU evaluation must use `MaskResolution::Scaled`,
 not the default `Proto`. Downstream validators should pin this with a
 small assertion at the materialize call site:
@@ -469,8 +409,8 @@ masks = proc.materialize_masks(
     letterbox=letterbox_norm,
     resolution=hal.MaskResolution.Scaled(orig_w, orig_h),
 )
-# Smoke-check the contract: tile shape (h, w, 1) uint8 at
-# orig-image resolution, binary {0, 255} after upsample-then-threshold.
+# Smoke-check the contract: tile shape (h, w, 1) uint8 at orig-image
+# resolution, binary {0, 255} after upsample-then-threshold.
 assert masks[0].shape[2] == 1
 assert masks[0].dtype == np.uint8
 ```
@@ -481,10 +421,10 @@ inspect this call first — the most common cause is calling
 and then thresholding the proto-resolution sigmoid in caller code
 before resizing, which produces blocky binary edges.
 
-### Quantifying Native CPU Feature Builds
+### Quantifying native CPU feature builds
 
-When benchmarking with `RUSTFLAGS="-C target-feature=+fp16"` (or `+f16c` on
-x86_64), confirm the kernel actually compiled to native instructions
+When benchmarking with `RUSTFLAGS="-C target-feature=+fp16"` (or `+f16c`
+on x86_64), confirm the kernel actually compiled to native instructions
 rather than the soft-float helper:
 
 ```bash
@@ -493,25 +433,30 @@ scripts/audit_f16_codegen.sh aarch64-unknown-linux-gnu
 
 The script disassembles a release build and fails if `__extendhfsf2` is
 present (soft-float fallback) or if `fcvt` / `vcvtph2ps` is absent. See
-[§ Benchmarking native fp16 paths](#benchmarking-native-fp16-paths-local-only)
-above for the full workflow.
+[`crates/image/TESTING.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md#native-fp16--avx2-build-overrides-for-local-benchmarking)
+for the full f16 benchmarking workflow.
 
 ---
 
 ## Coverage Thresholds
 
-| Scope | Minimum Threshold |
+| Scope | Minimum threshold |
 |-------|-------------------|
 | Overall workspace | 70% line coverage |
 | Critical paths (tensor ops, decoder, image processing hot paths) | 90% line coverage |
 
-Coverage is collected using `cargo-llvm-cov` for Rust and `slipcover` for Python. Both generate LCOV reports that are merged and reported to SonarCloud.
+Coverage is collected using `cargo-llvm-cov` for Rust and `slipcover` for
+Python. Both generate LCOV reports that are merged and reported to
+SonarCloud.
 
 Coverage reports:
 - Rust: `target/rust-coverage.lcov`
 - Python: `target/python-coverage.xml`
 
-CI enforces coverage gating on pull requests. A failing coverage check blocks the merge.
+CI enforces coverage gating on pull requests. A failing coverage check
+blocks the merge. See
+[`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml)
+for the merge logic between host-side and hardware-runner-side coverage.
 
 ---
 
@@ -521,19 +466,31 @@ Tests run across multiple runner types:
 
 | Job | Runner | Architecture | Hardware |
 |-----|--------|--------------|----------|
-| Build & Test (x86_64) | ubuntu-22.04 | x86_64 | No GPU |
-| Build & Test (macOS) | macos-latest | x86_64/arm64 | No GPU |
-| Build (aarch64) | ubuntu-22.04-arm-xlarge | aarch64 | No GPU (compile only) |
-| Test (aarch64) | ubuntu-22.04-arm | aarch64 | No GPU |
-| Hardware Test (imx8mp) | nxp-imx8mp-latest | aarch64 | G2D, DMA-heap |
+| Build & Test (x86_64) | `ubuntu-22.04-xlarge` | x86_64 | No GPU |
+| Doc Tests | `ubuntu-22.04-xlarge` | x86_64 | No GPU |
+| Build & Test (macOS) | `macos-latest` | x86_64 / arm64 | No GPU |
+| Build (aarch64) | `ubuntu-22.04-arm-xlarge` | aarch64 | No GPU (compile only) |
+| Test (aarch64) | `ubuntu-22.04-arm` | aarch64 | No GPU |
+| Hardware Test (imx8mp) | `nxp-imx8mp-latest` | aarch64 | G2D, DMA-heap |
+| Process Hardware Coverage | `ubuntu-22.04-arm` | aarch64 | (post-processing host) |
 
-The hardware runner (`nxp-imx8mp-latest`) is the only environment where G2D and DMA-BUF tests are fully exercised. Hardware-gated tests that return early on the x86 and arm runners are counted as passed (not skipped) because the gate is an explicit probe, not a `#[ignore]` attribute.
+The hardware runner (`nxp-imx8mp-latest`) is the only environment where
+G2D and DMA-BUF tests are fully exercised. Hardware-gated tests that
+return early on x86 and arm runners are counted as passed (not skipped)
+because the gate is an explicit probe, not a `#[ignore]` attribute.
+
+The x86_64 build steps moved to `ubuntu-22.04-xlarge` (16 vCPU) in the
+v0.22 → v0.23 cycle, cutting build time roughly 30 min → ~12 min.
+Hardware-test binaries are stripped on the build host before upload
+(`hardware-test-binaries-stripped` artifact); unstripped originals are
+preserved as `coverage-binaries-aarch64` so source-line attribution
+still works during the post-target coverage merge.
 
 ---
 
 ## Common Failures and Remedies
 
-| Symptom | Likely Cause | Remedy |
+| Symptom | Likely cause | Remedy |
 |---------|--------------|--------|
 | Intermittent EGL segfault | Tests running in parallel | Ensure `--test-threads=1` / `-j 1` |
 | `DMA-heap allocation failed` on target | CMA pool exhaustion from parallel tests | Reduce parallelism; use `-j 1` |
@@ -542,3 +499,5 @@ The hardware runner (`nxp-imx8mp-latest`) is the only environment where G2D and 
 | Python tests fail with `ModuleNotFoundError` | Bindings not built | `maturin develop -m crates/python/Cargo.toml` |
 | C API tests fail with `libedgefirst_hal.so not found` | C library not built | `cargo build --release -p edgefirst-hal-capi` |
 | GL tests all skip | No EGL display available | Expected on headless CI; set `DISPLAY` or use a virtual framebuffer |
+| `EDGEFIRST_TESTDATA_DIR not set` panic | Running cross-compiled bench without env | Export `EDGEFIRST_TESTDATA_DIR=$(pwd)/testdata` on target |
+| CI fmt / clippy failure | Local gate skipped | Run `make format lint check` before committing |

--- a/TESTING.md
+++ b/TESTING.md
@@ -492,13 +492,14 @@ for the full f16 benchmarking workflow.
 | Overall workspace | 70% line coverage |
 | Critical paths (tensor ops, decoder, image processing hot paths) | 90% line coverage |
 
-Coverage is collected using `cargo-llvm-cov` for Rust and `slipcover` for
-Python. Both generate LCOV reports that are merged and reported to
-SonarCloud.
+Coverage is collected using `cargo-llvm-cov` for Rust (LCOV output) and
+`slipcover --xml` for Python (Cobertura XML output). The two formats
+are uploaded to SonarCloud separately; the merge happens on the
+SonarCloud side, not in the workspace.
 
 Coverage reports:
-- Rust: `target/rust-coverage.lcov`
-- Python: `target/python-coverage.xml`
+- Rust: `target/rust-coverage.lcov` (LCOV)
+- Python: `target/python-coverage.xml` (Cobertura XML)
 
 CI enforces coverage gating on pull requests. A failing coverage check
 blocks the merge. See

--- a/TESTING.md
+++ b/TESTING.md
@@ -82,8 +82,10 @@ mod tests {
 }
 ```
 
-Every crate under `crates/` carries its own tests: `tensor`, `image`,
-`decoder`, `tracker`, `hal`, `capi`, `gpu-probe`. The `edgefirst_hal`
+Most crates under `crates/` carry their own Rust tests: `tensor`, `image`,
+`decoder`, `tracker`, `hal`, `capi`, and `bench`. The `gpu-probe` crate
+ships no `#[test]` modules — it is a runtime probe binary and is exercised
+indirectly through the tensor/image suites it informs. The `edgefirst_hal`
 Python crate is excluded from most workspace runs because it requires a
 live Python interpreter — see
 [`crates/python/TESTING.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/TESTING.md).

--- a/TESTING.md
+++ b/TESTING.md
@@ -106,7 +106,7 @@ nodes are absent.
 | `/dev/dma_heap/linux,cma` or `/dev/dma_heap/system` | DMA-BUF tensor allocation tests |
 | `/dev/galcore` | G2D hardware acceleration tests |
 | `/dev/neutron0` | Neutron NPU DMA-BUF EGLImage tests |
-| `/dev/dri/renderD128` | DRM render node; required for DMA-buf backend |
+| `/dev/dri/renderD128` (preferred) or `/dev/dri/card0` / `/dev/dri/card1` | DRM render/card node; the GL context opens the first that exists, so any one is sufficient |
 
 The hardware-gated test pattern (a single `OnceLock<bool>` probe that
 short-circuits on missing devices) is documented in
@@ -515,7 +515,7 @@ Tests run across multiple runner types:
 |-----|--------|--------------|----------|
 | Build & Test (x86_64) | `ubuntu-22.04-xlarge` | x86_64 | No GPU |
 | Doc Tests | `ubuntu-22.04-xlarge` | x86_64 | No GPU |
-| Build & Test (macOS) | `macos-latest` | x86_64 / arm64 | No GPU |
+| Build & Test (macOS) | `macos-latest` | arm64 (Apple Silicon) | No GPU |
 | Build (aarch64) | `ubuntu-22.04-arm-xlarge` | aarch64 | No GPU (compile only) |
 | Test (aarch64) | `ubuntu-22.04-arm` | aarch64 | No GPU |
 | Hardware Test (imx8mp) | `nxp-imx8mp-latest` | aarch64 | G2D, DMA-heap |

--- a/crates/capi/ARCHITECTURE.md
+++ b/crates/capi/ARCHITECTURE.md
@@ -48,7 +48,7 @@ struct churn — only the function signatures form the stable contract.
 | `struct hal_plane_descriptor *` | `edgefirst_tensor::PlaneDescriptor` | `hal_plane_descriptor_free` ONLY if the descriptor was never passed to `hal_import_image`. The import call consumes both descriptors unconditionally (success and failure paths alike — see `hal_import_image` docs), so calling `_free` after `_import_image` is a double-free. |
 | `struct hal_image_processor *` | `edgefirst_image::ImageProcessor` | `hal_image_processor_free` |
 | `struct hal_decoder *` | `edgefirst_decoder::Decoder` | `hal_decoder_free` |
-| `struct hal_decoder_params *` | `edgefirst_decoder::DecoderBuilder` (in-progress) | consumed by `hal_decoder_new` |
+| `struct hal_decoder_params *` | `edgefirst_decoder::DecoderBuilder` (in-progress) | `hal_decoder_params_free`. The handle is **not** consumed by `hal_decoder_new` — that call takes `const struct hal_decoder_params *` and clones the configuration into the new decoder, so the caller still owns the params and must free them after `hal_decoder_new` returns. |
 | `struct hal_detect_box_list *` | `Vec<DetectBox>` | `hal_detect_box_list_free` |
 | `struct hal_segmentation_list *` | `Vec<Segmentation>` | `hal_segmentation_list_free` |
 | `struct hal_bytetrack *` | `edgefirst_tracker::ByteTrack<DetectBox>` | `hal_bytetrack_free` |

--- a/crates/capi/ARCHITECTURE.md
+++ b/crates/capi/ARCHITECTURE.md
@@ -68,16 +68,31 @@ All `hal_*_free` functions accept `NULL` safely (no-op).
 `hal_error_message(errno_value)` returns a static string description for
 logging.
 
+### errno lifecycle
+
+The HAL only sets `errno` on failure paths; success paths leave it
+untouched. Some functions touch `errno` internally even when they
+succeed (e.g. probing whether an optional kernel device exists), so the
+value may be non-zero after a successful call. Integrators that surface
+`errno` to a higher logging layer should snapshot it **immediately**
+after the HAL call they care about, and clear it (`errno = 0;`) before
+the next call whose errno they intend to inspect. Never rely on `errno`
+to indicate success — always check the return value (`-1` / `NULL` /
+`0`) first and only then inspect `errno`.
+
 ## cbindgen Pipeline
 
 `crates/capi/build.rs` runs `cbindgen` against
 [`crates/capi/cbindgen.toml`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/cbindgen.toml)
 during a normal `cargo build`. The header is emitted to
 [`crates/capi/include/edgefirst/hal.h`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/include/edgefirst/hal.h)
-and is committed to the repository so downstream consumers can read the ABI
-without compiling Rust. CI verifies the committed header matches the
-freshly generated one (via the SBOM workflow's `make sbom` step) — drift
-between the two breaks the build.
+and is committed to the repository so downstream consumers can read the
+ABI without compiling Rust. The committed header is regenerated whenever
+the Rust source changes; contributors are expected to re-run
+`cargo build -p edgefirst-hal-capi` and commit the updated header along
+with their FFI change. CI does not currently run an explicit
+`git diff --exit-code` parity check on the header, so review is the
+gate against drift.
 
 The header preamble defines `HAL_DTYPE_*`, `HAL_PIXEL_FORMAT_*`,
 `HAL_TENSOR_MEMORY_*`, `HAL_ROTATION_*`, `HAL_FLIP_*`, and the
@@ -165,7 +180,7 @@ struct hal_tensor *mid = hal_image_processor_create_image(
 
 // Destination: PlanarRgb for model input, also processor-allocated.
 struct hal_tensor *dst = hal_image_processor_create_image(
-    proc, model_w, model_h, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
+    proc, model_w, model_h, HAL_PIXEL_FORMAT_PLANAR_RGB, HAL_DTYPE_U8);
 ```
 
 When the external buffer has row padding (`stride > width * bytes_per_pixel`),
@@ -275,6 +290,31 @@ if (pool_tensors[buf_index] == NULL) {
 | `hal_plane_descriptor_new()` | Dups eagerly — caller retains original | Never |
 | `hal_import_image()` | Consumes both descriptors (success or fail) | Never (descriptors already duped the fd) |
 | `hal_tensor_from_fd()` | Dups internally — caller retains original | Never |
+
+### Tensor ownership: cached imports vs. fresh allocations
+
+Once you adopt an inode-keyed cache, the `struct hal_tensor *` you hand
+to `hal_image_processor_convert()` will be one of two kinds:
+
+| Kind | Source | Caller must `hal_tensor_free`? | Notes |
+|------|--------|--------------------------------|-------|
+| **Cached** | returned from your `(inode, offset)` cache lookup; created **once** at the first cache miss via `hal_import_image()` / `hal_tensor_from_fd()` | **No** — the cache owns it for the lifetime of the pipeline | Freeing mid-pipeline drops the EGL image cache entry, churns `BufferIdentity`, and turns every subsequent frame into an import miss |
+| **Fresh** | allocated for this call (system-memory fallback when the source has no DMA-BUF, intermediate `create_image()` for chained `convert()`) | **Yes** — exactly once, after the last `convert()` that uses it | Forgetting leaks the underlying memory backend (DMA-BUF fd, PBO, or heap) |
+
+A robust pattern tracks the distinction with a small flag alongside the
+tensor pointer, e.g. an output parameter from the helper that produces
+the source tensor:
+
+```c
+struct hal_tensor *src = lookup_or_import(cache, fd, &src_owned);
+hal_image_processor_convert(proc, src, dst, /* ... */);
+if (src_owned) hal_tensor_free(src);   // only when not cached
+```
+
+The same distinction applies to destination tensors when chaining
+multiple `convert()` calls: the intermediate `create_image()` allocation
+is owned by the chain orchestrator and must be freed once at the end
+(not after each `convert()`).
 
 ### Anti-patterns
 
@@ -604,12 +644,6 @@ Delegate functions are not required to be thread-safe for concurrent
 calls on the same delegate instance. Callers must serialize access per
 delegate. Different delegate instances may be used concurrently from
 different threads.
-
-### Tracking
-
-- Epic: [EDGEAI-1185](https://au-zone.atlassian.net/browse/EDGEAI-1185) — NXP Neutron DMABUF Zero-Copy Support
-- Type definitions: [EDGEAI-1189](https://au-zone.atlassian.net/browse/EDGEAI-1189) — formalize `hal_dmabuf_*` interface
-- Implementation: [EDGEAI-1190](https://au-zone.atlassian.net/browse/EDGEAI-1190) — edgefirst-tflite probing for `hal_dmabuf_*` symbols
 
 ## Logging API
 

--- a/crates/capi/ARCHITECTURE.md
+++ b/crates/capi/ARCHITECTURE.md
@@ -45,7 +45,7 @@ struct churn — only the function signatures form the stable contract.
 |--------|-------|-----------|
 | `struct hal_tensor *` | `edgefirst_tensor::TensorDyn` | `hal_tensor_free` |
 | `struct hal_tensor_map *` | `TensorMap<T>` (RAII guard) | `hal_tensor_map_unmap` |
-| `struct hal_plane_descriptor *` | `edgefirst_tensor::PlaneDescriptor` | (consumed by `hal_import_image`, never freed by caller) |
+| `struct hal_plane_descriptor *` | `edgefirst_tensor::PlaneDescriptor` | `hal_plane_descriptor_free` if NOT consumed by `hal_import_image`; the import call takes ownership on success, so the caller must only free descriptors on abort/error paths before calling import |
 | `struct hal_image_processor *` | `edgefirst_image::ImageProcessor` | `hal_image_processor_free` |
 | `struct hal_decoder *` | `edgefirst_decoder::Decoder` | `hal_decoder_free` |
 | `struct hal_decoder_params *` | `edgefirst_decoder::DecoderBuilder` (in-progress) | consumed by `hal_decoder_new` |

--- a/crates/capi/ARCHITECTURE.md
+++ b/crates/capi/ARCHITECTURE.md
@@ -45,7 +45,7 @@ struct churn — only the function signatures form the stable contract.
 |--------|-------|-----------|
 | `struct hal_tensor *` | `edgefirst_tensor::TensorDyn` | `hal_tensor_free` |
 | `struct hal_tensor_map *` | `TensorMap<T>` (RAII guard) | `hal_tensor_map_unmap` |
-| `struct hal_plane_descriptor *` | `edgefirst_tensor::PlaneDescriptor` | `hal_plane_descriptor_free` if NOT consumed by `hal_import_image`; the import call takes ownership on success, so the caller must only free descriptors on abort/error paths before calling import |
+| `struct hal_plane_descriptor *` | `edgefirst_tensor::PlaneDescriptor` | `hal_plane_descriptor_free` ONLY if the descriptor was never passed to `hal_import_image`. The import call consumes both descriptors unconditionally (success and failure paths alike — see `hal_import_image` docs), so calling `_free` after `_import_image` is a double-free. |
 | `struct hal_image_processor *` | `edgefirst_image::ImageProcessor` | `hal_image_processor_free` |
 | `struct hal_decoder *` | `edgefirst_decoder::Decoder` | `hal_decoder_free` |
 | `struct hal_decoder_params *` | `edgefirst_decoder::DecoderBuilder` (in-progress) | consumed by `hal_decoder_new` |

--- a/crates/capi/ARCHITECTURE.md
+++ b/crates/capi/ARCHITECTURE.md
@@ -1,0 +1,654 @@
+# edgefirst-hal-capi Architecture
+
+## Overview
+
+`edgefirst-hal-capi` is the C API layer over the EdgeFirst HAL Rust
+workspace. It exposes tensor allocation, hardware-accelerated image
+processing, ML decoder post-processing, ByteTrack object tracking, and the
+delegate DMA-BUF framework as a stable C ABI suitable for consumption from
+C, C++, GStreamer plugins, OpenCV pipelines, NPU delegates, and Python
+extensions written outside PyO3. Headers are generated from Rust source
+annotations via `cbindgen`; the implementation builds as both `staticlib`
+and `cdylib`.
+
+This crate is the highest-stakes ABI surface in the workspace. Performance
+recommendations and lifecycle rules are not advisory — getting them wrong
+loses the zero-copy property of the underlying Rust APIs and makes the
+DMA-BUF / EGL / GL pipeline several times slower than its theoretical
+ceiling. The largest section of this document is therefore the
+[Performance recommendations](#performance-recommendations-dma-buf--egl-path)
+that downstream integrators must follow.
+
+## Module Map
+
+| Module | Source | Responsibility |
+|--------|--------|----------------|
+| [`lib.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/lib.rs) | local | crate-wide setup, panic-safe FFI helpers, error reporting |
+| [`tensor.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/tensor.rs) | local | ~1.2k lines — `hal_tensor_*` create/map/reshape/fd-share, `hal_plane_descriptor_*` |
+| [`image.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/image.rs) | local | ~2.6k lines — `hal_image_processor_*`, convert, draw masks (and tracked variants) |
+| [`decoder.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/decoder.rs) | local | ~3.2k lines — `hal_decoder_*` create / decode detection / decode segmentation |
+| [`tracker.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/tracker.rs) | local | ~300 lines — `hal_bytetrack_*` create / update / get_active_tracks |
+| [`delegate.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/delegate.rs) | local | ~200 lines — Delegate DMA-BUF ABI types and camera adaptor format info |
+| [`trace.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/trace.rs) | local | `hal_start_tracing` / `hal_stop_tracing` — surfaces the umbrella's tracing API |
+| [`error.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/error.rs) | local | ~120 lines — error code conversion and `hal_error_message` helper |
+| [`log.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/src/log.rs) | local | ~50 lines — `hal_log_init_file` / `hal_log_init_callback` |
+| [`include/edgefirst/hal.h`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/include/edgefirst/hal.h) | generated | cbindgen-emitted header consumed by C/C++ users |
+
+## Key Types
+
+The ABI is built on **opaque handle pointers**: C code holds
+`struct hal_tensor *`, `struct hal_image_processor *`, etc., and never
+inspects the layout. This insulates downstream binaries from internal
+struct churn — only the function signatures form the stable contract.
+
+| C type | Wraps | Free with |
+|--------|-------|-----------|
+| `struct hal_tensor *` | `edgefirst_tensor::TensorDyn` | `hal_tensor_free` |
+| `struct hal_tensor_map *` | `TensorMap<T>` (RAII guard) | `hal_tensor_map_unmap` |
+| `struct hal_plane_descriptor *` | `edgefirst_tensor::PlaneDescriptor` | (consumed by `hal_import_image`, never freed by caller) |
+| `struct hal_image_processor *` | `edgefirst_image::ImageProcessor` | `hal_image_processor_free` |
+| `struct hal_decoder *` | `edgefirst_decoder::Decoder` | `hal_decoder_free` |
+| `struct hal_decoder_params *` | `edgefirst_decoder::DecoderBuilder` (in-progress) | consumed by `hal_decoder_new` |
+| `struct hal_detect_box_list *` | `Vec<DetectBox>` | `hal_detect_box_list_free` |
+| `struct hal_segmentation_list *` | `Vec<Segmentation>` | `hal_segmentation_list_free` |
+| `struct hal_bytetrack *` | `edgefirst_tracker::ByteTrack<DetectBox>` | `hal_bytetrack_free` |
+| `struct hal_track_info_list *` | `Vec<TrackInfo>` | `hal_track_info_list_free` |
+| `hal_delegate_t` | opaque `void *` for delegate DMA-BUF queries | (caller-managed) |
+
+All `hal_*_free` functions accept `NULL` safely (no-op).
+
+## Error Convention
+
+| Return type | Success | Failure | Detail |
+|-------------|---------|---------|--------|
+| `int` | `0` | `-1` with `errno` set | `EINVAL`, `ENOMEM`, `EIO`, `ENOTSUP`, `ERANGE`, ... |
+| pointer | non-NULL | `NULL` with `errno` set | Same set |
+| `size_t` | actual size | `0` if handle is `NULL` | Treat `0` as "missing handle" |
+
+`hal_error_message(errno_value)` returns a static string description for
+logging.
+
+## cbindgen Pipeline
+
+`crates/capi/build.rs` runs `cbindgen` against
+[`crates/capi/cbindgen.toml`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/cbindgen.toml)
+during a normal `cargo build`. The header is emitted to
+[`crates/capi/include/edgefirst/hal.h`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/include/edgefirst/hal.h)
+and is committed to the repository so downstream consumers can read the ABI
+without compiling Rust. CI verifies the committed header matches the
+freshly generated one (via the SBOM workflow's `make sbom` step) — drift
+between the two breaks the build.
+
+The header preamble defines `HAL_DTYPE_*`, `HAL_PIXEL_FORMAT_*`,
+`HAL_TENSOR_MEMORY_*`, `HAL_ROTATION_*`, `HAL_FLIP_*`, and the
+`HAL_LOG_LEVEL_*` enums in plain C — no `enum class` or other C++-specific
+constructs — to keep the surface usable from straight C.
+
+## Performance Recommendations (DMA-BUF / EGL Path)
+
+> **Reference implementation:** the
+> [`bench_preproc`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/bench_preproc.c)
+> C benchmark demonstrates every pattern below in a complete, runnable
+> program. Build with `make bench` from
+> [`crates/capi/tests/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/capi/tests).
+
+These patterns apply when using the DMA-BUF tensor APIs
+(`hal_import_image()`, `hal_tensor_from_fd()`) together with
+`hal_image_processor_convert()` from C or C++.
+
+### Core principle: allocate once, reuse every frame, free on exit
+
+Every call to the tensor-from-fd family of functions allocates a new
+`BufferIdentity` with a globally unique ID. The OpenGL EGL image cache is
+keyed by this ID (see
+[`crates/image/ARCHITECTURE.md#egl-image-cache`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#egl-image-cache)).
+A new identity = cache miss = full `eglCreateImageKHR` import on the next
+`convert()` call. On the i.MX 8M Plus this costs roughly 0.5–1.5 ms per
+import — enough to drop below real-time at 30 fps when source and
+destination are both re-imported every frame.
+
+The correct lifecycle is three phases:
+
+```text
+INIT                           LOOP                          TEARDOWN
+─────────────────────────      ──────────────────────────    ─────────────
+Allocate processor             Reuse same tensors            Free tensors
+Allocate src/dst tensors       Call convert()                Free processor
+(from fd or create_image)      (EGL cache hits)
+```
+
+### Phase 1 — Initialization
+
+Allocate all tensors before entering the processing loop. When the source
+dimensions are not known until the first frame arrives (e.g., V4L2
+resolution negotiation), allocate on first use and keep the tensors for
+all subsequent frames.
+
+> **Important:** when using `hal_image_processor_convert()`, all
+> internally-allocated tensors (intermediate buffers, output buffers)
+> **must** be created via `hal_image_processor_create_image()`, **not**
+> via `hal_tensor_new()` or `hal_tensor_from_fd()`. The processor's
+> `create_image` method selects the optimal memory backend for the active
+> GPU: DMA-BUF when the GPU uses EGLImage imports (Vivante, Mali), PBO
+> when it uses pixel buffer transfers (NVIDIA desktop), heap as fallback.
+> Using `hal_tensor_new()` with a hardcoded memory type bypasses this
+> selection and can force a slow transfer path.
+>
+> **`hal_import_image` is NOT the same as `create_image`.** Despite living
+> on the processor object, `hal_import_image()` does not use the
+> processor's backend intelligence — it simply wraps an external DMA-BUF
+> fd as a DMA tensor. It exists only for importing buffers that are
+> **externally allocated** by V4L2, GStreamer, or codec output.
+
+| Function | Use for | Memory selection |
+|----------|---------|-----------------|
+| `hal_image_processor_create_image()` | Intermediate and output buffers | **Auto** (DMA / PBO / Mem based on GPU) |
+| `hal_import_image()` | External DMA-BUF import only | Always DMA (wraps caller's fd) |
+| `hal_tensor_new()` / `hal_tensor_from_fd()` | Low-level tensor creation | Caller-specified (no GPU awareness) |
+
+```c
+// --- Initialization (once) -----------------------------------------------
+
+struct hal_image_processor *proc = hal_image_processor_new();
+
+// Source: external DMA-BUF from a V4L2 capture buffer.
+// hal_plane_descriptor_new dups the fd — caller keeps its copy.
+struct hal_plane_descriptor *pd = hal_plane_descriptor_new(v4l2_buf.m.fd);
+struct hal_tensor *src = hal_import_image(
+    proc, pd, NULL, width, height, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+// pd is consumed by hal_import_image — do NOT free
+
+// Intermediate: processor-allocated RGBA for chained conversion.
+// MUST use create_image (not hal_tensor_new) for optimal memory backend.
+struct hal_tensor *mid = hal_image_processor_create_image(
+    proc, model_w, model_h, HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8);
+
+// Destination: PlanarRgb for model input, also processor-allocated.
+struct hal_tensor *dst = hal_image_processor_create_image(
+    proc, model_w, model_h, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
+```
+
+When the external buffer has row padding (`stride > width * bytes_per_pixel`),
+set the stride on the plane descriptor:
+
+```c
+struct hal_plane_descriptor *pd = hal_plane_descriptor_new(v4l2_buf.m.fd);
+hal_plane_descriptor_set_stride(pd, v4l2_fmt.fmt.pix.bytesperline);
+struct hal_tensor *src = hal_import_image(
+    proc, pd, NULL, width, height, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+```
+
+### Phase 2 — Main processing loop
+
+Reuse the same tensor objects on every frame. The EGL image cache hits on
+the second and all subsequent iterations because `BufferIdentity.id` has
+not changed.
+
+```c
+while (running) {
+    // Upstream writes new pixel data into the DMA-BUF (V4L2 DQBUF, decoder
+    // output, etc.). The tensor and its cached EGLImage remain valid — no
+    // need to recreate anything. EGLImage is a handle to live physical
+    // memory, not a snapshot.
+
+    // Two-pass conversion: NV12 → RGBA → PlanarRgb
+    hal_image_processor_convert(proc, src, mid,
+                                HAL_ROTATION_NONE, HAL_FLIP_NONE, &crop);
+    hal_image_processor_convert(proc, mid, dst,
+                                HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
+
+    // Feed dst to the model ...
+}
+```
+
+Both `mid` entries (destination in pass 1, source in pass 2) live in
+independent EGL image caches (`dst_egl_cache` and `src_egl_cache`), so
+both sides achieve cache hits after the first frame.
+
+The `glFinish()` issued at the end of each `convert()` call guarantees
+coherency, making chained calls safe without explicit synchronization.
+
+### Phase 3 — Teardown
+
+Free tensors only when the pipeline is torn down — typically at program
+exit or when a pipeline is reconfigured (e.g., resolution change):
+
+```c
+hal_tensor_free(dst);
+hal_tensor_free(mid);
+hal_tensor_free(src);
+hal_image_processor_free(proc);
+```
+
+### Buffer pool integration (V4L2 / GStreamer)
+
+When upstream provides DMA-BUF fds from a buffer pool (V4L2 MMAP,
+GStreamer allocator, codec output ring), a small number of physical
+buffers cycle through a queue. Map each pool slot to a HAL tensor that is
+created once and reused whenever that slot is dequeued.
+
+```c
+#define N_BUFS 4
+struct hal_tensor *pool_tensors[N_BUFS] = { NULL };
+
+// At DQBUF time, lazily create or reuse the tensor for this buffer index.
+int buf_index = v4l2_buf.index;  // 0..N_BUFS-1
+
+if (pool_tensors[buf_index] == NULL) {
+    // First time this pool slot is seen — create the HAL tensor.
+    struct hal_plane_descriptor *pd = hal_plane_descriptor_new(v4l2_buf.m.fd);
+    pool_tensors[buf_index] = hal_import_image(
+        proc, pd, NULL, width, height,
+        HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+    // pd is consumed — do NOT free
+}
+
+// Reuse the existing tensor — cache hit on every subsequent dequeue.
+hal_image_processor_convert(proc, pool_tensors[buf_index], dst, ...);
+
+// QBUF returns the buffer to the driver; the tensor stays alive.
+ioctl(fd, VIDIOC_QBUF, &v4l2_buf);
+
+// --- Teardown (when stopping capture) ---
+for (int i = 0; i < N_BUFS; i++) {
+    hal_tensor_free(pool_tensors[i]);  // NULL-safe
+    pool_tensors[i] = NULL;
+}
+```
+
+With `hal_tensor_from_fd()` the pattern is similar — it dups internally,
+so the caller retains the original fd:
+
+```c
+if (pool_tensors[buf_index] == NULL) {
+    size_t shape[] = { height, width, 1 };  // NV12 luma plane
+    pool_tensors[buf_index] = hal_tensor_from_fd(
+        HAL_DTYPE_U8, v4l2_buf.m.fd, shape, 3, "v4l2_src");
+    hal_tensor_set_format(pool_tensors[buf_index], HAL_PIXEL_FORMAT_NV12);
+}
+```
+
+### fd Ownership Summary
+
+| Function | fd ownership | When to `dup()` |
+|----------|--------------|-----------------|
+| `hal_plane_descriptor_new()` | Dups eagerly — caller retains original | Never |
+| `hal_import_image()` | Consumes both descriptors (success or fail) | Never (descriptors already duped the fd) |
+| `hal_tensor_from_fd()` | Dups internally — caller retains original | Never |
+
+### Anti-patterns
+
+The following patterns cause severe performance regressions. Each is
+explained with the underlying cost so the reason is clear, not just the
+rule.
+
+#### 1. Creating a tensor from fd every frame
+
+```c
+// BAD: ~1-3 ms overhead per frame from EGLImage re-import
+while (running) {
+    struct hal_plane_descriptor *pd = hal_plane_descriptor_new(v4l2_buf.m.fd);
+    struct hal_tensor *src = hal_import_image(
+        proc, pd, NULL, width, height, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+    hal_image_processor_convert(proc, src, dst, ...);
+    hal_tensor_free(src);
+}
+```
+
+*Why it is slow:* every call allocates a new `BufferIdentity` with a fresh
+ID. The EGL image cache keys on `(BufferIdentity.id, chroma_id)`, so the
+cache never hits. Each `convert()` call must call `eglCreateImageKHR` to
+re-import the DMA-BUF as a GL texture. On the Vivante GC7000UL this takes
+0.5–1.5 ms. When both source and destination are re-imported, the cost
+doubles.
+
+#### 2. Freeing and reallocating tensors between frames
+
+```c
+// BAD: same cost as #1, plus heap allocation overhead
+while (running) {
+    struct hal_tensor *dst = hal_image_processor_create_image(
+        proc, model_w, model_h, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_U8);
+    hal_image_processor_convert(proc, src, dst, ...);
+    // ... use dst ...
+    hal_tensor_free(dst);
+}
+```
+
+*Why it is slow:* in addition to EGL image cache misses, every iteration
+allocates and frees a DMA-BUF (or PBO), which involves kernel calls
+(`dma-heap ioctl` or `glBufferData`). On memory-constrained embedded
+targets, CMA pool fragmentation can also cause allocation failures after
+sustained operation.
+
+#### 3. Using the same tensor as both src and dst
+
+```c
+// BAD: undefined behavior
+hal_image_processor_convert(proc, tensor, tensor, ...);
+```
+
+*Why it fails:* the OpenGL backend binds `src` as a texture and `dst` as a
+framebuffer attachment. Sampling from and rendering to the same image in a
+single draw call is undefined behavior per the OpenGL ES specification.
+Results range from correct output (by accident) to GPU hangs.
+
+#### 4. Using `hal_tensor_new()` instead of `hal_image_processor_create_image()`
+
+```c
+// BAD: bypasses processor's memory backend selection
+size_t shape[] = { 640, 640, 3 };
+struct hal_tensor *dst = hal_tensor_new(HAL_DTYPE_U8, shape, 3,
+                                         HAL_TENSOR_MEMORY_DMA, "output");
+hal_image_processor_convert(proc, src, dst, ...);
+```
+
+*Why it is slow:* `hal_image_processor_create_image()` inspects the active
+GPU backend and selects the optimal memory type — DMA-BUF for
+EGLImage-capable GPUs (Vivante, Mali), PBO for desktop GPUs (NVIDIA), heap
+for CPU-only. Calling `hal_tensor_new()` with a hardcoded memory type
+skips this selection. On a PBO-preferred system, a DMA tensor forces a
+slow `glTexSubImage2D` upload; on a DMA-preferred system, a heap tensor
+forces a full CPU readback.
+
+#### 5. Ignoring row stride for padded buffers
+
+```c
+// BAD: corrupted output (skewed image)
+struct hal_plane_descriptor *pd = hal_plane_descriptor_new(padded_fd);
+struct hal_tensor *src = hal_import_image(
+    proc, pd, NULL, width, height, HAL_PIXEL_FORMAT_NV12, HAL_DTYPE_U8);
+```
+
+*Why it fails:* many V4L2 drivers and GStreamer allocators pad rows to
+alignment boundaries (e.g., 128-byte or 256-byte alignment). If the
+stride is not communicated to HAL, the GPU interprets rows at
+`width * bpp` spacing while the actual data is at `stride` spacing,
+producing a skewed or corrupted image. Set the stride on the plane
+descriptor via `hal_plane_descriptor_set_stride()` when
+`bytesperline > width * bytes_per_pixel`.
+
+### Live-memory semantics
+
+After a V4L2 decoder, camera ISP, or codec writes new pixel data into a
+DMA-BUF, the existing tensor and its cached EGLImage remain valid. **Do
+not** free and recreate the tensor. Simply call `convert()` again. The GPU
+reads the updated content because EGLImage is a handle to physical memory,
+not a snapshot of its contents at import time. This is the key property
+that makes the allocate-once / reuse-every-frame pattern work.
+
+## Delegate DMA-BUF Framework
+
+The Delegate DMA-BUF Framework defines an ABI contract for querying
+DMA-BUF tensor information from external TFLite delegates (NXP Neutron
+NPU, VxDelegate, etc.). The HAL owns the type definitions; function
+implementations live in delegate shared libraries.
+
+The API is **query-only by design**: delegates own all DMA-BUF
+allocations internally. Consumers query tensor metadata (fd, shape,
+dtype) and synchronize caches — they never register, allocate, bind, or
+release buffers through this API.
+
+Each delegate ships a self-contained `hal_dmabuf.h` header with all type
+definitions and function declarations. Consumers do **not** need the full
+`edgefirst/hal.h` — they either include the delegate's header or load
+symbols via `dlsym`.
+
+### Zero-copy data flow
+
+```text
+Camera DMA-BUF
+  → hal_plane_descriptor (wraps camera_fd, stride, offset)
+  → hal_import_image(proc, camera_pd, NULL, w, h, format, dtype)
+  → HAL Tensor with image attributes (camera source)
+
+NPU input DMA-BUF (fd/shape from hal_dmabuf_get_tensor_info)
+  → hal_plane_descriptor (wraps npu_input_fd, stride, offset)
+  → hal_import_image(proc, npu_pd, NULL, model_w, model_h, format, dtype)
+  → HAL Tensor with image attributes (NPU destination)
+
+ImageProcessor::convert(camera_tensor, npu_tensor)
+  → DMA→DMA convert (resize, colorspace, letterbox)
+
+hal_dmabuf_sync_for_device(delegate, input_tensor_index)
+  → flush CPU caches so NPU can read
+
+NPU inference
+
+hal_dmabuf_sync_for_cpu(delegate, output_tensor_index) [optional]
+  → invalidate CPU caches so CPU sees NPU writes
+```
+
+Both camera and NPU input tensors are imported via `hal_import_image()`
+so that `convert()` has the pixel format, dimensions, stride, and plane
+metadata it requires. `hal_tensor_from_fd()` creates raw tensors without
+image attributes; to use such tensors as a `convert()` source or
+destination you must either import them as images (via
+`hal_import_image()`) or attach the required image metadata (e.g. with
+`hal_tensor_set_format()`).
+
+Output DMA-BUF access via `hal_dmabuf_get_tensor_info()` is optional and
+depends on the use case: useful when feeding outputs to GPU (e.g., mask
+rendering via OpenGL), but for CPU-side post-processing (YOLO decode,
+NMS) it is simpler to read tensor data directly since the decode will
+memcpy anyway.
+
+### Type definitions
+
+**`hal_delegate_t`** — opaque handle for any delegate, defined as
+`void *`. Implementations receive this as a parameter and cast it
+internally to their concrete delegate type. The delegate lifetime is
+managed by the caller; the HAL never creates or destroys delegates.
+
+> **Important:** exported function signatures **must** use
+> `hal_delegate_t` (`void *`), not `TfLiteDelegate *` or any other
+> concrete type. This ensures ABI compatibility across different delegate
+> implementations.
+
+**`hal_dmabuf_tensor_info`** — describes a single delegate tensor's
+DMA-BUF:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `size` | `size_t` | Buffer size in bytes (may exceed logical tensor size for padded buffers) |
+| `offset` | `size_t` | Byte offset within the DMA-BUF |
+| `shape` | `size_t[HAL_DMABUF_MAX_NDIM]` | Tensor dimensions (max 8) |
+| `ndim` | `size_t` | Number of valid entries in `shape` |
+| `fd` | `int` | DMA-BUF file descriptor (**borrowed** — do not close) |
+| `dtype` | `hal_dtype` | Element data type |
+
+Fields are ordered to eliminate padding on LP64 (`size_t` first, then
+smaller 4-byte fields). Total: 96 bytes on LP64.
+
+All fields are **mandatory**. Implementations must populate `shape`,
+`ndim`, and `dtype` in addition to `fd`, `offset`, and `size`. An
+implementation that cannot determine the shape should set `ndim = 0`.
+
+**`hal_camera_adaptor_format_info`** — describes a camera format
+adaptor:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `input_channels` | `int` | Number of input channels (e.g., 4 for RGBA) |
+| `output_channels` | `int` | Number of output channels (e.g., 3 for RGB) |
+| `fourcc` | `char[HAL_FOURCC_MAX_LEN]` | NUL-terminated V4L2 FourCC string (ASCII, ≤ 4 bytes + NUL) |
+
+### DMA-BUF function ABI
+
+These functions are **not implemented in the HAL**. They document the
+exact ABI that delegate shared libraries must export and that consumers
+probe via `dlsym`. All exported symbols must use
+`__attribute__((visibility("default")))`.
+
+```c
+/* Get the delegate's internal handle.
+ * When TFLite creates a delegate via TfLiteExternalDelegateCreate(), it
+ * wraps the real delegate in an opaque adapter. This function returns
+ * the inner delegate pointer that the hal_dmabuf_* functions expect.
+ * Returns the inner delegate handle, or NULL if no delegate has been
+ * created. */
+hal_delegate_t hal_dmabuf_get_instance(void);
+
+/* Returns 1 if DMA-BUF tensor access is supported, 0 otherwise.
+ * Does not set errno. */
+int hal_dmabuf_is_supported(hal_delegate_t delegate);
+
+/* Get DMA-BUF tensor info for a given tensor index.
+ * Returns 0 on success, -1 on error (sets errno).
+ * info_size enables forward-compatible versioning: pass
+ * sizeof(hal_dmabuf_tensor_info). Implementations must:
+ *   1. memset(info, 0, info_size) before populating
+ *   2. Only write fields whose offsetof + sizeof fits within info_size
+ * Errno: EINVAL (NULL info, negative tensor_index, info_size too small),
+ *        ENOTSUP (DMA-BUF not supported),
+ *        ERANGE (tensor_index out of range),
+ *        EIO (DMA-BUF ioctl or internal failure) */
+int hal_dmabuf_get_tensor_info(hal_delegate_t delegate,
+                               int tensor_index,
+                               hal_dmabuf_tensor_info *info,
+                               size_t info_size);
+
+/* Flush CPU caches → device can read.
+ * Call after writing to an input tensor (e.g. via convert()), before NPU. */
+int hal_dmabuf_sync_for_device(hal_delegate_t delegate, int tensor_index);
+
+/* Invalidate CPU caches → CPU sees device writes.
+ * Call after NPU inference completes, before reading output tensor data. */
+int hal_dmabuf_sync_for_cpu(hal_delegate_t delegate, int tensor_index);
+```
+
+`tensor_index` must be non-negative; negative values return `-1` with
+`errno = EINVAL`.
+
+### Camera adaptor functions
+
+Some delegates support NPU-accelerated format conversion (e.g. RGBA →
+RGB channel slicing, uint8 → int8 quantization) that runs as part of
+the inference graph. These functions allow consumers to query format
+support without vendor-specific symbols.
+
+Format conversion is configured **before** graph compilation via
+delegate options (e.g. `DelegateOptions::option("camera_adaptor",
+"rgba")`), not through this query API.
+
+```c
+/* Returns 1 if the given format is supported, 0 otherwise.
+ * Does not set errno. Delegates without camera adaptor support
+ * always return 0. */
+int hal_camera_adaptor_is_supported(hal_delegate_t delegate,
+                                    const char *format);
+
+/* Query camera adaptor format information.
+ * Returns 0 on success, -1 on error (sets errno).
+ * info_size enables forward-compatible versioning.
+ * Errno: EINVAL (NULL format or info),
+ *        ENOTSUP (format not supported by this delegate) */
+int hal_camera_adaptor_get_format_info(hal_delegate_t delegate,
+                                       const char *format,
+                                       hal_camera_adaptor_format_info *info,
+                                       size_t info_size);
+```
+
+### errno requirements
+
+Implementations **must** set `errno` before returning `-1`:
+
+| Function | EINVAL | ENOTSUP | ERANGE | EIO |
+|----------|--------|---------|--------|-----|
+| `hal_dmabuf_get_tensor_info` | NULL info, negative index, info_size too small | DMA-BUF not supported | tensor_index out of range | ioctl or internal failure |
+| `hal_dmabuf_sync_for_device` | NULL delegate, negative index | — | tensor_index out of range | ioctl failure |
+| `hal_dmabuf_sync_for_cpu` | NULL delegate, negative index | — | tensor_index out of range | ioctl failure |
+| `hal_camera_adaptor_get_format_info` | NULL format or info | format not supported | — | — |
+
+Functions that return 1/0 (`hal_dmabuf_is_supported`,
+`hal_camera_adaptor_is_supported`) do **not** set errno.
+
+### Integration pattern
+
+1. The delegate shared library (e.g., `libvx_delegate.so`,
+   `libneutron_delegate.so`) implements the functions above and exports
+   them as public C symbols with default visibility.
+2. Consumers probe for the symbols at runtime via `dlsym` on the
+   delegate's shared library.
+3. Consumers call `hal_dmabuf_get_instance()` to obtain the inner
+   delegate handle (needed when the delegate was created via
+   `TfLiteExternalDelegateCreate()`).
+4. If `hal_dmabuf_is_supported()` returns 1, consumers call
+   `hal_dmabuf_get_tensor_info()` to obtain the DMA-BUF fd and shape for
+   each tensor of interest.
+5. The fd and metadata are passed to `hal_import_image()` to create a
+   HAL tensor with full image attributes for use with
+   `hal_image_processor_convert()`.
+
+### Lifecycle and ownership
+
+- The **delegate** owns all DMA-BUF allocations. File descriptors
+  returned by `hal_dmabuf_get_tensor_info()` are borrowed — callers must
+  not close them.
+- Sync functions (`sync_for_device`, `sync_for_cpu`) wrap
+  `DMA_BUF_IOCTL_SYNC` and bracket hardware access. They must be called
+  at the correct points in the pipeline (see data flow above).
+- The delegate instance itself is created and destroyed by the caller
+  (e.g., via the TFLite C API). The HAL never manages delegate
+  lifetime.
+
+### Symbol visibility
+
+All exported `hal_dmabuf_*` and `hal_camera_adaptor_*` functions must be
+annotated with `__attribute__((visibility("default")))` so they remain
+visible even when the delegate is compiled with `-fvisibility=hidden`.
+
+### Thread safety
+
+Delegate functions are not required to be thread-safe for concurrent
+calls on the same delegate instance. Callers must serialize access per
+delegate. Different delegate instances may be used concurrently from
+different threads.
+
+### Tracking
+
+- Epic: [EDGEAI-1185](https://au-zone.atlassian.net/browse/EDGEAI-1185) — NXP Neutron DMABUF Zero-Copy Support
+- Type definitions: [EDGEAI-1189](https://au-zone.atlassian.net/browse/EDGEAI-1189) — formalize `hal_dmabuf_*` interface
+- Implementation: [EDGEAI-1190](https://au-zone.atlassian.net/browse/EDGEAI-1190) — edgefirst-tflite probing for `hal_dmabuf_*` symbols
+
+## Logging API
+
+HAL logging is off by default. Initialise it once per process before any
+other HAL calls. Both APIs are race-safe: only the first successful call
+takes effect; subsequent calls return `-1` with `errno = EALREADY`.
+
+```c
+#include <edgefirst/hal.h>
+
+// Option 1: write [LEVEL] target: message lines to a FILE*
+hal_log_init_file(stderr, HAL_LOG_LEVEL_DEBUG);
+
+// Option 2: forward each record to a custom callback
+void my_logger(hal_log_level level, const char *target,
+               const char *message, void *userdata) {
+    fprintf(stderr, "[%d] %s: %s\n", level, target, message);
+}
+hal_log_init_callback(my_logger, NULL, HAL_LOG_LEVEL_INFO);
+```
+
+Available log levels: `HAL_LOG_LEVEL_ERROR`, `HAL_LOG_LEVEL_WARN`,
+`HAL_LOG_LEVEL_INFO`, `HAL_LOG_LEVEL_DEBUG`, `HAL_LOG_LEVEL_TRACE`.
+
+## Inter-Crate Interfaces
+
+| Direction | Crate | Interface |
+|-----------|-------|-----------|
+| Wraps | [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) | `Tensor`, `TensorDyn`, `PlaneDescriptor`, `from_planes` |
+| Wraps | [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) | `ImageProcessor`, draw / convert APIs |
+| Wraps | [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) | `Decoder`, `DecoderBuilder`, `DetectBox`, `Segmentation` |
+| Wraps | [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) | `ByteTrack`, `TrackInfo` |
+| Wraps | [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) | `trace::start_tracing` / `stop_tracing` (feature `tracing`) |
+
+## Cross-References
+
+- Project architecture: [../../ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
+- Image-side EGL cache and PBO dispatch: [../image/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
+- Tensor architecture (BufferIdentity, multi-plane DMA-BUF): [../tensor/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md)
+- DMA-BUF identity story: [ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
+- Optimization guide: [README.md#optimization-guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)
+- Performance tracing usage: [README.md#performance-tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)

--- a/crates/capi/README.md
+++ b/crates/capi/README.md
@@ -4,6 +4,15 @@ C language bindings for the EdgeFirst Hardware Abstraction Layer, providing
 zero-copy tensor operations, hardware-accelerated image processing, ML model
 output decoding, and multi-object tracking.
 
+## Role in edgefirst-hal
+
+`edgefirst-hal-capi` is the FFI bridge over the EdgeFirst HAL Rust workspace:
+
+- Wraps [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/), [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/), [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/), [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) as opaque-handle C APIs.
+- Builds as both `staticlib` (`libedgefirst_hal.a`) and `cdylib` (`libedgefirst_hal.so` / `.dylib`).
+- Used by GStreamer plugins, OpenCV pipelines, NPU delegates, and any C/C++ consumer that needs the HAL outside Rust.
+- Defines the [Delegate DMA-BUF Framework](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md#delegate-dma-buf-framework) ABI that NXP Neutron, VxDelegate, and other TFLite delegates implement to expose their internal DMA-BUF tensors.
+
 ## Features
 
 - **Tensor** - Create, reshape, map, and manage typed multi-dimensional tensors
@@ -395,8 +404,15 @@ vendor-specific symbols. Populated by the delegate's
 ## API Reference
 
 The full API is documented with Doxygen comments in
-[`include/edgefirst/hal.h`](include/edgefirst/hal.h).
+[`include/edgefirst/hal.h`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/include/edgefirst/hal.h).
+
+## Documentation
+
+- Architecture overview (incl. performance recommendations and Delegate DMA-BUF framework): [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md)
+- Testing guide: [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/TESTING.md)
+- Reference C benchmark / canonical example: [`bench_preproc.c`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/bench_preproc.c)
+- Project README: [../../README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md)
 
 ## License
 
-Apache-2.0 - see [LICENSE](../../LICENSE) for details.
+Apache-2.0 - see [LICENSE](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE) for details.

--- a/crates/capi/README.md
+++ b/crates/capi/README.md
@@ -1,8 +1,12 @@
 # edgefirst-hal-capi
 
-[![Crates.io](https://img.shields.io/crates/v/edgefirst-hal-capi.svg)](https://crates.io/crates/edgefirst-hal-capi)
-[![Documentation](https://docs.rs/edgefirst-hal-capi/badge.svg)](https://docs.rs/edgefirst-hal-capi)
-[![License](https://img.shields.io/crates/l/edgefirst-hal-capi.svg)](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/EdgeFirstAI/hal?label=release)](https://github.com/EdgeFirstAI/hal/releases)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE)
+
+> **Distribution:** the C library is shipped as a GitHub Release tarball,
+> not via crates.io. The `edgefirst-hal-capi` crate is marked
+> `publish = false` because its useful artifact is the static/shared
+> library plus the cbindgen-generated header — not the Rust source.
 
 **EdgeFirst HAL C API** — C language bindings for the EdgeFirst Hardware
 Abstraction Layer, providing zero-copy tensor operations,

--- a/crates/capi/README.md
+++ b/crates/capi/README.md
@@ -1,8 +1,13 @@
-# EdgeFirst HAL C API
+# edgefirst-hal-capi
 
-C language bindings for the EdgeFirst Hardware Abstraction Layer, providing
-zero-copy tensor operations, hardware-accelerated image processing, ML model
-output decoding, and multi-object tracking.
+[![Crates.io](https://img.shields.io/crates/v/edgefirst-hal-capi.svg)](https://crates.io/crates/edgefirst-hal-capi)
+[![Documentation](https://docs.rs/edgefirst-hal-capi/badge.svg)](https://docs.rs/edgefirst-hal-capi)
+[![License](https://img.shields.io/crates/l/edgefirst-hal-capi.svg)](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE)
+
+**EdgeFirst HAL C API** — C language bindings for the EdgeFirst Hardware
+Abstraction Layer, providing zero-copy tensor operations,
+hardware-accelerated image processing, ML model output decoding, and
+multi-object tracking.
 
 ## Role in edgefirst-hal
 

--- a/crates/capi/TESTING.md
+++ b/crates/capi/TESTING.md
@@ -34,9 +34,13 @@ suite under [`crates/capi/tests/`](https://github.com/EdgeFirstAI/hal/tree/main/
 
 ### Rust side
 
+`cargo test` runs with `-- --test-threads=1` per the workspace
+single-threaded rule
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+
 ```bash
 # Rust unit + doc-tests
-cargo test -p edgefirst-hal-capi
+cargo test -p edgefirst-hal-capi -- --test-threads=1
 ```
 
 ### C side

--- a/crates/capi/TESTING.md
+++ b/crates/capi/TESTING.md
@@ -1,0 +1,127 @@
+# edgefirst-hal-capi Testing
+
+## Test Layout
+
+```
+crates/capi/
+├── src/
+│   ├── tensor.rs       # Doc-tests on hal_tensor_* functions
+│   ├── image.rs        # Doc-tests on hal_image_processor_* functions
+│   ├── decoder.rs      # Doc-tests on hal_decoder_* functions
+│   ├── tracker.rs      # Doc-tests on hal_bytetrack_* functions
+│   ├── delegate.rs     # Doc-tests on delegate ABI types
+│   └── ...
+├── tests/              # C-side integration suite (built via Makefile)
+│   ├── test_all.c
+│   ├── test_tensor.c
+│   ├── test_image.c
+│   ├── test_decoder.c
+│   ├── test_tracker.c
+│   ├── test_neutron_dmabuf.c
+│   ├── test_neutron_dmabuf_infer.c
+│   ├── bench_preproc.c
+│   ├── test_common.h
+│   └── Makefile
+└── include/edgefirst/
+    └── hal.h           # cbindgen-generated; CI verifies header parity
+```
+
+The Rust side has thin per-function `#[test]` modules and doc-tests on the
+public FFI surface. The bulk of the coverage lives in the C-side test
+suite under [`crates/capi/tests/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/capi/tests).
+
+## Running Tests
+
+### Rust side
+
+```bash
+# Rust unit + doc-tests
+cargo test -p edgefirst-hal-capi
+```
+
+### C side
+
+```bash
+# 1. Build the C library (release artifacts the Makefile expects)
+cargo build --release -p edgefirst-hal-capi
+
+# 2. Build and run the full C test suite
+cd crates/capi/tests
+make test
+
+# 3. Individual test programs
+make test_tensor
+make test_image
+make test_decoder
+make test_tracker
+
+# 4. Memory check (valgrind on Linux)
+make valgrind
+```
+
+The C suite links against `target/release/libedgefirst_hal.{so,a}`; the
+Makefile resolves include paths relative to the workspace root, so you
+must `cargo build` first.
+
+| Source file | Coverage |
+|-------------|----------|
+| [`test_tensor.c`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/test_tensor.c) | Tensor allocation, DMA-BUF, memory types, fd ownership |
+| [`test_image.c`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/test_image.c) | Image loading, format conversion, draw masks |
+| [`test_decoder.c`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/test_decoder.c) | YOLO/ModelPack decoder, post-processing parity |
+| [`test_tracker.c`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/test_tracker.c) | ByteTrack create/update/get_active_tracks |
+| [`test_neutron_dmabuf.c`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/test_neutron_dmabuf.c) | On-target Neutron NPU DMA-BUF regression |
+| [`test_neutron_dmabuf_infer.c`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/test_neutron_dmabuf_infer.c) | End-to-end zero-copy inference path |
+| [`bench_preproc.c`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/tests/bench_preproc.c) | Reference C preprocessing benchmark — also serves as the canonical example for the [Performance Recommendations](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md#performance-recommendations-dma-buf--egl-path) in `ARCHITECTURE.md` |
+
+## Special Requirements
+
+- **Single-threaded execution** — when the C tests exercise the GL
+  backend, they inherit the
+  [project-wide single-threaded rule](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution).
+  The C test Makefile runs each `test_*` binary serially.
+- **LFS testdata** — image/decoder C tests load fixtures from `testdata/`
+  (LFS-tracked). The Makefile resolves `EDGEFIRST_TESTDATA_DIR` from the
+  environment and falls back to `<workspace>/testdata`.
+- **Hardware gates** — `test_neutron_dmabuf*` requires a live TFLite
+  delegate, model, and the i.MX 95 NPU device tree. Run on target with
+  `NEUTRON_ENABLE_ZERO_COPY=1`.
+- **No special features required** for the Rust-side tests; default
+  features build the full FFI surface.
+- **`opencv` feature** — when enabled, additional comparison test paths
+  are exercised. CI runs both `--features default,opencv` and the default
+  feature set.
+
+## Coverage Notes
+
+- The Rust side participates in workspace `cargo llvm-cov`; lcov output
+  appears under `crates/capi/`.
+- C-side coverage is collected via `gcov` instrumentation when the
+  Makefile is invoked with `make test COV=1`. Combined Rust + C coverage
+  is uploaded to SonarCloud by the
+  [`Process Hardware Coverage`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml)
+  CI job.
+- The C tests are the primary correctness gate for the public ABI: any
+  signature drift between the Rust source, the cbindgen-generated header,
+  and the C call sites is caught here at compile time.
+
+## Header Parity Check
+
+`crates/capi/build.rs` runs `cbindgen` during `cargo build` and writes
+the result to `include/edgefirst/hal.h`. The committed copy must match
+the generated copy. CI catches drift via the
+[`Generate SBOM & Check License Compliance`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/sbom.yml)
+workflow's `make sbom` step, which fails the build if the header changed
+without being committed. Locally, run:
+
+```bash
+cargo build -p edgefirst-hal-capi
+git diff -- crates/capi/include/edgefirst/hal.h    # should be empty
+```
+
+## Cross-References
+
+- Project testing patterns: [../../TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md)
+- Validating optimizations: [TESTING.md#validating-optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations)
+- C API performance patterns: [ARCHITECTURE.md#performance-recommendations-dma-buf--egl-path](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md#performance-recommendations-dma-buf--egl-path)
+- Image-side test gating (GL/G2D probes): [../image/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md)
+- Tensor-side DMA tests: [../tensor/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/TESTING.md)

--- a/crates/capi/TESTING.md
+++ b/crates/capi/TESTING.md
@@ -23,7 +23,7 @@ crates/capi/
 │   ├── test_common.h
 │   └── Makefile
 └── include/edgefirst/
-    └── hal.h           # cbindgen-generated; CI verifies header parity
+    └── hal.h           # cbindgen-generated; committed in-tree (review is the parity gate)
 ```
 
 The Rust side has thin per-function `#[test]` modules and doc-tests on the
@@ -87,19 +87,17 @@ must `cargo build` first.
   `NEUTRON_ENABLE_ZERO_COPY=1`.
 - **No special features required** for the Rust-side tests; default
   features build the full FFI surface.
-- **`opencv` feature** — when enabled, additional comparison test paths
-  are exercised. CI runs both `--features default,opencv` and the default
-  feature set.
 
 ## Coverage Notes
 
 - The Rust side participates in workspace `cargo llvm-cov`; lcov output
   appears under `crates/capi/`.
-- C-side coverage is collected via `gcov` instrumentation when the
-  Makefile is invoked with `make test COV=1`. Combined Rust + C coverage
-  is uploaded to SonarCloud by the
-  [`Process Hardware Coverage`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml)
-  CI job.
+- The Rust llvm-cov coverage is merged with Python slipcover coverage by
+  the [`Process Hardware Coverage`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml)
+  CI job and uploaded to SonarCloud. The C test binaries are not
+  instrumented with `gcov` today; they validate behaviour and provide a
+  compile-time link-check of the cbindgen header, but C-side line
+  coverage is not currently reported.
 - The C tests are the primary correctness gate for the public ABI: any
   signature drift between the Rust source, the cbindgen-generated header,
   and the C call sites is caught here at compile time.
@@ -107,16 +105,18 @@ must `cargo build` first.
 ## Header Parity Check
 
 `crates/capi/build.rs` runs `cbindgen` during `cargo build` and writes
-the result to `include/edgefirst/hal.h`. The committed copy must match
-the generated copy. CI catches drift via the
-[`Generate SBOM & Check License Compliance`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/sbom.yml)
-workflow's `make sbom` step, which fails the build if the header changed
-without being committed. Locally, run:
+the result to `include/edgefirst/hal.h`. The committed copy must stay
+in sync with the generated copy — contributors are expected to commit
+the regenerated header alongside any Rust FFI change. CI does not
+currently enforce this with an explicit `git diff --exit-code` step, so
+review is the gate. Locally:
 
 ```bash
 cargo build -p edgefirst-hal-capi
 git diff -- crates/capi/include/edgefirst/hal.h    # should be empty
 ```
+
+If the diff is non-empty, commit the regenerated header.
 
 ## Cross-References
 

--- a/crates/capi/TESTING.md
+++ b/crates/capi/TESTING.md
@@ -36,7 +36,7 @@ suite under [`crates/capi/tests/`](https://github.com/EdgeFirstAI/hal/tree/main/
 
 `cargo test` runs with `-- --test-threads=1` per the workspace
 single-threaded rule
-([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution)).
 
 ```bash
 # Rust unit + doc-tests

--- a/crates/capi/TESTING.md
+++ b/crates/capi/TESTING.md
@@ -83,9 +83,14 @@ must `cargo build` first.
   backend, they inherit the
   [project-wide single-threaded rule](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution).
   The C test Makefile runs each `test_*` binary serially.
-- **LFS testdata** — image/decoder C tests load fixtures from `testdata/`
-  (LFS-tracked). The Makefile resolves `EDGEFIRST_TESTDATA_DIR` from the
-  environment and falls back to `<workspace>/testdata`.
+- **No LFS testdata for the standard C suite.** The C tests
+  (`test_tensor`, `test_image`, `test_decoder`, `test_tracker`,
+  `bench_preproc`) synthesize all inputs in-process — they do not
+  read from `testdata/` and the Makefile does not resolve
+  `EDGEFIRST_TESTDATA_DIR`. The `test_neutron_dmabuf*` programs do
+  consume external data (a TFLite model and an input frame), but the
+  paths are passed as command-line arguments per the per-binary
+  `--help` output, not via an env var.
 - **Hardware gates** — `test_neutron_dmabuf*` requires a live TFLite
   delegate, model, and the i.MX 95 NPU device tree. Run on target with
   `NEUTRON_ENABLE_ZERO_COPY=1`.

--- a/crates/decoder/ARCHITECTURE.md
+++ b/crates/decoder/ARCHITECTURE.md
@@ -258,11 +258,17 @@ mask_raw[i] = coefficients[i] @ protos       # (proto_h, proto_w)
 
 The decoder exposes three mask APIs that pair with image-side rendering:
 
-| Workflow | Decoder API | Image-side render | Use case |
-|----------|-------------|-------------------|----------|
-| Materialized masks | `decode_quantized` / `decode_float` | `processor.draw_decoded_masks()` | When you need mask matrices on the CPU side |
-| Proto data (preferred for GPU) | `decode_quantized_proto` / `decode_float_proto` | `processor.draw_proto_masks()` | Fused proto→pixel GPU path; never materializes full-res masks on CPU |
-| Tracked + drawn in one call | (consumer of [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/)) | `processor.draw_masks_tracked()` | Single-call decode + track + render |
+| Workflow | Decoder API (public) | Image-side render | Use case |
+|----------|----------------------|-------------------|----------|
+| Materialized masks | [`Decoder::decode()`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html#method.decode) | `processor.draw_decoded_masks()` | When you need mask matrices on the CPU side |
+| Proto data (preferred for GPU) | [`Decoder::decode_proto()`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html#method.decode_proto) | `processor.draw_proto_masks()` | Fused proto→pixel GPU path; never materializes full-res masks on CPU |
+| Tracked materialized | [`Decoder::decode_tracked()`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html#method.decode_tracked) | `processor.draw_masks_tracked()` | Single-call decode + track + render |
+| Tracked proto | [`Decoder::decode_proto_tracked()`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html#method.decode_proto_tracked) | `processor.draw_proto_masks()` (with track-augmented detections) | Tracked GPU-fused path |
+
+`decode()` and `decode_proto()` dispatch internally to crate-private
+`decode_quantized` / `decode_float` / `decode_quantized_proto` /
+`decode_float_proto` based on the model's output dtype; external
+callers never invoke those helpers directly.
 
 The proto-data path is the recommended GPU path. It avoids the CPU cost of
 materializing full-resolution masks; the GPU evaluates `sigmoid(coeffs @

--- a/crates/decoder/ARCHITECTURE.md
+++ b/crates/decoder/ARCHITECTURE.md
@@ -33,7 +33,7 @@ based on the output tensor layout.
 - [`DetectBox`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.DetectBox.html) — output bounding box + score + class label.
 - [`Segmentation`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Segmentation.html) — per-detection mask matrix.
 - [`Quantization`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Quantization.html) — `(scale, zero_point)` for int8/uint8 outputs.
-- [`Nms`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/configs/enum.Nms.html) — `ClassAgnostic` / `ClassAware` / `None` (bypass).
+- [`Nms`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/configs/enum.Nms.html) — `Auto` / `ClassAgnostic` / `ClassAware`. Bypass is expressed as `Option<Nms>::None` on the decoder configuration, not a variant of the enum.
 - [`SchemaV2`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/schema/struct.SchemaV2.html) — model metadata document (current schema version).
 
 ## Internal Architecture

--- a/crates/decoder/ARCHITECTURE.md
+++ b/crates/decoder/ARCHITECTURE.md
@@ -1,0 +1,273 @@
+# edgefirst-decoder Architecture
+
+## Overview
+
+`edgefirst-decoder` is the post-processing layer that turns raw inference
+outputs from object-detection and segmentation models into typed
+`DetectBox` and `Segmentation` values. It supports both floating-point and
+quantized (int8 / uint8) inputs without an intermediate dequantization
+buffer, configurable NMS modes, end-to-end YOLOv26 models with embedded NMS,
+and a fused proto-mask GPU rendering path that bypasses CPU mask
+materialization. The crate is configured through a single
+[`DecoderBuilder`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.DecoderBuilder.html)
+that ingests JSON or YAML model metadata and selects the right code path
+based on the output tensor layout.
+
+## Module Map
+
+| Module | Source | Responsibility |
+|--------|--------|----------------|
+| [`lib.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/lib.rs) | local | Public surface: `Decoder`, `DetectBox`, `Segmentation`, `Quantization`, `BoundingBox`, dequantize utilities |
+| [`decoder/`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/decoder/) | local | `DecoderBuilder`, `ConfigOutputs`, model-type selection, per-scale bridge, post-processing |
+| [`yolo.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/yolo.rs) | local | YOLOv5/8/11 detection + segmentation kernels |
+| [`modelpack.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/modelpack.rs) | local | Au-Zone ModelPack format kernels |
+| [`per_scale/`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/per_scale/) | local | Per-scale split-tensor decoder framework (NEON-optimized hot path) |
+| [`schema.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/schema.rs) | local | `SchemaV2` parser — model metadata document used by EdgeFirst Studio |
+| [`float.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/float.rs) / [`byte.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/byte.rs) | local | NMS implementations (float and byte-quantized) |
+| [`error.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/error.rs) | local | `DecoderError`, `DecoderResult` |
+
+## Key Types and Traits
+
+- [`Decoder`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html) — built once, then called per inference frame.
+- [`DecoderBuilder`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.DecoderBuilder.html) — fluent configuration with sensible defaults; consumes JSON/YAML or programmatic `ConfigOutputs`.
+- [`DetectBox`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.DetectBox.html) — output bounding box + score + class label.
+- [`Segmentation`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Segmentation.html) — per-detection mask matrix.
+- [`Quantization`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Quantization.html) — `(scale, zero_point)` for int8/uint8 outputs.
+- [`Nms`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/configs/enum.Nms.html) — `ClassAgnostic` / `ClassAware` / `None` (bypass).
+- [`SchemaV2`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/schema/struct.SchemaV2.html) — model metadata document (current schema version).
+
+## Internal Architecture
+
+### Builder → Decoder
+
+```mermaid
+flowchart LR
+    Builder[DecoderBuilder]
+    Decoder[Decoder]
+    Det[decode<br/>→ bboxes, scores, classes]
+    Seg[decode_segmentation<br/>→ bboxes, scores, classes, masks]
+    Proto[decode_quantized_proto<br/>→ raw protos + coefficients]
+
+    Builder --> Decoder
+    Decoder --> Det
+    Decoder --> Seg
+    Decoder --> Proto
+
+    style Builder fill:#e1f5ff
+    style Decoder fill:#fff4e1
+    style Det fill:#e8f5e9
+    style Seg fill:#e8f5e9
+    style Proto fill:#87ceeb
+```
+
+### Detection pipeline
+
+```mermaid
+flowchart TD
+    Raw[Model raw output<br/>quantized or float]
+    E2E{End-to-end?<br/>decoder_version = yolo26}
+
+    Quant{Quantized?}
+    Dequant[Dequantization<br/>scale, zero_point]
+    Parse[Parse boxes &amp; scores<br/>XYWH → XYXY]
+    NMS[Non-Maximum Suppression<br/>IoU threshold filtering]
+    Filter[Filter by score threshold]
+
+    E2EParse[Parse post-NMS output<br/>XYXY + conf + class directly]
+    E2EFilter[Filter by score threshold]
+
+    Det[Detection boxes]
+    Seg[Segmentation masks]
+
+    Raw --> E2E
+    E2E -->|Yes| E2EParse
+    E2EParse --> E2EFilter
+    E2EFilter --> Det
+    E2EFilter --> Seg
+
+    E2E -->|No| Quant
+    Quant -->|Yes| Dequant
+    Quant -->|No| Parse
+    Dequant --> Parse
+    Parse --> NMS
+    NMS --> Filter
+    Filter --> Det
+    Filter --> Seg
+
+    style E2E fill:#fff4e1
+    style Dequant fill:#fff4e1
+    style NMS fill:#ffeb9c
+    style E2EParse fill:#87ceeb
+    style Det fill:#90ee90
+    style Seg fill:#90ee90
+```
+
+### Model-type selection
+
+The builder classifies a model's output topology by **shape alone**, not by
+output count. The result is one of:
+
+| Variant | Tensors | Format |
+|---------|---------|--------|
+| `YoloDet` | 1 (detection) | Standard YOLO detection |
+| `YoloSegDet` | 2 (detection + protos) | YOLO detection + segmentation |
+| `YoloSegDet2Way` | 3 (detection + mask_coefs + protos) | INT8 segmentation with separate mask-coef quant scale |
+| `YoloSplitDet` | 2 (boxes + scores) | Split-output detection |
+| `YoloSplitSegDet` | 4 (boxes + scores + mask_coefs + protos) | Split-output segmentation |
+| `YoloEndToEndDet` | 1 | Post-NMS `[B, N, 6+]` |
+| `YoloEndToEndSegDet` | 2 | Post-NMS + protos |
+| `YoloSplitEndToEndDet` | 3 | Split post-NMS (boxes + scores + classes) |
+| `YoloSplitEndToEndSegDet` | 5 | Split post-NMS + mask_coefs + protos |
+| `ModelPackDet` | 2 (boxes + scores) | ModelPack detection |
+| `ModelPackSegDet` | 3 (boxes + scores + segmentation) | ModelPack segmentation |
+| `ModelPackDetSplit` | N (detection layers) | ModelPack split detection |
+| `ModelPackSegDetSplit` | N+1 (detection layers + segmentation) | ModelPack split segmentation |
+| `ModelPackSeg` | 1 (segmentation) | ModelPack semantic segmentation |
+
+#### `YoloSegDet2Way` shape-based classification
+
+INT8 TFLite segmentation models split mask coefficients off the combined
+detection tensor because the unbounded linear projection that produces them
+needs a separate quantization scale from the (bounded, similarly-ranged)
+boxes and class scores. The builder identifies the three outputs by shape:
+
+| Output | Shape | Identification rule |
+|--------|-------|---------------------|
+| `detection` | `[1, nc+4, N]` | 3D, feature_dim ≠ 32 |
+| `mask_coefs` | `[1, 32, N]` | 3D, feature_dim == 32 |
+| `protos` | `[1, H/4, W/4, 32]` | 4D |
+
+The feature dimension is the smaller of the two non-batch dimensions
+(channels-first: `shape[1]`; channels-last: `shape[2]`).
+
+**Edge case (nc=28):** when `num_classes + 4 == 32`, detection and
+`mask_coefs` collide on feature dim. In this case the model emits 2 outputs
+(unsplit detection + protos) and is decoded as `YoloSegDet`.
+
+#### YOLOv26 end-to-end selection
+
+`decoder_version: "yolo26"` triggers `DecoderVersion::is_end_to_end() == true`
+and selects one of the `YoloEndToEnd*` variants. NMS is bypassed entirely;
+the model emits post-NMS `[B, N, 6+]` rows of `(x1, y1, x2, y2, conf,
+class, ...)`.
+
+For non-end-to-end YOLO26 exports (`end2end=false`), use
+`decoder_version: "yolov8"` with an explicit `nms` configuration.
+
+### Output tensor physical-order contract (EDGEAI-1288)
+
+Every output declared to the decoder — whether programmatically via
+`hal_decoder_params_add_output` / `DecoderBuilder`, or through YAML/JSON
+config — must list `shape` and `dshape` fields in **physical memory order,
+outermost axis first, innermost axis last**. The decoder derives C-contiguous
+strides from `shape` and wraps the raw buffer bytes with those strides; it
+never reorders bytes. When `dshape` is also supplied, HAL uses it to permute
+the stride tuple into the decoder's canonical logical order for the role
+(e.g. `[batch, height, width, num_protos]` for protos); only stride indices
+change, not bytes.
+
+When `dshape` is omitted, HAL assumes `shape` is already in the canonical
+order for the role. This is appropriate for producers like Ultralytics
+ONNX/TFLite flat-detection.
+
+`DecoderBuilder::build` validates each output at construction time:
+
+- `dshape.len()` must equal `shape.len()` when `dshape` is present.
+- Each `dshape[i].size` must equal `shape[i]` — catches the common mistake
+  of declaring `dshape` in a different order than `shape`.
+- No axis name may appear twice within a single output's `dshape`.
+
+Mis-declaring physical order causes every element access to index the wrong
+byte. This was the root cause of two production bugs: a vertical-stripe mask
+artifact on i.MX 8M Plus TFLite segmentation, and a coordinate mis-decode
+with Ara-2 anchor-first split-tensor boxes. HAL cannot detect the mismatch
+at runtime — it has no visibility into how the inference engine laid out
+bytes. **Producer ownership:** the entity emitting the model metadata is
+responsible for matching the physical layout it produced.
+
+Common physical layouts by framework:
+
+| Framework | Typical proto layout | Declaration |
+|-----------|---------------------|-------------|
+| TFLite (NNStreamer) | `[1, H, W, C]` NHWC | `shape=[1,H,W,C]`, `dshape=[batch,height,width,num_protos]` |
+| ONNX / PyTorch | `[1, C, H, W]` NCHW | `shape=[1,C,H,W]`, `dshape=[batch,num_protos,height,width]` |
+| Ara-2 DVM | `[1, N, 1, 4]` anchor-first | `shape=[1,N,1,4]`, `dshape=[batch,num_boxes,padding,box_coords]` |
+| Ultralytics flat | already canonical | `shape=[1,C,N]`, `dshape` may be omitted |
+
+### Per-scale split-tensor framework
+
+The [`per_scale`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/per_scale/)
+module is the high-performance hot path used for split-tensor models
+(Ara-2 DVM, certain TFLite exports). Detection headers come pre-split into
+per-scale tensors (e.g. 80×80, 40×40, 20×20). The pipeline:
+
+1. **Plan** ([`per_scale/plan.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/per_scale/plan.rs)) — walks the schema once, validating shapes and producing a stride-typed `Plan` that captures every per-scale tensor's role.
+2. **Pipeline** ([`per_scale/pipeline.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/per_scale/pipeline.rs)) — drives the per-frame decode using the `Plan`. Hot inner loops are NEON-vectorized on aarch64 (see `kernels/`).
+3. **Helper** ([`per_scale/helper.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/per_scale/helper.rs)) — small math primitives (sigmoid, dequant) shared between the planner and the pipeline.
+
+The per-scale path achieved 17–45× mask-materialize speedup on i.MX 8M Plus
+in the v0.18 → v0.20 cycle through batched GEMM, NEON FP16 fused-multiply,
+and tile-transpose layout changes. See the historical plans in
+[`.claude/plans/`](https://github.com/EdgeFirstAI/hal/tree/main/.claude/plans)
+(local-only, not part of the published crate) for full design notes.
+
+### Mask rendering APIs
+
+YOLO segmentation models produce **proto masks** (shared basis at reduced
+resolution, typically 160×160) and **mask coefficients** (per-detection
+linear combination weights):
+
+```
+mask_raw[i] = coefficients[i] @ protos       # (proto_h, proto_w)
+```
+
+The decoder exposes three mask APIs that pair with image-side rendering:
+
+| Workflow | Decoder API | Image-side render | Use case |
+|----------|-------------|-------------------|----------|
+| Materialized masks | `decode_quantized` / `decode_float` | `processor.draw_decoded_masks()` | When you need mask matrices on the CPU side |
+| Proto data (preferred for GPU) | `decode_quantized_proto` / `decode_float_proto` | `processor.draw_proto_masks()` | Fused proto→pixel GPU path; never materializes full-res masks on CPU |
+| Tracked + drawn in one call | (consumer of [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/)) | `processor.draw_masks_tracked()` | Single-call decode + track + render |
+
+The proto-data path is the recommended GPU path. It avoids the CPU cost of
+materializing full-resolution masks; the GPU evaluates `sigmoid(coeffs @
+upsampled_protos)` per output pixel using a fragment shader. See
+[`../image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
+for the GPU-side fused algorithm.
+
+## Performance Considerations
+
+- **Quantized integer math** — `decode_quantized` and `decode_quantized_proto` operate directly on int8/uint8 buffers, avoiding the cost of producing an intermediate dequantized `f32` tensor.
+- **Vectorized operations via ndarray** — bulk box and score arithmetic uses ndarray's iterator-fused operations.
+- **Parallel processing with Rayon** — per-detection mask matmul is parallelized when the candidate pool is large enough to amortize the rayon overhead.
+- **Early termination in NMS loops** — once the partial score-sort top-K is reached, NMS exits without examining lower-confidence anchors.
+- **NEON FP16 hot paths on aarch64** — see [`per_scale/kernels/`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/per_scale/kernels/). Stable Rust lacks f16 intrinsics, so the kernels use inline `.arch_extension fp16` assembly. Tile-transpose plus 2^k injection (k ∈ [-14, 15]) keeps the GEMM in F16 throughout the inner loop.
+- **Tracing spans** — emitted via `tracing::trace_span!` at every public decode entry point. Near-zero cost when no subscriber is active. See [`README.md#performance-tracing`](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing).
+
+### `pre_nms_top_k` for deployment vs. mAP evaluation
+
+The default `pre_nms_top_k = 300` is tuned for deployment workloads where
+`score_threshold ≥ 0.25` already filters most candidates. For COCO-style mAP
+evaluation at `score_threshold = 0.001`, **raise this cap** (typically to the
+full anchor count, e.g. 8400 for 640×640 YOLO) or set it to `0` (no limit).
+The default silently truncates ~74% of valid candidates at validation
+thresholds, costing ~9 pp box mAP — a measurement artifact, not a model
+quality issue. The decoder math is correct in both cases.
+
+## Inter-Crate Interfaces
+
+| Direction | Crate | Interface |
+|-----------|-------|-----------|
+| Depends on | [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) | `TensorDyn`, `Tensor<T>`, `TensorMap` for reading model output buffers |
+| Optional dep | [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) (feature `tracker`) | `Tracker<DetectBox>` for `decode_tracked()` |
+| Consumed by | [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) | `DetectBox`, `Segmentation`, proto data for `draw_*` rendering APIs |
+| Consumed by | [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) | re-export as `edgefirst_hal::decoder` |
+| Consumed by | [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) | C-API bindings for `Decoder`, `DetectBox`, `Segmentation` |
+
+## Cross-References
+
+- Project architecture: [../../ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
+- Image-side mask rendering: [../image/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
+- Tracker integration: [../tracker/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/ARCHITECTURE.md)
+- Performance tracing usage: [README.md#performance-tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)
+- Optimization guide (cross-crate user rules): [README.md#optimization-guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)

--- a/crates/decoder/ARCHITECTURE.md
+++ b/crates/decoder/ARCHITECTURE.md
@@ -154,7 +154,7 @@ class, ...)`.
 For non-end-to-end YOLO26 exports (`end2end=false`), use
 `decoder_version: "yolov8"` with an explicit `nms` configuration.
 
-### Output tensor physical-order contract (EDGEAI-1288)
+### Output tensor physical-order contract
 
 Every output declared to the decoder — whether programmatically via
 `hal_decoder_params_add_output` / `DecoderBuilder`, or through YAML/JSON
@@ -194,6 +194,39 @@ Common physical layouts by framework:
 | Ara-2 DVM | `[1, N, 1, 4]` anchor-first | `shape=[1,N,1,4]`, `dshape=[batch,num_boxes,padding,box_coords]` |
 | Ultralytics flat | already canonical | `shape=[1,C,N]`, `dshape` may be omitted |
 
+### Quantization on output tensors
+
+The per-scale decode path reads quantization parameters **from the
+output `Tensor`** (`tensor.quantization()`), not from the schema
+metadata. The integrator is responsible for propagating each output
+tensor's `(scale, zero_point)` onto the HAL `Tensor` before calling
+`decode_*` / `decode_*_proto`:
+
+```rust
+if dtype != DType::F32 {
+    let q = edgefirst_decoder::Quantization::from((scale, zero_point));
+    tensor.set_quantization(q)?;
+}
+```
+
+Failure modes when this step is skipped on quantized outputs:
+
+- **Per-scale path:** returns `DecoderError::QuantMissing` for split
+  tensors that have no per-scale quantization in the schema, or
+  silently identity-dequantizes (scale = 1.0, zero = 0) for the flat
+  variants — scores stay in raw int8 / uint8 units and never cross
+  thresholds, producing zero detections.
+- **Flat-detection path:** reads quantization from the schema if
+  present and falls back to identity otherwise; same silent-zero
+  failure mode for models whose quantization is only carried on the
+  runtime tensor.
+
+A producer that allocates the HAL output tensors should attach
+quantization at allocation time. A producer that receives output
+tensors from another layer (e.g. a TFLite delegate's output binding)
+must read the runtime's quantization metadata and call
+`set_quantization` before the first decode of that tensor.
+
 ### Per-scale split-tensor framework
 
 The [`per_scale`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/src/per_scale/)
@@ -207,9 +240,11 @@ per-scale tensors (e.g. 80×80, 40×40, 20×20). The pipeline:
 
 The per-scale path achieved 17–45× mask-materialize speedup on i.MX 8M Plus
 in the v0.18 → v0.20 cycle through batched GEMM, NEON FP16 fused-multiply,
-and tile-transpose layout changes. See the historical plans in
-[`.claude/plans/`](https://github.com/EdgeFirstAI/hal/tree/main/.claude/plans)
-(local-only, not part of the published crate) for full design notes.
+and tile-transpose layout changes. See
+[`BENCHMARKS.md`](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md)
+for the empirical numbers and
+[`CHANGELOG.md`](https://github.com/EdgeFirstAI/hal/blob/main/CHANGELOG.md)
+for the release-by-release history.
 
 ### Mask rendering APIs
 

--- a/crates/decoder/README.md
+++ b/crates/decoder/README.md
@@ -17,7 +17,8 @@ side of the EdgeFirst HAL workspace:
 - Optionally depends on [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) (feature `tracker`) for `decode_tracked()`.
 - Consumed by [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) — its `DetectBox`, `Segmentation`, and proto-data outputs feed the `draw_decoded_masks` / `draw_proto_masks` / `draw_masks_tracked` rendering APIs.
 - Re-exported from [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) as `edgefirst_hal::decoder`.
-- Bridged to C/Python via [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/).
+- Bridged to C via [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) (cbindgen-generated C ABI).
+- Bridged to Python via [`crates/python`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/) (PyO3 binding over the Rust umbrella crate; does not go through the C ABI).
 
 ## Supported Models
 
@@ -202,61 +203,13 @@ processor.draw_proto_masks(&mut frame, &detections, &proto_data)?;
 
 ## Model Type Variants
 
-The decoder automatically selects the appropriate model type based on the config:
-
-| Variant | Tensors | Description |
-|---------|---------|-------------|
-| `YoloDet` | 1 (detection) | Standard YOLO detection |
-| `YoloSegDet` | 2 (detection + protos) | YOLO detection + segmentation |
-| `YoloSegDet2Way` | 3 (detection + mask_coefs + protos) | YOLO segmentation with 2-way split output |
-| `YoloSplitDet` | 2 (boxes + scores) | Split-output detection |
-| `YoloSplitSegDet` | 4 (boxes + scores + mask_coeff + protos) | Split-output segmentation |
-| `YoloEndToEndDet` | 1 (detection) | End-to-end detection (post-NMS) |
-| `YoloEndToEndSegDet` | 2 (detection + protos) | End-to-end segmentation |
-| `YoloSplitEndToEndDet` | 3 (boxes + scores + classes) | Split end-to-end detection |
-| `YoloSplitEndToEndSegDet` | 5 (boxes + scores + classes + mask_coeff + protos) | Split end-to-end segmentation |
-| `ModelPackDet` | 2 (boxes + scores) | ModelPack detection |
-| `ModelPackSegDet` | 3 (boxes + scores + segmentation) | ModelPack segmentation |
-| `ModelPackDetSplit` | N (detection layers) | ModelPack split detection |
-| `ModelPackSegDetSplit` | N+1 (detection layers + segmentation) | ModelPack split segmentation |
-| `ModelPackSeg` | 1 (segmentation) | ModelPack semantic segmentation |
-
-### YOLO-SEG 2-Way Split Format
-
-`YoloSegDet2Way` handles TFLite INT8 segmentation models that use a **2-way split** to separate mask coefficients from the combined detection output. Boxes and class scores remain merged — they share similar value ranges so splitting them yields no quantization benefit. Only mask coefficients (unbounded linear projection) need a separate quantization scale.
-
-#### Output Tensor Layout
-
-| Output | Name | Shape | Content |
-|--------|------|-------|---------|
-| `output0` | detection | `[1, nc+4, N]` | Boxes (4 channels) + class scores (nc channels), combined |
-| `output1` | protos | `[1, H/4, W/4, 32]` | Prototype masks (4D NHWC) |
-| `output2` | mask_coefs | `[1, 32, N]` | Mask coefficients per anchor |
-
-Where `N=8400` for 640×640 input (standard YOLO multi-scale anchors: 80×80 + 40×40 + 20×20).
-**COCO example** (nc=80): detection is `[1, 84, 8400]`, mask_coefs is `[1, 32, 8400]`, protos is `[1, 160, 160, 32]`.
-
-#### Output Identification by Shape
-
-The builder classifies the three outputs by shape alone:
-
-- **4D tensor** → protos (only protos are 4D)
-- **3D, feature_dim == 32** → mask_coefs
-- **3D, feature_dim != 32** → detection (nc+4 channels)
-
-The feature dimension is the smaller of the two non-batch dimensions (channels-first: `shape[1]`; channels-last: `shape[2]`).
-
-#### Edge Case: nc=28
-
-When `num_classes + 4 == 32`, the detection and mask_coefs feature dimensions collide, making shape-based classification ambiguous. In this case the split is **not performed** — the model exports 2 outputs (unsplit detection + protos) and is decoded as `YoloSegDet` instead.
-
-#### Auto-Selection
-
-The builder selects `YoloSegDet2Way` automatically when it detects exactly 3 outputs whose shapes match the pattern above (one 4D proto tensor, one 3D tensor with feature_dim=32, one 3D tensor with feature_dim≠32). No extra configuration is required.
-
-#### Backwards Compatibility
-
-Older 4-output models (separate boxes + scores + mask_coefs + protos, i.e., `YoloSplitSegDet`) remain supported. The decoder classifies by shape, not by output count.
+The decoder automatically selects the appropriate model type from the
+output schema, supporting YOLO (detection / segmentation, with or
+without end-to-end NMS and split outputs) and ModelPack (detection,
+segmentation, split variants). The full variant matrix, output-shape
+disambiguation rules, the 2-way split format used by TFLite INT8
+segmentation models, and the `nc=28` edge case are documented in
+[ARCHITECTURE.md § Model-type selection](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md#model-type-selection).
 
 ## Tracked Decoding
 

--- a/crates/decoder/README.md
+++ b/crates/decoder/README.md
@@ -8,6 +8,17 @@
 
 This crate provides efficient post-processing for YOLO and ModelPack model outputs, supporting both floating-point and quantized inference results.
 
+## Role in edgefirst-hal
+
+`edgefirst-decoder` sits between the inference engine and the image-rendering
+side of the EdgeFirst HAL workspace:
+
+- Depends on [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) for reading model output buffers.
+- Optionally depends on [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) (feature `tracker`) for `decode_tracked()`.
+- Consumed by [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) — its `DetectBox`, `Segmentation`, and proto-data outputs feed the `draw_decoded_masks` / `draw_proto_masks` / `draw_masks_tracked` rendering APIs.
+- Re-exported from [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) as `edgefirst_hal::decoder`.
+- Bridged to C/Python via [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/).
+
 ## Supported Models
 
 | Family | Detection | Segmentation | Formats |
@@ -309,6 +320,13 @@ for (det, track) in detections.iter().zip(tracks.iter()) {
 | `last_updated` | `u64` | Timestamp of the most recent update |
 
 The `tracked_location` reflects the Kalman-filter prediction and may differ slightly from `det.bbox`, which is the raw decoded box before smoothing.
+
+## Documentation
+
+- Architecture overview: [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md)
+- Testing guide: [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/TESTING.md)
+- Full API reference: [docs.rs/edgefirst-decoder](https://docs.rs/edgefirst-decoder)
+- Project README: [../../README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md)
 
 ## License
 

--- a/crates/decoder/TESTING.md
+++ b/crates/decoder/TESTING.md
@@ -28,15 +28,21 @@ crates/decoder/
 
 ## Running Tests
 
+All `cargo test` invocations below pass `-- --test-threads=1` per the
+workspace single-threaded rule
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+Decoder tests are CPU-only, but the rule applies workspace-wide so commands
+stay consistent and copy-pasteable across crates.
+
 ```bash
 # Full suite (unit + integration + doc-tests)
-cargo test -p edgefirst-decoder
+cargo test -p edgefirst-decoder -- --test-threads=1
 
 # Just the integration tests
-cargo test -p edgefirst-decoder --tests
+cargo test -p edgefirst-decoder --tests -- --test-threads=1
 
 # Single integration test
-cargo test -p edgefirst-decoder --test per_scale_parity
+cargo test -p edgefirst-decoder --test per_scale_parity -- --test-threads=1
 
 # Doc-tests only
 cargo test -p edgefirst-decoder --doc

--- a/crates/decoder/TESTING.md
+++ b/crates/decoder/TESTING.md
@@ -70,17 +70,19 @@ cargo test -p edgefirst-decoder --doc
 # Native-host bench
 cargo bench -p edgefirst-decoder
 
-# Cross-compile + deploy (see project Makefile)
-make bench-arm
+# Cross-compile for a target (see BENCHMARKS.md for the deploy workflow)
+cargo-zigbuild zigbuild --target aarch64-unknown-linux-gnu --release \
+  -p edgefirst-decoder --bench decoder_benchmark
 ```
 
 | Benchmark | Source | What it measures |
 |-----------|--------|------------------|
 | `decoder_benchmark` | [`benches/decoder_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/benches/decoder_benchmark.rs) | End-to-end decode latency: detection-only, segmentation, proto-data, per-scale split-tensor; both quantized and float paths |
 
-The benchmark uses the project's standard `--bench` flag for host runs and
-the deploy targets in the workspace `Makefile` for cross-compile + on-target
-runs (i.MX 8M Plus, i.MX 95).
+The benchmark uses the project's standard `--bench` flag for host runs.
+The aarch64 cross-compile flow plus `scp` + on-target run procedure is
+documented in
+[`BENCHMARKS.md`](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md).
 
 ## Coverage Notes
 

--- a/crates/decoder/TESTING.md
+++ b/crates/decoder/TESTING.md
@@ -50,7 +50,7 @@ cargo test -p edgefirst-decoder --tests -- --test-threads=1
 cargo test -p edgefirst-decoder --test per_scale_parity -- --test-threads=1
 
 # Doc-tests only
-cargo test -p edgefirst-decoder --doc
+cargo test -p edgefirst-decoder --doc -- --test-threads=1
 ```
 
 ## Special Requirements

--- a/crates/decoder/TESTING.md
+++ b/crates/decoder/TESTING.md
@@ -13,7 +13,12 @@ crates/decoder/
 │   ├── per_scale/
 │   │   ├── pipeline.rs                 # Per-scale pipeline correctness tests
 │   │   ├── plan.rs                     # Schema → Plan validation tests
-│   │   └── helper.rs                   # NEON kernel unit tests
+│   │   ├── helper.rs                   # Per-scale helper math unit tests
+│   │   └── kernels/                    # NEON kernel unit tests
+│   │       ├── neon_baseline.rs        # Scalar reference + NEON parity
+│   │       ├── dequant.rs              # Quant → float dequant kernels
+│   │       ├── sigmoid.rs / softmax.rs # Activation kernels
+│   │       └── level_box.rs / level_score.rs / level_mc.rs
 │   └── schema.rs                       # SchemaV2 round-trip + fixture tests
 ├── tests/                              # Cross-cutting integration suites
 │   ├── decoder_capacity.rs
@@ -30,7 +35,7 @@ crates/decoder/
 
 All `cargo test` invocations below pass `-- --test-threads=1` per the
 workspace single-threaded rule
-([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution)).
 Decoder tests are CPU-only, but the rule applies workspace-wide so commands
 stay consistent and copy-pasteable across crates.
 
@@ -58,7 +63,7 @@ cargo test -p edgefirst-decoder --doc
 - **No hardware gates.** All decoder tests run on any host; there is no GPU
   or NPU dependency.
 - **`tracker` feature** — gates the `decode_tracked` test paths. Run
-  `cargo test -p edgefirst-decoder --features tracker` to exercise them.
+  `cargo test -p edgefirst-decoder --features tracker -- --test-threads=1` to exercise them.
 - **Per-scale fixtures** — synthetic schemas under
   [`testdata/per_scale/`](https://github.com/EdgeFirstAI/hal/tree/main/testdata/per_scale)
   validate the per-scale planner against multiple split-tensor topologies

--- a/crates/decoder/TESTING.md
+++ b/crates/decoder/TESTING.md
@@ -1,0 +1,101 @@
+# edgefirst-decoder Testing
+
+## Test Layout
+
+```
+crates/decoder/
+├── src/
+│   ├── lib.rs                          # Doc-tests on the public API surface
+│   ├── decoder/
+│   │   ├── tests.rs                    # Builder, segmentation, parity tests
+│   │   ├── builder.rs                  # Doc-tests on DecoderBuilder methods
+│   │   └── config.rs                   # Doc-tests on ConfigOutputs
+│   ├── per_scale/
+│   │   ├── pipeline.rs                 # Per-scale pipeline correctness tests
+│   │   ├── plan.rs                     # Schema → Plan validation tests
+│   │   └── helper.rs                   # NEON kernel unit tests
+│   └── schema.rs                       # SchemaV2 round-trip + fixture tests
+├── tests/                              # Cross-cutting integration suites
+│   ├── decoder_capacity.rs
+│   ├── decoder_decode_vs_proto_parity.rs
+│   ├── decoder_from_edgefirst_json.rs
+│   ├── decoder_normalized_flag.rs
+│   ├── per_scale_parity.rs
+│   └── common/                         # Shared fixture loaders
+└── benches/
+    └── decoder_benchmark.rs
+```
+
+## Running Tests
+
+```bash
+# Full suite (unit + integration + doc-tests)
+cargo test -p edgefirst-decoder
+
+# Just the integration tests
+cargo test -p edgefirst-decoder --tests
+
+# Single integration test
+cargo test -p edgefirst-decoder --test per_scale_parity
+
+# Doc-tests only
+cargo test -p edgefirst-decoder --doc
+```
+
+## Special Requirements
+
+- **LFS testdata** — model fixtures live under `testdata/` and are tracked
+  via Git LFS. Tests load them through `edgefirst_bench::testdata::read*`,
+  which honors the `EDGEFIRST_TESTDATA_DIR` environment variable. CI sets
+  this to `${{ github.workspace }}/testdata`. Locally, the helper falls back
+  to `<workspace>/testdata` so no env var is needed.
+- **No hardware gates.** All decoder tests run on any host; there is no GPU
+  or NPU dependency.
+- **`tracker` feature** — gates the `decode_tracked` test paths. Run
+  `cargo test -p edgefirst-decoder --features tracker` to exercise them.
+- **Per-scale fixtures** — synthetic schemas under
+  [`testdata/per_scale/`](https://github.com/EdgeFirstAI/hal/tree/main/testdata/per_scale)
+  validate the per-scale planner against multiple split-tensor topologies
+  (yolov8n, yolo26n, flat). The fixture generator is in
+  [`crates/decoder/tests/common/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/decoder/tests/common).
+- **Decoder fixture framework** — the
+  [`crates/decoder/tests/decoder_decode_vs_proto_parity.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/tests/decoder_decode_vs_proto_parity.rs)
+  suite validates that `decode_quantized` and `decode_quantized_proto`
+  produce identical detections for the same inputs (the key invariant for
+  the GPU fused mask path).
+
+## Benchmarks
+
+```bash
+# Native-host bench
+cargo bench -p edgefirst-decoder
+
+# Cross-compile + deploy (see project Makefile)
+make bench-arm
+```
+
+| Benchmark | Source | What it measures |
+|-----------|--------|------------------|
+| `decoder_benchmark` | [`benches/decoder_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/benches/decoder_benchmark.rs) | End-to-end decode latency: detection-only, segmentation, proto-data, per-scale split-tensor; both quantized and float paths |
+
+The benchmark uses the project's standard `--bench` flag for host runs and
+the deploy targets in the workspace `Makefile` for cross-compile + on-target
+runs (i.MX 8M Plus, i.MX 95).
+
+## Coverage Notes
+
+- The crate participates in workspace `cargo llvm-cov`; lcov output appears
+  under `crates/decoder/`.
+- The split-tensor framework's NEON kernels are exercised by
+  `per_scale_parity` against a scalar reference implementation in the same
+  test file — this is the primary correctness gate for the optimized path.
+- Doc-tests on the public API surface (e.g. `DecoderBuilder` methods) are
+  marked `no_run` because they require model fixtures to load. The
+  underlying logic is exercised by the unit tests in `decoder/tests.rs`.
+
+## Cross-References
+
+- Project testing patterns: [../../TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md)
+- Validating optimizations: [TESTING.md#validating-optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations)
+- Image-side mask rendering tests: [../image/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md)
+- Tracker tests: [../tracker/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/TESTING.md)

--- a/crates/hal/ARCHITECTURE.md
+++ b/crates/hal/ARCHITECTURE.md
@@ -1,0 +1,78 @@
+# edgefirst-hal Architecture
+
+## Overview
+
+`edgefirst-hal` is the umbrella crate for the EdgeFirst Hardware Abstraction
+Layer. Its job is to give downstream applications a single dependency that
+re-exports the four core HAL crates, plus an optional process-wide tracing
+subscriber for end-to-end performance analysis. The umbrella owns no domain
+types of its own — every type a user interacts with is defined in one of the
+sub-crates.
+
+## Module Map
+
+| Module | Source | Re-exports / owns |
+|--------|--------|-------------------|
+| `edgefirst_hal::tensor` | `edgefirst-tensor` | Zero-copy tensor memory (DMA, SHM, PBO, system memory) |
+| `edgefirst_hal::image` | `edgefirst-image` | Hardware-accelerated image processing (OpenGL, G2D, CPU) |
+| `edgefirst_hal::decoder` | `edgefirst-decoder` | ML model output decoding (YOLOv5/v8/v11/v26, ModelPack) |
+| `edgefirst_hal::tracker` | `edgefirst-tracker` (feature `tracker`) | ByteTrack multi-object tracking |
+| `edgefirst_hal::trace` | local (feature `tracing`) | Process-wide span subscriber + Chrome/Perfetto trace capture |
+
+## Key Types
+
+The umbrella owns only the tracing API:
+
+- [`trace::start_tracing(path)`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs) — install the global subscriber and begin writing spans to `path`.
+- [`trace::stop_tracing()`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs) — flush and close the trace file.
+
+All other public types live in the sub-crates. See each sub-crate's
+ARCHITECTURE.md for the type-level detail.
+
+## Internal Architecture
+
+### Re-export layer
+
+`crates/hal/src/lib.rs` is a thin file (~12 lines) that does only `pub use`
+re-exports. The `tracker` re-export is gated on the `tracker` Cargo feature
+because tracking is an optional capability that pulls in additional
+dependencies. The `trace` module is gated on the `tracing` feature.
+
+This shape means the umbrella has zero runtime cost over depending directly on
+each sub-crate; it exists only for ergonomics (one dependency, one version
+number, one feature surface).
+
+### Tracing subscriber
+
+The optional `trace` module installs a process-wide
+[`tracing-subscriber`](https://docs.rs/tracing-subscriber) once, on the first
+call to `start_tracing`. The subscriber consists of a
+[`tracing-chrome`](https://docs.rs/tracing-chrome) layer that writes spans to a
+JSON file viewable at <https://ui.perfetto.dev/>.
+
+Sub-crate hot paths emit `tracing::trace_span!` spans with near-zero overhead
+when no subscriber is active (a single relaxed atomic load per span site). The
+umbrella's tracing layer is what activates them. See
+[Performance Tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)
+in the project README for the user-facing guide and span name reference.
+
+Only one trace capture session is supported per process lifetime — this is a
+limitation of Rust's global subscriber model and is acceptable for profiling
+workflows where a single trace per run is the norm.
+
+## Inter-Crate Interfaces
+
+The umbrella has no inter-crate interfaces beyond the re-exports listed in the
+Module Map. Sub-crate inter-dependencies are documented in the
+[Internal Dependency Graph](https://github.com/EdgeFirstAI/hal/blob/main/README.md#internal-dependency-graph)
+section of the project README.
+
+## Cross-References
+
+- Project architecture: [../../ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
+- Tracing usage: [README.md#performance-tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)
+- Sub-crate architectures:
+  [tensor](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md),
+  [image](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md),
+  [decoder](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md),
+  [tracker](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/ARCHITECTURE.md)

--- a/crates/hal/ARCHITECTURE.md
+++ b/crates/hal/ARCHITECTURE.md
@@ -60,6 +60,19 @@ Only one trace capture session is supported per process lifetime — this is a
 limitation of Rust's global subscriber model and is acceptable for profiling
 workflows where a single trace per run is the norm.
 
+## Performance Considerations
+
+The umbrella crate has no hot paths of its own; runtime cost is identical
+to depending on each sub-crate directly. The only umbrella-owned code is
+the optional `trace` module, whose span sites in the sub-crates compile
+to a single relaxed atomic load when no subscriber is installed. See
+[`crates/decoder/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md),
+[`crates/image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md),
+and
+[`crates/tensor/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md)
+for the per-crate performance notes that the umbrella's tracing layer
+exposes.
+
 ## Inter-Crate Interfaces
 
 The umbrella has no inter-crate interfaces beyond the re-exports listed in the

--- a/crates/hal/README.md
+++ b/crates/hal/README.md
@@ -87,14 +87,9 @@ Python-specific documentation.
 - Testing guide: [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/TESTING.md)
 - Full API reference: [docs.rs/edgefirst-hal](https://docs.rs/edgefirst-hal)
 - Project README: [README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md)
+- Python package: [pypi.org/project/edgefirst-hal](https://pypi.org/project/edgefirst-hal/)
+- [EdgeFirst AI](https://edgefirst.ai)
 
 ## License
 
 Licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE) for details.
-
-## Links
-
-- [EdgeFirst AI](https://edgefirst.ai)
-- [GitHub Repository](https://github.com/EdgeFirstAI/hal)
-- [API Documentation](https://docs.rs/edgefirst-hal)
-- [Python Package](https://pypi.org/project/edgefirst-hal/)

--- a/crates/hal/README.md
+++ b/crates/hal/README.md
@@ -81,6 +81,13 @@ pip install edgefirst-hal
 See [`edgefirst-hal` on PyPI](https://pypi.org/project/edgefirst-hal/) for
 Python-specific documentation.
 
+## Documentation
+
+- Architecture overview: [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/ARCHITECTURE.md)
+- Testing guide: [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/TESTING.md)
+- Full API reference: [docs.rs/edgefirst-hal](https://docs.rs/edgefirst-hal)
+- Project README: [README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md)
+
 ## License
 
 Licensed under the Apache License, Version 2.0. See [LICENSE](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE) for details.

--- a/crates/hal/TESTING.md
+++ b/crates/hal/TESTING.md
@@ -1,0 +1,56 @@
+# edgefirst-hal Testing
+
+## Test Layout
+
+The umbrella crate has no unit tests of its own; all test coverage comes from
+the sub-crates it re-exports. The two narrow concerns the umbrella tests
+itself are:
+
+- **Doc-tests** for the `trace::start_tracing` / `stop_tracing` API in
+  [`crates/hal/src/trace.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs).
+- **Compile-time feature-flag conditionals** are exercised by building the
+  crate with each combination of `default`, `tracker`, and `tracing` enabled.
+
+## Running Tests
+
+```bash
+# Default features (ndarray, opengl, tracing)
+cargo test -p edgefirst-hal
+
+# All features
+cargo test -p edgefirst-hal --all-features
+
+# No default features (verifies the lib compiles minimally)
+cargo test -p edgefirst-hal --no-default-features
+```
+
+The doc-tests for `trace::*` are marked `no_run` because installing a global
+tracing subscriber has process-lifetime side effects; they verify only that
+the example code compiles against the public API.
+
+## Special Requirements
+
+- The `tracing` feature pulls in `tracing-subscriber` and `tracing-chrome`.
+  CI builds with `--features tracing` so doc-tests for the trace module
+  participate in coverage.
+- The `tracker` feature pulls in `edgefirst-tracker` and enables the
+  `edgefirst_hal::tracker` re-export. CI exercises this via the workspace
+  feature matrix in
+  [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml).
+
+## Coverage Notes
+
+Coverage for the umbrella is collected through the workspace `cargo
+llvm-cov` run; the small surface of `lib.rs` re-exports and the `trace`
+module's doc-tests show up under `crates/hal/` in the lcov report. The
+substantive coverage numbers come from the sub-crates.
+
+## Cross-References
+
+- Project testing patterns: [../../TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md)
+- Validating optimizations: [TESTING.md#validating-optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations)
+- Sub-crate testing guides:
+  [tensor](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/TESTING.md),
+  [image](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md),
+  [decoder](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/TESTING.md),
+  [tracker](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/TESTING.md)

--- a/crates/hal/TESTING.md
+++ b/crates/hal/TESTING.md
@@ -75,10 +75,12 @@ Coverage for the umbrella is collected through the workspace
 `cargo llvm-cov nextest` run; the small surface of `lib.rs` re-exports
 shows up under `crates/hal/` in the lcov report. Doc-tests are not
 included in the llvm-cov report — the workspace `cargo test --doc`
-job runs separately and is not coverage-instrumented, so the `trace`
-module's doc-tests verify only that the example code compiles and
-runs against the public API. The substantive coverage numbers come
-from the sub-crates.
+job runs separately and is not coverage-instrumented. The `trace`
+module's executable Rust doc-tests are additionally marked `no_run`
+(installing a global tracing subscriber has process-lifetime side
+effects), so they only **compile** against the public API; they are
+not actually executed. The substantive coverage numbers come from
+the sub-crates.
 
 ## Cross-References
 

--- a/crates/hal/TESTING.md
+++ b/crates/hal/TESTING.md
@@ -38,6 +38,18 @@ the example code compiles against the public API.
   feature matrix in
   [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml).
 
+## Benchmarks
+
+The umbrella crate ships no benchmarks of its own — every measurable
+hot path is owned by a sub-crate. Use the sub-crate benchmarks
+(`tensor_benchmark`, `image_benchmark`, `decoder_benchmark`,
+`tracker_benchmark`) for per-component numbers, and combine them with
+the `trace` module to capture end-to-end Chrome JSON traces. See the
+[Benchmarking](https://github.com/EdgeFirstAI/hal/blob/main/README.md#benchmarking)
+and
+[Performance Tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)
+sections of the project README.
+
 ## Coverage Notes
 
 Coverage for the umbrella is collected through the workspace `cargo

--- a/crates/hal/TESTING.md
+++ b/crates/hal/TESTING.md
@@ -13,15 +13,19 @@ itself are:
 
 ## Running Tests
 
+All `cargo test` invocations below pass `-- --test-threads=1` per the
+workspace single-threaded rule
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+
 ```bash
 # Default features (ndarray, opengl, tracing)
-cargo test -p edgefirst-hal
+cargo test -p edgefirst-hal -- --test-threads=1
 
 # All features
-cargo test -p edgefirst-hal --all-features
+cargo test -p edgefirst-hal --all-features -- --test-threads=1
 
 # No default features (verifies the lib compiles minimally)
-cargo test -p edgefirst-hal --no-default-features
+cargo test -p edgefirst-hal --no-default-features -- --test-threads=1
 ```
 
 The doc-tests for `trace::*` are marked `no_run` because installing a global
@@ -34,8 +38,9 @@ the example code compiles against the public API.
   CI builds with `--features tracing` so doc-tests for the trace module
   participate in coverage.
 - The `tracker` feature pulls in `edgefirst-tracker` and enables the
-  `edgefirst_hal::tracker` re-export. CI exercises this via the workspace
-  feature matrix in
+  `edgefirst_hal::tracker` re-export. CI exercises this through the
+  workspace doc-test job (`cargo test --doc --workspace --all-features`)
+  and the per-platform `cargo nextest run` jobs in
   [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml).
 
 ## Benchmarks

--- a/crates/hal/TESTING.md
+++ b/crates/hal/TESTING.md
@@ -8,12 +8,18 @@ itself are:
 
 - **Doc-tests** for the `trace::start_tracing` / `stop_tracing` API in
   [`crates/hal/src/trace.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs).
-- **Compile-time feature-flag conditionals** are exercised by the CI
-  jobs that build the crate under three feature configurations:
-  `default`, `--all-features`, and `--no-default-features`. CI does not
-  iterate every pairwise combination of `default` / `tracker` /
-  `tracing`; contributors who need a specific combination should run
-  it locally (see the commands below).
+- **Compile-time feature-flag conditionals** are exercised in CI by:
+  - the workspace doc-test job, which runs with `--all-features`
+    (`cargo test --doc --workspace --all-features`); and
+  - the per-platform `cargo nextest` jobs, which run with
+    `--features default,opencv` on the `--workspace`.
+
+  CI does **not** build the umbrella with `--no-default-features` and
+  does not iterate every combination of `default` / `tracker` /
+  `tracing`. The `tracker` feature on the umbrella is therefore only
+  exercised through the all-features doc-test job; contributors who
+  need a specific combination should run it locally (see the commands
+  below).
 
 ## Running Tests
 
@@ -42,10 +48,14 @@ the example code compiles against the public API.
   CI builds with `--features tracing` so doc-tests for the trace module
   participate in coverage.
 - The `tracker` feature pulls in `edgefirst-tracker` and enables the
-  `edgefirst_hal::tracker` re-export. CI exercises this through the
-  workspace doc-test job (`cargo test --doc --workspace --all-features`)
-  and the per-platform `cargo nextest run` jobs in
-  [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml).
+  `edgefirst_hal::tracker` re-export. CI exercises this only through
+  the workspace doc-test job
+  (`cargo test --doc --workspace --all-features`) — the per-platform
+  `cargo nextest` jobs run with `--features default,opencv`, which
+  does **not** include `tracker` (see
+  [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml)).
+  Run `cargo test -p edgefirst-hal --features tracker -- --test-threads=1`
+  locally if you need to exercise the re-export in nextest-style tests.
 
 ## Benchmarks
 
@@ -61,10 +71,14 @@ sections of the project README.
 
 ## Coverage Notes
 
-Coverage for the umbrella is collected through the workspace `cargo
-llvm-cov` run; the small surface of `lib.rs` re-exports and the `trace`
-module's doc-tests show up under `crates/hal/` in the lcov report. The
-substantive coverage numbers come from the sub-crates.
+Coverage for the umbrella is collected through the workspace
+`cargo llvm-cov nextest` run; the small surface of `lib.rs` re-exports
+shows up under `crates/hal/` in the lcov report. Doc-tests are not
+included in the llvm-cov report — the workspace `cargo test --doc`
+job runs separately and is not coverage-instrumented, so the `trace`
+module's doc-tests verify only that the example code compiles and
+runs against the public API. The substantive coverage numbers come
+from the sub-crates.
 
 ## Cross-References
 

--- a/crates/hal/TESTING.md
+++ b/crates/hal/TESTING.md
@@ -8,14 +8,18 @@ itself are:
 
 - **Doc-tests** for the `trace::start_tracing` / `stop_tracing` API in
   [`crates/hal/src/trace.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs).
-- **Compile-time feature-flag conditionals** are exercised by building the
-  crate with each combination of `default`, `tracker`, and `tracing` enabled.
+- **Compile-time feature-flag conditionals** are exercised by the CI
+  jobs that build the crate under three feature configurations:
+  `default`, `--all-features`, and `--no-default-features`. CI does not
+  iterate every pairwise combination of `default` / `tracker` /
+  `tracing`; contributors who need a specific combination should run
+  it locally (see the commands below).
 
 ## Running Tests
 
 All `cargo test` invocations below pass `-- --test-threads=1` per the
 workspace single-threaded rule
-([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution)).
 
 ```bash
 # Default features (ndarray, opengl, tracing)

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -230,8 +230,8 @@ Key implications:
   making it safe to chain calls.
 
 See [Appendix C: DMA-BUF Identity and Tensor Caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
-in the project ARCHITECTURE.md for the cross-crate cache story (V4L2 fd
-recycling, inode-keyed cache, `edgefirstcameraadaptor` integration).
+in the project ARCHITECTURE.md for the cross-crate cache story (V4L2
+fd recycling, inode-keyed cache, GStreamer adaptor integration).
 
 ### Vivante NV12 → PlanarRgb two-pass workaround
 
@@ -333,6 +333,44 @@ Control quantized proto interpolation via
 > i.MX 8M Plus without EGL), all `draw_*` methods return
 > `NotImplemented`. Use an OpenGL-capable processor (pass an
 > `egl_display`) or fall back to CPU rendering.
+
+#### Vivante shader performance cliff and the eager-materialize workaround
+
+The fused `draw_proto_masks` path is the preferred GPU pipeline on
+Mali / Panfrost (i.MX 95) and on desktop GPUs, where the per-pixel
+sigmoid + dot product runs comfortably under real-time even at large
+detection counts. **On Vivante GC7000UL (i.MX 8M Plus)** the same
+shader can fall off a cliff for models with many detections or large
+proto fields, reaching multi-second per-frame latency. The driver's
+fragment-shader scheduling on this part does not amortise the
+per-quad-per-pixel work the way mainline GPUs do.
+
+The safe pattern on Vivante (and as a defensive choice for any
+deployment that may run on it) is to **materialise masks once on the
+CPU** via `materialize_masks` immediately after decode, free the proto
+data, and then render with the cheap `draw_decoded_masks` blit:
+
+```rust
+// On the decode thread:
+let masks = processor.materialize_masks(
+    &boxes, &scores, &classes, &proto_data,
+    letterbox_norm,
+    MaskResolution::Scaled { width: dst_w, height: dst_h },
+)?;
+drop(proto_data); // free the proto tensor immediately
+
+// On the render thread (or the same thread, just later):
+processor.draw_decoded_masks(&mut frame, &boxes, &masks, overlay)?;
+```
+
+`materialize_masks` runs the same batched-GEMM kernel exercised by
+`mask_benchmark` (see [`TESTING.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md#benchmarks)),
+which is well-amortised across detections; `draw_decoded_masks`
+becomes a cheap RGBA blit. The combined CPU + GPU cost on i.MX 8M
+Plus is comfortably real-time at typical COCO detection counts. On
+Mali / desktop GPUs, switching back to the fused `draw_proto_masks`
+is straightforward — the data flow is the same up to the choice of
+render call.
 
 ## Process-Shutdown Resource Cleanup
 

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -427,18 +427,21 @@ The crash arises from a fundamental conflict between four systems:
 │   Catches panics from eglDestroyContext/eglMakeCurrent  │
 │   if function pointers are invalidated                  │
 ├─────────────────────────────────────────────────────────┤
-│ Layer 4: eglTerminate inside catch_unwind               │
-│   Releases ref-counted display; catch_unwind absorbs    │
-│   any driver-side misbehaviour                          │
+│ Layer 4: Skip eglTerminate entirely                     │
+│   Display lives in a process-global OnceLock and is     │
+│   intentionally leaked; eglTerminate is never called    │
 └─────────────────────────────────────────────────────────┘
 ```
 
-`GlContext::drop` performs explicit EGL resource cleanup (destroy context,
-destroy surface, terminate display) inside `catch_unwind`, then
-intentionally skips dropping the `Rc<Egl>` wrapper. The EGL library handle
-is leaked via `Box::leak` at load time so it is never `dlclose`'d.
-`eglTerminate` is ref-counted per the EGL spec — each `eglInitialize`
-increments the count, each `eglTerminate` decrements it.
+`GlContext::drop` calls `eglMakeCurrent(EGL_NO_CONTEXT)` and
+`eglDestroyContext` inside `catch_unwind`, then intentionally skips
+dropping the `Rc<Egl>` wrapper. The EGL library handle is leaked via
+`Box::leak` at load time so it is never `dlclose`'d. The EGL display
+itself lives in the `SHARED_DISPLAY` `OnceLock` (`SharedEglDisplay`) and
+is never terminated — the EGL spec ref-counts `eglTerminate` against
+`eglInitialize`, but calling it from `GlContext::drop` would tear the
+display down for every other live `GlContext` in the process, so the
+HAL leaks it on purpose.
 
 ### Industry precedent
 
@@ -475,21 +478,26 @@ code (where many G2D processors are created/destroyed in one process), the
 avoid repeated `g2d_close` + `dlclose` cycles that exhaust driver
 resources.
 
-### Resource leak prevention policy
+### Resource cleanup policy
 
-- **EGL displays** — `eglTerminate` in `GlContext::drop`. EGL spec
-  ref-counts; only the last terminate tears down state.
-- **EGL contexts** — `eglDestroyContext` before `eglTerminate`. No EGL
-  surfaces are created — the HAL uses surfaceless contexts
-  (`EGL_KHR_surfaceless_context` + `EGL_KHR_no_config_context`) and
-  renders exclusively through FBOs backed by EGLImages.
+- **EGL displays** — never terminated. The process-global
+  `SharedEglDisplay` is created once via `OnceLock` and leaked on
+  process exit. `eglTerminate` is the *EGL way* to release a display
+  but in practice causes driver crashes (see the defense-in-depth
+  section above), so the HAL never calls it.
+- **EGL contexts** — `eglDestroyContext` in `GlContext::drop`, inside
+  `catch_unwind`. No EGL surfaces are created — the HAL uses
+  surfaceless contexts (`EGL_KHR_surfaceless_context` +
+  `EGL_KHR_no_config_context`) and renders exclusively through FBOs
+  backed by EGLImages.
 - **DMA buffers** — fd `close()` in `Drop`.
 - **G2D contexts** — `g2d_close` in `G2DProcessor::drop`.
 
-Intentional leaks are restricted to the EGL library handle (`Box::leak`)
-and the `Rc<Egl>` wrapper (`ManuallyDrop`) — lightweight Rust-side
-objects. Actual GPU/display resources are released by the explicit
-cleanup calls.
+Intentional leaks: the EGL library handle (`Box::leak`), the `Rc<Egl>`
+wrapper (`ManuallyDrop`), and the shared EGL display
+(`SHARED_DISPLAY: OnceLock`). All three are process-lifetime objects;
+the OS reclaims them at exit. GPU contexts, DMA buffers, and G2D
+contexts are released eagerly by their `Drop` impls.
 
 ## GL Command Serialization (GL_MUTEX)
 
@@ -519,8 +527,10 @@ instance. Acquired in three places:
 2. **Message dispatch** — wraps every incoming GL-thread message
    (convert, draw masks, PBO create/download, etc.) so only one GL thread
    executes driver calls at a time.
-3. **Teardown** — wraps `GLProcessorST::drop()` → `GlContext::drop()` so
-   `eglDestroyContext` / `eglTerminate` are serialized.
+3. **Teardown** — wraps `GLProcessorST::drop()` → `GlContext::drop()`
+   so `eglDestroyContext` (and `eglMakeCurrent(EGL_NO_CONTEXT)`) are
+   serialized. The shared display is never terminated, so teardown
+   does not race against display state.
 
 The mutex uses `unwrap_or_else(|e| e.into_inner())` to recover from
 poisoning: if a prior GL operation panicked, subsequent operations on
@@ -549,7 +559,7 @@ approach prioritizes correctness across all targets.
 |--------------|----------------|
 | Reuse tensors across frames | Each new tensor allocates a fresh `BufferIdentity`. EGL image cache is keyed by `(BufferIdentity.id, chroma_id)`. New ID → cache miss → full `eglCreateImageKHR` import (~100–300 µs). Hold tensors alive. |
 | Allocate via `create_image()` | The processor selects DMA-buf, PBO, or heap based on the runtime GPU probe at `new()` time. Bypassing with `Tensor::new(memory=...)` forces a slow transfer path on every `convert()`. |
-| One `ImageProcessor` per pipeline | Each instance owns an EGL display, a GL thread, per-thread caches. Multiple instances serialize on `GL_MUTEX`. |
+| One `ImageProcessor` per pipeline | Each instance owns its OpenGL context, GL thread, and per-thread caches (the EGL display is process-global and shared). Multiple instances still serialize on `GL_MUTEX`, so concurrent use across instances buys nothing. |
 | Native CPU feature builds (Rule 6) | A build-time concern. `RUSTFLAGS` controls whether the f16 mask kernel at [`crates/image/src/cpu/masks.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/cpu/masks.rs) compiles to native widening instructions or to the soft-float `__extendhfsf2` helper. Distributed binaries stay on triple baseline ISA; benchmark hosts opt in via `RUSTFLAGS` overrides. |
 
 See the [Optimization Guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -270,11 +270,12 @@ mask_raw[i] = coefficients[i] @ protos       # (proto_h, proto_w)
 The image crate exposes three rendering pipelines paired with the decoder's
 mask APIs:
 
-| Workflow | Decoder source | Image-side render | Best for |
-|----------|----------------|-------------------|----------|
-| Materialized | `decode_quantized` / `decode_float` | `draw_decoded_masks` | Already have mask matrices |
-| Fused proto path | `decode_quantized_proto` / `decode_float_proto` | `draw_proto_masks` | Real-time GPU overlay (preferred) |
-| Tracked + drawn | (consumes [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/)) | `draw_masks_tracked` | Single-call decode + track + render |
+| Workflow | Decoder source (public API) | Image-side render | Best for |
+|----------|-----------------------------|-------------------|----------|
+| Materialized | [`Decoder::decode()`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html#method.decode) | `draw_decoded_masks` | Already have mask matrices |
+| Fused proto path | [`Decoder::decode_proto()`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html#method.decode_proto) | `draw_proto_masks` | Real-time GPU overlay (preferred) |
+| Tracked materialized | [`Decoder::decode_tracked()`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html#method.decode_tracked) (via [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/)) | `draw_masks_tracked` | Single-call decode + track + render |
+| Tracked proto | [`Decoder::decode_proto_tracked()`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html#method.decode_proto_tracked) | `draw_proto_masks` (with track-augmented detections) | Tracked GPU-fused path |
 
 ### MaskOverlay
 
@@ -286,7 +287,9 @@ pub struct MaskOverlay<'a> {
                                             // model-input normalized space;
                                             // maps decoder output back to
                                             // original image coords when set
-    pub color_mode: ColorMode,             // Class | Instance | TrackId
+    pub color_mode: ColorMode,             // Class | Instance | Track
+                                            // (Track currently behaves
+                                            //  like Instance — see below)
 }
 ```
 

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -85,8 +85,12 @@ Variables](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/README.md#e
 The image-side type system reuses [`edgefirst_tensor::TensorDyn`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/struct.TensorDyn.html)
 as the dtype-erased image carrier. `TensorDyn` wraps a `Tensor<T>` and a
 `PixelFormat`; the format describes the spatial layout, the `DType` describes
-element storage. Width / height / channels / stride are **not stored** — they
-are computed from shape + format on every access:
+element storage. Width / height / channels are **not stored** — they
+are computed from shape + format on every access. Row stride is **optional
+metadata** (`Tensor::row_stride()` / `set_row_stride()` /
+`effective_row_stride()`); it is left unset for tightly packed buffers and
+is required for padded DMA-BUF imports where the producer's stride differs
+from `width * bytes_per_pixel`.
 
 | Format | Tensor shape | Notes |
 |--------|--------------|-------|
@@ -155,10 +159,13 @@ required because EGL contexts are thread-local — every GL call must happen
 on the thread that created the context.
 
 The [`PboOps`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/trait.PboOps.html)
-trait bridges the tensor crate and the GL thread: `PboTensor` holds a
-`WeakSender` to the GL thread channel. When the tensor needs to map / unmap
-/ delete the PBO, it sends a message through this channel. The weak sender
-ensures PBO tensors don't prevent GL thread shutdown — see
+trait bridges the tensor crate and the GL thread. `PboTensor` (defined in
+the tensor crate) holds an `Arc<dyn PboOps>`; the image crate's
+`GlPboOps` implementation of that trait is what owns the `WeakSender` to
+the GL-thread channel. When the tensor needs to map / unmap / delete the
+PBO, it calls into the `PboOps` impl, which sends a message through the
+channel. The weak sender ensures PBO tensors don't prevent GL thread
+shutdown — see
 [`crates/tensor/ARCHITECTURE.md#pbo-tensors-and-the-weaksender-pattern`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md#pbo-tensors-and-the-weaksender-pattern).
 
 ### GLES 3.1 context and the optional compute path
@@ -275,6 +282,11 @@ mask APIs:
 pub struct MaskOverlay<'a> {
     pub background: Option<&'a TensorDyn>, // blit before drawing masks
     pub opacity: f32,                       // 0.0 invisible, 1.0 opaque
+    pub letterbox: Option<[f32; 4]>,       // [xmin, ymin, xmax, ymax] in
+                                            // model-input normalized space;
+                                            // maps decoder output back to
+                                            // original image coords when set
+    pub color_mode: ColorMode,             // Class | Instance | TrackId
 }
 ```
 
@@ -548,10 +560,11 @@ in the project README for the user-facing rules and validation patterns.
 | Direction | Crate | Interface |
 |-----------|-------|-----------|
 | Depends on | [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) | `TensorDyn`, `Tensor<T>`, `BufferIdentity`, `PboOps` impl |
-| Depends on (feature `decoder`) | [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) | `DetectBox`, `Segmentation`, proto data for `draw_*` |
+| Depends on (unconditional) | [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) | `DetectBox`, `Segmentation`, proto data for `draw_*` |
 | Depends on (feature `tracker`) | [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) | `Tracker<DetectBox>` for `draw_masks_tracked` |
 | Consumed by | [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) | re-export as `edgefirst_hal::image` |
-| Consumed by | [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) | C/Python bindings for `ImageProcessor` and rendering APIs |
+| Consumed by | [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) | C bindings for `ImageProcessor` and rendering APIs (does **not** bridge to Python) |
+| Consumed by | [`crates/python`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/) | PyO3 binding over the Rust umbrella crate (does not go through the C API) |
 
 ## Platform-Specific Notes
 

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -1,0 +1,536 @@
+# edgefirst-image Architecture
+
+## Overview
+
+`edgefirst-image` provides hardware-accelerated image format conversion,
+resizing, rotation, cropping, and segmentation-mask rendering for EdgeFirst
+inference pipelines. The crate's central type is
+[`ImageProcessor`](https://docs.rs/edgefirst-image/latest/edgefirst_image/struct.ImageProcessor.html),
+an orchestrator that probes available hardware once at construction time and
+then dispatches per-call to the most efficient backend in the chain
+**OpenGL → G2D → CPU**. The processor owns the lifecycle of the GL thread,
+the EGL/PBO caches, and the GPU shader programs that implement the visual
+operations.
+
+This crate carries the largest body of platform-specific code in the
+EdgeFirst HAL. Most of the architectural surface area is concerned with
+keeping zero-copy paths working across i.MX 8M Plus (Vivante), i.MX 95
+(Mali/Panfrost), and desktop Mesa, while respecting the lifecycle and
+shutdown quirks of each driver stack.
+
+## Module Map
+
+| Module | Source | Responsibility |
+|--------|--------|----------------|
+| [`lib.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/lib.rs) | local | Public surface: `ImageProcessor`, `ImageProcessorTrait`, `Rotation`, `Flip`, `Crop`, `MaskOverlay`, `load_image` / `save_jpeg` / `save_png` |
+| [`cpu/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/image/src/cpu) | local | `CPUProcessor` — fast_image_resize + rayon, plus the f16 mask kernels |
+| [`g2d.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/g2d.rs) | local | `G2DProcessor` — NXP i.MX G2D 2D-engine bindings |
+| [`gl/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/image/src/gl) | local | OpenGL backend: threaded wrapper, context, EGL+PBO caches, shaders, DMA-BUF import |
+| [`error.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/error.rs) | local | `Error` (with `From<std::io::Error>` for ergonomic `?` propagation in user code) |
+
+## Key Types and Traits
+
+- [`ImageProcessor`](https://docs.rs/edgefirst-image/latest/edgefirst_image/struct.ImageProcessor.html) — the orchestrator. Owns CPU + G2D + GL backends and dispatches per call.
+- [`ImageProcessorTrait`](https://docs.rs/edgefirst-image/latest/edgefirst_image/trait.ImageProcessorTrait.html) — the convert/draw API common to every backend.
+- [`Rotation`](https://docs.rs/edgefirst-image/latest/edgefirst_image/enum.Rotation.html), [`Flip`](https://docs.rs/edgefirst-image/latest/edgefirst_image/enum.Flip.html), [`Crop`](https://docs.rs/edgefirst-image/latest/edgefirst_image/struct.Crop.html) — geometric parameters; `Crop::letterbox()` preserves aspect ratio.
+- [`MaskOverlay`](https://docs.rs/edgefirst-image/latest/edgefirst_image/struct.MaskOverlay.html) — composite control for mask-rendering APIs (`background`, `opacity`).
+- [`load_image`](https://docs.rs/edgefirst-image/latest/edgefirst_image/fn.load_image.html) / [`save_jpeg`](https://docs.rs/edgefirst-image/latest/edgefirst_image/fn.save_jpeg.html) / [`save_png`](https://docs.rs/edgefirst-image/latest/edgefirst_image/fn.save_png.html) — JPEG/PNG decode/encode with EXIF orientation handling.
+
+## Internal Architecture
+
+### Backend dispatch
+
+```mermaid
+classDiagram
+    class ImageProcessorTrait {
+        <<trait>>
+        +convert(src, dst, rotation, flip, crop)
+        +draw_decoded_masks(dst, detections, segmentations)
+        +draw_proto_masks(dst, detections, proto_data)
+        +set_class_colors(colors)
+    }
+
+    class ImageProcessor {
+        cpu: Option~CPUProcessor~
+        g2d: Option~G2DProcessor~
+        opengl: Option~GLProcessorThreaded~
+        +new() orchestrator with fallback chain
+        +create_image(w, h, PixelFormat, DType, mem) GPU-optimal alloc
+    }
+
+    class G2DProcessor { NXP i.MX G2D hardware }
+    class GLProcessorThreaded { Owns the GL thread + message channel }
+    class GLProcessorST { Single-threaded GL impl, owns EGL + GL state }
+    class CPUProcessor { fast_image_resize + rayon }
+
+    ImageProcessorTrait <|.. ImageProcessor
+    ImageProcessorTrait <|.. G2DProcessor
+    ImageProcessorTrait <|.. GLProcessorThreaded
+    ImageProcessorTrait <|.. GLProcessorST
+    ImageProcessorTrait <|.. CPUProcessor
+    ImageProcessor o-- G2DProcessor
+    ImageProcessor o-- GLProcessorThreaded
+    ImageProcessor o-- CPUProcessor
+    GLProcessorThreaded *-- GLProcessorST : owns via thread
+```
+
+`ImageProcessor` dispatch priority is **OpenGL (GPU) → G2D (where supported)
+→ CPU (always available)**. Environment variables `EDGEFIRST_DISABLE_GL`,
+`EDGEFIRST_DISABLE_G2D`, `EDGEFIRST_DISABLE_CPU` and `EDGEFIRST_FORCE_BACKEND`
+override this chain at runtime; see [`README.md` Environment
+Variables](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/README.md#environment-variables).
+
+### TensorDyn as the image type
+
+The image-side type system reuses [`edgefirst_tensor::TensorDyn`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/struct.TensorDyn.html)
+as the dtype-erased image carrier. `TensorDyn` wraps a `Tensor<T>` and a
+`PixelFormat`; the format describes the spatial layout, the `DType` describes
+element storage. Width / height / channels / stride are **not stored** — they
+are computed from shape + format on every access:
+
+| Format | Tensor shape | Notes |
+|--------|--------------|-------|
+| `Rgb`, `Rgba`, `Bgra`, `Grey`, `Yuyv`, `Vyuy` | `[H, W, C]` | Interleaved (channels-last) |
+| `PlanarRgb`, `PlanarRgba` | `[C, H, W]` | Channels-first |
+| `Nv12` | `[H*3/2, W]` | 2D — Y plane (H rows) + UV (H/2 rows) |
+| `Nv16` | `[H*2, W]` | 2D — Y plane (H rows) + UV (H rows) |
+
+For multi-plane DMA-BUF NV12/NV16 (V4L2 `NV12M` from VPU/NeoISP), Y and UV
+live in separate allocations. `Tensor::from_planes(luma, chroma,
+PixelFormat::Nv12)` keeps each plane's fd independent for zero-copy GPU
+import via per-plane EGL attributes (`DMA_BUF_PLANE0_FD` / `DMA_BUF_PLANE1_FD`).
+
+### `create_image()` and zero-copy memory selection
+
+`ImageProcessor::create_image()` is the preferred way to allocate destination
+tensors for `convert()`. It selects the optimal backend based on a probe done
+at `ImageProcessor::new()` time:
+
+```mermaid
+flowchart TD
+    Create["create_image(w, h, PixelFormat, DType, mem)"]
+    DMA{DMA-buf roundtrip<br/>verified at init?}
+    PBO{OpenGL PBO<br/>available?}
+    Mem[MemTensor<br/>heap fallback]
+
+    Create --> DMA
+    DMA -->|Yes| UseDMA["DmaTensor<br/>Zero-copy EGLImage import"]
+    DMA -->|No| PBO
+    PBO -->|Yes| UsePBO["PboTensor<br/>Zero-copy GL buffer binding"]
+    PBO -->|No| Mem
+
+    style UseDMA fill:#90ee90
+    style UsePBO fill:#87ceeb
+    style Mem fill:#ffeb9c
+```
+
+| Backend | When selected | GPU transfer | Platforms |
+|---------|---------------|--------------|-----------|
+| DMA-buf | GPU supports `EGL_EXT_image_dma_buf_import` | Zero-copy: GPU reads/writes the DMA buffer directly | NXP i.MX 8M Plus (Vivante), i.MX 95 (Mali/Panfrost) |
+| PBO | GLES 3.0 available, DMA-buf roundtrip fails | Zero-copy GL: `GL_PIXEL_UNPACK_BUFFER` / `GL_PIXEL_PACK_BUFFER` | NVIDIA desktop, hosts without DMA-heap permissions |
+| Mem | No GPU or GL unavailable | CPU `memcpy` via `glTexImage2D` / `glReadnPixels` | Universal fallback |
+
+**Why PBO matters:** on desktop Linux with NVIDIA GPUs, DMA-buf allocation
+succeeds (`/dev/dma_heap/system`) but the NVIDIA EGL driver cannot import
+those buffers — the `verify_dma_buf_roundtrip()` check catches this at init.
+Without PBO, every `convert()` would fall back to CPU `memcpy` for upload and
+readback. PBO keeps the data in GPU-accessible memory, enabling the same
+zero-copy shader pipeline used on DMA platforms.
+
+### GL transfer backend selection
+
+| Backend | Detection | GPU upload | GPU readback |
+|---------|-----------|------------|--------------|
+| `DmaBuf` | `verify_dma_buf_roundtrip()` passes | `EGL_EXT_image_dma_buf_import` (zero-copy) | EGLImage export (zero-copy) |
+| `Pbo` | GLES 3.0 available, DMA-buf fails | `GL_PIXEL_UNPACK_BUFFER` | `GL_PIXEL_PACK_BUFFER` |
+| `Sync` | Final fallback | `glTexImage2D` (host pointer) | `glReadnPixels` (host pointer) |
+
+### GL thread architecture
+
+`GLProcessorThreaded` is the public, thread-safe wrapper. It spawns a
+dedicated OS thread that owns the EGL context and all GL state
+(`GLProcessorST`). All operations are sent as `GLProcessorMessage` enum
+variants through a channel and block on a oneshot reply. This design is
+required because EGL contexts are thread-local — every GL call must happen
+on the thread that created the context.
+
+The [`PboOps`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/trait.PboOps.html)
+trait bridges the tensor crate and the GL thread: `PboTensor` holds a
+`WeakSender` to the GL thread channel. When the tensor needs to map / unmap
+/ delete the PBO, it sends a message through this channel. The weak sender
+ensures PBO tensors don't prevent GL thread shutdown — see
+[`crates/tensor/ARCHITECTURE.md#pbo-tensors-and-the-weaksender-pattern`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md#pbo-tensors-and-the-weaksender-pattern).
+
+### GLES 3.1 context and the optional compute path
+
+At context creation time, the GL thread attempts a GLES 3.1 context first;
+on failure it falls back to GLES 3.0 (no compute shaders).
+
+When GLES 3.1 is available, an opt-in compute shader path can perform the
+HWC→CHW proto-tensor repack on the GPU. Enable it with
+`EDGEFIRST_PROTO_COMPUTE=1`. If compilation fails at runtime, the
+implementation logs a warning and falls back to CPU repack transparently —
+no API changes.
+
+### PBO convert dispatch
+
+When `convert()` is called with PBO-backed images, the GL thread must not
+call `tensor.map()` on those images — that would send a message back to
+itself and deadlock. The convert path dispatches to specialized methods:
+
+| Source → Destination | Method |
+|---------------------|--------|
+| DMA → DMA | `convert_dest_dma` (EGLImage on both sides) |
+| PBO → PBO | `convert_pbo_to_pbo` (UNPACK + PACK) |
+| Mem/DMA → PBO | `convert_any_to_pbo` (texture + PACK) |
+| PBO → Mem | `convert_pbo_to_mem` (UNPACK + ReadnPixels) |
+| Mem/DMA → Mem/DMA | `convert_dest_non_dma` (texture + memcpy) |
+
+### EGL image cache
+
+The OpenGL backend maintains two independent LRU caches of EGLImages —
+`src_egl_cache` for source tensors and `dst_egl_cache` for destination
+tensors. Each entry is keyed by `(BufferIdentity.id, chroma_id)`.
+
+`BufferIdentity` is defined in
+[`crates/tensor/src/lib.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/lib.rs)
+and pairs a globally unique monotonic ID with an `Arc<()>` liveness guard:
+
+```text
+BufferIdentity {
+    id:    u64,     // unique per allocation; new value from each from_fd() call
+    guard: Arc<()>, // cache entries hold Weak<()>; when tensor drops, weak dies
+}
+```
+
+When a tensor is freed, its `Arc<()>` guard drops. The cache holds only a
+`Weak<()>` reference, so `sweep()` detects dead entries without an explicit
+removal call.
+
+| Pattern | Cache behavior | Performance |
+|---------|----------------|-------------|
+| Same tensor object reused across frames | Hit on every frame | Fast — no EGLImage re-import |
+| New tensor wrapping the same fd each frame | Miss on every frame | Slow — re-imports each call |
+| `dst` of call N reused as `src` of call N+1 | Hit in both caches | Two separate entries, no collision |
+
+Key implications:
+
+- `hal_tensor_from_fd()` and `hal_import_image()` always allocate a new
+  `BufferIdentity`. Callers that re-wrap the same fd each frame will see a
+  cache miss every `convert()`. **Hold the tensor alive across frames.**
+- Content written into a DMA-BUF between calls (e.g. by a V4L2 decoder) is
+  visible on the next call. EGLImage is a handle to live physical memory,
+  not a snapshot.
+- The `last_bound_src_egl` optimization skips
+  `glEGLImageTargetTexture2DOES` when the source EGLImage has not changed
+  between consecutive calls. Safe — the texture already points at the
+  correct DMA-BUF memory.
+- A `glFinish()` is issued at the end of every `convert()`. This guarantees
+  GPU reads of source and writes to destination are complete before return,
+  making it safe to chain calls.
+
+See [Appendix C: DMA-BUF Identity and Tensor Caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
+in the project ARCHITECTURE.md for the cross-crate cache story (V4L2 fd
+recycling, inode-keyed cache, `edgefirstcameraadaptor` integration).
+
+### Vivante NV12 → PlanarRgb two-pass workaround
+
+A single-pass NV12 → PlanarRgb shader causes a GPU hang on the Vivante
+GC7000UL (NXP i.MX 8M Plus). The workaround splits the conversion:
+
+```text
+Pass 1:  NV12 → RGBA (intermediate)
+         All geometry: resize, crop, rotation, flip, letterbox
+Pass 2:  RGBA → PlanarRgb (at destination resolution)
+         Deinterleaves RGBA to three planes via sampler2D variants
+```
+
+Pass 1 reuses the existing `packed_rgb_intermediate_tex` texture — no new
+GPU resources allocated. Pass 2 uses the same shader infrastructure as
+direct RGBA → PlanarRgb. The two-pass path is selected automatically when
+`is_vivante && src_fmt == Nv12 && dst_fmt.layout() == Planar`. No API
+changes required from callers.
+
+## Mask Rendering
+
+YOLO segmentation models produce **proto masks** (shared basis at reduced
+resolution, typically 160×160) and per-detection **mask coefficients**:
+
+```text
+mask_raw[i] = coefficients[i] @ protos       # (proto_h, proto_w)
+```
+
+The image crate exposes three rendering pipelines paired with the decoder's
+mask APIs:
+
+| Workflow | Decoder source | Image-side render | Best for |
+|----------|----------------|-------------------|----------|
+| Materialized | `decode_quantized` / `decode_float` | `draw_decoded_masks` | Already have mask matrices |
+| Fused proto path | `decode_quantized_proto` / `decode_float_proto` | `draw_proto_masks` | Real-time GPU overlay (preferred) |
+| Tracked + drawn | (consumes [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/)) | `draw_masks_tracked` | Single-call decode + track + render |
+
+### MaskOverlay
+
+```rust,ignore
+pub struct MaskOverlay<'a> {
+    pub background: Option<&'a TensorDyn>, // blit before drawing masks
+    pub opacity: f32,                       // 0.0 invisible, 1.0 opaque
+}
+```
+
+### Fused proto→pixel algorithm (`draw_proto_masks`)
+
+Instead of computing the matmul at proto resolution and upsampling the
+result, the fused path upsamples the proto field itself and evaluates the
+dot product at every output pixel:
+
+```text
+For each output pixel (x, y) inside detection bbox at 640×640:
+    bilinear_sample(protos, proto_coords(x, y))  → 32 interpolated values
+    dot(coefficients, interpolated_protos)        → raw logit
+    sigmoid(raw)                                  → mask value [0, 1]
+    threshold at 0.5 → blend color onto pixel
+```
+
+Algebraically equivalent to bilinear-after-matmul (both bilinear
+interpolation and the dot product are linear), but avoids materializing the
+intermediate tensors. Key design choices:
+
+- **No proto-resolution crop** — the full 160×160 proto field is sampled,
+  avoiding the boundary erosion artifact of crop-before-upsample approaches.
+- **Sigmoid after interpolation** — sigmoid is nonlinear, so applying it
+  after spatial operations preserves dynamic range through interpolation.
+- The draw path uses the sigmoid value directly for alpha-blend weighting.
+
+This is mathematically equivalent to Ultralytics' `retina_masks=True`
+(`process_mask_native`) for binary mask output. Empirical validation across
+26 matched detections on COCO val2017 confirms **0.993 mean mask IoU**
+between the two methods.
+
+### GPU implementation (OpenGL)
+
+Draw path (`draw_proto_masks`) — sigmoid shaders with alpha blending:
+
+The fragment shader computes `sigmoid(logit)` and blends the detection color
+onto the framebuffer using `GL_SRC_ALPHA / GL_ONE_MINUS_SRC_ALPHA`. The GPU
+renders one quad per detection; the fragment shader evaluates the mask at
+every output pixel.
+
+#### Shader variants
+
+| Variant | Proto storage | Interpolation |
+|---------|---------------|---------------|
+| int8-nearest | `R8I` quantized | Nearest neighbor |
+| int8-bilinear | `R8I` quantized | Manual 4-tap bilinear |
+| f32 | `R32F` float | Hardware `GL_LINEAR` |
+| f16 | `R16F` half | Hardware `GL_LINEAR` |
+
+Control quantized proto interpolation via
+`processor.set_int8_interpolation_mode(...)`.
+
+> **G2D limitation:** the NXP G2D hardware accelerator does not support
+> mask rendering. On platforms where G2D is the primary backend (e.g.
+> i.MX 8M Plus without EGL), all `draw_*` methods return
+> `NotImplemented`. Use an OpenGL-capable processor (pass an
+> `egl_display`) or fall back to CPU rendering.
+
+## Process-Shutdown Resource Cleanup
+
+The OpenGL headless renderer
+([`crates/image/src/gl/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/image/src/gl))
+loads EGL and OpenGL ES via dynamically loaded shared libraries
+(`libEGL.so.1`, `libGLESv2.so`). When the process exits — particularly from
+a Python interpreter running PyO3 extensions — EGL resource cleanup can
+crash with heap corruption, segfaults, or panics. This is a well-documented
+industry-wide problem with no clean solution.
+
+The crash arises from a fundamental conflict between four systems:
+
+1. **Python finalization order is non-deterministic.** During
+   `Py_FinalizeEx()`, Python destroys modules and objects in arbitrary
+   order. A PyO3 `#[pyclass]` wrapping `GlContext` may have its Rust `Drop`
+   invoked after dependent state is gone.
+2. **Linux `atexit` handler ordering is unreliable.** glibc's
+   `__cxa_finalize` interacts with `dlclose` in non-deterministic ways
+   between handlers registered by different shared libraries
+   ([glibc #21032](https://sourceware.org/bugzilla/show_bug.cgi?id=21032)).
+3. **Mesa's `_eglAtExit` use-after-free.** Mesa's atexit handler frees
+   per-thread EGL state (`_EGLThreadInfo`). If `Drop` calls
+   `eglReleaseThread()` after this handler runs, it dereferences freed
+   memory ([Ubuntu Bug #1946621](https://bugs.launchpad.net/ubuntu/+source/mesa/+bug/1946621)).
+4. **Vendor EGL driver bugs.** Some vendor drivers (Qualcomm Adreno, older
+   NVIDIA) misbehave during cleanup. The `catch_unwind` guard absorbs
+   driver-side panics.
+
+### Defense-in-depth solution
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│ Layer 1: Box::leak — EGL library handle                 │
+│   Prevents dlclose from unmapping shared library code   │
+├─────────────────────────────────────────────────────────┤
+│ Layer 2: ManuallyDrop<Rc<Egl>> — EGL instance           │
+│   Prevents khronos-egl Drop from calling                │
+│   eglReleaseThread() into freed Mesa state              │
+├─────────────────────────────────────────────────────────┤
+│ Layer 3: catch_unwind — EGL cleanup calls               │
+│   Catches panics from eglDestroyContext/eglMakeCurrent  │
+│   if function pointers are invalidated                  │
+├─────────────────────────────────────────────────────────┤
+│ Layer 4: eglTerminate inside catch_unwind               │
+│   Releases ref-counted display; catch_unwind absorbs    │
+│   any driver-side misbehaviour                          │
+└─────────────────────────────────────────────────────────┘
+```
+
+`GlContext::drop` performs explicit EGL resource cleanup (destroy context,
+destroy surface, terminate display) inside `catch_unwind`, then
+intentionally skips dropping the `Rc<Egl>` wrapper. The EGL library handle
+is leaked via `Box::leak` at load time so it is never `dlclose`'d.
+`eglTerminate` is ref-counted per the EGL spec — each `eglInitialize`
+increments the count, each `eglTerminate` decrements it.
+
+### Industry precedent
+
+- **Chromium/ANGLE** skips full EGL teardown on GPU process exit, treating
+  cleanup as more dangerous than no cleanup during shutdown.
+- **wgpu** wraps `glow::Context` in `ManuallyDrop` and loads EGL with
+  `RTLD_NODELETE` to prevent library unloading. The `khronos-egl` crate
+  itself adopted `RTLD_NOW | RTLD_NODELETE` after
+  [khronos-egl #14](https://github.com/timothee-haudebourg/khronos-egl/issues/14),
+  citing the same glibc root cause.
+- **Smithay** supports skipping `eglTerminate` via a feature flag for the
+  same class of driver bugs.
+
+### Limitations
+
+`catch_unwind` catches Rust panics but cannot catch fatal signals
+(`SIGABRT`, `SIGSEGV`, `SIGBUS`) from heap corruption inside the C driver.
+The defense layers prevent the most common failure modes, but a
+sufficiently broken driver could still crash the process — none has been
+observed on the supported platforms (Vivante, Mali/Panfrost, Mesa x86_64).
+
+### G2D resource cleanup
+
+On NXP i.MX, `libg2d.so.2` and `libEGL.so.1` share kernel state through the
+Vivante `galcore` device (`/dev/galcore`). When both libraries are loaded,
+calling `dlclose` on either one can trigger heap corruption (`corrupted
+double-linked list`) during process exit — the atexit handlers from the
+shared `galcore` driver become inconsistent.
+
+For production code, `G2DProcessor` is dropped normally; the EGL
+`Box::leak` (Layer 1) keeps shared `galcore` state intact. For benchmark
+code (where many G2D processors are created/destroyed in one process), the
+`crates/bench` harness wraps G2D processor instances in `ManuallyDrop` to
+avoid repeated `g2d_close` + `dlclose` cycles that exhaust driver
+resources.
+
+### Resource leak prevention policy
+
+- **EGL displays** — `eglTerminate` in `GlContext::drop`. EGL spec
+  ref-counts; only the last terminate tears down state.
+- **EGL contexts** — `eglDestroyContext` before `eglTerminate`. No EGL
+  surfaces are created — the HAL uses surfaceless contexts
+  (`EGL_KHR_surfaceless_context` + `EGL_KHR_no_config_context`) and
+  renders exclusively through FBOs backed by EGLImages.
+- **DMA buffers** — fd `close()` in `Drop`.
+- **G2D contexts** — `g2d_close` in `G2DProcessor::drop`.
+
+Intentional leaks are restricted to the EGL library handle (`Box::leak`)
+and the `Rc<Egl>` wrapper (`ManuallyDrop`) — lightweight Rust-side
+objects. Actual GPU/display resources are released by the explicit
+cleanup calls.
+
+## GL Command Serialization (GL_MUTEX)
+
+Multiple `ImageProcessor` instances can coexist in the same process. EGL
+and OpenGL ES specify that independent contexts on separate threads should
+not interfere, but several embedded GPU drivers violate this:
+
+- **Vivante `galcore` (i.MX 8M Plus)** — concurrent `eglInitialize`,
+  `eglCreateContext`, DMA-BUF import ioctls, and `eglTerminate` from
+  multiple threads corrupt driver-internal state. Causes SIGSEGV (null
+  pointer at offset `0x18` in `galcore` ioctl) and futex deadlocks.
+- **Broadcom V3D 7.1.10.2 (Raspberry Pi 5)** — concurrent `eglTerminate`
+  breaks ref-counting, causing `EGL(NotInitialized)` on surviving
+  contexts; subsequent GL operations fail with `GL_INVALID_OPERATION`.
+- **ARM Mali-G310 (i.MX 95)** — Panfrost handles concurrent EGL/GL
+  correctly. No issues observed.
+
+### Solution
+
+A global `GL_MUTEX` (`std::sync::Mutex<()>` in
+[`crates/image/src/gl/context.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/gl/context.rs))
+serializes **all** EGL and GL operations across every `GLProcessorST`
+instance. Acquired in three places:
+
+1. **Initialization** — wraps `GLProcessorST::new()` (display creation,
+   context setup, shader compilation, DMA-BUF roundtrip verification).
+2. **Message dispatch** — wraps every incoming GL-thread message
+   (convert, draw masks, PBO create/download, etc.) so only one GL thread
+   executes driver calls at a time.
+3. **Teardown** — wraps `GLProcessorST::drop()` → `GlContext::drop()` so
+   `eglDestroyContext` / `eglTerminate` are serialized.
+
+The mutex uses `unwrap_or_else(|e| e.into_inner())` to recover from
+poisoning: if a prior GL operation panicked, subsequent operations on
+other instances can still proceed rather than propagating a poison error.
+
+### Performance implications
+
+All GL operations are serialized — no concurrent GPU execution across
+`ImageProcessor` instances. Acceptable because:
+
+- The primary use case (edge AI inference pipelines) typically uses a
+  single processor per pipeline. Multiple instances exist mainly in test
+  scenarios.
+- GPU operations are I/O-bound on embedded targets; mutex overhead
+  (microseconds) is negligible compared to DMA transfers and shader
+  execution (milliseconds).
+- The alternative (concurrent GPU access) crashes on Vivante.
+
+Future work could relax to init/teardown-only serialization on drivers
+known to be safe for concurrent runtime ops (e.g. Mali), but the current
+approach prioritizes correctness across all targets.
+
+## Performance Considerations
+
+| Optimization | Why it matters |
+|--------------|----------------|
+| Reuse tensors across frames | Each new tensor allocates a fresh `BufferIdentity`. EGL image cache is keyed by `(BufferIdentity.id, chroma_id)`. New ID → cache miss → full `eglCreateImageKHR` import (~100–300 µs). Hold tensors alive. |
+| Allocate via `create_image()` | The processor selects DMA-buf, PBO, or heap based on the runtime GPU probe at `new()` time. Bypassing with `Tensor::new(memory=...)` forces a slow transfer path on every `convert()`. |
+| One `ImageProcessor` per pipeline | Each instance owns an EGL display, a GL thread, per-thread caches. Multiple instances serialize on `GL_MUTEX`. |
+| Native CPU feature builds (Rule 6) | A build-time concern. `RUSTFLAGS` controls whether the f16 mask kernel at [`crates/image/src/cpu/masks.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/cpu/masks.rs) compiles to native widening instructions or to the soft-float `__extendhfsf2` helper. Distributed binaries stay on triple baseline ISA; benchmark hosts opt in via `RUSTFLAGS` overrides. |
+
+See the [Optimization Guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)
+in the project README for the user-facing rules and validation patterns.
+
+## Inter-Crate Interfaces
+
+| Direction | Crate | Interface |
+|-----------|-------|-----------|
+| Depends on | [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) | `TensorDyn`, `Tensor<T>`, `BufferIdentity`, `PboOps` impl |
+| Depends on (feature `decoder`) | [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) | `DetectBox`, `Segmentation`, proto data for `draw_*` |
+| Depends on (feature `tracker`) | [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) | `Tracker<DetectBox>` for `draw_masks_tracked` |
+| Consumed by | [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) | re-export as `edgefirst_hal::image` |
+| Consumed by | [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) | C/Python bindings for `ImageProcessor` and rendering APIs |
+
+## Platform-Specific Notes
+
+| Platform | Backends available | Notes |
+|----------|--------------------|-------|
+| Linux NXP i.MX 8M Plus (Vivante GC7000UL) | OpenGL, G2D, CPU | NV12 → PlanarRgb requires the two-pass workaround |
+| Linux NXP i.MX 95 (Mali-G310 / Panfrost) | OpenGL, CPU | Concurrent GL works; `EDGEFIRST_OPENGL_RENDERSURFACE=1` required for Neutron NPU DMA-BUF destinations |
+| Linux desktop / NVIDIA | OpenGL (PBO path), CPU | DMA-buf import unsupported; PBO path provides zero-copy |
+| Linux desktop / Mesa x86_64 | OpenGL, CPU | DMA-heap permission required for DMA path |
+| macOS | CPU | No GPU/G2D |
+| Other Unix | CPU | No GPU/G2D |
+
+## Cross-References
+
+- Project architecture: [../../ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
+- Tensor architecture (DMA-BUF, BufferIdentity, PboOps): [../tensor/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md)
+- Decoder architecture (proto mask APIs): [../decoder/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md)
+- DMA-BUF identity story: [ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
+- Optimization guide: [README.md#optimization-guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)
+- Performance tracing usage: [README.md#performance-tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)

--- a/crates/image/README.md
+++ b/crates/image/README.md
@@ -8,6 +8,18 @@
 
 This crate provides hardware-accelerated image loading, format conversion, resizing, rotation, and cropping operations optimized for ML preprocessing workflows.
 
+## Role in edgefirst-hal
+
+`edgefirst-image` sits at the centre of the EdgeFirst HAL workspace, owning
+the GPU/G2D/CPU dispatch and segmentation-mask rendering. Its dependency
+neighbours:
+
+- Depends on [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) for `TensorDyn`, `BufferIdentity`, and the `PboOps` trait it implements for the GL backend.
+- Depends on [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) (feature `decoder`, default-on) for `DetectBox`, `Segmentation`, and the proto-mask data feeding `draw_proto_masks`.
+- Optionally depends on [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) (feature `tracker`) for `draw_masks_tracked`.
+- Re-exported from [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) as `edgefirst_hal::image`.
+- Bridged to C/Python via [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/).
+
 ## Features
 
 - **Multiple backends** — Automatic selection: OpenGL (GPU) → G2D (NXP i.MX) → CPU (fallback)
@@ -228,6 +240,13 @@ processor.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())?;
 ```
 
 The OpenGL backend imports each plane's DMA-BUF fd separately for zero-copy GPU access.
+
+## Documentation
+
+- Architecture overview: [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
+- Testing guide: [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md)
+- Full API reference: [docs.rs/edgefirst-image](https://docs.rs/edgefirst-image)
+- Project README: [../../README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md)
 
 ## License
 

--- a/crates/image/README.md
+++ b/crates/image/README.md
@@ -18,7 +18,8 @@ neighbours:
 - Depends on [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) (feature `decoder`, default-on) for `DetectBox`, `Segmentation`, and the proto-mask data feeding `draw_proto_masks`.
 - Optionally depends on [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) (feature `tracker`) for `draw_masks_tracked`.
 - Re-exported from [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) as `edgefirst_hal::image`.
-- Bridged to C/Python via [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/).
+- Bridged to C via [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) (cbindgen-generated C ABI).
+- Bridged to Python via [`crates/python`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/) (PyO3 binding over the Rust umbrella crate; does not go through the C ABI).
 
 ## Features
 
@@ -177,7 +178,7 @@ Control quantized proto interpolation quality:
 processor.set_int8_interpolation_mode(Int8InterpolationMode::Bilinear);
 ```
 
-See [BENCHMARKS.md](../../BENCHMARKS.md) for per-platform performance numbers.
+See [BENCHMARKS.md](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md) for per-platform performance numbers.
 
 ## Zero-Copy Model Input
 

--- a/crates/image/README.md
+++ b/crates/image/README.md
@@ -15,7 +15,7 @@ the GPU/G2D/CPU dispatch and segmentation-mask rendering. Its dependency
 neighbours:
 
 - Depends on [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) for `TensorDyn`, `BufferIdentity`, and the `PboOps` trait it implements for the GL backend.
-- Depends on [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) (feature `decoder`, default-on) for `DetectBox`, `Segmentation`, and the proto-mask data feeding `draw_proto_masks`.
+- Depends unconditionally on [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) for `DetectBox`, `Segmentation`, and the proto-mask data feeding `draw_proto_masks` (there is no opt-out feature flag).
 - Optionally depends on [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) (feature `tracker`) for `draw_masks_tracked`.
 - Re-exported from [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) as `edgefirst_hal::image`.
 - Bridged to C via [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) (cbindgen-generated C ABI).

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -38,7 +38,7 @@ EDGEFIRST_DISABLE_GL=1 EDGEFIRST_DISABLE_G2D=1 \
 cargo test -p edgefirst-image --lib gl::tests -- --test-threads=1
 
 # Doc-tests
-cargo test -p edgefirst-image --doc
+cargo test -p edgefirst-image --doc -- --test-threads=1
 ```
 
 ## Special Requirements
@@ -97,7 +97,7 @@ cargo test -p edgefirst-image --features g2d_test_formats -- --test-threads=1
 | `/dev/dma_heap/linux,cma` or `/dev/dma_heap/system` | DMA-BUF tensor allocation |
 | `/dev/galcore` | G2D hardware acceleration |
 | `/dev/neutron0` | Neutron NPU DMA-BUF EGLImage |
-| `/dev/dri/renderD128` | DRM render node; required for DMA-buf backend |
+| `/dev/dri/renderD128` (preferred) or `/dev/dri/card0` / `/dev/dri/card1` | DRM render/card node; the GL context opens the first that exists |
 
 ### Disabling backends for isolation
 
@@ -109,7 +109,7 @@ cargo test -p edgefirst-image --features g2d_test_formats -- --test-threads=1
 | `EDGEFIRST_FORCE_BACKEND=g2d` | G2D-only |
 | `EDGEFIRST_DISABLE_GL=1` | Disable OpenGL even if available |
 | `EDGEFIRST_DISABLE_G2D=1` | Disable G2D even if available |
-| `EDGEFIRST_FORCE_TRANSFER=pbo` / `=dmabuf` | Force GL transfer backend |
+| `EDGEFIRST_FORCE_TRANSFER=dmabuf` / `=pbo` / `=sync` | Force GL transfer backend (the `sync` value pins the non-zero-copy `glReadPixels` baseline used for benchmarking) |
 
 Example — run tests without any GPU backend:
 

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -41,33 +41,24 @@ cargo test -p edgefirst-image --lib gl::tests -- --test-threads=1
 cargo test -p edgefirst-image --doc
 ```
 
-## Single-Threaded Execution Is Required
-
-All `edgefirst-image` tests must run with `--test-threads=1`. Three
-independent constraints each require it:
-
-1. **EGL display sharing** — concurrent `eglTerminate` from multiple test
-   threads can tear down a display while other threads still reference it.
-2. **G2D driver state** — Vivante `galcore` maintains per-process state that
-   is unsafe to access from concurrent threads creating/destroying G2D
-   contexts.
-3. **DMA-heap CMA pool exhaustion** — concurrent DMA-heap allocations from
-   multiple test threads can exhaust the CMA pool on memory-constrained
-   targets, masking the real failures.
-
-`cargo nextest` provides per-test process isolation, but `-j 1` is still
-required to prevent DMA/GPU contention across processes. The project
-[`Makefile`](https://github.com/EdgeFirstAI/hal/blob/main/Makefile)
-enforces this automatically.
-
-See [`ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#gl-command-serialization-gl_mutex)
-for the full technical rationale and the GL_MUTEX implementation.
-
 ## Special Requirements
+
+### Single-threaded execution is mandatory
+
+All `edgefirst-image` tests must run with `--test-threads=1`. The image
+crate is the load-bearing reason for the
+[project-wide single-threaded rule](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution)
+— concurrent EGL, G2D, and DMA-heap operations crash on Vivante
+hardware and risk CMA pool exhaustion on memory-constrained targets.
+The
+[`Makefile`](https://github.com/EdgeFirstAI/hal/blob/main/Makefile)
+enforces `-j 1` automatically. See
+[`ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#gl-command-serialization-gl_mutex)
+for the `GL_MUTEX` implementation that makes this rule load-bearing.
 
 ### GL hardware-gated tests
 
-OpenGL and G2D tests in
+OpenGL tests in
 [`crates/image/src/gl/tests.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/gl/tests.rs)
 use `OnceLock<bool>` to probe hardware availability once and skip if absent:
 
@@ -87,6 +78,17 @@ The Neutron-scenario tests gate on `/dev/neutron0` as a platform
 discriminator for i.MX 95 with Mali GPU. This device node indicates that
 large-offset DMA-BUF EGLImage imports are supported — these fail with
 `EGL(BadAccess)` on Vivante (i.MX 8M Plus) even without the NPU driver.
+
+G2D tests live in
+[`crates/image/src/g2d.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/g2d.rs)
+behind the `g2d_test_formats` Cargo feature and use their own DMA / G2D
+availability checks (probing `/dev/galcore` and the DMA-heap nodes). They
+are run by CI on the i.MX 8M Plus hardware runner. To exercise them
+locally on i.MX hardware:
+
+```bash
+cargo test -p edgefirst-image --features g2d_test_formats -- --test-threads=1
+```
 
 ### Device-node gates
 
@@ -145,10 +147,13 @@ Run on host:
 cargo bench -p edgefirst-image --bench mask_benchmark
 ```
 
-Cross-compile + deploy to target:
+Cross-compile for a target (see
+[`BENCHMARKS.md`](https://github.com/EdgeFirstAI/hal/blob/main/BENCHMARKS.md)
+for the full deploy workflow):
 
 ```bash
-make bench-arm
+cargo-zigbuild zigbuild --target aarch64-unknown-linux-gnu --release \
+  -p edgefirst-image --features opengl --bench mask_benchmark
 ```
 
 ### Native fp16 / AVX2 build overrides for local benchmarking
@@ -190,10 +195,11 @@ soft-float `__extendhfsf2` helper) via
   which is why per-target coverage numbers vary between developer
   workstations and CI hardware runners. The hardware-test job on i.MX 8M
   Plus is the source of truth for backend-coverage parity.
-- `EDGEFIRST_DISABLE_GL=1` runs are added to the matrix in
-  [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml)
-  to keep the CPU-fallback paths covered even on machines where GL would
-  succeed.
+- To exercise the CPU-fallback paths on a host that would otherwise
+  pick OpenGL, set `EDGEFIRST_DISABLE_GL=1` locally before invoking
+  `cargo test`. CI does not currently include this configuration in the
+  matrix; downstream contributors covering specific fallback regressions
+  may want to enable it on a per-PR basis.
 
 ## Cross-References
 

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -1,0 +1,204 @@
+# edgefirst-image Testing
+
+## Test Layout
+
+```
+crates/image/
+├── src/
+│   ├── lib.rs              # Doc-tests on the public API surface
+│   ├── cpu/
+│   │   ├── tests.rs        # CPU backend conversion + mask tests
+│   │   ├── convert.rs      # fast_image_resize-based format conversion
+│   │   ├── resize.rs       # Resize kernels
+│   │   └── masks.rs        # CPU mask materialization (f16 hot path)
+│   ├── g2d.rs              # G2D backend tests (gated on /dev/galcore)
+│   └── gl/
+│       └── tests.rs        # OpenGL backend tests (gated via OnceLock probe)
+└── benches/
+    ├── image_benchmark.rs       # Convert/resize/rotate throughput
+    ├── mask_benchmark.rs        # Mask decode + draw paths
+    ├── mask_decode_benchmark.rs # Mask materialization vs proto-only
+    ├── pipeline_benchmark.rs    # End-to-end pipeline measurements
+    ├── opencv_benchmark.rs      # Comparison vs OpenCV reference (optional)
+    ├── sanity_check.rs          # Quick smoke tests for bench harness setup
+    └── common.rs                # Shared bench fixture helpers
+```
+
+## Running Tests
+
+```bash
+# Full image suite — single-threaded is mandatory
+cargo test -p edgefirst-image -- --test-threads=1
+
+# Single backend (skips others)
+EDGEFIRST_DISABLE_GL=1 EDGEFIRST_DISABLE_G2D=1 \
+  cargo test -p edgefirst-image -- --test-threads=1
+
+# Just the GL tests (skipped automatically without GPU)
+cargo test -p edgefirst-image --lib gl::tests -- --test-threads=1
+
+# Doc-tests
+cargo test -p edgefirst-image --doc
+```
+
+## Single-Threaded Execution Is Required
+
+All `edgefirst-image` tests must run with `--test-threads=1`. Three
+independent constraints each require it:
+
+1. **EGL display sharing** — concurrent `eglTerminate` from multiple test
+   threads can tear down a display while other threads still reference it.
+2. **G2D driver state** — Vivante `galcore` maintains per-process state that
+   is unsafe to access from concurrent threads creating/destroying G2D
+   contexts.
+3. **DMA-heap CMA pool exhaustion** — concurrent DMA-heap allocations from
+   multiple test threads can exhaust the CMA pool on memory-constrained
+   targets, masking the real failures.
+
+`cargo nextest` provides per-test process isolation, but `-j 1` is still
+required to prevent DMA/GPU contention across processes. The project
+[`Makefile`](https://github.com/EdgeFirstAI/hal/blob/main/Makefile)
+enforces this automatically.
+
+See [`ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#gl-command-serialization-gl_mutex)
+for the full technical rationale and the GL_MUTEX implementation.
+
+## Special Requirements
+
+### GL hardware-gated tests
+
+OpenGL and G2D tests in
+[`crates/image/src/gl/tests.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/gl/tests.rs)
+use `OnceLock<bool>` to probe hardware availability once and skip if absent:
+
+```rust
+static GL_AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+fn is_opengl_available() -> bool {
+    *GL_AVAILABLE.get_or_init(|| GLProcessorThreaded::new(None).is_ok())
+}
+```
+
+A test that requires OpenGL calls `is_opengl_available()` at the start and
+returns early if it returns `false`. This keeps the suite green on developer
+machines without GPU hardware while still exercising the full hardware path
+on target boards and CI runners.
+
+The Neutron-scenario tests gate on `/dev/neutron0` as a platform
+discriminator for i.MX 95 with Mali GPU. This device node indicates that
+large-offset DMA-BUF EGLImage imports are supported — these fail with
+`EGL(BadAccess)` on Vivante (i.MX 8M Plus) even without the NPU driver.
+
+### Device-node gates
+
+| Device node | Tests gated |
+|-------------|-------------|
+| `/dev/dma_heap/linux,cma` or `/dev/dma_heap/system` | DMA-BUF tensor allocation |
+| `/dev/galcore` | G2D hardware acceleration |
+| `/dev/neutron0` | Neutron NPU DMA-BUF EGLImage |
+| `/dev/dri/renderD128` | DRM render node; required for DMA-buf backend |
+
+### Disabling backends for isolation
+
+| Variable | Effect |
+|----------|--------|
+| `EDGEFIRST_TENSOR_FORCE_MEM=1` | Force heap allocation; skip DMA / SHM |
+| `EDGEFIRST_FORCE_BACKEND=cpu` | CPU-only image processing |
+| `EDGEFIRST_FORCE_BACKEND=opengl` | OpenGL-only |
+| `EDGEFIRST_FORCE_BACKEND=g2d` | G2D-only |
+| `EDGEFIRST_DISABLE_GL=1` | Disable OpenGL even if available |
+| `EDGEFIRST_DISABLE_G2D=1` | Disable G2D even if available |
+| `EDGEFIRST_FORCE_TRANSFER=pbo` / `=dmabuf` | Force GL transfer backend |
+
+Example — run tests without any GPU backend:
+
+```bash
+EDGEFIRST_DISABLE_GL=1 EDGEFIRST_DISABLE_G2D=1 \
+  cargo test -p edgefirst-image -- --test-threads=1
+```
+
+### LFS testdata
+
+JPEG/PNG fixtures and proto-mask test vectors live under `testdata/` and
+are tracked via Git LFS. Tests load them through
+`edgefirst_bench::testdata::read*`, which honors `EDGEFIRST_TESTDATA_DIR`.
+CI sets this to `${{ github.workspace }}/testdata`. Locally, the helper
+falls back to `<workspace>/testdata` so no env var is needed.
+
+## Benchmarks
+
+The mask rendering benchmarks use a custom in-process harness
+([`edgefirst-bench`](https://github.com/EdgeFirstAI/hal/tree/main/crates/bench))
+instead of Criterion to avoid GPU driver crashes from fork-based benchmarking
+on i.MX 8/i.MX 95 targets.
+
+| Benchmark | Source | What it measures |
+|-----------|--------|------------------|
+| `image_benchmark` | [`benches/image_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/benches/image_benchmark.rs) | Format conversion + resize + rotation throughput per backend |
+| `mask_benchmark` | [`benches/mask_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/benches/mask_benchmark.rs) | `decode_masks/{proto,materialize}`, `draw_masks/{cpu,opengl}`, `draw_proto_masks/{cpu,opengl}` |
+| `mask_decode_benchmark` | [`benches/mask_decode_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/benches/mask_decode_benchmark.rs) | NMS + mask coefficient extraction (proto-only path) vs. full materialization |
+| `pipeline_benchmark` | [`benches/pipeline_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/benches/pipeline_benchmark.rs) | End-to-end inference + decode + draw pipeline |
+| `opencv_benchmark` | [`benches/opencv_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/benches/opencv_benchmark.rs) | Comparison vs OpenCV reference (requires `opencv` feature) |
+
+Run on host:
+
+```bash
+cargo bench -p edgefirst-image --bench mask_benchmark
+```
+
+Cross-compile + deploy to target:
+
+```bash
+make bench-arm
+```
+
+### Native fp16 / AVX2 build overrides for local benchmarking
+
+The default build does **not** enable `+fp16` (aarch64) or `+f16c`
+(x86_64) — distributed HAL binaries stay on each target triple's baseline
+ISA so they run on older CPUs within the same triple. Benchmarks that need
+to exercise the native f16 mask kernel
+(`fused_dot_sigmoid_f16_slice` in
+[`crates/image/src/cpu/masks.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/cpu/masks.rs))
+must set `RUSTFLAGS` explicitly on the host that supports the extension:
+
+```bash
+# Orin Nano (Cortex-A78AE)
+RUSTFLAGS="-C target-cpu=cortex-a78ae" \
+  cargo bench -p edgefirst-image --bench mask_benchmark
+
+# Generic aarch64 with FEAT_FP16 (verify the host first —
+# imx8mp / Cortex-A53 will SIGILL!)
+RUSTFLAGS="-C target-feature=+fp16" \
+  cargo bench -p edgefirst-image --bench mask_benchmark
+
+# x86_64 Haswell+ (enables the explicit _mm256_cvtph_ps intrinsic kernel
+# in addition to the scalar path)
+RUSTFLAGS="-C target-feature=+f16c,+fma,+avx2" \
+  cargo bench -p edgefirst-image --bench mask_benchmark
+```
+
+Verify the release build actually compiled to native instructions (not the
+soft-float `__extendhfsf2` helper) via
+[`scripts/audit_f16_codegen.sh`](https://github.com/EdgeFirstAI/hal/blob/main/scripts/audit_f16_codegen.sh)
+`<target-triple>`. Requires `cargo install cargo-show-asm`.
+
+## Coverage Notes
+
+- Participates in workspace `cargo llvm-cov`; lcov output appears under
+  `crates/image/`.
+- GPU-gated tests are excluded from coverage on hosts without hardware,
+  which is why per-target coverage numbers vary between developer
+  workstations and CI hardware runners. The hardware-test job on i.MX 8M
+  Plus is the source of truth for backend-coverage parity.
+- `EDGEFIRST_DISABLE_GL=1` runs are added to the matrix in
+  [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml)
+  to keep the CPU-fallback paths covered even on machines where GL would
+  succeed.
+
+## Cross-References
+
+- Project testing patterns: [../../TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md)
+- Validating optimizations: [TESTING.md#validating-optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations)
+- GL_MUTEX rationale and resource-cleanup layers: [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#gl-command-serialization-gl_mutex)
+- Decoder testing (proto API consumer): [../decoder/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/TESTING.md)
+- Tensor backend tests: [../tensor/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/TESTING.md)

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -162,9 +162,13 @@ The default build does **not** enable `+fp16` (aarch64) or `+f16c`
 (x86_64) — distributed HAL binaries stay on each target triple's baseline
 ISA so they run on older CPUs within the same triple. Benchmarks that need
 to exercise the native f16 mask kernel
-(`fused_dot_sigmoid_f16_slice` in
+(`fused_dot_sign_f16_slice` in
 [`crates/image/src/cpu/masks.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/cpu/masks.rs))
-must set `RUSTFLAGS` explicitly on the host that supports the extension:
+must set `RUSTFLAGS` explicitly on the host that supports the extension.
+The relevant kernel symbol is `fused_dot_sign_f16_slice` (see
+[`crates/image/src/cpu/masks.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/cpu/masks.rs)
+— search for `fused_dot_sign_*`); the `_f16c` variant is the AVX2
+intrinsic path enabled by `+f16c,+fma`.
 
 ```bash
 # Orin Nano (Cortex-A78AE)

--- a/crates/python/ARCHITECTURE.md
+++ b/crates/python/ARCHITECTURE.md
@@ -34,7 +34,7 @@ build matrix lives in
 
 | Python class | Wraps | Notes |
 |--------------|-------|-------|
-| `Tensor` | `edgefirst_tensor::TensorDyn` | Implements the numpy buffer protocol — `np.frombuffer(t.map())` is zero-copy when the backend supports it |
+| `Tensor` | `edgefirst_tensor::TensorDyn` | Buffer protocol is exposed by `TensorMap` (returned by `Tensor.map()`), not by `Tensor` itself. The portable zero-copy pattern is `with t.map() as m: np.frombuffer(m.view(), dtype=...).reshape(t.shape())`. The shorter `np.frombuffer(t.map(), ...)` works only on the abi3-py311 wheel (see § Stable ABI). |
 | `ImageProcessor` | `edgefirst_image::ImageProcessor` | One-per-pipeline; owns the GL thread |
 | `Decoder` | `edgefirst_decoder::Decoder` | Built once from a metadata dict or YAML/JSON string |
 | `ByteTrack` | `edgefirst_tracker::ByteTrack<DetectBox>` | Stable per-track UUIDs |
@@ -144,8 +144,17 @@ relies on the Rust-side `Drop` chain.
 
 ## Performance Considerations
 
-- **`Tensor` buffer protocol is zero-copy when the backend allows.** Use
-  `np.frombuffer(t.map(), dtype=...)` instead of `np.array(t.map(), copy=True)`.
+- **Map + view is zero-copy when the backend allows.** Prefer the
+  context-manager form (portable across both wheels):
+
+  ```python
+  with t.map() as m:
+      arr = np.frombuffer(m.view(), dtype=...).reshape(t.shape())
+  ```
+
+  rather than copying with `np.array(t.map(), copy=True)`. The
+  shorter `np.frombuffer(t.map(), ...)` is also zero-copy but
+  requires the abi3-py311 wheel.
 - **Pass numpy arrays directly to `from_numpy` and `decode`** — do not
   pre-call `np.ascontiguousarray()`. The binding handles strided inputs
   internally via the three-path dispatch above; pre-materializing

--- a/crates/python/ARCHITECTURE.md
+++ b/crates/python/ARCHITECTURE.md
@@ -1,0 +1,174 @@
+# edgefirst-hal (Python) Architecture
+
+## Overview
+
+The `edgefirst-hal` Python package is a PyO3 binding over the EdgeFirst HAL
+Rust workspace. It exposes the same tensor / image / decoder / tracker APIs
+that the C and Rust users see, with idiomatic Python types: `np.ndarray` for
+buffer access, `pathlib.Path` for file APIs, exceptions for error reporting,
+and `.pyi` stubs for IDE autocompletion. The binding uses
+[PyO3](https://docs.rs/pyo3) and [maturin](https://maturin.rs) for wheel
+building.
+
+The crate is published to PyPI as
+[`edgefirst-hal`](https://pypi.org/project/edgefirst-hal/). Pre-built wheels
+ship for Linux x86_64 / aarch64 (manylinux2014 + abi3-py38), macOS Apple
+Silicon, and Windows.
+
+## Module Map
+
+| Module | Source | Responsibility |
+|--------|--------|----------------|
+| [`lib.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/src/lib.rs) | local | `#[pymodule]` registration; module-level docstring |
+| [`tensor.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/src/tensor.rs) | local | `Tensor`, `PixelFormat`, `DType`; numpy buffer protocol; `from_fd` / `dmabuf_clone` |
+| [`image.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/src/image.rs) | local | `ImageProcessor`, `Rect`, `Rotation`, `Flip`; `convert`, `draw_masks`, `draw_decoded_masks`, `import_image` |
+| [`decoder.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/src/decoder.rs) | local | `Decoder`; `decode`, `decode_tracked`, proto-mask APIs |
+| [`tracker.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/src/tracker.rs) | local | `ByteTrack`; `update`, `get_active_tracks` |
+
+## Key Types
+
+| Python class | Wraps | Notes |
+|--------------|-------|-------|
+| `Tensor` | `edgefirst_tensor::TensorDyn` | Implements the numpy buffer protocol — `np.frombuffer(t.map())` is zero-copy when the backend supports it |
+| `ImageProcessor` | `edgefirst_image::ImageProcessor` | One-per-pipeline; owns the GL thread |
+| `Decoder` | `edgefirst_decoder::Decoder` | Built once from a metadata dict or YAML/JSON string |
+| `ByteTrack` | `edgefirst_tracker::ByteTrack<DetectBox>` | Stable per-track UUIDs |
+| `PixelFormat`, `DType`, `Rotation`, `Flip`, `Rect` | corresponding Rust enums | `repr()` matches Rust naming |
+| `Tracing` (context manager) | umbrella `trace::start_tracing` / `stop_tracing` | `with hal.Tracing("/tmp/trace.json"): ...` |
+
+## Internal Architecture
+
+### Binding shape
+
+```mermaid
+flowchart LR
+    Py[Python code]
+    PyO3[PyO3 bindings<br/>edgefirst_hal package]
+    Rust[Rust workspace<br/>tensor / image / decoder / tracker]
+    HW[GPU / G2D / CPU]
+
+    Py --> PyO3
+    PyO3 --> Rust
+    Rust --> HW
+
+    style Py fill:#3776ab,color:#fff
+    style PyO3 fill:#ce422b,color:#fff
+    style Rust fill:#dea584
+    style HW fill:#90ee90
+```
+
+The `lib.rs` `#[pymodule]` registers each `#[pyclass]` from the four
+sub-modules. PyO3 generates the necessary `__init__`, `__repr__`, and
+property-accessor glue from `#[pymethods]` attributes, so the Python class
+shapes track the Rust source automatically.
+
+### Stable ABI / abi3
+
+The wheels are built with `--features pyo3/abi3-py38`, producing a single
+binary that runs on Python 3.8 through the latest 3.x. The trade-off is
+that Python 3.11+ buffer-protocol features fall back to the 3.8-compatible
+path; users on 3.11+ still get full functionality, just without the
+zero-overhead 3.11-specific shortcuts. The CI matrix builds both stable-ABI
+wheels and per-version wheels where measurement showed the abi3 fallback
+materially slower; pip resolves the best wheel per host.
+
+### NumPy → Tensor copy strategy
+
+[`crates/python/src/tensor.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/src/tensor.rs)
+contains `copy_numpy_to_tensor_dyn`, which inspects the source array's
+strides and dispatches to one of three paths to balance copy cost against
+allocation overhead:
+
+| Path | Source layout | Strategy | Cost |
+|------|---------------|----------|------|
+| 1 | Fully contiguous | `copy_from_slice` (memcpy), rayon-parallel ≥ 256 KiB | Lower bound — no allocation |
+| 2 | Strided with contiguous inner rows (column slice, sub-volume, negative stride) | Per-row memcpy, iterate outer dimensions | Within ≈ 5 % of Path 1 for typical row sizes |
+| 3 | Fully strided (transposed view, every-other-element) | Internal `np.ascontiguousarray()` (numpy's vectorised C strided→contig pass), then Path 1 memcpy | ≈ 4× Path 1 — but ≈ 4× faster than the legacy element-wise iteration the binding used to do here |
+
+Path 3 is the case that bit early users: a HailoRT output naturally arrives
+as `arr.transpose(0, 2, 1)` over a `(1, anchors, channels)` buffer, which
+has no contiguous inner row. The legacy element-wise loop incurred stride
+arithmetic and broke vectorisation. PR #58 replaced it with the
+`np.ascontiguousarray` materialisation path. Callers therefore no longer
+need to maintain a manual `np.ascontiguousarray()` workaround above HAL —
+see [README § Rule 7 — Pass arrays straight to from_numpy](https://github.com/EdgeFirstAI/hal/blob/main/README.md#rule-7--numpy-interop-pass-arrays-straight-to-from_numpy)
+for the user-facing rule.
+
+### Tensor buffer protocol
+
+`Tensor.map()` returns a `memoryview` over the tensor's mapped memory. For
+`Mem` and `Dma` backends this is a zero-copy view; for `Pbo` the GL thread
+performs an `glMapBufferRange` round-trip via the message channel. The
+`memoryview` carries the right shape, strides, and dtype so
+`np.frombuffer(t.map(), dtype=...).reshape(t.shape())` produces a zero-copy
+numpy array.
+
+For DMA-backed tensors, `Tensor.dmabuf_clone()` returns the `int` fd
+suitable for handing to a TFLite delegate. Non-DMA tensors raise
+`NotImplementedError` on this call (matches the C API's `ENOTSUP`).
+
+### Process-shutdown safety with Python finalization
+
+The image crate's GL backend installs a defense-in-depth shutdown strategy
+to survive Python's non-deterministic finalization order — see
+[`crates/image/ARCHITECTURE.md#process-shutdown-resource-cleanup`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#process-shutdown-resource-cleanup).
+The Python binding inherits this for free: a PyO3 `#[pyclass]` wrapping
+`ImageProcessor` whose `Drop` runs after `Py_FinalizeEx()` will not crash
+the interpreter. The binding does not add Python-specific finalizers; it
+relies on the Rust-side `Drop` chain.
+
+## Performance Considerations
+
+- **`Tensor` buffer protocol is zero-copy when the backend allows.** Use
+  `np.frombuffer(t.map(), dtype=...)` instead of `np.array(t.map(), copy=True)`.
+- **Pass numpy arrays directly to `from_numpy` and `decode`** — do not
+  pre-call `np.ascontiguousarray()`. The binding handles strided inputs
+  internally via the three-path dispatch above; pre-materializing
+  duplicates that work.
+- **Hold tensors alive across frames.** Each new tensor allocates a fresh
+  `BufferIdentity`; the EGL image cache keys on it, so re-creating tensors
+  defeats the cache. Same rule as the Rust and C APIs.
+- **Use `processor.create_image()` for `convert()` destinations.** Direct
+  `Tensor.new()` allocations bypass the GPU memory-backend probe.
+- **Tracing has near-zero cost when no subscriber is active.** Wrap the
+  hot loop in `with hal.Tracing(...)` only when collecting a profile.
+
+See the [Optimization Guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)
+in the project README for the full cross-crate user rules and validation
+patterns.
+
+## Inter-Crate Interfaces
+
+| Direction | Crate | Interface |
+|-----------|-------|-----------|
+| Wraps | [`edgefirst-tensor`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/) | `Tensor`, `TensorDyn`, `PixelFormat`, `DType` |
+| Wraps | [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) | `ImageProcessor`, draw / convert APIs |
+| Wraps | [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) | `Decoder`, `DetectBox`, `Segmentation` |
+| Wraps | [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) | `ByteTrack`, `TrackInfo` |
+| Wraps | [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) (feature `tracing`) | `trace::start_tracing` / `stop_tracing` |
+
+## Build System
+
+Wheels are built with [`maturin`](https://maturin.rs):
+
+```bash
+# Local development install (editable)
+maturin develop -m crates/python/Cargo.toml --release
+
+# Build a wheel for the current platform
+maturin build -m crates/python/Cargo.toml --release
+
+# Cross-compile a manylinux2014 + abi3-py38 wheel
+make wheel-arm    # uses zig + cross
+```
+
+The release pipeline ([`.github/workflows/release.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/release.yml))
+publishes wheels to PyPI on tag push.
+
+## Cross-References
+
+- Project architecture: [../../ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
+- Optimization guide: [README.md#optimization-guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)
+- Image GL shutdown defense: [../image/ARCHITECTURE.md#process-shutdown-resource-cleanup](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md#process-shutdown-resource-cleanup)
+- Decoder architecture: [../decoder/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md)
+- Performance tracing usage: [README.md#performance-tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)

--- a/crates/python/ARCHITECTURE.md
+++ b/crates/python/ARCHITECTURE.md
@@ -104,12 +104,23 @@ for the user-facing rule.
 
 ### Tensor buffer protocol
 
-`Tensor.map()` returns a `memoryview` over the tensor's mapped memory. For
-`Mem` and `Dma` backends this is a zero-copy view; for `Pbo` the GL thread
-performs an `glMapBufferRange` round-trip via the message channel. The
-`memoryview` carries the right shape, strides, and dtype so
-`np.frombuffer(t.map(), dtype=...).reshape(t.shape())` produces a zero-copy
-numpy array.
+`Tensor.map()` returns a `TensorMap` — a Python context manager
+(`__enter__` / `__exit__`) that wraps the underlying mapped buffer
+and unmaps it on exit. The actual buffer is exposed via
+`TensorMap.view()`, which returns a `memoryview` over the mapped
+memory. For `Mem` and `Dma` backends the view is zero-copy; for
+`Pbo` the GL thread performs a `glMapBufferRange` round-trip via the
+message channel. The `memoryview` carries the right shape, strides,
+and dtype so the typical pattern is:
+
+```python
+with t.map() as m:
+    arr = np.frombuffer(m.view(), dtype=...).reshape(t.shape())
+```
+
+The context manager is required because `Pbo` and `Dma` mappings
+hold driver state that must be released deterministically — letting
+the `TensorMap` outlive its `with` block keeps the buffer locked.
 
 For DMA-backed tensors, `Tensor.dmabuf_clone()` returns the `int` fd
 suitable for handing to a TFLite delegate. Tensor-side errors

--- a/crates/python/ARCHITECTURE.md
+++ b/crates/python/ARCHITECTURE.md
@@ -64,13 +64,16 @@ shapes track the Rust source automatically.
 
 ### Stable ABI / abi3
 
-The wheels are built with `--features pyo3/abi3-py38`, producing a single
-binary that runs on Python 3.8 through the latest 3.x. The trade-off is
-that Python 3.11+ buffer-protocol features fall back to the 3.8-compatible
-path; users on 3.11+ still get full functionality, just without the
-zero-overhead 3.11-specific shortcuts. The CI matrix builds both stable-ABI
-wheels and per-version wheels where measurement showed the abi3 fallback
-materially slower; pip resolves the best wheel per host.
+The release pipeline
+([`.github/workflows/release.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/release.yml))
+builds **two stable-ABI wheels per platform**: one with
+`--features abi3-py311` and one with `--features abi3-py38`. Each
+single binary runs on its abi3 floor and every later 3.x release. The
+`abi3-py38` variant is the broadest-compatibility fallback; the
+`abi3-py311` variant is built because some 3.11+ buffer-protocol
+features benefit from a fresher abi3 floor. There are no per-version
+(non-abi3) wheels; pip selects the appropriate abi3 wheel from the
+two published per platform.
 
 ### NumPy → Tensor copy strategy
 
@@ -104,8 +107,14 @@ performs an `glMapBufferRange` round-trip via the message channel. The
 numpy array.
 
 For DMA-backed tensors, `Tensor.dmabuf_clone()` returns the `int` fd
-suitable for handing to a TFLite delegate. Non-DMA tensors raise
-`NotImplementedError` on this call (matches the C API's `ENOTSUP`).
+suitable for handing to a TFLite delegate. Tensor-side errors
+(non-DMA backend, fd duplication failure, etc.) surface as
+`RuntimeError` — the binding's `From<Error> for PyErr` implementation
+in
+[`crates/python/src/tensor.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/src/tensor.rs)
+maps every tensor error to `pyo3::exceptions::PyRuntimeError`. The
+C API surfaces the same condition as `errno = ENOTSUP`, but the
+Python exception type is `RuntimeError`, not `NotImplementedError`.
 
 ### Process-shutdown safety with Python finalization
 
@@ -158,8 +167,8 @@ maturin develop -m crates/python/Cargo.toml --release
 # Build a wheel for the current platform
 maturin build -m crates/python/Cargo.toml --release
 
-# Cross-compile a manylinux2014 + abi3-py38 wheel
-make wheel-arm    # uses zig + cross
+# Cross-compile a manylinux2014 wheel for an alternate target (zig + maturin)
+make TARGET=aarch64-unknown-linux-gnu PYABI=py38 wheel
 ```
 
 The release pipeline ([`.github/workflows/release.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/release.yml))

--- a/crates/python/ARCHITECTURE.md
+++ b/crates/python/ARCHITECTURE.md
@@ -11,9 +11,14 @@ and `.pyi` stubs for IDE autocompletion. The binding uses
 building.
 
 The crate is published to PyPI as
-[`edgefirst-hal`](https://pypi.org/project/edgefirst-hal/). Pre-built wheels
-ship for Linux x86_64 / aarch64 (manylinux2014 + abi3-py38), macOS Apple
-Silicon, and Windows.
+[`edgefirst-hal`](https://pypi.org/project/edgefirst-hal/). Pre-built
+wheels ship two stable-ABI variants per platform — `abi3-py311`
+(preferred; supports buffer-protocol features added in 3.11) and
+`abi3-py38` (compatibility fallback for 3.8–3.10). Coverage:
+Linux x86_64 / aarch64 (manylinux2014), macOS Apple Silicon, and
+Windows. Pip selects the best wheel automatically. The full wheel
+build matrix lives in
+[`.github/workflows/release.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/release.yml).
 
 ## Module Map
 

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -234,6 +234,13 @@ fall back to CPU.
 - **[GitHub](https://github.com/EdgeFirstAI/hal)** — source code,
   architecture docs, benchmarks, and contribution guide
 
+## Documentation
+
+- Architecture overview: [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/ARCHITECTURE.md)
+- Testing guide: [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/python/TESTING.md)
+- Project README (cross-language overview): [../../README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md)
+- Optimization guide (cross-language user rules): [README.md#optimization-guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)
+
 ## License
 
 Apache-2.0 — see [LICENSE](https://github.com/EdgeFirstAI/hal/blob/main/LICENSE).

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -39,9 +39,16 @@ dst = processor.create_image(640, 640, ef.PixelFormat.Rgb)
 # Convert with letterbox resize (preserves aspect ratio)
 processor.convert(src, dst)
 
-# Access pixel data as a numpy array
+# Access pixel data as a numpy array. Use the context manager + .view()
+# form — this is the portable pattern that works on both wheel variants.
 import numpy as np
-pixels = np.frombuffer(dst.map(), dtype=np.uint8).reshape(dst.shape())
+with dst.map() as m:
+    pixels = np.frombuffer(m.view(), dtype=np.uint8).reshape(dst.shape())
+
+# The shorter `np.frombuffer(dst.map(), ...)` form only works on the
+# abi3-py311 wheel, where `TensorMap` exposes Python's buffer protocol
+# directly. The abi3-py38 compatibility wheel disables `__getbuffer__`,
+# so use `.view()` if your code needs to run on Python 3.8–3.10.
 ```
 
 ## Role in edgefirst-hal

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -44,6 +44,23 @@ import numpy as np
 pixels = np.frombuffer(dst.map(), dtype=np.uint8).reshape(dst.shape())
 ```
 
+## Role in edgefirst-hal
+
+The `edgefirst-hal` package on PyPI is the Python face of the EdgeFirst
+HAL Rust workspace:
+
+- Built from [`crates/python`](https://github.com/EdgeFirstAI/hal/tree/main/crates/python),
+  which is a PyO3 binding over the `edgefirst-hal` Rust umbrella crate.
+- Does **not** consume the C API ([`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/));
+  the binding goes directly through Rust.
+- Exposes the same `Tensor`, `ImageProcessor`, `Decoder`, and `Tracker`
+  surfaces as the Rust crate, with numpy-friendly conversions and the
+  buffer protocol for zero-copy interop.
+- Wheels are distributed as two stable-ABI variants per platform —
+  `abi3-py311` (preferred, supports buffer protocol features added in
+  3.11) and `abi3-py38` (compatibility fallback for 3.8–3.10).
+  Pip selects the best wheel automatically.
+
 ## Key Features
 
 - **Zero-copy tensors** — DMA-BUF, POSIX shared memory, and PBO-backed

--- a/crates/python/TESTING.md
+++ b/crates/python/TESTING.md
@@ -44,9 +44,12 @@ python -m pytest tests/decoder/test_decoder.py
 python -m slipcover --xml --out target/python-coverage.xml -m pytest tests/
 ```
 
-The Makefile target `make test-python` wraps steps 2–4. CI uses the same
-target; coverage from slipcover is uploaded to SonarCloud alongside the
-Rust lcov coverage.
+The Makefile target `make test-python` wraps step 2 (install via
+`pip install -q crates/python/[test]`) and then runs the full pytest
+suite (step 3) under `slipcover --xml` when slipcover is available.
+It does **not** wrap step 4 — single-module invocations have to be
+run by hand. CI uses the same target; the slipcover XML is uploaded
+to SonarCloud alongside the Rust lcov coverage.
 
 ## Special Requirements
 

--- a/crates/python/TESTING.md
+++ b/crates/python/TESTING.md
@@ -1,0 +1,117 @@
+# edgefirst-hal (Python) Testing
+
+## Test Layout
+
+```
+tests/                          # Project-level Python tests
+├── test_tensor.py
+├── tensor/                     # Tensor-specific tests
+├── image/                      # ImageProcessor tests
+├── decoder/                    # Decoder tests
+├── python/                     # PyO3 binding-specific edge cases
+├── bench_decode_render.py      # Decoder + draw_decoded_masks benchmark
+├── profile_decode_render.py    # Hot-loop profiling target for `perf record`
+└── example_seg_pipeline.py     # End-to-end pipeline example
+```
+
+The Python crate's source under
+[`crates/python/src/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/python/src)
+contains the PyO3 binding layer; the actual test code lives at the
+workspace root in `tests/` so it can drive the installed `edgefirst_hal`
+package the same way an end user would.
+
+## Running Tests
+
+```bash
+# 1. Activate the project venv (per global rule — never install into
+#    the system Python)
+source venv/bin/activate
+
+# 2. Build and install the bindings into the venv in development mode
+maturin develop -m crates/python/Cargo.toml
+
+# 3. Run the full Python suite
+python -m pytest tests/
+
+# 4. Single test module
+python -m pytest tests/image/test_image.py
+python -m pytest tests/decoder/test_decoder.py
+
+# 5. With slipcover for coverage (preferred over coverage.py for Rust+PyO3)
+python -m slipcover --xml --out target/python-coverage.xml -m pytest tests/
+```
+
+The Makefile target `make test-python` wraps steps 2–4. CI uses the same
+target; coverage from slipcover is uploaded to SonarCloud alongside the
+Rust lcov coverage.
+
+## Special Requirements
+
+- **venv is mandatory.** Per the global CLAUDE.md rule, never `pip install`
+  into the system Python. The `venv/` directory at the workspace root is
+  the canonical environment.
+- **`maturin develop` rebuilds the Rust shared object** when the Rust
+  source changes. Run it after any change under `crates/` or after pulling
+  new commits before running tests.
+- **Single-threaded execution** — the Python suite inherits the
+  [project-wide single-threaded rule](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution)
+  whenever GL or G2D code paths are exercised. `pytest -p no:randomly` is
+  recommended; the Makefile already disables parallelism.
+- **LFS testdata** — fixtures live under `testdata/`. The Python tests
+  resolve paths relative to the workspace root; no env var is needed
+  locally. CI sets `EDGEFIRST_TESTDATA_DIR` for parity with the Rust
+  bench harness.
+- **Hardware gates** — GL/G2D tests skip themselves on hosts without the
+  required device nodes (mirroring the Rust-side `OnceLock` probes). On
+  the i.MX 8M Plus and i.MX 95 hardware runners the full hardware path is
+  exercised.
+- **`abi3-py38` wheels** — when running tests against a release wheel
+  rather than `maturin develop`, install the wheel into a clean venv and
+  point `pytest` at the install location. CI does this for the
+  `Hardware Test (imx8mp)` job.
+
+## Benchmarks
+
+```bash
+# 2-step path: decode() then draw_decoded_masks()
+python tests/bench_decode_render.py --iterations 100
+
+# Single-call fused decode+draw
+python tests/bench_decode_render.py --fused --iterations 100
+
+# JSON output for tracking in CI
+python tests/bench_decode_render.py --json results.json
+```
+
+For sampling profiles:
+
+```bash
+# Records the fused hot loop with full call stacks
+perf record -F 997 --call-graph dwarf -- \
+  python tests/profile_decode_render.py fused
+```
+
+`profile_decode_render.py` is intentionally separated from
+`bench_decode_render.py` so that setup (model load, EGL init) does not
+appear in the sampled profile.
+
+## Coverage Notes
+
+- Python coverage uses [`slipcover`](https://github.com/plasma-umass/slipcover)
+  rather than `coverage.py` — slipcover handles native extensions
+  (Rust/PyO3) without losing line-level attribution.
+- The XML output (`target/python-coverage.xml`) is merged with the Rust
+  lcov by the
+  [`Process Hardware Coverage`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml)
+  job and uploaded to SonarCloud.
+- Test discovery uses pytest's default conventions — no `conftest.py`
+  magic. Test classes that need shared fixtures use module-level
+  `@pytest.fixture(scope="module")` to amortize processor / decoder
+  construction across cases.
+
+## Cross-References
+
+- Project testing patterns: [../../TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md)
+- Validating optimizations: [TESTING.md#validating-optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations)
+- Image-side GL gating: [../image/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md)
+- Decoder testing: [../decoder/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/TESTING.md)

--- a/crates/python/TESTING.md
+++ b/crates/python/TESTING.md
@@ -4,8 +4,7 @@
 
 ```
 tests/                          # Project-level Python tests
-├── test_tensor.py
-├── tensor/                     # Tensor-specific tests
+├── test_tensor.py              # Tensor binding coverage (single file)
 ├── image/                      # ImageProcessor tests
 ├── decoder/                    # Decoder tests
 ├── python/                     # PyO3 binding-specific edge cases
@@ -13,6 +12,10 @@ tests/                          # Project-level Python tests
 ├── profile_decode_render.py    # Hot-loop profiling target for `perf record`
 └── example_seg_pipeline.py     # End-to-end pipeline example
 ```
+
+Tensor tests live as a single file (`tests/test_tensor.py`) rather than
+under `tests/tensor/`; the binding surface for `Tensor` is narrow enough
+that a flat file is easier to navigate than a directory.
 
 The Python crate's source under
 [`crates/python/src/`](https://github.com/EdgeFirstAI/hal/tree/main/crates/python/src)

--- a/crates/python/TESTING.md
+++ b/crates/python/TESTING.md
@@ -63,8 +63,10 @@ Rust lcov coverage.
   recommended; the Makefile already disables parallelism.
 - **LFS testdata** — fixtures live under `testdata/`. The Python tests
   resolve paths relative to the workspace root; no env var is needed
-  locally. CI sets `EDGEFIRST_TESTDATA_DIR` for parity with the Rust
-  bench harness.
+  locally. The aarch64 (`test-arm`) and `hardware-test` CI jobs export
+  `EDGEFIRST_TESTDATA_DIR=${{ github.workspace }}/testdata` for parity
+  with the Rust bench harness; the x86_64 Python test job relies on
+  the workspace-relative fallback and does not set the variable.
 - **Hardware gates** — GL/G2D tests skip themselves on hosts without the
   required device nodes (mirroring the Rust-side `OnceLock` probes). On
   the i.MX 8M Plus and i.MX 95 hardware runners the full hardware path is

--- a/crates/python/TESTING.md
+++ b/crates/python/TESTING.md
@@ -47,9 +47,10 @@ Rust lcov coverage.
 
 ## Special Requirements
 
-- **venv is mandatory.** Per the global CLAUDE.md rule, never `pip install`
-  into the system Python. The `venv/` directory at the workspace root is
-  the canonical environment.
+- **Use a Python virtual environment.** Never `pip install` into the
+  system Python; activate the `venv/` directory at the workspace root
+  before running the Python tooling. The Makefile targets assume `venv/`
+  is the active environment.
 - **`maturin develop` rebuilds the Rust shared object** when the Rust
   source changes. Run it after any change under `crates/` or after pulling
   new commits before running tests.
@@ -65,10 +66,13 @@ Rust lcov coverage.
   required device nodes (mirroring the Rust-side `OnceLock` probes). On
   the i.MX 8M Plus and i.MX 95 hardware runners the full hardware path is
   exercised.
-- **`abi3-py38` wheels** — when running tests against a release wheel
-  rather than `maturin develop`, install the wheel into a clean venv and
-  point `pytest` at the install location. CI does this for the
-  `Hardware Test (imx8mp)` job.
+- **abi3 wheels** — `.github/workflows/test.yml` builds the Python
+  binding with `--features abi3-py311` for the CI test legs (including
+  the `Hardware Test (imx8mp)` job that downloads the wheel into a
+  fresh venv). The release pipeline additionally builds an
+  `abi3-py38` variant for broader compatibility. When testing against
+  a release wheel locally, install it into a clean venv and point
+  `pytest` at that environment.
 
 ## Benchmarks
 

--- a/crates/tensor/ARCHITECTURE.md
+++ b/crates/tensor/ARCHITECTURE.md
@@ -108,29 +108,46 @@ managed by the GL thread inside `edgefirst-image`. The tensor crate provides
 the `PboTensor` wrapper and the `PboOps` trait that the GL backend implements
 to perform map / unmap / delete operations.
 
-`PboTensor` holds a `WeakSender` (not a `Sender`) for the channel that talks
-to the GL thread. This is a deliberate design choice: if `PboTensor` held a
-strong `Sender`, any surviving PBO tensor would keep the channel alive,
-preventing `GLProcessorThreaded::drop()` from joining the GL thread at
-shutdown. The `WeakSender` pattern lets the GL thread exit cleanly when
-the `ImageProcessor` is dropped, even if PBO tensors still exist; subsequent
-PBO operations on orphaned tensors return `PboDisconnected`.
+`PboTensor` holds an `Arc<dyn PboOps>` — a trait object the GL backend
+implements to perform map / unmap / delete on the tensor's behalf. The
+image crate's `GlPboOps` is the concrete implementation; it owns a
+`WeakSender` to the GL thread's message channel. The weak-sender
+ownership lives **inside the trait impl**, not in `PboTensor` itself,
+so the tensor crate has no compile-time dependency on the image
+crate's channel implementation. The `WeakSender` is the mechanism
+that lets the GL thread exit cleanly when `ImageProcessor` is
+dropped, even while PBO tensors are still alive; subsequent PBO
+operations on orphaned tensors return `PboDisconnected`.
 
 ### BufferIdentity and EGL image caching
 
-Every tensor allocation or import creates a fresh `BufferIdentity` carrying:
+Every tensor allocation or import creates a fresh `BufferIdentity`
+carrying:
 
-- `id() -> u64` — monotonically increasing integer. Suitable as a HashMap or
-  EGL image cache key; changes every time the underlying buffer changes.
-- `weak() -> Weak<()>` — goes dead when the owning tensor (and all clones)
-  are dropped, allowing caches to detect stale entries without holding a
-  strong reference.
+- `id() -> u64` — monotonically increasing integer. Used by the image
+  crate's EGL image cache as the lookup key.
+- `weak() -> Weak<()>` — goes dead when the owning tensor (and all
+  clones) are dropped, allowing caches to detect stale entries without
+  holding a strong reference.
 
-The image processing backends use `BufferIdentity::id()` to key an EGL image
-cache so that re-importing the same camera buffer across frames does not
-re-create a GPU texture. See
+The image processing backends key their EGL image cache on
+`BufferIdentity.id()` so that the **same tensor object** reused across
+frames hits the cache. The cache does **not** rescue a pipeline that
+re-imports the same DMA-BUF every frame: each `hal_import_image` /
+`hal_tensor_from_fd` call mints a new `BufferIdentity` with a fresh
+ID, so re-imports always miss. The contract is:
+
+- Downstream caches (V4L2 / GStreamer adaptors) cache external
+  DMA-BUFs by stable `(inode, plane_offset)` and hold each
+  `hal_tensor *` alive across frames.
+- That keeps `BufferIdentity.id()` constant for the same physical
+  buffer, which in turn keeps the in-HAL EGL image cache hitting.
+
+See
 [`crates/image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
-for the cache implementation.
+for the EGL image cache implementation and
+[the project ARCHITECTURE Appendix C](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
+for the full cross-cutting story.
 
 ## Performance Considerations
 
@@ -176,13 +193,16 @@ Each plane keeps its own DMA-BUF fd and per-plane stride / offset.
 The C API exposes this through
 [`hal_import_image(proc, y_pd, uv_pd, ...)`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/include/edgefirst/hal.h)
 which takes two `PlaneDescriptor`s and combines them via `from_planes`. The
-GStreamer integration element `edgefirstcameraadaptor` detects multi-plane
-buffers (`gst_buffer_n_memory() > 1`) and extracts per-plane fds via
-`gst_dmabuf_memory_get_fd()`.
+A downstream GStreamer source/transform element that wants to feed
+multi-plane buffers into the HAL detects them via
+`gst_buffer_n_memory() > 1` and extracts per-plane fds with
+`gst_dmabuf_memory_get_fd()` on each `GstMemory` block, then passes
+each fd into a separate `hal_plane_descriptor`.
 
-This work was implemented under **EDGEAI-1107**. See
-[`../image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
-for the OpenGL-side multi-plane path (`create_image_from_dma2`).
+See
+[`crates/image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
+for the OpenGL-side multi-plane import path that consumes per-plane fds
+via EGL attributes.
 
 ## Inter-Crate Interfaces
 
@@ -196,12 +216,18 @@ on it:
 | [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) | `pub use edgefirst_tensor as tensor` | Re-export |
 | [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) | `from_fd`, `clone_fd`, `from_planes` | Tensor lifetime across the FFI boundary |
 
-The `BufferIdentity` API is the inter-crate cache contract: image-side EGL
-caches and downstream consumers (e.g. `edgefirstcameraadaptor`) all key on
-`buffer_identity().id()` to detect when a logical buffer's contents have
-changed. See
+`BufferIdentity` is the in-HAL cache contract: the image crate's EGL
+image cache keys on `buffer_identity().id()`, which is stable for the
+lifetime of a tensor object. **Downstream import caches** (V4L2 /
+libcamera / GStreamer adaptors) must not key on
+`buffer_identity().id()` —
+that id is regenerated on every HAL import. Downstream caches key on
+the stable kernel `(inode, plane_offset)` of the external DMA-BUF and
+then keep the resulting `hal_tensor *` alive across frames, which
+keeps `buffer_identity().id()` stable and so keeps the image-side
+cache hitting. See
 [Appendix C: DMA-BUF Identity and Tensor Caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
-in the project ARCHITECTURE.md for the cross-crate story.
+in the project ARCHITECTURE.md for the full two-layer story.
 
 ## Platform-Specific Notes
 

--- a/crates/tensor/ARCHITECTURE.md
+++ b/crates/tensor/ARCHITECTURE.md
@@ -192,7 +192,7 @@ Each plane keeps its own DMA-BUF fd and per-plane stride / offset.
 
 The C API exposes this through
 [`hal_import_image(proc, y_pd, uv_pd, ...)`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/include/edgefirst/hal.h)
-which takes two `PlaneDescriptor`s and combines them via `from_planes`. The
+which takes two `PlaneDescriptor`s and combines them via `from_planes`.
 A downstream GStreamer source/transform element that wants to feed
 multi-plane buffers into the HAL detects them via
 `gst_buffer_n_memory() > 1` and extracts per-plane fds with

--- a/crates/tensor/ARCHITECTURE.md
+++ b/crates/tensor/ARCHITECTURE.md
@@ -206,8 +206,10 @@ via EGL attributes.
 
 ## Inter-Crate Interfaces
 
-The tensor crate is the foundation; every other `edgefirst-*` crate depends
-on it:
+The tensor crate is the foundation of the data-plane crates — image,
+decoder, capi, and gpu-probe all depend on it. The tracker and bench
+crates are independent of it (tracker operates on `DetectionBox` and
+`nalgebra`; bench is a thin `serde_json` wrapper for benchmark IO):
 
 | Consumer | Interface | Purpose |
 |----------|-----------|---------|
@@ -215,6 +217,7 @@ on it:
 | [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) | `Tensor<T>`, `TensorMap` | Reading model output tensors |
 | [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) | `pub use edgefirst_tensor as tensor` | Re-export |
 | [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) | `from_fd`, `clone_fd`, `from_planes` | Tensor lifetime across the FFI boundary |
+| [`gpu-probe`](https://github.com/EdgeFirstAI/hal/blob/main/crates/gpu-probe/) | `Tensor` allocation | Allocates the DMA-BUF round-trip buffer the probe verifies |
 
 `BufferIdentity` is the in-HAL cache contract: the image crate's EGL
 image cache keys on `buffer_identity().id()`, which is stable for the

--- a/crates/tensor/ARCHITECTURE.md
+++ b/crates/tensor/ARCHITECTURE.md
@@ -1,0 +1,224 @@
+# edgefirst-tensor Architecture
+
+## Overview
+
+`edgefirst-tensor` is the zero-copy tensor primitive that the rest of the
+EdgeFirst HAL is built on. Its job is to give the higher-level crates a
+uniform multi-dimensional array type that can be backed by any of four memory
+sources — DMA-BUF, POSIX shared memory, the system heap, or an OpenGL Pixel
+Buffer Object — without forcing the consumer to know which backend is in use.
+A single `Tensor<T>` value is enough to feed CPU code, hand a buffer to a GPU
+shader, share an inference output with another process, or import a frame
+straight from a V4L2 camera.
+
+## Module Map
+
+| Module | Source | Responsibility |
+|--------|--------|----------------|
+| [`lib.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/lib.rs) | local | Public surface: `Tensor<T>`, `TensorTrait`, `TensorMemory`, `BufferIdentity`, multi-plane composition (`from_planes`) |
+| [`dma.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/dma.rs) | local | `DmaTensor<T>` — Linux DMA-BUF allocation via `dma-heap` |
+| [`dmabuf.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/dmabuf.rs) | local | `mmap` + `DMA_BUF_IOCTL_SYNC` cache-coherency helpers used by `DmaMap` |
+| [`shm.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/shm.rs) | local | `ShmTensor<T>` — POSIX shared memory backend |
+| [`mem.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/mem.rs) | local | `MemTensor<T>` — heap-backed tensor with no syscalls |
+| [`pbo.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/pbo.rs) | local | `PboTensor<T>` — wrapper around an OpenGL Pixel Buffer Object plus the `PboOps` trait the GL backend implements |
+| [`tensor_dyn.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/tensor_dyn.rs) | local | `TensorDyn` — dtype-erased tensor, image metadata (`PixelFormat`, row stride, plane offset, multi-plane composition) |
+| [`format.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/format.rs) | local | `PixelFormat`, `DType`, format/shape compatibility checks |
+| [`error.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/error.rs) | local | `Error`, `Result` |
+
+## Key Types and Traits
+
+- [`Tensor<T>`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/struct.Tensor.html) — generic strongly-typed tensor.
+- [`TensorDyn`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/struct.TensorDyn.html) — dtype-erased tensor used by image processing and the C API.
+- [`TensorTrait`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/trait.TensorTrait.html) — common operations across all backends (`shape`, `size`, `map`, `clone_fd`, `buffer_identity`).
+- [`TensorMapTrait`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/trait.TensorMapTrait.html) — RAII map handle giving slice access (and ndarray views with the `ndarray` feature).
+- [`TensorMemory`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/enum.TensorMemory.html) — request a specific backend at construction time.
+- [`BufferIdentity`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/struct.BufferIdentity.html) — stable cache key (`id() -> u64`) plus a `Weak<()>` liveness guard for caches that need to detect stale entries.
+- [`PlaneDescriptor`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/struct.PlaneDescriptor.html) — duplicated fd plus optional stride/offset, used for multi-plane DMA-BUF imports.
+- [`PixelFormat`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/enum.PixelFormat.html) / [`DType`](https://docs.rs/edgefirst-tensor/latest/edgefirst_tensor/enum.DType.html) — image metadata attached via `set_format` / `with_format`.
+
+## Internal Architecture
+
+### Backend dispatch
+
+```mermaid
+classDiagram
+    class TensorTrait~T~ {
+        <<trait>>
+        +shape() Vec~usize~
+        +size() usize
+        +map() TensorMap~T~
+        +clone_fd() Result~OwnedFd~
+        +buffer_identity() &BufferIdentity
+    }
+
+    class DmaTensor~T~ { Linux DMA-Heap }
+    class ShmTensor~T~ { POSIX shared memory }
+    class MemTensor~T~ { System heap }
+    class PboTensor~T~ { OpenGL PBO via WeakSender }
+
+    TensorTrait <|.. DmaTensor
+    TensorTrait <|.. ShmTensor
+    TensorTrait <|.. MemTensor
+    TensorTrait <|.. PboTensor
+```
+
+Each backend provides its own map type implementing `TensorMapTrait<T>`:
+
+| Tensor | Map | Mechanism |
+|--------|-----|-----------|
+| `DmaTensor<T>` | `DmaMap<T>` | `mmap` + `DMA_BUF_IOCTL_SYNC` for cache coherency |
+| `ShmTensor<T>` | `ShmMap<T>` | `mmap`/`munmap` on the POSIX shared memory fd |
+| `MemTensor<T>` | `MemMap<T>` | Direct raw pointer into `Vec<T>` (no syscall) |
+| `PboTensor<T>` | `PboMap<T>` | GL thread `glMapBufferRange` / `glUnmapBuffer` via channel |
+
+`TensorMap<T>` implements `Deref<Target=[T]>` and `DerefMut`. With the
+`ndarray` feature enabled, `TensorMapTrait` also provides `view()` /
+`view_mut()` returning ndarray `ArrayView` / `ArrayViewMut`.
+
+### Memory selection logic
+
+```mermaid
+flowchart TD
+    Start[Tensor::new] --> Explicit{Explicit TensorMemory?}
+    Explicit -->|Yes| UseSpec[Use specified backend]
+    Explicit -->|No| CheckEnv{EDGEFIRST_TENSOR_FORCE_MEM=1?}
+    CheckEnv -->|Yes| UseMem[MemTensor]
+    CheckEnv -->|No| TryDMA[Try DmaTensor]
+    TryDMA --> DMASuccess{Success?}
+    DMASuccess -->|Yes| UseDMA[DmaTensor]
+    DMASuccess -->|No| TryShm[Try ShmTensor]
+    TryShm --> ShmSuccess{Success?}
+    ShmSuccess -->|Yes| UseShm[ShmTensor]
+    ShmSuccess -->|No| UseMem
+
+    style UseDMA fill:#90ee90
+    style UseShm fill:#87ceeb
+    style UseMem fill:#ffeb9c
+```
+
+The fallback chain is **DMA → SHM → Heap**. `EDGEFIRST_TENSOR_FORCE_MEM=1`
+short-circuits the chain to `MemTensor`, primarily for unit tests on hosts
+without DMA-heap permissions.
+
+### PBO tensors and the WeakSender pattern
+
+PBO tensors are different from the other three backends: they are not
+allocated by the tensor crate at all. They are OpenGL Pixel Buffer Objects
+managed by the GL thread inside `edgefirst-image`. The tensor crate provides
+the `PboTensor` wrapper and the `PboOps` trait that the GL backend implements
+to perform map / unmap / delete operations.
+
+`PboTensor` holds a `WeakSender` (not a `Sender`) for the channel that talks
+to the GL thread. This is a deliberate design choice: if `PboTensor` held a
+strong `Sender`, any surviving PBO tensor would keep the channel alive,
+preventing `GLProcessorThreaded::drop()` from joining the GL thread at
+shutdown. The `WeakSender` pattern lets the GL thread exit cleanly when
+the `ImageProcessor` is dropped, even if PBO tensors still exist; subsequent
+PBO operations on orphaned tensors return `PboDisconnected`.
+
+### BufferIdentity and EGL image caching
+
+Every tensor allocation or import creates a fresh `BufferIdentity` carrying:
+
+- `id() -> u64` — monotonically increasing integer. Suitable as a HashMap or
+  EGL image cache key; changes every time the underlying buffer changes.
+- `weak() -> Weak<()>` — goes dead when the owning tensor (and all clones)
+  are dropped, allowing caches to detect stale entries without holding a
+  strong reference.
+
+The image processing backends use `BufferIdentity::id()` to key an EGL image
+cache so that re-importing the same camera buffer across frames does not
+re-create a GPU texture. See
+[`crates/image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
+for the cache implementation.
+
+## Performance Considerations
+
+### When to use each backend
+
+The choice of memory type significantly impacts performance depending on the
+workload:
+
+1. **Heap memory (`MemTensor<T>`)** — fastest for pure CPU algorithms (image
+   resize, filtering, format conversion). Standard heap allocation has
+   minimal overhead and is OS-optimized. Recommended when no hardware
+   acceleration is required.
+
+2. **DMA memory (`DmaTensor<T>`)** — adds CPU-level overhead for allocation
+   and mapping but provides substantial benefits when interfacing with
+   hardware accelerators:
+   - Zero-copy access from G2D (NXP i.MX graphics processor)
+   - Zero-copy access from OpenGL/GPU
+   - Zero-copy access from V4L2 video capture and codec engines
+   - Hardware DMA operations benefit from DMA-capable memory alignment and
+     page locking
+
+3. **Shared memory (`ShmTensor<T>`)** — slowest option, with CPU overhead
+   from POSIX shared memory operations. Does not support hardware DMA. Use
+   only for cross-process buffer sharing when DMA-BUF is unavailable
+   (insufficient permissions, non-Linux platforms, persistent memory
+   requirements).
+
+**Selection guidance:**
+- Pure CPU workloads → `MemTensor` (Heap).
+- Hardware-accelerated paths (G2D, OpenGL, V4L2, codec) → `DmaTensor`.
+- Cross-process buffer sharing when DMA cannot be used → `ShmTensor`.
+
+### Multi-plane DMA-BUF support
+
+Single-plane DMA-BUF buffers (one fd per buffer) are the common case: V4L2
+single-planar capture, MIPI-CSI direct capture, and HAL-allocated buffers
+all hit this path. The tensor crate also supports multi-plane formats
+(NV12/NV16 from VPU and NeoISP, where Y and UV reside in separate
+allocations) via `Tensor::from_planes(luma, chroma, PixelFormat::Nv12)`.
+Each plane keeps its own DMA-BUF fd and per-plane stride / offset.
+
+The C API exposes this through
+[`hal_import_image(proc, y_pd, uv_pd, ...)`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/include/edgefirst/hal.h)
+which takes two `PlaneDescriptor`s and combines them via `from_planes`. The
+GStreamer integration element `edgefirstcameraadaptor` detects multi-plane
+buffers (`gst_buffer_n_memory() > 1`) and extracts per-plane fds via
+`gst_dmabuf_memory_get_fd()`.
+
+This work was implemented under **EDGEAI-1107**. See
+[`../image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
+for the OpenGL-side multi-plane path (`create_image_from_dma2`).
+
+## Inter-Crate Interfaces
+
+The tensor crate is the foundation; every other `edgefirst-*` crate depends
+on it:
+
+| Consumer | Interface | Purpose |
+|----------|-----------|---------|
+| [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) | `Tensor<u8>`, `TensorDyn`, `PboOps` impl | Image processor input/output buffers, PBO management |
+| [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) | `Tensor<T>`, `TensorMap` | Reading model output tensors |
+| [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) | `pub use edgefirst_tensor as tensor` | Re-export |
+| [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) | `from_fd`, `clone_fd`, `from_planes` | Tensor lifetime across the FFI boundary |
+
+The `BufferIdentity` API is the inter-crate cache contract: image-side EGL
+caches and downstream consumers (e.g. `edgefirstcameraadaptor`) all key on
+`buffer_identity().id()` to detect when a logical buffer's contents have
+changed. See
+[Appendix C: DMA-BUF Identity and Tensor Caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
+in the project ARCHITECTURE.md for the cross-crate story.
+
+## Platform-Specific Notes
+
+| Platform | DMA | SHM | Mem | PBO |
+|----------|-----|-----|-----|-----|
+| Linux (NXP i.MX, x86_64, aarch64) | Yes | Yes | Yes | Yes (with OpenGL feature) |
+| macOS | No | Yes | Yes | No |
+| Other Unix | No | Yes | Yes | No |
+| Windows | No | No | Yes | No |
+
+The `dma-heap` and `libc` dependencies are gated on `cfg(target_os =
+"linux")` in `Cargo.toml`; non-Linux builds simply skip the DMA backend
+without compile errors.
+
+## Cross-References
+
+- Project architecture: [../../ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
+- DMA-BUF identity story: [ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md#appendix-c-dma-buf-identity-and-tensor-caching)
+- Image-side EGL cache and PBO dispatch: [../image/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
+- C API tensor lifetime: [../capi/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/ARCHITECTURE.md)

--- a/crates/tensor/README.md
+++ b/crates/tensor/README.md
@@ -8,6 +8,18 @@
 
 This crate provides a unified interface for managing multi-dimensional arrays (tensors) with support for different memory backends optimized for ML inference pipelines.
 
+## Role in edgefirst-hal
+
+`edgefirst-tensor` is the foundation of the EdgeFirst HAL workspace. Every
+other `edgefirst-*` crate depends on it:
+
+- [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) consumes `Tensor<u8>` / `TensorDyn` for image processor input/output buffers and provides the `PboOps` trait impl that backs `PboTensor`.
+- [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) reads model output via `Tensor<T>` and `TensorMap`.
+- [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) re-exports this crate as `edgefirst_hal::tensor`.
+- [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) crosses the FFI boundary using `from_fd`, `clone_fd`, and `from_planes`.
+
+This crate has **no internal `edgefirst-*` dependencies**.
+
 ## Memory Types
 
 | Type | Description | Use Case |
@@ -146,6 +158,13 @@ let guard = t.buffer_identity().weak();
 
 `BufferIdentity` is used internally by the image processing backends as an EGL
 image cache key to avoid redundant GPU texture imports across frames.
+
+## Documentation
+
+- Architecture overview: [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md)
+- Testing guide: [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/TESTING.md)
+- Full API reference: [docs.rs/edgefirst-tensor](https://docs.rs/edgefirst-tensor)
+- Project README: [../../README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md)
 
 ## License
 

--- a/crates/tensor/README.md
+++ b/crates/tensor/README.md
@@ -10,13 +10,17 @@ This crate provides a unified interface for managing multi-dimensional arrays (t
 
 ## Role in edgefirst-hal
 
-`edgefirst-tensor` is the foundation of the EdgeFirst HAL workspace. Every
-other `edgefirst-*` crate depends on it:
+`edgefirst-tensor` is the foundation of the data-plane crates in the
+EdgeFirst HAL workspace. The image, decoder, capi, and gpu-probe crates
+all depend on it; the tracker and bench crates are independent and
+operate on their own types.
 
 - [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) consumes `Tensor<u8>` / `TensorDyn` for image processor input/output buffers and provides the `PboOps` trait impl that backs `PboTensor`.
 - [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) reads model output via `Tensor<T>` and `TensorMap`.
 - [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) re-exports this crate as `edgefirst_hal::tensor`.
 - [`edgefirst-hal-capi`](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/) crosses the FFI boundary using `from_fd`, `clone_fd`, and `from_planes`.
+- [`gpu-probe`](https://github.com/EdgeFirstAI/hal/blob/main/crates/gpu-probe/) uses it to allocate the DMA-BUF round-trip buffer the probe verifies.
+- [`edgefirst-tracker`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/) and [`edgefirst-bench`](https://github.com/EdgeFirstAI/hal/blob/main/crates/bench/) do **not** depend on this crate — tracker works against `DetectionBox` and `nalgebra`, bench wraps `serde_json` for benchmark IO.
 
 This crate has **no internal `edgefirst-*` dependencies**.
 

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -21,24 +21,28 @@ files alongside the implementation.
 
 ## Running Tests
 
+All `cargo test` invocations below pass `-- --test-threads=1` per the
+workspace single-threaded rule
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+
 ```bash
 # All tensor tests on the host
-cargo test -p edgefirst-tensor
+cargo test -p edgefirst-tensor -- --test-threads=1
 
 # Heap-only (skips DMA tests when DMA-heap permissions are missing)
-EDGEFIRST_TENSOR_FORCE_MEM=1 cargo test -p edgefirst-tensor
+EDGEFIRST_TENSOR_FORCE_MEM=1 cargo test -p edgefirst-tensor -- --test-threads=1
 
 # Doc-tests only
 cargo test -p edgefirst-tensor --doc
 
 # With ndarray feature exercised explicitly
-cargo test -p edgefirst-tensor --features ndarray
+cargo test -p edgefirst-tensor --features ndarray -- --test-threads=1
 ```
 
 ## Special Requirements
 
 - **DMA tests** require Linux **and** read+write access to a DMA-heap device
-  (typically `/dev/dma_heap/system` or `/dev/dma_heap/cma`). On a workstation
+  (typically `/dev/dma_heap/linux,cma` or `/dev/dma_heap/system`). On a workstation
   this usually means being in the `video` group. If permissions are missing,
   DMA tests are skipped at runtime and the suite falls back to heap-only
   coverage; nothing fails outright. Set `EDGEFIRST_TENSOR_FORCE_MEM=1` to

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -23,7 +23,7 @@ files alongside the implementation.
 
 All `cargo test` invocations below pass `-- --test-threads=1` per the
 workspace single-threaded rule
-([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution)).
 
 ```bash
 # All tensor tests on the host

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -43,14 +43,17 @@ cargo test -p edgefirst-tensor --features ndarray
   DMA tests are skipped at runtime and the suite falls back to heap-only
   coverage; nothing fails outright. Set `EDGEFIRST_TENSOR_FORCE_MEM=1` to
   skip even the probe.
-- **PBO tests** are gated by the `opengl` feature (which is *not* a feature
-  of this crate but of `edgefirst-image`). PBO behavior is exercised
-  end-to-end by the image crate's tests, not here.
-- **No LFS testdata.** All shapes and inputs are synthesized in-test. The
-  `tensor_benchmark` is the only consumer of `edgefirst_bench::testdata` and
-  uses small synthetic blobs.
-- **No feature flags required by default**; `ndarray` is on by default and
-  is required for `view()` / `view_mut()` doc-tests.
+- **PBO tests** live in
+  [`crates/tensor/src/pbo.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/pbo.rs)
+  and exercise `PboTensor` against a mock `PboOps` implementation. They
+  are not gated on any feature — `cargo test -p edgefirst-tensor` runs
+  them on every host. End-to-end PBO behavior (real GL thread, EGL
+  context) is additionally exercised by the image crate's tests.
+- **No LFS testdata.** All shapes and inputs are synthesized in-test.
+  `tensor_benchmark` does not use `edgefirst_bench::testdata`; it
+  generates its inputs in memory.
+- **No feature flags required by default**; `ndarray` is on by default
+  and is required for `view()` / `view_mut()` doc-tests.
 
 ## Benchmarks
 
@@ -58,8 +61,10 @@ cargo test -p edgefirst-tensor --features ndarray
 # Native-host benchmark
 cargo bench -p edgefirst-tensor
 
-# Cross-compile + deploy to a target
-make bench-arm
+# Cross-compile for a target (see the project Makefile / BENCHMARKS.md
+# for the full deploy workflow)
+cargo-zigbuild zigbuild --target aarch64-unknown-linux-gnu --release \
+  -p edgefirst-tensor --bench tensor_benchmark
 ```
 
 | Benchmark | Source | What it measures |

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -1,0 +1,85 @@
+# edgefirst-tensor Testing
+
+## Test Layout
+
+```
+crates/tensor/
+├── src/
+│   ├── lib.rs           # Doc-tests on Tensor<T> public API
+│   ├── dma.rs           # DMA backend unit tests (Linux-only)
+│   ├── shm.rs           # POSIX shared-memory backend unit tests
+│   ├── mem.rs           # Heap backend unit tests
+│   ├── pbo.rs           # PboTensor + WeakSender behavior
+│   ├── tensor_dyn.rs    # TensorDyn metadata, multi-plane, format/stride checks
+│   └── format.rs        # PixelFormat + DType compatibility
+└── benches/
+    └── tensor_benchmark.rs   # Allocation + map/unmap throughput
+```
+
+There is no `tests/` directory; per-backend coverage lives in the source
+files alongside the implementation.
+
+## Running Tests
+
+```bash
+# All tensor tests on the host
+cargo test -p edgefirst-tensor
+
+# Heap-only (skips DMA tests when DMA-heap permissions are missing)
+EDGEFIRST_TENSOR_FORCE_MEM=1 cargo test -p edgefirst-tensor
+
+# Doc-tests only
+cargo test -p edgefirst-tensor --doc
+
+# With ndarray feature exercised explicitly
+cargo test -p edgefirst-tensor --features ndarray
+```
+
+## Special Requirements
+
+- **DMA tests** require Linux **and** read+write access to a DMA-heap device
+  (typically `/dev/dma_heap/system` or `/dev/dma_heap/cma`). On a workstation
+  this usually means being in the `video` group. If permissions are missing,
+  DMA tests are skipped at runtime and the suite falls back to heap-only
+  coverage; nothing fails outright. Set `EDGEFIRST_TENSOR_FORCE_MEM=1` to
+  skip even the probe.
+- **PBO tests** are gated by the `opengl` feature (which is *not* a feature
+  of this crate but of `edgefirst-image`). PBO behavior is exercised
+  end-to-end by the image crate's tests, not here.
+- **No LFS testdata.** All shapes and inputs are synthesized in-test. The
+  `tensor_benchmark` is the only consumer of `edgefirst_bench::testdata` and
+  uses small synthetic blobs.
+- **No feature flags required by default**; `ndarray` is on by default and
+  is required for `view()` / `view_mut()` doc-tests.
+
+## Benchmarks
+
+```bash
+# Native-host benchmark
+cargo bench -p edgefirst-tensor
+
+# Cross-compile + deploy to a target
+make bench-arm
+```
+
+| Benchmark | Source | What it measures |
+|-----------|--------|------------------|
+| `tensor_benchmark` | [`benches/tensor_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/benches/tensor_benchmark.rs) | Allocation cost across DMA/SHM/Mem backends; map/unmap throughput; clone_fd cost |
+
+## Coverage Notes
+
+- The crate participates in workspace `cargo llvm-cov`; lcov output
+  appears under `crates/tensor/`.
+- `cfg(target_os = "linux")`-gated code (`dma.rs`, `dmabuf.rs`) is only
+  exercised on the Linux host runners and on the i.MX 8M Plus hardware
+  runner. macOS and Windows CI legs cover the heap and SHM paths.
+- The `procfs` dev-dependency on Linux is used to assert that mapped DMA
+  buffers actually appear in `/proc/self/maps` — guards against silent
+  fallback-to-heap regressions.
+
+## Cross-References
+
+- Project testing patterns: [../../TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md)
+- Validating optimizations: [TESTING.md#validating-optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations)
+- Image-side PBO testing: [../image/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/TESTING.md)
+- C API DMA tests: [../capi/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/capi/TESTING.md)

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -33,7 +33,7 @@ cargo test -p edgefirst-tensor -- --test-threads=1
 EDGEFIRST_TENSOR_FORCE_MEM=1 cargo test -p edgefirst-tensor -- --test-threads=1
 
 # Doc-tests only
-cargo test -p edgefirst-tensor --doc
+cargo test -p edgefirst-tensor --doc -- --test-threads=1
 
 # With ndarray feature exercised explicitly
 cargo test -p edgefirst-tensor --features ndarray -- --test-threads=1
@@ -81,10 +81,14 @@ cargo-zigbuild zigbuild --target aarch64-unknown-linux-gnu --release \
   appears under `crates/tensor/`.
 - `cfg(target_os = "linux")`-gated code (`dma.rs`, `dmabuf.rs`) is only
   exercised on the Linux host runners and on the i.MX 8M Plus hardware
-  runner. macOS and Windows CI legs cover the heap and SHM paths.
-- The `procfs` dev-dependency on Linux is used to assert that mapped DMA
-  buffers actually appear in `/proc/self/maps` — guards against silent
-  fallback-to-heap regressions.
+  runner. The macOS CI leg covers the heap path. There is no Windows
+  test job today; SHM coverage comes from the Linux runners (where
+  `shm.rs` is `#[cfg(unix)]`-gated and active).
+- The `procfs` dev-dependency on Linux is used to read open-fd counts
+  for the current process via `procfs::process::Process::myself()` —
+  the leak-regression tests assert that fd count returns to its
+  baseline after DMA / SHM tensors are dropped. The check is fd-count
+  based, not a `/proc/self/maps` parse.
 
 ## Cross-References
 

--- a/crates/tracker/ARCHITECTURE.md
+++ b/crates/tracker/ARCHITECTURE.md
@@ -1,0 +1,130 @@
+# edgefirst-tracker Architecture
+
+## Overview
+
+`edgefirst-tracker` provides multi-object tracking algorithms for associating
+detections across video frames. Today it ships a single algorithm,
+**ByteTrack**, with Kalman-smoothed trajectory prediction and two-pass
+detection association. The crate is generic over the detection box type, so it
+plugs into any pipeline that produces XYXY bounding boxes with a confidence
+score and a class label.
+
+## Module Map
+
+| Module | Source | Responsibility |
+|--------|--------|----------------|
+| [`lib.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/src/lib.rs) | local | `Tracker` and `DetectionBox` traits, `TrackInfo`, `ActiveTrackInfo` |
+| [`bytetrack.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/src/bytetrack.rs) | local | `ByteTrack<T>` and `ByteTrackBuilder`; tracklet lifecycle and association |
+| [`kalman.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/src/kalman.rs) | local | Kalman filter for box-state prediction and update |
+
+## Key Types and Traits
+
+- [`Tracker<T>`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/trait.Tracker.html) — minimal trait every tracker implements (`update` + `get_active_tracks`).
+- [`DetectionBox`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/trait.DetectionBox.html) — trait detection types implement so the tracker can read XYXY boxes, scores, and labels without copying.
+- [`TrackInfo`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/struct.TrackInfo.html) — per-track metadata returned by `update`: UUID, Kalman-smoothed location, age, timestamps.
+- [`ActiveTrackInfo<T>`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/struct.ActiveTrackInfo.html) — `TrackInfo` paired with the last raw detection box for inspection.
+- [`ByteTrack<T>`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/bytetrack/struct.ByteTrack.html) / [`ByteTrackBuilder`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/bytetrack/struct.ByteTrackBuilder.html) — concrete tracker plus a builder for tunable thresholds.
+
+## Internal Architecture
+
+### Class layout
+
+```mermaid
+classDiagram
+    class ByteTrack {
+        +update(detections) TrackInfo[]
+        +get_active_tracks() ActiveTrackInfo[]
+    }
+
+    class Tracklet {
+        +UUID uuid
+        +KalmanFilter filter
+        +i32 track_count
+        +Timestamps timestamps
+    }
+
+    ByteTrack *-- Tracklet : manages
+```
+
+### Tracking flow
+
+Each call to `ByteTrack::update` runs through a fixed pipeline:
+
+```mermaid
+flowchart TD
+    NewFrame[New frame detections]
+    Predict[Predict tracklet positions<br/>Kalman forward step]
+    Cost[Compute cost matrix<br/>IoU between predictions and detections]
+    Hungarian[Hungarian assignment LAPJV<br/>optimal global match]
+
+    Matched[Matched: update tracklet]
+    UnmatchedDet[Unmatched detection: create new tracklet]
+    UnmatchedTrack[Unmatched tracklet: increment lost count]
+
+    CheckLost{Lost > extra_lifespan?}
+    Delete[Delete tracklet]
+    Keep[Keep tracklet]
+
+    NewFrame --> Predict
+    Predict --> Cost
+    Cost --> Hungarian
+    Hungarian --> Matched
+    Hungarian --> UnmatchedDet
+    Hungarian --> UnmatchedTrack
+    UnmatchedTrack --> CheckLost
+    CheckLost -->|Yes| Delete
+    CheckLost -->|No| Keep
+
+    style Matched fill:#90ee90
+    style UnmatchedDet fill:#87ceeb
+    style Delete fill:#ffcccb
+```
+
+The two-pass nature of ByteTrack means high-confidence detections are matched
+first (using `track_high_conf` as the gating threshold); on the second pass,
+remaining low-confidence detections are tried against still-unmatched
+tracklets to recover briefly occluded objects without admitting noise into the
+high-confidence pool.
+
+### Kalman filter state
+
+Each tracklet owns a constant-velocity Kalman filter modeling box state as
+`[x_center, y_center, aspect, height, ẋ, ẏ, ȧ, ḣ]`. The `track_update`
+parameter on the builder controls the gain — lower values trust the predicted
+trajectory more, higher values trust the new measurement more. See
+[`crates/tracker/src/kalman.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/src/kalman.rs)
+for the matrix definitions.
+
+## Performance Considerations
+
+- **No GPU code paths.** ByteTrack is a CPU-only algorithm; the cost matrix
+  uses [`lapjv`](https://docs.rs/lapjv) which is small enough that a single
+  Rayon thread comfortably handles realtime workloads at ≤300 simultaneous
+  tracks.
+- **UUID generation** uses [`uuid`](https://docs.rs/uuid)'s `v4` random
+  generator. This is a per-track one-time cost (~hundreds of ns), not a
+  per-frame cost.
+- **Tracing spans** are emitted via [`tracing`](https://docs.rs/tracing) on
+  the `update` hot path; they cost a single relaxed atomic load when no
+  subscriber is installed. See the
+  [Performance Tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)
+  section of the project README for capture and viewing instructions.
+
+## Inter-Crate Interfaces
+
+The tracker crate has no compile-time dependency on any other `edgefirst-*`
+crate. It is consumed as an optional feature by:
+
+- [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) (feature `tracker`) — exposes `decode_tracked()` which accepts any `Tracker<DetectBox>` implementation.
+- [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) (feature `tracker`) — adds `draw_masks_tracked()` for rendering color-stable masks per track UUID.
+- [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) (feature `tracker`) — re-exports as `edgefirst_hal::tracker`.
+
+The boundary type is the [`DetectionBox`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/trait.DetectionBox.html)
+trait; the decoder's `DetectBox` implements it, but any third-party detection
+type can plug in by implementing the trait.
+
+## Cross-References
+
+- Project architecture: [../../ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
+- Decoder integration: [../decoder/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md)
+- Performance tracing usage: [README.md#performance-tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)

--- a/crates/tracker/ARCHITECTURE.md
+++ b/crates/tracker/ARCHITECTURE.md
@@ -117,7 +117,7 @@ The tracker crate has no compile-time dependency on any other `edgefirst-*`
 crate. It is consumed as an optional feature by:
 
 - [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) (feature `tracker`) — exposes `decode_tracked()` which accepts any `Tracker<DetectBox>` implementation.
-- [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) (feature `tracker`) — adds `draw_masks_tracked()` for rendering color-stable masks per track UUID.
+- [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) (feature `tracker`) — adds `draw_masks_tracked()` for rendering masks for tracked detections and returning track info. `ColorMode::Track` is the planned per-UUID palette mode, but currently aliases `ColorMode::Instance` (detection-order coloring) until the per-track palette lands.
 - [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) (feature `tracker`) — re-exports as `edgefirst_hal::tracker`.
 
 The boundary type is the [`DetectionBox`](https://docs.rs/edgefirst-tracker/latest/edgefirst_tracker/trait.DetectionBox.html)

--- a/crates/tracker/ARCHITECTURE.md
+++ b/crates/tracker/ARCHITECTURE.md
@@ -127,4 +127,5 @@ type can plug in by implementing the trait.
 
 - Project architecture: [../../ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/ARCHITECTURE.md)
 - Decoder integration: [../decoder/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/ARCHITECTURE.md)
+- Image-side consumer (`draw_masks_tracked`): [../image/ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
 - Performance tracing usage: [README.md#performance-tracing](https://github.com/EdgeFirstAI/hal/blob/main/README.md#performance-tracing)

--- a/crates/tracker/ARCHITECTURE.md
+++ b/crates/tracker/ARCHITECTURE.md
@@ -97,9 +97,10 @@ for the matrix definitions.
 
 ## Performance Considerations
 
-- **No GPU code paths.** ByteTrack is a CPU-only algorithm; the cost matrix
-  uses [`lapjv`](https://docs.rs/lapjv) which is small enough that a single
-  Rayon thread comfortably handles realtime workloads at ≤300 simultaneous
+- **No GPU code paths.** ByteTrack is a CPU-only, single-threaded
+  algorithm — the crate does not depend on Rayon. The cost matrix uses
+  [`lapjv`](https://docs.rs/lapjv) which is small enough that a single
+  thread comfortably handles realtime workloads at ≤300 simultaneous
   tracks.
 - **UUID generation** uses [`uuid`](https://docs.rs/uuid)'s `v4` random
   generator. This is a per-track one-time cost (~hundreds of ns), not a

--- a/crates/tracker/README.md
+++ b/crates/tracker/README.md
@@ -15,7 +15,7 @@ It has no dependency on any other `edgefirst-*` crate; instead, it is consumed
 as a feature by the decoder and image crates:
 
 - [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) (feature `tracker`) calls `Tracker::update` from `decode_tracked()`.
-- [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) (feature `tracker`) uses track UUIDs for color-stable mask rendering via `draw_masks_tracked()`.
+- [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) (feature `tracker`) calls `draw_masks_tracked()` to render masks for tracked detections and surface track info to the caller. Color stability per track UUID is the planned use of `ColorMode::Track`, but `Track` currently aliases `Instance` (detection-order coloring) — the slot is reserved so the API surface won't change once the per-UUID palette lands.
 - [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) (feature `tracker`) re-exports the crate as `edgefirst_hal::tracker`.
 
 ## Algorithms

--- a/crates/tracker/README.md
+++ b/crates/tracker/README.md
@@ -8,6 +8,16 @@
 
 This crate provides object tracking algorithms for associating detections across video frames, enabling applications like counting, path analysis, and re-identification.
 
+## Role in edgefirst-hal
+
+`edgefirst-tracker` is an optional component of the EdgeFirst HAL workspace.
+It has no dependency on any other `edgefirst-*` crate; instead, it is consumed
+as a feature by the decoder and image crates:
+
+- [`edgefirst-decoder`](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/) (feature `tracker`) calls `Tracker::update` from `decode_tracked()`.
+- [`edgefirst-image`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/) (feature `tracker`) uses track UUIDs for color-stable mask rendering via `draw_masks_tracked()`.
+- [`edgefirst-hal`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/) (feature `tracker`) re-exports the crate as `edgefirst_hal::tracker`.
+
 ## Algorithms
 
 | Algorithm | Description | Use Case |
@@ -167,6 +177,13 @@ decoder.decode_tracked(
 - `output_boxes` — decoded detection boxes
 - `output_masks` — segmentation masks (empty if the model has no mask head)
 - `output_tracks` — `Vec<TrackInfo>` with one entry per matched detection
+
+## Documentation
+
+- Architecture overview: [ARCHITECTURE.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/ARCHITECTURE.md)
+- Testing guide: [TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/TESTING.md)
+- Full API reference: [docs.rs/edgefirst-tracker](https://docs.rs/edgefirst-tracker)
+- Project README: [../../README.md](https://github.com/EdgeFirstAI/hal/blob/main/README.md)
 
 ## License
 

--- a/crates/tracker/TESTING.md
+++ b/crates/tracker/TESTING.md
@@ -29,7 +29,7 @@ stay consistent and copy-pasteable across crates.
 cargo test -p edgefirst-tracker -- --test-threads=1
 
 # Doc-tests only
-cargo test -p edgefirst-tracker --doc
+cargo test -p edgefirst-tracker --doc -- --test-threads=1
 
 # Single test
 cargo test -p edgefirst-tracker bytetrack::tests::two_pass_recovery -- --test-threads=1
@@ -39,8 +39,13 @@ cargo test -p edgefirst-tracker bytetrack::tests::two_pass_recovery -- --test-th
 
 - **No hardware gates.** The tracker is pure CPU; tests run identically on
   any host.
-- **No LFS testdata.** Detections are synthesized in-test (random walks
-  through a frame to exercise association and lifecycle paths).
+- **No LFS testdata.** Detections are synthesized in-test as
+  deterministic
+  [`MockDetection`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/src/lib.rs)
+  sequences (fixed coordinates per frame, hand-tuned to exercise
+  initial track creation, multi-pass association recovery, kill-on-miss
+  lifecycle, and class-aware matching). The benchmark harness uses a
+  similar deterministic grid.
 - **No feature flags.** All tests run under default features.
 
 ## Benchmarks

--- a/crates/tracker/TESTING.md
+++ b/crates/tracker/TESTING.md
@@ -20,7 +20,7 @@ API.
 
 All `cargo test` invocations below pass `-- --test-threads=1` per the
 workspace single-threaded rule
-([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#single-threaded-execution)).
 The tracker is CPU-only, but the rule applies workspace-wide so commands
 stay consistent and copy-pasteable across crates.
 

--- a/crates/tracker/TESTING.md
+++ b/crates/tracker/TESTING.md
@@ -31,8 +31,8 @@ cargo test -p edgefirst-tracker -- --test-threads=1
 # Doc-tests only
 cargo test -p edgefirst-tracker --doc -- --test-threads=1
 
-# Single test
-cargo test -p edgefirst-tracker bytetrack::tests::two_pass_recovery -- --test-threads=1
+# Single test (e.g. the multi-frame association test)
+cargo test -p edgefirst-tracker bytetrack::tests::test_two_stage_matching -- --test-threads=1
 ```
 
 ## Special Requirements

--- a/crates/tracker/TESTING.md
+++ b/crates/tracker/TESTING.md
@@ -1,0 +1,74 @@
+# edgefirst-tracker Testing
+
+## Test Layout
+
+```
+crates/tracker/
+├── src/
+│   ├── lib.rs          # Doc-tests for Tracker / DetectionBox traits
+│   ├── bytetrack.rs    # Unit tests for ByteTrackBuilder, association
+│   └── kalman.rs       # Unit tests for the Kalman filter math
+└── benches/
+    └── tracker_benchmark.rs   # End-to-end ByteTrack throughput
+```
+
+The crate has no `tests/` directory — all coverage comes from `#[test]`
+modules colocated with the source they exercise, plus doc-tests on the public
+API.
+
+## Running Tests
+
+```bash
+# All tracker tests
+cargo test -p edgefirst-tracker
+
+# Doc-tests only
+cargo test -p edgefirst-tracker --doc
+
+# Single test
+cargo test -p edgefirst-tracker bytetrack::tests::two_pass_recovery
+```
+
+## Special Requirements
+
+- **No hardware gates.** The tracker is pure CPU; tests run identically on
+  any host.
+- **No LFS testdata.** Detections are synthesized in-test (random walks
+  through a frame to exercise association and lifecycle paths).
+- **No feature flags.** All tests run under default features.
+
+## Benchmarks
+
+Run benchmarks from the workspace root:
+
+```bash
+# Native-host benchmark
+cargo bench -p edgefirst-tracker
+
+# Cross-compile + deploy to a target (see project Makefile)
+make bench-arm
+```
+
+| Benchmark | Source | What it measures |
+|-----------|--------|------------------|
+| `tracker_benchmark` | [`benches/tracker_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/benches/tracker_benchmark.rs) | `ByteTrack::update` throughput vs. number of simultaneous tracks |
+
+The benchmark uses `edgefirst_bench::testdata` (workspace dev-dependency) for
+its synthetic detection corpus. See
+[`crates/bench/src/testdata.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/bench/src/testdata.rs)
+for the helper API.
+
+## Coverage Notes
+
+- The crate participates in workspace `cargo llvm-cov`; lcov output is
+  produced under `crates/tracker/`.
+- The Kalman filter math is exercised both by direct unit tests (numeric
+  identities) and indirectly by `tracker_benchmark` and the bytetrack
+  association tests.
+- No `#[cfg(test)]`-only branches affect production builds.
+
+## Cross-References
+
+- Project testing patterns: [../../TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md)
+- Validating optimizations: [TESTING.md#validating-optimizations](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#validating-optimizations)
+- Decoder testing (consumer of `Tracker`): [../decoder/TESTING.md](https://github.com/EdgeFirstAI/hal/blob/main/crates/decoder/TESTING.md)

--- a/crates/tracker/TESTING.md
+++ b/crates/tracker/TESTING.md
@@ -45,18 +45,18 @@ Run benchmarks from the workspace root:
 # Native-host benchmark
 cargo bench -p edgefirst-tracker
 
-# Cross-compile + deploy to a target (see project Makefile)
-make bench-arm
+# Cross-compile for a target (see BENCHMARKS.md for the deploy workflow)
+cargo-zigbuild zigbuild --target aarch64-unknown-linux-gnu --release \
+  -p edgefirst-tracker --bench tracker_benchmark
 ```
 
 | Benchmark | Source | What it measures |
 |-----------|--------|------------------|
 | `tracker_benchmark` | [`benches/tracker_benchmark.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tracker/benches/tracker_benchmark.rs) | `ByteTrack::update` throughput vs. number of simultaneous tracks |
 
-The benchmark uses `edgefirst_bench::testdata` (workspace dev-dependency) for
-its synthetic detection corpus. See
-[`crates/bench/src/testdata.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/bench/src/testdata.rs)
-for the helper API.
+The benchmark synthesizes its detection corpus internally (see
+`generate_detections` in the bench source); it does not load LFS
+testdata.
 
 ## Coverage Notes
 

--- a/crates/tracker/TESTING.md
+++ b/crates/tracker/TESTING.md
@@ -18,15 +18,21 @@ API.
 
 ## Running Tests
 
+All `cargo test` invocations below pass `-- --test-threads=1` per the
+workspace single-threaded rule
+([root TESTING.md § Single-threaded execution](https://github.com/EdgeFirstAI/hal/blob/main/TESTING.md#why-single-threaded-execution)).
+The tracker is CPU-only, but the rule applies workspace-wide so commands
+stay consistent and copy-pasteable across crates.
+
 ```bash
 # All tracker tests
-cargo test -p edgefirst-tracker
+cargo test -p edgefirst-tracker -- --test-threads=1
 
 # Doc-tests only
 cargo test -p edgefirst-tracker --doc
 
 # Single test
-cargo test -p edgefirst-tracker bytetrack::tests::two_pass_recovery
+cargo test -p edgefirst-tracker bytetrack::tests::two_pass_recovery -- --test-threads=1
 ```
 
 ## Special Requirements


### PR DESCRIPTION
## Summary

Restructures the project documentation into a publish-ready hierarchy:
root docs become high-level coordinators; per-crate docs own
crate-specific detail and are suitable for crates.io / pypi.org publishing.

This is the third (and largest) of the internal-cleanup PRs discussed
on 2026-05-14, completing the documentation half of that effort.

## Per-crate docs (Stream D)

Adds new `ARCHITECTURE.md` and `TESTING.md` for all 7 sub-crates and
revises each sub-crate `README.md` with a "Role in edgefirst-hal" section
and a "Documentation" section. Strict template across all crates.

| Crate | README | ARCHITECTURE.md | TESTING.md |
|-------|--------|-----------------|------------|
| `tensor` | revised | NEW | NEW |
| `image` | revised | NEW (largest) | NEW |
| `decoder` | revised | NEW | NEW |
| `tracker` | revised | NEW | NEW |
| `hal` (umbrella) | revised | NEW (minimal) | NEW (minimal) |
| `capi` (C API) | revised | NEW (largest content — performance recs + Delegate DMA-BUF framework) | NEW |
| `python` | revised | NEW | NEW |

## Root restructure (Stream C)

| File | Before | After | Delta |
|------|--------|-------|-------|
| `README.md` | 1508 | 702 | -54% |
| `ARCHITECTURE.md` | 2447 | 512 | -79% |
| `TESTING.md` | 544 | 503 | -8% (mostly content reorganization, kept Validating Optimizations in full) |
| **Root total** | **4499** | **1717** | **-62%** |

What stays at root:

- `README.md`: Quick Start, System Architecture diagram, Core Components index table, full Optimization Guide (8 rules), Platform Support, Environment Variables, Benchmarking workflow, Performance Tracing usage, Dependencies + internal dep graph, ecosystem links.
- `ARCHITECTURE.md`: Per-crate summary index, full Design Patterns, Performance Tracing internals (zero-cost impl, span conventions, subscriber model, multi-pass visibility), Source Code Organization, and the canonical Appendix C cross-cutting story on DMA-BUF identity and tensor caching (V4L2 fd recycling, inode-keyed cache, edgefirstcameraadaptor pattern).
- `TESTING.md`: Cross-cutting workspace rules — single-threaded execution, on-target gating, cross-compilation flow, full Validating Optimizations section, CI/CD matrix (updated for the xlarge runners landed in #72), common failures.

What moved out:

- Per-crate Core Components deep-dives → per-crate `ARCHITECTURE.md`
- C API Performance Recommendations (~300 lines) → `crates/capi/ARCHITECTURE.md`
- Appendix B Delegate DMA-BUF Framework (~250 lines) → `crates/capi/ARCHITECTURE.md`
- EGL/GL shutdown defense, GL_MUTEX, G2D cleanup, Vivante workaround → `crates/image/ARCHITECTURE.md`
- Per-language test specifics (GL gating, fp16 benches, Python venv flow, C Makefile) → `crates/{image,python,capi}/TESTING.md`

## Cross-link strategy

All cross-references use **absolute GitHub URLs**
(`https://github.com/EdgeFirstAI/hal/blob/main/...`) so they render
correctly on crates.io, docs.rs, and pypi.org as well as on GitHub.
All 105 cross-links verified to resolve to existing files
(see audit script in commit body).

## What this PR does NOT do

- No code changes. Markdown files only.
- No new crates or feature flags.
- No CI workflow changes (those landed in PR #72).
- The stray local files at repo root (`BUG_*.md`, `FEATURE_*.md`,
  `*.tflite`) are already gitignored — no action needed in this PR.

## Test plan

- [ ] `make format / lint / check` green (already verified locally)
- [ ] CI green (no Rust changes, but doc-tests may exercise the
      doctest paths in the moved sub-crate READMEs)
- [ ] Spot-check a few rendered links in the GitHub PR diff view
      to confirm absolute URLs work in the GitHub UI
- [ ] On the next release, verify the rendered crates.io / pypi.org
      pages display correctly (per-crate READMEs link to ARCHITECTURE.md
      / TESTING.md via absolute GitHub URLs that resolve from off-site
      contexts)