### PR TITLE
Release v0.23.2 — tracing span naming refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,30 +11,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Tracing span rename — observable surface, not API.** All `tracing::trace_span!`
-  call sites across the workspace adopt a uniform `<crate>.<subsystem>.<operation>`
-  naming convention (snake_case, dotted). Span names appear as labels in
-  Perfetto / Chrome traces; any saved query, dashboard, or filter that targets
-  the old names will need updating. See the per-crate ARCHITECTURE.md "Tracing
-  Spans" sections for the authoritative mapping.
+- **Tracing span rename — observable surface, not API.** All
+  `tracing::trace_span!` call sites across the workspace adopt a uniform
+  `<crate>.<function>[.<operation>[.<sub-operation>]]` naming convention
+  (snake_case, dotted). The `<function>` component is the public user-facing
+  function the trace was rooted at (`decoder.decode`, `image.convert`,
+  `codec.decode_jpeg`, …); inner spans nest under it. Shared internal
+  building blocks reached from multiple top-level functions
+  (`decoder.per_scale_run`, `decoder.nms_get_boxes`) omit the function prefix
+  because a single source location can only carry one static name — the
+  parent span in the recorded trace identifies the caller. New spans should
+  follow the rough guideline of >500 µs on Cortex-A53 to justify the
+  instrumentation.
+
+  Span names appear as labels in Perfetto / Chrome traces; any saved query,
+  dashboard, or filter that targets the old names will need updating. See
+  the per-crate ARCHITECTURE.md "Tracing Spans" sections for the
+  authoritative mapping.
 
   Notable replacements (full list in the per-crate docs):
 
   | Old name (collision) | New name |
   |---|---|
-  | `decode` (4 YOLO entry points + 2 segdet inner kernels) | `decoder.yolo.decode_{quant,float}_{flat,split}` and `decoder.nms.get_boxes` |
-  | `score_filter` / `top_k` / `nms` / `box_dequant` | `decoder.nms.{score_filter,top_k,suppress,dequant_boxes}` |
-  | `process_masks` | `decoder.process_masks` |
-  | `extract_proto` | `decoder.extract_proto_data` |
-  | `per_scale_decode` and `box` / `score` / `mc` | `decoder.per_scale.{run,boxes,scores,mask_coefs}` |
-  | `per_scale_bridge::*` | `decoder.per_scale.{widen_f32,to_proto_data,to_masks,bridge_*}` |
+  | `decode` (4 YOLO entry points + 2 segdet inner kernels) | `decoder.decode.yolo_{quant,float}_{flat,split}` and `decoder.nms_get_boxes` |
+  | `score_filter` / `top_k` / `nms` / `box_dequant` | `decoder.nms_get_boxes.{score_filter,top_k,suppress,dequant_boxes}` |
+  | `process_masks` | `decoder.decode.process_masks` |
+  | `extract_proto` | `decoder.decode_proto.extract_proto_data` |
+  | `per_scale_decode` and `box` / `score` / `mc` | `decoder.per_scale_run` and `decoder.per_scale_run.level.{boxes,scores,mask_coefs}` |
+  | `per_scale_bridge::*` | `decoder.{decode.per_scale_to_masks,decode_proto.per_scale_to_proto_data,per_scale_run.widen_f32}` |
   | `Decoder::decode` / `Decoder::decode_proto` | `decoder.{decode,decode_proto}` |
   | `image_convert` / `draw_masks` | `image.{convert,draw_decoded_masks}` |
-  | `g2d_convert` / `gl_convert` | `image.{g2d,gl}.convert` |
-  | `gl_pass1_to_rgba` / `gl_pass2_pack_rgb` / `gl_pass2_to_planar` | `image.gl.{pack_rgb.pass1_rgba,pack_rgb.pass2_pack,nv12_to_planar.pass1_rgba,nv12_to_planar.pass2_deinterleave}` |
-  | `cpu_format_convert` / `cpu_resize` | `image.cpu.{format_convert,resize_flip_rotate}` |
-  | `materialize_masks` / `mask_i8_fastpath` / `mask_i16_i8_fastpath` | `image.materialize_masks` and `image.masks.{kernel_i8,kernel_i16xi8,kernel_i8_scaled,kernel_i16xi8_scaled}` |
-  | `tracker_update` / `predict` / `match_*` | `tracker.{update,predict,match_high_conf,match_low_conf}` |
+  | `g2d_convert` / `gl_convert` | `image.convert.{g2d,gl}` |
+  | `gl_pass1_to_rgba` / `gl_pass2_pack_rgb` / `gl_pass2_to_planar` | `image.convert.gl.{pack_rgb.pass1_rgba,pack_rgb.pass2_pack,nv12_to_planar.pass1_rgba,nv12_to_planar.pass2_deinterleave}` |
+  | `cpu_format_convert` / `cpu_resize` | `image.convert.cpu.{format_convert,resize_flip_rotate}` |
+  | `materialize_masks` / `mask_i8_fastpath` / `mask_i16_i8_fastpath` | `image.materialize_masks` and `image.materialize_masks.{kernel_i8,kernel_i16xi8,kernel_i8_scaled,kernel_i16xi8_scaled}` |
+  | `tracker_update` / `predict` / `match_*` | `tracker.update` and `tracker.update.{predict,match_high_conf,match_low_conf}` |
   | `tensor_alloc` / `tensor_map` | `tensor.{alloc,map}` |
   | `py_*` | `python.*` |
 
@@ -42,9 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tracing spans in the `edgefirst-codec` crate (previously had none):
   `codec.decode_jpeg`, `codec.decode_png`, plus inner spans
-  `codec.jpeg.{parse_markers,mcu_loop,apply_exif,type_convert}` and
-  `codec.png.zune_decode`. The JPEG marker-parse, MCU decode loop, and EXIF
-  rotation phases are now individually visible in Perfetto.
+  `codec.decode_jpeg.{parse_markers,mcu_loop,apply_exif,type_convert}` and
+  `codec.decode_png.zune_decode`. The JPEG marker-parse, MCU decode loop,
+  and EXIF rotation phases are now individually visible in Perfetto.
 - `tracing` workspace dependency added to `edgefirst-codec`.
 - "Tracing Spans" sections in `crates/decoder/ARCHITECTURE.md`,
   `crates/image/ARCHITECTURE.md`, and `crates/codec/ARCHITECTURE.md` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.2] - 2026-05-21
+
+### Changed
+
+- **Tracing span rename — observable surface, not API.** All `tracing::trace_span!`
+  call sites across the workspace adopt a uniform `<crate>.<subsystem>.<operation>`
+  naming convention (snake_case, dotted). Span names appear as labels in
+  Perfetto / Chrome traces; any saved query, dashboard, or filter that targets
+  the old names will need updating. See the per-crate ARCHITECTURE.md "Tracing
+  Spans" sections for the authoritative mapping.
+
+  Notable replacements (full list in the per-crate docs):
+
+  | Old name (collision) | New name |
+  |---|---|
+  | `decode` (4 YOLO entry points + 2 segdet inner kernels) | `decoder.yolo.decode_{quant,float}_{flat,split}` and `decoder.nms.get_boxes` |
+  | `score_filter` / `top_k` / `nms` / `box_dequant` | `decoder.nms.{score_filter,top_k,suppress,dequant_boxes}` |
+  | `process_masks` | `decoder.process_masks` |
+  | `extract_proto` | `decoder.extract_proto_data` |
+  | `per_scale_decode` and `box` / `score` / `mc` | `decoder.per_scale.{run,boxes,scores,mask_coefs}` |
+  | `per_scale_bridge::*` | `decoder.per_scale.{widen_f32,to_proto_data,to_masks,bridge_*}` |
+  | `Decoder::decode` / `Decoder::decode_proto` | `decoder.{decode,decode_proto}` |
+  | `image_convert` / `draw_masks` | `image.{convert,draw_decoded_masks}` |
+  | `g2d_convert` / `gl_convert` | `image.{g2d,gl}.convert` |
+  | `gl_pass1_to_rgba` / `gl_pass2_pack_rgb` / `gl_pass2_to_planar` | `image.gl.{pack_rgb.pass1_rgba,pack_rgb.pass2_pack,nv12_to_planar.pass1_rgba,nv12_to_planar.pass2_deinterleave}` |
+  | `cpu_format_convert` / `cpu_resize` | `image.cpu.{format_convert,resize_flip_rotate}` |
+  | `materialize_masks` / `mask_i8_fastpath` / `mask_i16_i8_fastpath` | `image.materialize_masks` and `image.masks.{kernel_i8,kernel_i16xi8,kernel_i8_scaled,kernel_i16xi8_scaled}` |
+  | `tracker_update` / `predict` / `match_*` | `tracker.{update,predict,match_high_conf,match_low_conf}` |
+  | `tensor_alloc` / `tensor_map` | `tensor.{alloc,map}` |
+  | `py_*` | `python.*` |
+
+### Added
+
+- Tracing spans in the `edgefirst-codec` crate (previously had none):
+  `codec.decode_jpeg`, `codec.decode_png`, plus inner spans
+  `codec.jpeg.{parse_markers,mcu_loop,apply_exif,type_convert}` and
+  `codec.png.zune_decode`. The JPEG marker-parse, MCU decode loop, and EXIF
+  rotation phases are now individually visible in Perfetto.
+- `tracing` workspace dependency added to `edgefirst-codec`.
+- "Tracing Spans" sections in `crates/decoder/ARCHITECTURE.md`,
+  `crates/image/ARCHITECTURE.md`, and `crates/codec/ARCHITECTURE.md` —
+  authoritative span tree + per-span operation description, satisfying the
+  cross-reference promise made in `README.md#performance-tracing`.
+
 ## [0.23.1] - 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,14 +569,14 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "edgefirst-bench"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "edgefirst-codec"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "edgefirst-bench",
  "edgefirst-tensor",
@@ -585,6 +585,7 @@ dependencies = [
  "log",
  "num-traits",
  "opencv",
+ "tracing",
  "turbojpeg",
  "zune-jpeg",
  "zune-png",
@@ -592,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-decoder"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "argminmax",
  "edgefirst-bench",
@@ -642,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-hal"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "edgefirst-codec",
  "edgefirst-decoder",
@@ -656,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-hal-capi"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "cbindgen",
  "edgefirst-bench",
@@ -678,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-image"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "ctor",
  "dma-heap",
@@ -715,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-tensor"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "ctor",
  "dma-heap",
@@ -736,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst-tracker"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "edgefirst-bench",
  "enum_dispatch",
@@ -751,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "edgefirst_hal"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "approx",
  "edgefirst-hal",
@@ -1150,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "gpu-probe"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "edgefirst-bench",
  "edgefirst-gbm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Au-Zone Technologies <support@au-zone.com>"]
 homepage = "https://edgefirst.ai"
 repository = "https://github.com/EdgeFirstAI/hal"
 license = "Apache-2.0"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2021"
 readme = "README.md"
 
@@ -30,12 +30,12 @@ ctor = "0.4.2"
 dma-heap = "0.4.1"
 # Internal crates
 edgefirst-bench = { path = "crates/bench" }
-edgefirst-codec = { version = "0.23.1", path = "crates/codec" }
-edgefirst-hal = { version = "0.23.1", path = "crates/hal" }
-edgefirst-decoder = { version = "0.23.1", path = "crates/decoder" }
-edgefirst-image = { version = "0.23.1", path = "crates/image" }
-edgefirst-tensor = { version = "0.23.1", path = "crates/tensor" }
-edgefirst-tracker = { version = "0.23.1", path = "crates/tracker" }
+edgefirst-codec = { version = "0.23.2", path = "crates/codec" }
+edgefirst-hal = { version = "0.23.2", path = "crates/hal" }
+edgefirst-decoder = { version = "0.23.2", path = "crates/decoder" }
+edgefirst-image = { version = "0.23.2", path = "crates/image" }
+edgefirst-tensor = { version = "0.23.2", path = "crates/tensor" }
+edgefirst-tracker = { version = "0.23.2", path = "crates/tracker" }
 enum_dispatch = "0.3.13"
 env_logger = "0.11.10"
 fast-math = "0.1.1"

--- a/crates/codec/ARCHITECTURE.md
+++ b/crates/codec/ARCHITECTURE.md
@@ -301,41 +301,50 @@ decode. Spans are captured by
 into Chrome JSON for Perfetto. The cost when no subscriber is active is a
 single relaxed atomic load per call site.
 
-Span names follow `<crate>.<subsystem>.<operation>`. The codec entry points
-are format-specific (`codec.decode_jpeg`, `codec.decode_png`) and the inner
-spans isolate the structural phases of each decoder.
+### Naming convention
+
+Span names follow `<crate>.<function>[.<operation>[.<sub-operation>]]`:
+
+- **`<crate>.<function>`** — top-level span: the public function the user
+  invoked. The codec exposes format-specific entry points (`codec.decode_jpeg`,
+  `codec.decode_png`) selected automatically from the magic bytes.
+- **`<crate>.<function>.<operation>`** — meaningful internal work
+  (`codec.decode_jpeg.parse_markers`, `codec.decode_jpeg.mcu_loop`, etc.).
+- A span is worth adding when the work inside it is meaningful for
+  optimisation and has enough complexity to justify the overhead — roughly
+  500 µs on Cortex-A53 as a guideline.
 
 ### Span tree
 
 ```text
-codec.decode_jpeg                                       [JPEG entry point]
+codec.decode_jpeg                                       [user-facing fn]
 │ fields: dtype = "u8" | "i8" | "u16" | "i16" | "f32", n_bytes
 │
-├── codec.jpeg.parse_markers                            ← parse SOF0/DQT/DHT/DRI/SOS/APP1, read EXIF
-├── codec.jpeg.mcu_loop                                 ← Huffman + IDCT + upsample + colour-convert
-├── codec.jpeg.apply_exif                               ← EXIF orientation transform (rotation/flip)
+├── codec.decode_jpeg.parse_markers                     ← parse SOF0/DQT/DHT/DRI/SOS/APP1, read EXIF
+├── codec.decode_jpeg.mcu_loop                          ← Huffman + IDCT + upsample + colour-convert
+├── codec.decode_jpeg.apply_exif                        ← EXIF orientation transform (rotation/flip)
 │   fields: rotation_deg, flip_h
-└── codec.jpeg.type_convert                             ← u8 → T conversion (skipped for u8 target)
+└── codec.decode_jpeg.type_convert                      ← u8 → T conversion (skipped for u8 target)
     field: dtype
 
-codec.decode_png                                        [PNG entry point]
+codec.decode_png                                        [user-facing fn]
 │ fields: dtype, n_bytes
 │
-└── codec.png.zune_decode                               ← delegate to zune-png
+└── codec.decode_png.zune_decode                        ← delegate to zune-png
     field: path = "u8" | "native_u16"
 ```
 
 ### What each span measures (mapped to the JPEG / PNG decode pipeline)
 
-| Span                       | What is happening inside | Reference equivalent |
-|----------------------------|--------------------------|----------------------|
-| `codec.decode_jpeg`        | Full JPEG decode: marker parsing, MCU decode loop, optional EXIF rotation, optional type conversion to non-u8 targets. | Baseline JPEG decode per ITU T.81 + EXIF 2.32. |
-| `codec.jpeg.parse_markers` | Walk the JPEG byte stream once: parse SOF0 (start-of-frame), DQT (quantisation tables), DHT (Huffman tables), DRI (restart interval), SOS (start-of-scan), and APP1 (EXIF) segments. Builds Huffman LUTs and quant tables, extracts EXIF bytes. | Equivalent to libjpeg's `jpeg_read_header` + DHT/DQT table builds. |
-| `codec.jpeg.mcu_loop`      | The core decode loop: for each MCU row, Huffman-decode + dequant-fuse blocks → two-pass Loeffler IDCT (scalar / NEON / SSE4.1 / SSE2 selected at init) → bilinear chroma upsample (4:2:0 / 4:2:2 → 4:4:4) → BT.601 YCbCr → RGB/RGBA/BGRA/Grey/NV12 colour conversion → strided write into the tensor. Allocation-free after warmup. | Equivalent to libjpeg's `jpeg_read_scanlines` loop, but with the IDCT / chroma-upsample / colour-convert kernels handwritten and SIMD-dispatched per-CPU. |
-| `codec.jpeg.apply_exif`    | In-place rotation / horizontal flip on the decoded scratch buffer using `kamadak-exif`'s orientation tag. Skipped when `apply_exif=false` or for NV12 output (which doesn't support rotation). | Equivalent to libjpeg-turbo's `jpegtran -copy all -rotate ...` orientation transform. |
-| `codec.jpeg.type_convert`  | Vectorised u8 → target-type conversion at the row level: `*1/255` for f32, `*257` for u16, `*257 ^ 0x8000` for i16, `^ 0x80` for i8. NEON or SSE2 dispatch per row. Skipped for u8 targets (those write directly into the tensor during the MCU loop). | No libjpeg equivalent — this is the ML-quantisation conversion layer specific to EdgeFirst's tensor types. |
-| `codec.decode_png`         | Full PNG decode: header parse, native or 8-bit `zune-png` decode, optional EXIF rotation, format conversion to the requested `PixelFormat`. | PNG decode per ISO/IEC 15948 (RFC 2083). |
-| `codec.png.zune_decode`    | The bulk of PNG cost: zlib inflate + PNG filter reversal inside [`zune-png`](https://docs.rs/zune-png). `path = "u8"` is the strided-output fast path; `path = "native_u16"` preserves 16-bit-per-channel PNGs and is used for u16/i16/f32 tensor targets. | Equivalent to libpng's `png_read_image`. |
+| Span                              | What is happening inside | Reference equivalent |
+|-----------------------------------|--------------------------|----------------------|
+| `codec.decode_jpeg`               | Full JPEG decode: marker parsing, MCU decode loop, optional EXIF rotation, optional type conversion to non-u8 targets. | Baseline JPEG decode per ITU T.81 + EXIF 2.32. |
+| `codec.decode_jpeg.parse_markers` | Walk the JPEG byte stream once: parse SOF0 (start-of-frame), DQT (quantisation tables), DHT (Huffman tables), DRI (restart interval), SOS (start-of-scan), and APP1 (EXIF) segments. Builds Huffman LUTs and quant tables, extracts EXIF bytes. | Equivalent to libjpeg's `jpeg_read_header` + DHT/DQT table builds. |
+| `codec.decode_jpeg.mcu_loop`      | The core decode loop: for each MCU row, Huffman-decode + dequant-fuse blocks → two-pass Loeffler IDCT (scalar / NEON / SSE4.1 / SSE2 selected at init) → bilinear chroma upsample (4:2:0 / 4:2:2 → 4:4:4) → BT.601 YCbCr → RGB/RGBA/BGRA/Grey/NV12 colour conversion → strided write into the tensor. Allocation-free after warmup. | Equivalent to libjpeg's `jpeg_read_scanlines` loop, but with the IDCT / chroma-upsample / colour-convert kernels handwritten and SIMD-dispatched per-CPU. |
+| `codec.decode_jpeg.apply_exif`    | In-place rotation / horizontal flip on the decoded scratch buffer using `kamadak-exif`'s orientation tag. Skipped when `apply_exif=false` or for NV12 output (which doesn't support rotation). | Equivalent to libjpeg-turbo's `jpegtran -copy all -rotate ...` orientation transform. |
+| `codec.decode_jpeg.type_convert`  | Vectorised u8 → target-type conversion at the row level: `*1/255` for f32, `*257` for u16, `*257 ^ 0x8000` for i16, `^ 0x80` for i8. NEON or SSE2 dispatch per row. Skipped for u8 targets (those write directly into the tensor during the MCU loop). | No libjpeg equivalent — this is the ML-quantisation conversion layer specific to EdgeFirst's tensor types. |
+| `codec.decode_png`                | Full PNG decode: header parse, native or 8-bit `zune-png` decode, optional EXIF rotation, format conversion to the requested `PixelFormat`. | PNG decode per ISO/IEC 15948 (RFC 2083). |
+| `codec.decode_png.zune_decode`    | The bulk of PNG cost: zlib inflate + PNG filter reversal inside [`zune-png`](https://docs.rs/zune-png). `path = "u8"` is the strided-output fast path; `path = "native_u16"` preserves 16-bit-per-channel PNGs and is used for u16/i16/f32 tensor targets. | Equivalent to libpng's `png_read_image`. |
 
 [`tracing::trace_span!`]: https://docs.rs/tracing/latest/tracing/macro.trace_span.html
 

--- a/crates/codec/ARCHITECTURE.md
+++ b/crates/codec/ARCHITECTURE.md
@@ -292,6 +292,53 @@ The decoder inspects magic bytes:
 - `89 50 4E 47` → PNG
 - Otherwise → `CodecError::InvalidData`
 
+## Tracing Spans
+
+`ImageDecoder::decode_into` (and the trait-method `Tensor::load_image`)
+emits a [`tracing::trace_span!`] tree describing each phase of the JPEG/PNG
+decode. Spans are captured by
+[`edgefirst_hal::trace::start_tracing`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs)
+into Chrome JSON for Perfetto. The cost when no subscriber is active is a
+single relaxed atomic load per call site.
+
+Span names follow `<crate>.<subsystem>.<operation>`. The codec entry points
+are format-specific (`codec.decode_jpeg`, `codec.decode_png`) and the inner
+spans isolate the structural phases of each decoder.
+
+### Span tree
+
+```text
+codec.decode_jpeg                                       [JPEG entry point]
+│ fields: dtype = "u8" | "i8" | "u16" | "i16" | "f32", n_bytes
+│
+├── codec.jpeg.parse_markers                            ← parse SOF0/DQT/DHT/DRI/SOS/APP1, read EXIF
+├── codec.jpeg.mcu_loop                                 ← Huffman + IDCT + upsample + colour-convert
+├── codec.jpeg.apply_exif                               ← EXIF orientation transform (rotation/flip)
+│   fields: rotation_deg, flip_h
+└── codec.jpeg.type_convert                             ← u8 → T conversion (skipped for u8 target)
+    field: dtype
+
+codec.decode_png                                        [PNG entry point]
+│ fields: dtype, n_bytes
+│
+└── codec.png.zune_decode                               ← delegate to zune-png
+    field: path = "u8" | "native_u16"
+```
+
+### What each span measures (mapped to the JPEG / PNG decode pipeline)
+
+| Span                       | What is happening inside | Reference equivalent |
+|----------------------------|--------------------------|----------------------|
+| `codec.decode_jpeg`        | Full JPEG decode: marker parsing, MCU decode loop, optional EXIF rotation, optional type conversion to non-u8 targets. | Baseline JPEG decode per ITU T.81 + EXIF 2.32. |
+| `codec.jpeg.parse_markers` | Walk the JPEG byte stream once: parse SOF0 (start-of-frame), DQT (quantisation tables), DHT (Huffman tables), DRI (restart interval), SOS (start-of-scan), and APP1 (EXIF) segments. Builds Huffman LUTs and quant tables, extracts EXIF bytes. | Equivalent to libjpeg's `jpeg_read_header` + DHT/DQT table builds. |
+| `codec.jpeg.mcu_loop`      | The core decode loop: for each MCU row, Huffman-decode + dequant-fuse blocks → two-pass Loeffler IDCT (scalar / NEON / SSE4.1 / SSE2 selected at init) → bilinear chroma upsample (4:2:0 / 4:2:2 → 4:4:4) → BT.601 YCbCr → RGB/RGBA/BGRA/Grey/NV12 colour conversion → strided write into the tensor. Allocation-free after warmup. | Equivalent to libjpeg's `jpeg_read_scanlines` loop, but with the IDCT / chroma-upsample / colour-convert kernels handwritten and SIMD-dispatched per-CPU. |
+| `codec.jpeg.apply_exif`    | In-place rotation / horizontal flip on the decoded scratch buffer using `kamadak-exif`'s orientation tag. Skipped when `apply_exif=false` or for NV12 output (which doesn't support rotation). | Equivalent to libjpeg-turbo's `jpegtran -copy all -rotate ...` orientation transform. |
+| `codec.jpeg.type_convert`  | Vectorised u8 → target-type conversion at the row level: `*1/255` for f32, `*257` for u16, `*257 ^ 0x8000` for i16, `^ 0x80` for i8. NEON or SSE2 dispatch per row. Skipped for u8 targets (those write directly into the tensor during the MCU loop). | No libjpeg equivalent — this is the ML-quantisation conversion layer specific to EdgeFirst's tensor types. |
+| `codec.decode_png`         | Full PNG decode: header parse, native or 8-bit `zune-png` decode, optional EXIF rotation, format conversion to the requested `PixelFormat`. | PNG decode per ISO/IEC 15948 (RFC 2083). |
+| `codec.png.zune_decode`    | The bulk of PNG cost: zlib inflate + PNG filter reversal inside [`zune-png`](https://docs.rs/zune-png). `path = "u8"` is the strided-output fast path; `path = "native_u16"` preserves 16-bit-per-channel PNGs and is used for u16/i16/f32 tensor targets. | Equivalent to libpng's `png_read_image`. |
+
+[`tracing::trace_span!`]: https://docs.rs/tracing/latest/tracing/macro.trace_span.html
+
 ## Supported Pixel Formats
 
 | Output Format | JPEG | PNG  | Notes                           |

--- a/crates/codec/Cargo.toml
+++ b/crates/codec/Cargo.toml
@@ -23,6 +23,7 @@ kamadak-exif = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
 opencv = { workspace = true, optional = true }
+tracing = { workspace = true }
 turbojpeg = { version = "0.5", optional = true }
 zune-png = { workspace = true }
 

--- a/crates/codec/src/jpeg/mod.rs
+++ b/crates/codec/src/jpeg/mod.rs
@@ -133,7 +133,7 @@ pub fn decode_jpeg_into<T: ImagePixel>(
     .entered();
     // Parse all marker segments
     let headers = {
-        let _s = tracing::trace_span!("codec.jpeg.parse_markers").entered();
+        let _s = tracing::trace_span!("codec.decode_jpeg.parse_markers").entered();
         markers::parse_markers(data)?
     };
 
@@ -231,7 +231,7 @@ pub fn decode_jpeg_into<T: ImagePixel>(
             let native_stride = img_w * channels;
             state.exif_scratch.resize(native_stride * img_h, 0);
             {
-                let _s = tracing::trace_span!("codec.jpeg.mcu_loop").entered();
+                let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
                 mcu::decode_image(
                     data,
                     &headers,
@@ -243,7 +243,8 @@ pub fn decode_jpeg_into<T: ImagePixel>(
             }
             {
                 let _s =
-                    tracing::trace_span!("codec.jpeg.apply_exif", rotation_deg, flip_h,).entered();
+                    tracing::trace_span!("codec.decode_jpeg.apply_exif", rotation_deg, flip_h,)
+                        .entered();
                 apply_exif_u8(
                     &mut state.exif_scratch,
                     native_stride,
@@ -266,7 +267,7 @@ pub fn decode_jpeg_into<T: ImagePixel>(
                     .copy_from_slice(&state.exif_scratch[src_off..src_off + final_native_stride]);
             }
         } else {
-            let _s = tracing::trace_span!("codec.jpeg.mcu_loop").entered();
+            let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
             mcu::decode_image(data, &headers, mcu_scratch, dst_u8, dst_stride, output_fmt)?;
         }
     } else {
@@ -276,7 +277,7 @@ pub fn decode_jpeg_into<T: ImagePixel>(
         state.exif_scratch.resize(temp_size, 0);
 
         {
-            let _s = tracing::trace_span!("codec.jpeg.mcu_loop").entered();
+            let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
             mcu::decode_image(
                 data,
                 &headers,
@@ -289,7 +290,8 @@ pub fn decode_jpeg_into<T: ImagePixel>(
 
         // Apply EXIF transformations on the temp buffer
         if flip_h || rotation_deg != 0 {
-            let _s = tracing::trace_span!("codec.jpeg.apply_exif", rotation_deg, flip_h,).entered();
+            let _s = tracing::trace_span!("codec.decode_jpeg.apply_exif", rotation_deg, flip_h,)
+                .entered();
             apply_exif_u8(
                 &mut state.exif_scratch,
                 temp_stride,
@@ -304,7 +306,7 @@ pub fn decode_jpeg_into<T: ImagePixel>(
 
         // Convert u8 → T and write to tensor at stride offsets
         let _s = tracing::trace_span!(
-            "codec.jpeg.type_convert",
+            "codec.decode_jpeg.type_convert",
             dtype = std::any::type_name::<T>(),
         )
         .entered();

--- a/crates/codec/src/jpeg/mod.rs
+++ b/crates/codec/src/jpeg/mod.rs
@@ -125,8 +125,17 @@ pub fn decode_jpeg_into<T: ImagePixel>(
     opts: &DecodeOptions,
     state: &mut JpegDecoderState,
 ) -> crate::Result<ImageInfo> {
+    let _span = tracing::trace_span!(
+        "codec.decode_jpeg",
+        dtype = std::any::type_name::<T>(),
+        n_bytes = data.len(),
+    )
+    .entered();
     // Parse all marker segments
-    let headers = markers::parse_markers(data)?;
+    let headers = {
+        let _s = tracing::trace_span!("codec.jpeg.parse_markers").entered();
+        markers::parse_markers(data)?
+    };
 
     let hdr = &headers.header;
     let mut img_w = hdr.width as usize;
@@ -221,24 +230,31 @@ pub fn decode_jpeg_into<T: ImagePixel>(
             // because native rows would overflow the rotated tensor stride.
             let native_stride = img_w * channels;
             state.exif_scratch.resize(native_stride * img_h, 0);
-            mcu::decode_image(
-                data,
-                &headers,
-                mcu_scratch,
-                &mut state.exif_scratch,
-                native_stride,
-                output_fmt,
-            )?;
-            apply_exif_u8(
-                &mut state.exif_scratch,
-                native_stride,
-                &mut img_w,
-                &mut img_h,
-                channels,
-                rotation_deg,
-                flip_h,
-                &mut state.rot_scratch,
-            );
+            {
+                let _s = tracing::trace_span!("codec.jpeg.mcu_loop").entered();
+                mcu::decode_image(
+                    data,
+                    &headers,
+                    mcu_scratch,
+                    &mut state.exif_scratch,
+                    native_stride,
+                    output_fmt,
+                )?;
+            }
+            {
+                let _s =
+                    tracing::trace_span!("codec.jpeg.apply_exif", rotation_deg, flip_h,).entered();
+                apply_exif_u8(
+                    &mut state.exif_scratch,
+                    native_stride,
+                    &mut img_w,
+                    &mut img_h,
+                    channels,
+                    rotation_deg,
+                    flip_h,
+                    &mut state.rot_scratch,
+                );
+            }
             // exif_scratch now holds post-rotation pixels at stride
             // `img_w * channels`. Copy into the tensor at `dst_stride`,
             // which honors any pitch padding.
@@ -250,6 +266,7 @@ pub fn decode_jpeg_into<T: ImagePixel>(
                     .copy_from_slice(&state.exif_scratch[src_off..src_off + final_native_stride]);
             }
         } else {
+            let _s = tracing::trace_span!("codec.jpeg.mcu_loop").entered();
             mcu::decode_image(data, &headers, mcu_scratch, dst_u8, dst_stride, output_fmt)?;
         }
     } else {
@@ -258,17 +275,21 @@ pub fn decode_jpeg_into<T: ImagePixel>(
         let temp_size = temp_stride * img_h;
         state.exif_scratch.resize(temp_size, 0);
 
-        mcu::decode_image(
-            data,
-            &headers,
-            mcu_scratch,
-            &mut state.exif_scratch,
-            temp_stride,
-            output_fmt,
-        )?;
+        {
+            let _s = tracing::trace_span!("codec.jpeg.mcu_loop").entered();
+            mcu::decode_image(
+                data,
+                &headers,
+                mcu_scratch,
+                &mut state.exif_scratch,
+                temp_stride,
+                output_fmt,
+            )?;
+        }
 
         // Apply EXIF transformations on the temp buffer
         if flip_h || rotation_deg != 0 {
+            let _s = tracing::trace_span!("codec.jpeg.apply_exif", rotation_deg, flip_h,).entered();
             apply_exif_u8(
                 &mut state.exif_scratch,
                 temp_stride,
@@ -282,6 +303,11 @@ pub fn decode_jpeg_into<T: ImagePixel>(
         }
 
         // Convert u8 → T and write to tensor at stride offsets
+        let _s = tracing::trace_span!(
+            "codec.jpeg.type_convert",
+            dtype = std::any::type_name::<T>(),
+        )
+        .entered();
         let src_stride = img_w * channels;
         let dst_stride_elems = dst_stride / elem_size;
 

--- a/crates/codec/src/jpeg/mod.rs
+++ b/crates/codec/src/jpeg/mod.rs
@@ -212,169 +212,45 @@ pub fn decode_jpeg_into<T: ImagePixel>(
     let mut map = dst.map()?;
     let dst_bytes: &mut [T] = &mut map;
 
-    // We need to decode into u8 first, then convert to the target type.
-    // For u8 targets, we can decode directly. For other types, use a
-    // temporary u8 buffer then convert row-by-row.
+    // Dispatch to the u8-direct path when T == u8 (lets the MCU loop write
+    // directly into the tensor); otherwise stage in `exif_scratch` and convert.
     if T::dtype() == edgefirst_tensor::DType::U8 {
-        // Fast path: decode directly into tensor buffer
-        // SAFETY: T is u8, layout-identical
+        // SAFETY: T is u8 — layout-identical reinterpret of the tensor slice.
         let dst_u8: &mut [u8] = unsafe {
             std::slice::from_raw_parts_mut(dst_bytes.as_mut_ptr() as *mut u8, dst_bytes.len())
         };
-
-        if flip_h || rotation_deg != 0 {
-            // EXIF rotation/flip path: decode at native (pre-rotation) stride
-            // into the codec's scratch buffer, rotate in-place there, then
-            // stride-copy into the (possibly pitch-padded) destination. We
-            // cannot decode directly into `dst_u8` when rotation swaps dims
-            // because native rows would overflow the rotated tensor stride.
-            let native_stride = img_w * channels;
-            state.exif_scratch.resize(native_stride * img_h, 0);
-            {
-                let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
-                mcu::decode_image(
-                    data,
-                    &headers,
-                    mcu_scratch,
-                    &mut state.exif_scratch,
-                    native_stride,
-                    output_fmt,
-                )?;
-            }
-            {
-                let _s =
-                    tracing::trace_span!("codec.decode_jpeg.apply_exif", rotation_deg, flip_h,)
-                        .entered();
-                apply_exif_u8(
-                    &mut state.exif_scratch,
-                    native_stride,
-                    &mut img_w,
-                    &mut img_h,
-                    channels,
-                    rotation_deg,
-                    flip_h,
-                    &mut state.rot_scratch,
-                );
-            }
-            // exif_scratch now holds post-rotation pixels at stride
-            // `img_w * channels`. Copy into the tensor at `dst_stride`,
-            // which honors any pitch padding.
-            let final_native_stride = img_w * channels;
-            for y in 0..img_h {
-                let src_off = y * final_native_stride;
-                let dst_off = y * dst_stride;
-                dst_u8[dst_off..dst_off + final_native_stride]
-                    .copy_from_slice(&state.exif_scratch[src_off..src_off + final_native_stride]);
-            }
-        } else {
-            let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
-            mcu::decode_image(data, &headers, mcu_scratch, dst_u8, dst_stride, output_fmt)?;
-        }
+        decode_u8_path(
+            data,
+            &headers,
+            mcu_scratch,
+            &mut state.exif_scratch,
+            &mut state.rot_scratch,
+            dst_u8,
+            output_fmt,
+            &mut img_w,
+            &mut img_h,
+            channels,
+            dst_stride,
+            rotation_deg,
+            flip_h,
+        )?;
     } else {
-        // Generic path: decode into temporary u8 buffer, then convert
-        let temp_stride = img_w * channels;
-        let temp_size = temp_stride * img_h;
-        state.exif_scratch.resize(temp_size, 0);
-
-        {
-            let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
-            mcu::decode_image(
-                data,
-                &headers,
-                mcu_scratch,
-                &mut state.exif_scratch,
-                temp_stride,
-                output_fmt,
-            )?;
-        }
-
-        // Apply EXIF transformations on the temp buffer
-        if flip_h || rotation_deg != 0 {
-            let _s = tracing::trace_span!("codec.decode_jpeg.apply_exif", rotation_deg, flip_h,)
-                .entered();
-            apply_exif_u8(
-                &mut state.exif_scratch,
-                temp_stride,
-                &mut img_w,
-                &mut img_h,
-                channels,
-                rotation_deg,
-                flip_h,
-                &mut state.rot_scratch,
-            );
-        }
-
-        // Convert u8 → T and write to tensor at stride offsets
-        let _s = tracing::trace_span!(
-            "codec.decode_jpeg.type_convert",
-            dtype = std::any::type_name::<T>(),
-        )
-        .entered();
-        let src_stride = img_w * channels;
-        let dst_stride_elems = dst_stride / elem_size;
-
-        if T::dtype() == edgefirst_tensor::DType::I8 {
-            // Fast path: copy + XOR 0x80
-            let dst_u8: &mut [u8] = unsafe {
-                std::slice::from_raw_parts_mut(dst_bytes.as_mut_ptr() as *mut u8, dst_bytes.len())
-            };
-            for y in 0..img_h {
-                let s = y * src_stride;
-                let d = y * dst_stride;
-                dst_u8[d..d + src_stride].copy_from_slice(&state.exif_scratch[s..s + src_stride]);
-                for b in &mut dst_u8[d..d + src_stride] {
-                    *b ^= 0x80;
-                }
-            }
-        } else if T::dtype() == edgefirst_tensor::DType::F32 {
-            // SIMD-vectorized u8 → f32 normalisation
-            let dst_f32: &mut [f32] = unsafe {
-                std::slice::from_raw_parts_mut(dst_bytes.as_mut_ptr() as *mut f32, dst_bytes.len())
-            };
-            for y in 0..img_h {
-                let s = y * src_stride;
-                let d = y * dst_stride_elems;
-                convert::convert_u8_to_f32(
-                    &state.exif_scratch[s..s + src_stride],
-                    &mut dst_f32[d..d + src_stride],
-                );
-            }
-        } else if T::dtype() == edgefirst_tensor::DType::U16 {
-            // SIMD-vectorized u8 → u16 scaling (×257)
-            let dst_u16: &mut [u16] = unsafe {
-                std::slice::from_raw_parts_mut(dst_bytes.as_mut_ptr() as *mut u16, dst_bytes.len())
-            };
-            for y in 0..img_h {
-                let s = y * src_stride;
-                let d = y * dst_stride_elems;
-                convert::convert_u8_to_u16(
-                    &state.exif_scratch[s..s + src_stride],
-                    &mut dst_u16[d..d + src_stride],
-                );
-            }
-        } else if T::dtype() == edgefirst_tensor::DType::I16 {
-            // SIMD-vectorized u8 → i16 (×257 XOR 0x8000)
-            let dst_i16: &mut [i16] = unsafe {
-                std::slice::from_raw_parts_mut(dst_bytes.as_mut_ptr() as *mut i16, dst_bytes.len())
-            };
-            for y in 0..img_h {
-                let s = y * src_stride;
-                let d = y * dst_stride_elems;
-                convert::convert_u8_to_i16(
-                    &state.exif_scratch[s..s + src_stride],
-                    &mut dst_i16[d..d + src_stride],
-                );
-            }
-        } else {
-            // Fallback for any other type
-            for y in 0..img_h {
-                let s = y * src_stride;
-                let d = y * dst_stride_elems;
-                for x in 0..src_stride {
-                    dst_bytes[d + x] = T::from_u8(state.exif_scratch[s + x]);
-                }
-            }
-        }
+        decode_typed_path::<T>(
+            data,
+            &headers,
+            mcu_scratch,
+            &mut state.exif_scratch,
+            &mut state.rot_scratch,
+            dst_bytes,
+            output_fmt,
+            &mut img_w,
+            &mut img_h,
+            channels,
+            elem_size,
+            dst_stride,
+            rotation_deg,
+            flip_h,
+        )?;
     }
 
     Ok(ImageInfo {
@@ -383,4 +259,246 @@ pub fn decode_jpeg_into<T: ImagePixel>(
         format: output_fmt,
         row_stride: dst_stride,
     })
+}
+
+/// u8 decode path: MCU writes into the tensor directly when no EXIF transform
+/// applies; otherwise stages into `exif_scratch`, rotates in place, then
+/// stride-copies into the (possibly pitch-padded) destination.
+#[allow(clippy::too_many_arguments)]
+fn decode_u8_path(
+    data: &[u8],
+    headers: &markers::JpegHeaders,
+    mcu_scratch: &mut mcu::McuScratch,
+    exif_scratch: &mut Vec<u8>,
+    rot_scratch: &mut Vec<u8>,
+    dst_u8: &mut [u8],
+    output_fmt: PixelFormat,
+    img_w: &mut usize,
+    img_h: &mut usize,
+    channels: usize,
+    dst_stride: usize,
+    rotation_deg: u16,
+    flip_h: bool,
+) -> crate::Result<()> {
+    if !flip_h && rotation_deg == 0 {
+        let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
+        return mcu::decode_image(data, headers, mcu_scratch, dst_u8, dst_stride, output_fmt);
+    }
+
+    // EXIF rotation/flip path: cannot decode directly into `dst_u8` when
+    // rotation swaps dims, because native rows would overflow the rotated
+    // tensor stride. Decode into scratch at native stride, rotate, copy out.
+    let native_stride = *img_w * channels;
+    exif_scratch.resize(native_stride * *img_h, 0);
+    decode_mcu_into(
+        data,
+        headers,
+        mcu_scratch,
+        exif_scratch,
+        native_stride,
+        output_fmt,
+    )?;
+    run_apply_exif(
+        exif_scratch,
+        native_stride,
+        img_w,
+        img_h,
+        channels,
+        rotation_deg,
+        flip_h,
+        rot_scratch,
+    );
+    // exif_scratch now holds post-rotation pixels at `img_w * channels`
+    // stride. Copy into the tensor at `dst_stride`, honouring pitch padding.
+    let final_native_stride = *img_w * channels;
+    for y in 0..*img_h {
+        let src_off = y * final_native_stride;
+        let dst_off = y * dst_stride;
+        dst_u8[dst_off..dst_off + final_native_stride]
+            .copy_from_slice(&exif_scratch[src_off..src_off + final_native_stride]);
+    }
+    Ok(())
+}
+
+/// Non-u8 decode path: MCU writes u8 into `exif_scratch`, EXIF (if needed)
+/// rotates in place, then `convert_rows_to_target` does the typed conversion.
+#[allow(clippy::too_many_arguments)]
+fn decode_typed_path<T: ImagePixel>(
+    data: &[u8],
+    headers: &markers::JpegHeaders,
+    mcu_scratch: &mut mcu::McuScratch,
+    exif_scratch: &mut Vec<u8>,
+    rot_scratch: &mut Vec<u8>,
+    dst_bytes: &mut [T],
+    output_fmt: PixelFormat,
+    img_w: &mut usize,
+    img_h: &mut usize,
+    channels: usize,
+    elem_size: usize,
+    dst_stride: usize,
+    rotation_deg: u16,
+    flip_h: bool,
+) -> crate::Result<()> {
+    let temp_stride = *img_w * channels;
+    exif_scratch.resize(temp_stride * *img_h, 0);
+    decode_mcu_into(
+        data,
+        headers,
+        mcu_scratch,
+        exif_scratch,
+        temp_stride,
+        output_fmt,
+    )?;
+
+    if flip_h || rotation_deg != 0 {
+        run_apply_exif(
+            exif_scratch,
+            temp_stride,
+            img_w,
+            img_h,
+            channels,
+            rotation_deg,
+            flip_h,
+            rot_scratch,
+        );
+    }
+
+    convert_rows_to_target::<T>(
+        exif_scratch,
+        dst_bytes,
+        *img_w,
+        *img_h,
+        channels,
+        dst_stride,
+        elem_size,
+    );
+    Ok(())
+}
+
+/// MCU decode wrapped in its own span so the cost is attributable in traces
+/// regardless of which decode path called it.
+#[inline]
+fn decode_mcu_into(
+    data: &[u8],
+    headers: &markers::JpegHeaders,
+    mcu_scratch: &mut mcu::McuScratch,
+    dst: &mut [u8],
+    dst_stride: usize,
+    output_fmt: PixelFormat,
+) -> crate::Result<()> {
+    let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
+    mcu::decode_image(data, headers, mcu_scratch, dst, dst_stride, output_fmt)
+}
+
+/// EXIF rotation wrapped in its own span. `img_w` / `img_h` may swap on
+/// 90°/270° rotations — that's why the caller passes them through `&mut`.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn run_apply_exif(
+    data: &mut [u8],
+    stride: usize,
+    img_w: &mut usize,
+    img_h: &mut usize,
+    channels: usize,
+    rotation_deg: u16,
+    flip_h: bool,
+    rot_scratch: &mut Vec<u8>,
+) {
+    let _s = tracing::trace_span!("codec.decode_jpeg.apply_exif", rotation_deg, flip_h).entered();
+    apply_exif_u8(
+        data,
+        stride,
+        img_w,
+        img_h,
+        channels,
+        rotation_deg,
+        flip_h,
+        rot_scratch,
+    );
+}
+
+/// Per-row u8 → T conversion dispatch. Pulled out of `decode_jpeg_into` so
+/// the dtype if/else chain doesn't inflate the top-level function's
+/// cognitive complexity.
+fn convert_rows_to_target<T: ImagePixel>(
+    src: &[u8],
+    dst: &mut [T],
+    img_w: usize,
+    img_h: usize,
+    channels: usize,
+    dst_stride: usize,
+    elem_size: usize,
+) {
+    let _s = tracing::trace_span!(
+        "codec.decode_jpeg.type_convert",
+        dtype = std::any::type_name::<T>(),
+    )
+    .entered();
+    let src_stride = img_w * channels;
+    let dst_stride_elems = dst_stride / elem_size;
+
+    match T::dtype() {
+        edgefirst_tensor::DType::I8 => {
+            // SAFETY: T is i8 — layout-identical reinterpret of the dst slice.
+            let dst_u8: &mut [u8] =
+                unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u8, dst.len()) };
+            for y in 0..img_h {
+                let s = y * src_stride;
+                let d = y * dst_stride;
+                dst_u8[d..d + src_stride].copy_from_slice(&src[s..s + src_stride]);
+                for b in &mut dst_u8[d..d + src_stride] {
+                    *b ^= 0x80;
+                }
+            }
+        }
+        edgefirst_tensor::DType::F32 => {
+            // SAFETY: T is f32 — layout-identical reinterpret of the dst slice.
+            let dst_f32: &mut [f32] =
+                unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut f32, dst.len()) };
+            for y in 0..img_h {
+                let s = y * src_stride;
+                let d = y * dst_stride_elems;
+                convert::convert_u8_to_f32(
+                    &src[s..s + src_stride],
+                    &mut dst_f32[d..d + src_stride],
+                );
+            }
+        }
+        edgefirst_tensor::DType::U16 => {
+            // SAFETY: T is u16 — layout-identical reinterpret of the dst slice.
+            let dst_u16: &mut [u16] =
+                unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u16, dst.len()) };
+            for y in 0..img_h {
+                let s = y * src_stride;
+                let d = y * dst_stride_elems;
+                convert::convert_u8_to_u16(
+                    &src[s..s + src_stride],
+                    &mut dst_u16[d..d + src_stride],
+                );
+            }
+        }
+        edgefirst_tensor::DType::I16 => {
+            // SAFETY: T is i16 — layout-identical reinterpret of the dst slice.
+            let dst_i16: &mut [i16] =
+                unsafe { std::slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut i16, dst.len()) };
+            for y in 0..img_h {
+                let s = y * src_stride;
+                let d = y * dst_stride_elems;
+                convert::convert_u8_to_i16(
+                    &src[s..s + src_stride],
+                    &mut dst_i16[d..d + src_stride],
+                );
+            }
+        }
+        _ => {
+            // Fallback for any other type — slow per-element via ImagePixel.
+            for y in 0..img_h {
+                let s = y * src_stride;
+                let d = y * dst_stride_elems;
+                for x in 0..src_stride {
+                    dst[d + x] = T::from_u8(src[s + x]);
+                }
+            }
+        }
+    }
 }

--- a/crates/codec/src/png.rs
+++ b/crates/codec/src/png.rs
@@ -191,11 +191,7 @@ fn decode_png_via_decoding_result<T: ImagePixel>(
     img_w: usize,
     img_h: usize,
 ) -> crate::Result<ImageInfo> {
-    let result = {
-        let _s =
-            tracing::trace_span!("codec.decode_png.zune_decode", path = "native_u16").entered();
-        decoder.decode()?
-    };
+    let result = run_zune_decode(&mut decoder)?;
 
     let final_channels = dest_fmt.channels();
     let elem_size = std::mem::size_of::<T>();
@@ -370,10 +366,7 @@ fn decode_png_via_u8<T: ImagePixel>(
     };
     let decoded_size = img_w * img_h * decode_channels;
     scratch.resize(decoded_size, 0);
-    {
-        let _s = tracing::trace_span!("codec.decode_png.zune_decode", path = "u8").entered();
-        decoder.decode_into(scratch)?;
-    }
+    run_zune_decode_into(&mut decoder, scratch)?;
 
     // Strip LumaA → Grey if needed
     let (src_pixels, src_channels) = if strip_luma_alpha {
@@ -594,6 +587,29 @@ fn convert_pixels_u16(src: &[u16], src_ch: usize, dst_ch: usize, pixel_count: us
         }
     }
     out
+}
+
+/// Native-bit-depth `decode()` wrapped in its own span. Lifted out of
+/// `decode_png_via_decoding_result` so the per-row dispatch loop there
+/// doesn't pay a cognitive-complexity point for the span scope.
+#[inline]
+fn run_zune_decode(
+    decoder: &mut PngDecoder<zune_png::zune_core::bytestream::ZCursor<&[u8]>>,
+) -> crate::Result<DecodingResult> {
+    let _s = tracing::trace_span!("codec.decode_png.zune_decode", path = "native_u16").entered();
+    Ok(decoder.decode()?)
+}
+
+/// `decode_into(&mut [u8])` wrapped in its own span. Counterpart to
+/// `run_zune_decode` for the u8 fast path.
+#[inline]
+fn run_zune_decode_into(
+    decoder: &mut PngDecoder<zune_png::zune_core::bytestream::ZCursor<&[u8]>>,
+    scratch: &mut [u8],
+) -> crate::Result<()> {
+    let _s = tracing::trace_span!("codec.decode_png.zune_decode", path = "u8").entered();
+    decoder.decode_into(scratch)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/codec/src/png.rs
+++ b/crates/codec/src/png.rs
@@ -84,6 +84,12 @@ pub(crate) fn decode_png_into<T: ImagePixel>(
     scratch: &mut Vec<u8>,
     rot_scratch: &mut Vec<u8>,
 ) -> crate::Result<ImageInfo> {
+    let _span = tracing::trace_span!(
+        "codec.decode_png",
+        dtype = std::any::type_name::<T>(),
+        n_bytes = data.len(),
+    )
+    .entered();
     let dest_fmt = opts.format.unwrap_or(PixelFormat::Rgb);
 
     let zune_opts = DecoderOptions::default()
@@ -185,7 +191,10 @@ fn decode_png_via_decoding_result<T: ImagePixel>(
     img_w: usize,
     img_h: usize,
 ) -> crate::Result<ImageInfo> {
-    let result = decoder.decode()?;
+    let result = {
+        let _s = tracing::trace_span!("codec.png.zune_decode", path = "native_u16").entered();
+        decoder.decode()?
+    };
 
     let final_channels = dest_fmt.channels();
     let elem_size = std::mem::size_of::<T>();
@@ -360,7 +369,10 @@ fn decode_png_via_u8<T: ImagePixel>(
     };
     let decoded_size = img_w * img_h * decode_channels;
     scratch.resize(decoded_size, 0);
-    decoder.decode_into(scratch)?;
+    {
+        let _s = tracing::trace_span!("codec.png.zune_decode", path = "u8").entered();
+        decoder.decode_into(scratch)?;
+    }
 
     // Strip LumaA → Grey if needed
     let (src_pixels, src_channels) = if strip_luma_alpha {

--- a/crates/codec/src/png.rs
+++ b/crates/codec/src/png.rs
@@ -192,7 +192,8 @@ fn decode_png_via_decoding_result<T: ImagePixel>(
     img_h: usize,
 ) -> crate::Result<ImageInfo> {
     let result = {
-        let _s = tracing::trace_span!("codec.png.zune_decode", path = "native_u16").entered();
+        let _s =
+            tracing::trace_span!("codec.decode_png.zune_decode", path = "native_u16").entered();
         decoder.decode()?
     };
 
@@ -370,7 +371,7 @@ fn decode_png_via_u8<T: ImagePixel>(
     let decoded_size = img_w * img_h * decode_channels;
     scratch.resize(decoded_size, 0);
     {
-        let _s = tracing::trace_span!("codec.png.zune_decode", path = "u8").entered();
+        let _s = tracing::trace_span!("codec.decode_png.zune_decode", path = "u8").entered();
         decoder.decode_into(scratch)?;
     }
 

--- a/crates/decoder/ARCHITECTURE.md
+++ b/crates/decoder/ARCHITECTURE.md
@@ -283,88 +283,114 @@ spans are recorded as Chrome JSON when [`edgefirst_hal::trace::start_tracing`](h
 is active and have near-zero overhead otherwise (a single relaxed atomic
 load per call site).
 
-Span names follow the convention `<crate>.<subsystem>.<operation>`. Inner
-spans keep the full prefix so a Perfetto cell makes sense in isolation and
-queries can filter by subsystem (e.g. all `decoder.nms.*`).
+### Naming convention
+
+Span names follow `<crate>.<function>[.<operation>[.<sub-operation>]]`:
+
+- **`<crate>.<function>`** — top-level span: the public function the user
+  invoked (e.g. `decoder.decode`, `decoder.decode_proto`). For this crate
+  those are the entry points on [`Decoder`](https://docs.rs/edgefirst-decoder/latest/edgefirst_decoder/struct.Decoder.html).
+- **`<crate>.<function>.<operation>`** — meaningful internal work done as
+  part of that function (e.g. `decoder.decode.yolo_quant_flat`,
+  `decoder.decode.process_masks`).
+- **`<crate>.<function>.<operation>.<sub-operation>`** — further
+  decomposition where it aids optimisation (e.g.
+  `decoder.decode.per_scale_to_masks.process_masks`).
+- **`<crate>.<shared_op>[.<sub-operation>]`** — shared building blocks
+  reached from *multiple* user-facing functions; the function prefix is
+  omitted because a single source location can only carry one static name
+  (e.g. `decoder.nms_get_boxes.suppress` and `decoder.per_scale_run.level`
+  are both invoked from `decoder.decode` and `decoder.decode_proto`). The
+  parent span in the recorded trace identifies the actual caller.
+
+A span is worth adding when the work inside it is **meaningful for
+optimisation and has enough complexity to justify the overhead** — roughly
+500 µs on Cortex-A53 as a guideline.
 
 ### Span tree
 
 ```text
-decoder.decode  (or decoder.decode_proto)               [entry point]
+decoder.decode                                          [user-facing fn]
 │ fields: path = "yolo_seg_det" | "yolo_split_seg_det" | "modelpack" | …
 │         n_outputs
 │
-├── decoder.per_scale.run                                [per-scale fast path]
-│   │ fields: n_levels, encoding, nc, nm
-│   ├── decoder.per_scale.resolve_bindings
-│   ├── decoder.per_scale.level                          ← per FPN scale (80×80, 40×40, 20×20)
-│   │   │ fields: li, stride, h, w, anchors, layout
-│   │   ├── decoder.per_scale.boxes                      ← DFL or LTRB box decode
-│   │   │   fields: encoding
-│   │   ├── decoder.per_scale.scores                     ← class-score dequant + sigmoid
-│   │   │   fields: activation
-│   │   └── decoder.per_scale.mask_coefs                 ← mask coefficient dequant (32-D)
-│   └── decoder.per_scale.protos                         ← proto-mask dequant (160×160×32)
+├── decoder.decode.yolo_quant_flat                      [flat-tensor kernels]
+├── decoder.decode.yolo_float_flat
+├── decoder.decode.yolo_quant_split
+├── decoder.decode.yolo_float_split
 │
-├── decoder.per_scale.widen_f32                          [f16 → f32 widen or zero-copy borrow]
-│   field: kind = "f32_borrow" | "f16_widen"
-│
-├── decoder.per_scale.to_proto_data                      [bridge → ProtoData]
-│   ├── decoder.per_scale.bridge_get_boxes               ← wraps decoder.nms.get_boxes
-│   │   └── decoder.nms.get_boxes
-│   └── decoder.per_scale.bridge_extract_proto
-│       └── decoder.extract_proto_data (mode = "float")
-│
-├── decoder.per_scale.to_masks                           [bridge → materialised masks]
-│   ├── decoder.per_scale.bridge_get_boxes
-│   │   └── decoder.nms.get_boxes
-│   └── decoder.per_scale.bridge_process_masks
-│       └── decoder.process_masks (mode = "float")
-│
-├── decoder.yolo.decode_quant_flat                       [flat/legacy quant detection]
-├── decoder.yolo.decode_float_flat                       [flat/legacy float detection]
-├── decoder.yolo.decode_quant_split                      [split-tensor quant detection]
-├── decoder.yolo.decode_float_split                      [split-tensor float detection]
-│
-├── decoder.nms.get_boxes                                [post-NMS candidate selection]
-│   │ fields: n_candidates, n_after_topk, n_after_nms, n_detections
-│   ├── decoder.nms.score_filter                         ← max-class score threshold filter
-│   ├── decoder.nms.top_k                                ← partial sort, retain pre_nms_top_k
-│   │   field: k
-│   ├── decoder.nms.suppress                             ← class-agnostic / class-aware IoU NMS
-│   └── decoder.nms.dequant_boxes                        ← int8 → f32 on survivors only (quant path)
-│       field: n
-│
-├── decoder.process_masks                                [coefficient @ protos → per-detect mask]
+├── decoder.decode.process_masks                        [coeff @ protos → per-detect mask, materialised path]
 │   fields: n, mode = "float" | "quant"
 │
-└── decoder.extract_proto_data                           [build ProtoData for GPU fused render]
-    fields: n, num_protos, layout = "nhwc" | "nchw", mode = "float" | "quant"
+└── decoder.decode.per_scale_to_masks                   [per-scale → materialised masks bridge]
+    ├── decoder.decode.per_scale_to_masks.get_boxes     ← wraps decoder.nms_get_boxes
+    │   └── decoder.nms_get_boxes
+    └── decoder.decode.per_scale_to_masks.process_masks ← wraps decoder.decode.process_masks
+        └── decoder.decode.process_masks
+
+decoder.decode_proto                                    [user-facing fn]
+│ fields: path, n_outputs
+│
+├── decoder.decode_proto.extract_proto_data             [build ProtoData; no mask materialisation]
+│   fields: n, num_protos, layout, mode = "float" | "quant"
+│
+└── decoder.decode_proto.per_scale_to_proto_data        [per-scale → ProtoData bridge]
+    ├── decoder.decode_proto.per_scale_to_proto_data.get_boxes
+    │   └── decoder.nms_get_boxes
+    └── decoder.decode_proto.per_scale_to_proto_data.extract
+        └── decoder.decode_proto.extract_proto_data
+
+# Shared building blocks (reached from both decode and decode_proto;
+# parent in the trace tells you which one)
+
+decoder.per_scale_run                                   [the per-scale NEON hot path]
+│ fields: n_levels, encoding, nc, nm
+├── decoder.per_scale_run.resolve_bindings
+├── decoder.per_scale_run.level                         ← per FPN scale (80×80, 40×40, 20×20)
+│   │ fields: li, stride, h, w, anchors, layout
+│   ├── decoder.per_scale_run.level.boxes               ← DFL or LTRB box decode
+│   │   field: encoding
+│   ├── decoder.per_scale_run.level.scores              ← class-score dequant + sigmoid
+│   │   field: activation
+│   └── decoder.per_scale_run.level.mask_coefs          ← mask coefficient dequant (32-D)
+├── decoder.per_scale_run.protos                        ← proto-mask dequant (160×160×32)
+└── decoder.per_scale_run.widen_f32                     ← f16 → f32 widen or zero-copy borrow
+    field: kind = "f32_borrow" | "f16_widen"
+
+decoder.nms_get_boxes                                   [post-NMS candidate selection]
+│ fields: n_candidates, n_after_topk, n_after_nms, n_detections
+├── decoder.nms_get_boxes.score_filter                  ← max-class score threshold filter
+├── decoder.nms_get_boxes.top_k                         ← partial sort, retain pre_nms_top_k
+│   field: k
+├── decoder.nms_get_boxes.suppress                      ← class-agnostic / class-aware IoU NMS
+└── decoder.nms_get_boxes.dequant_boxes                 ← int8 → f32 on survivors only (quant path)
+    field: n
 ```
 
 ### What each span measures (mapped to reference YOLO post-processing)
 
-| Span                                | Reference equivalent (Ultralytics)                      | What it does |
-|-------------------------------------|---------------------------------------------------------|--------------|
-| `decoder.decode`                    | `non_max_suppression(...)` + segmentation `process_mask`| Top-level decode entry. The `path` field tells you which model topology was selected at builder time. |
-| `decoder.decode_proto`              | `decode` + skip `process_mask` (returns coeffs/protos)  | Returns proto data instead of materialised masks; pair with `image.materialize_masks` or the fused GPU shader. |
-| `decoder.yolo.decode_*_{flat,split}`| `preds.transpose(-1, -2)` + `xywh2xyxy` + per-row filter| Flat-tensor and legacy split-tensor YOLO post-processing (pre-per-scale). Each kernel walks `(4 + nc, anchors)` once. |
-| `decoder.per_scale.run`             | Anchor-free `dist2bbox` over multi-scale FPN heads      | The NEON-vectorised hot path for Ara-2 DVM and certain TFLite exports where the head is pre-split per FPN scale. |
-| `decoder.per_scale.resolve_bindings`| Plan-time tensor → role mapping                         | Walks the schema-derived `Plan` once to match input tensors to box / score / mc / protos roles. |
-| `decoder.per_scale.level`           | One FPN scale (e.g. 80×80, 40×40, 20×20)                | All per-anchor work for one scale. Use the `li` and `anchors` fields to attribute cost to the dominant scale (level 0 has ~16× more anchors than level 2). |
-| `decoder.per_scale.boxes`           | `dist2bbox(dfl(x[:4*reg_max]))` or `ltrb2bbox`          | Box decode; DFL is the per-anchor bottleneck on Cortex-A53. |
-| `decoder.per_scale.scores`          | `sigmoid(class_logits)` per anchor                      | ~32% of decode time on imx95-evk per the per-stage estimate. The `activation` field distinguishes `sigmoid` from `none`. |
-| `decoder.per_scale.mask_coefs`      | Mask-coefficient dequant (no sigmoid)                   | 32-D coefficient stream per anchor. |
-| `decoder.per_scale.protos`          | `protos` head dequant (NHWC or NCHW → NHWC)             | One-time per-frame protein-mask dequant; the GPU shader consumes the resulting f32/f16 array as a texture. |
-| `decoder.per_scale.widen_f32`       | n/a (HAL-specific)                                      | If the per-scale path produced f16 buffers, widen to f32 for the legacy NMS kernels. `kind = "f32_borrow"` means zero allocation. |
-| `decoder.per_scale.to_*`            | n/a (HAL-specific bridge)                               | Plumbing between the per-scale outputs and the legacy `impl_yolo_segdet_*` kernels. The `bridge_*` inner spans wrap the corresponding shared kernel spans. |
-| `decoder.nms.get_boxes`             | `non_max_suppression`                                   | Composite span over score_filter + top_k + suppress + dequant_boxes. The `n_candidates → n_after_topk → n_after_nms → n_detections` fields tell you where candidates were dropped. |
-| `decoder.nms.score_filter`          | `xc = candidates.amax(1) > conf`                        | Per-row max-class score threshold filter. |
-| `decoder.nms.top_k`                 | `x[x[:, 4].argsort(descending=True)[:max_nms]]`         | Partial sort to `pre_nms_top_k` candidates (default 300; raise to anchor count for COCO mAP at `conf=0.001`). |
-| `decoder.nms.suppress`              | `torchvision.ops.nms` or `batched_nms`                  | IoU-based suppression. Class-agnostic or class-aware per the decoder's `Nms` setting. |
-| `decoder.nms.dequant_boxes`         | (quant path only)                                       | Int8 → f32 dequant applied only to survivors of NMS — avoids dequantising filtered candidates. |
-| `decoder.process_masks`             | `process_mask` / `process_mask_native`                  | `sigmoid(coefficients @ protos)` + crop to detection bbox. The `mode` field is the input dtype (float kernel vs. fused i8/i16 path). |
-| `decoder.extract_proto_data`        | n/a (HAL-specific)                                      | Pack per-detection coefficient rows + protos into a `ProtoData` for the GPU fused shader. The `n == 0` early-exit avoids a ~819 KB proto copy. |
+| Span                                            | Reference equivalent (Ultralytics)                      | What it does |
+|-------------------------------------------------|---------------------------------------------------------|--------------|
+| `decoder.decode`                                | `non_max_suppression(...)` + segmentation `process_mask`| Top-level decode entry. The `path` field tells you which model topology was selected at builder time. |
+| `decoder.decode_proto`                          | `decode` + skip `process_mask` (returns coeffs/protos)  | Returns proto data instead of materialised masks; pair with `image.materialize_masks` or the fused GPU shader. |
+| `decoder.decode.yolo_{quant,float}_{flat,split}`| `preds.transpose(-1, -2)` + `xywh2xyxy` + per-row filter| Flat-tensor and legacy split-tensor YOLO post-processing (pre-per-scale). Each kernel walks `(4 + nc, anchors)` once. |
+| `decoder.decode.process_masks`                  | `process_mask` / `process_mask_native`                  | `sigmoid(coefficients @ protos)` + crop to detection bbox. The `mode` field is the input dtype (float kernel vs. fused i8/i16 path). |
+| `decoder.decode_proto.extract_proto_data`       | n/a (HAL-specific)                                      | Pack per-detection coefficient rows + protos into a `ProtoData` for the GPU fused shader. The `n == 0` early-exit avoids a ~819 KB proto copy. |
+| `decoder.decode.per_scale_to_masks`             | n/a (HAL-specific bridge)                               | Plumbing between the per-scale outputs and the materialised-mask post-processing. |
+| `decoder.decode_proto.per_scale_to_proto_data`  | n/a (HAL-specific bridge)                               | Same bridge into the proto-extraction post-processing. |
+| `decoder.per_scale_run`                         | Anchor-free `dist2bbox` over multi-scale FPN heads      | The NEON-vectorised hot path for Ara-2 DVM and certain TFLite exports where the head is pre-split per FPN scale. Shared across `decode` and `decode_proto`. |
+| `decoder.per_scale_run.resolve_bindings`        | Plan-time tensor → role mapping                         | Walks the schema-derived `Plan` once to match input tensors to box / score / mc / protos roles. |
+| `decoder.per_scale_run.level`                   | One FPN scale (e.g. 80×80, 40×40, 20×20)                | All per-anchor work for one scale. Use the `li` and `anchors` fields to attribute cost to the dominant scale (level 0 has ~16× more anchors than level 2). |
+| `decoder.per_scale_run.level.boxes`             | `dist2bbox(dfl(x[:4*reg_max]))` or `ltrb2bbox`          | Box decode; DFL is the per-anchor bottleneck on Cortex-A53. |
+| `decoder.per_scale_run.level.scores`            | `sigmoid(class_logits)` per anchor                      | ~32% of decode time on imx95-evk per the per-stage estimate. The `activation` field distinguishes `sigmoid` from `none`. |
+| `decoder.per_scale_run.level.mask_coefs`        | Mask-coefficient dequant (no sigmoid)                   | 32-D coefficient stream per anchor. |
+| `decoder.per_scale_run.protos`                  | `protos` head dequant (NHWC or NCHW → NHWC)             | One-time per-frame proto-mask dequant; the GPU shader consumes the resulting f32/f16 array as a texture. |
+| `decoder.per_scale_run.widen_f32`               | n/a (HAL-specific)                                      | If the per-scale path produced f16 buffers, widen to f32 for the legacy NMS kernels. `kind = "f32_borrow"` means zero allocation. |
+| `decoder.nms_get_boxes`                         | `non_max_suppression`                                   | Composite span over score_filter + top_k + suppress + dequant_boxes. The `n_candidates → n_after_topk → n_after_nms → n_detections` fields tell you where candidates were dropped. Shared across detection paths. |
+| `decoder.nms_get_boxes.score_filter`            | `xc = candidates.amax(1) > conf`                        | Per-row max-class score threshold filter. |
+| `decoder.nms_get_boxes.top_k`                   | `x[x[:, 4].argsort(descending=True)[:max_nms]]`         | Partial sort to `pre_nms_top_k` candidates (default 300; raise to anchor count for COCO mAP at `conf=0.001`). |
+| `decoder.nms_get_boxes.suppress`                | `torchvision.ops.nms` or `batched_nms`                  | IoU-based suppression. Class-agnostic or class-aware per the decoder's `Nms` setting. |
+| `decoder.nms_get_boxes.dequant_boxes`           | (quant path only)                                       | Int8 → f32 dequant applied only to survivors of NMS — avoids dequantising filtered candidates. |
 
 [`tracing::trace_span!`]: https://docs.rs/tracing/latest/tracing/macro.trace_span.html
 

--- a/crates/decoder/ARCHITECTURE.md
+++ b/crates/decoder/ARCHITECTURE.md
@@ -276,6 +276,98 @@ upsampled_protos)` per output pixel using a fragment shader. See
 [`../image/ARCHITECTURE.md`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/ARCHITECTURE.md)
 for the GPU-side fused algorithm.
 
+## Tracing Spans
+
+Every public decode entry point emits a [`tracing::trace_span!`] tree. The
+spans are recorded as Chrome JSON when [`edgefirst_hal::trace::start_tracing`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs)
+is active and have near-zero overhead otherwise (a single relaxed atomic
+load per call site).
+
+Span names follow the convention `<crate>.<subsystem>.<operation>`. Inner
+spans keep the full prefix so a Perfetto cell makes sense in isolation and
+queries can filter by subsystem (e.g. all `decoder.nms.*`).
+
+### Span tree
+
+```text
+decoder.decode  (or decoder.decode_proto)               [entry point]
+│ fields: path = "yolo_seg_det" | "yolo_split_seg_det" | "modelpack" | …
+│         n_outputs
+│
+├── decoder.per_scale.run                                [per-scale fast path]
+│   │ fields: n_levels, encoding, nc, nm
+│   ├── decoder.per_scale.resolve_bindings
+│   ├── decoder.per_scale.level                          ← per FPN scale (80×80, 40×40, 20×20)
+│   │   │ fields: li, stride, h, w, anchors, layout
+│   │   ├── decoder.per_scale.boxes                      ← DFL or LTRB box decode
+│   │   │   fields: encoding
+│   │   ├── decoder.per_scale.scores                     ← class-score dequant + sigmoid
+│   │   │   fields: activation
+│   │   └── decoder.per_scale.mask_coefs                 ← mask coefficient dequant (32-D)
+│   └── decoder.per_scale.protos                         ← proto-mask dequant (160×160×32)
+│
+├── decoder.per_scale.widen_f32                          [f16 → f32 widen or zero-copy borrow]
+│   field: kind = "f32_borrow" | "f16_widen"
+│
+├── decoder.per_scale.to_proto_data                      [bridge → ProtoData]
+│   ├── decoder.per_scale.bridge_get_boxes               ← wraps decoder.nms.get_boxes
+│   │   └── decoder.nms.get_boxes
+│   └── decoder.per_scale.bridge_extract_proto
+│       └── decoder.extract_proto_data (mode = "float")
+│
+├── decoder.per_scale.to_masks                           [bridge → materialised masks]
+│   ├── decoder.per_scale.bridge_get_boxes
+│   │   └── decoder.nms.get_boxes
+│   └── decoder.per_scale.bridge_process_masks
+│       └── decoder.process_masks (mode = "float")
+│
+├── decoder.yolo.decode_quant_flat                       [flat/legacy quant detection]
+├── decoder.yolo.decode_float_flat                       [flat/legacy float detection]
+├── decoder.yolo.decode_quant_split                      [split-tensor quant detection]
+├── decoder.yolo.decode_float_split                      [split-tensor float detection]
+│
+├── decoder.nms.get_boxes                                [post-NMS candidate selection]
+│   │ fields: n_candidates, n_after_topk, n_after_nms, n_detections
+│   ├── decoder.nms.score_filter                         ← max-class score threshold filter
+│   ├── decoder.nms.top_k                                ← partial sort, retain pre_nms_top_k
+│   │   field: k
+│   ├── decoder.nms.suppress                             ← class-agnostic / class-aware IoU NMS
+│   └── decoder.nms.dequant_boxes                        ← int8 → f32 on survivors only (quant path)
+│       field: n
+│
+├── decoder.process_masks                                [coefficient @ protos → per-detect mask]
+│   fields: n, mode = "float" | "quant"
+│
+└── decoder.extract_proto_data                           [build ProtoData for GPU fused render]
+    fields: n, num_protos, layout = "nhwc" | "nchw", mode = "float" | "quant"
+```
+
+### What each span measures (mapped to reference YOLO post-processing)
+
+| Span                                | Reference equivalent (Ultralytics)                      | What it does |
+|-------------------------------------|---------------------------------------------------------|--------------|
+| `decoder.decode`                    | `non_max_suppression(...)` + segmentation `process_mask`| Top-level decode entry. The `path` field tells you which model topology was selected at builder time. |
+| `decoder.decode_proto`              | `decode` + skip `process_mask` (returns coeffs/protos)  | Returns proto data instead of materialised masks; pair with `image.materialize_masks` or the fused GPU shader. |
+| `decoder.yolo.decode_*_{flat,split}`| `preds.transpose(-1, -2)` + `xywh2xyxy` + per-row filter| Flat-tensor and legacy split-tensor YOLO post-processing (pre-per-scale). Each kernel walks `(4 + nc, anchors)` once. |
+| `decoder.per_scale.run`             | Anchor-free `dist2bbox` over multi-scale FPN heads      | The NEON-vectorised hot path for Ara-2 DVM and certain TFLite exports where the head is pre-split per FPN scale. |
+| `decoder.per_scale.resolve_bindings`| Plan-time tensor → role mapping                         | Walks the schema-derived `Plan` once to match input tensors to box / score / mc / protos roles. |
+| `decoder.per_scale.level`           | One FPN scale (e.g. 80×80, 40×40, 20×20)                | All per-anchor work for one scale. Use the `li` and `anchors` fields to attribute cost to the dominant scale (level 0 has ~16× more anchors than level 2). |
+| `decoder.per_scale.boxes`           | `dist2bbox(dfl(x[:4*reg_max]))` or `ltrb2bbox`          | Box decode; DFL is the per-anchor bottleneck on Cortex-A53. |
+| `decoder.per_scale.scores`          | `sigmoid(class_logits)` per anchor                      | ~32% of decode time on imx95-evk per the per-stage estimate. The `activation` field distinguishes `sigmoid` from `none`. |
+| `decoder.per_scale.mask_coefs`      | Mask-coefficient dequant (no sigmoid)                   | 32-D coefficient stream per anchor. |
+| `decoder.per_scale.protos`          | `protos` head dequant (NHWC or NCHW → NHWC)             | One-time per-frame protein-mask dequant; the GPU shader consumes the resulting f32/f16 array as a texture. |
+| `decoder.per_scale.widen_f32`       | n/a (HAL-specific)                                      | If the per-scale path produced f16 buffers, widen to f32 for the legacy NMS kernels. `kind = "f32_borrow"` means zero allocation. |
+| `decoder.per_scale.to_*`            | n/a (HAL-specific bridge)                               | Plumbing between the per-scale outputs and the legacy `impl_yolo_segdet_*` kernels. The `bridge_*` inner spans wrap the corresponding shared kernel spans. |
+| `decoder.nms.get_boxes`             | `non_max_suppression`                                   | Composite span over score_filter + top_k + suppress + dequant_boxes. The `n_candidates → n_after_topk → n_after_nms → n_detections` fields tell you where candidates were dropped. |
+| `decoder.nms.score_filter`          | `xc = candidates.amax(1) > conf`                        | Per-row max-class score threshold filter. |
+| `decoder.nms.top_k`                 | `x[x[:, 4].argsort(descending=True)[:max_nms]]`         | Partial sort to `pre_nms_top_k` candidates (default 300; raise to anchor count for COCO mAP at `conf=0.001`). |
+| `decoder.nms.suppress`              | `torchvision.ops.nms` or `batched_nms`                  | IoU-based suppression. Class-agnostic or class-aware per the decoder's `Nms` setting. |
+| `decoder.nms.dequant_boxes`         | (quant path only)                                       | Int8 → f32 dequant applied only to survivors of NMS — avoids dequantising filtered candidates. |
+| `decoder.process_masks`             | `process_mask` / `process_mask_native`                  | `sigmoid(coefficients @ protos)` + crop to detection bbox. The `mode` field is the input dtype (float kernel vs. fused i8/i16 path). |
+| `decoder.extract_proto_data`        | n/a (HAL-specific)                                      | Pack per-detection coefficient rows + protos into a `ProtoData` for the GPU fused shader. The `n == 0` early-exit avoids a ~819 KB proto copy. |
+
+[`tracing::trace_span!`]: https://docs.rs/tracing/latest/tracing/macro.trace_span.html
+
 ## Performance Considerations
 
 - **Quantized integer math** — `decode_quantized` and `decode_quantized_proto` operate directly on int8/uint8 buffers, avoiding the cost of producing an intermediate dequantized `f32` tensor.

--- a/crates/decoder/src/decoder/mod.rs
+++ b/crates/decoder/src/decoder/mod.rs
@@ -906,7 +906,7 @@ impl Decoder {
         output_masks: &mut Vec<Segmentation>,
     ) -> Result<(), DecoderError> {
         let path = self.decode_path_label();
-        let _span = tracing::trace_span!("Decoder::decode", path = path, n_outputs = outputs.len())
+        let _span = tracing::trace_span!("decoder.decode", path = path, n_outputs = outputs.len())
             .entered();
         // Per-scale fast path — selected at builder time when the schema
         // declares per-scale children with DFL or LTRB encoding.
@@ -990,7 +990,7 @@ impl Decoder {
     ) -> Result<Option<ProtoData>, DecoderError> {
         let path = self.decode_path_label();
         let _span = tracing::trace_span!(
-            "Decoder::decode_proto",
+            "decoder.decode_proto",
             path = path,
             n_outputs = outputs.len()
         )

--- a/crates/decoder/src/decoder/per_scale_bridge.rs
+++ b/crates/decoder/src/decoder/per_scale_bridge.rs
@@ -68,7 +68,7 @@ fn widen_to_f32<'a>(decoded: &'a DecodedOutputsRef<'a>) -> WidenedF32<'a> {
         BufferRef::F32(_) => "f32_borrow",
         BufferRef::F16(_) => "f16_widen",
     };
-    let _span = trace_span!("decoder.per_scale.widen_f32", kind = kind).entered();
+    let _span = trace_span!("decoder.per_scale_run.widen_f32", kind = kind).entered();
 
     let n = decoded.total_anchors;
     let nc = decoded.num_classes;
@@ -119,7 +119,7 @@ pub(super) fn per_scale_to_proto_data<'a>(
     normalized: Option<bool>,
     input_dims: Option<(usize, usize)>,
 ) -> Result<Option<ProtoData>, DecoderError> {
-    let _span = trace_span!("decoder.per_scale.to_proto_data").entered();
+    let _span = trace_span!("decoder.decode_proto.per_scale_to_proto_data").entered();
     let widened = widen_to_f32(decoded);
     let n = widened.n;
     let nc = widened.nc;
@@ -133,7 +133,7 @@ pub(super) fn per_scale_to_proto_data<'a>(
     output_boxes.clear();
 
     let mut det_indices = {
-        let _s = trace_span!("decoder.per_scale.bridge_get_boxes").entered();
+        let _s = trace_span!("decoder.decode_proto.per_scale_to_proto_data.get_boxes").entered();
         impl_yolo_segdet_get_boxes::<XYWH, _, _>(
             boxes_view,
             scores_view,
@@ -151,7 +151,7 @@ pub(super) fn per_scale_to_proto_data<'a>(
 
     match (widened.mask_coefs.as_ref(), widened.protos.as_ref()) {
         (Some(mc), Some(pr)) => {
-            let _s = trace_span!("decoder.per_scale.bridge_extract_proto").entered();
+            let _s = trace_span!("decoder.decode_proto.per_scale_to_proto_data.extract").entered();
             let mc_view = ArrayView2::<f32>::from_shape((n, nm), mc.as_ref())
                 .map_err(|e| DecoderError::Internal(format!("per_scale mc view: {e}")))?;
             let pr_view = pr.view();
@@ -184,7 +184,7 @@ pub(super) fn per_scale_to_masks<'a>(
     normalized: Option<bool>,
     input_dims: Option<(usize, usize)>,
 ) -> Result<(), DecoderError> {
-    let _span = trace_span!("decoder.per_scale.to_masks").entered();
+    let _span = trace_span!("decoder.decode.per_scale_to_masks").entered();
     let widened = widen_to_f32(decoded);
     let n = widened.n;
     let nc = widened.nc;
@@ -199,7 +199,7 @@ pub(super) fn per_scale_to_masks<'a>(
     output_masks.clear();
 
     let mut det_indices = {
-        let _s = trace_span!("decoder.per_scale.bridge_get_boxes").entered();
+        let _s = trace_span!("decoder.decode.per_scale_to_masks.get_boxes").entered();
         impl_yolo_segdet_get_boxes::<XYWH, _, _>(
             boxes_view,
             scores_view,
@@ -218,7 +218,7 @@ pub(super) fn per_scale_to_masks<'a>(
 
     match (widened.mask_coefs.as_ref(), widened.protos.as_ref()) {
         (Some(mc), Some(pr)) => {
-            let _s = trace_span!("decoder.per_scale.bridge_process_masks").entered();
+            let _s = trace_span!("decoder.decode.per_scale_to_masks.process_masks").entered();
             let mc_view = ArrayView2::<f32>::from_shape((n, nm), mc.as_ref())
                 .map_err(|e| DecoderError::Internal(format!("per_scale mc view: {e}")))?;
             let pr_view = pr.view();

--- a/crates/decoder/src/decoder/per_scale_bridge.rs
+++ b/crates/decoder/src/decoder/per_scale_bridge.rs
@@ -68,7 +68,7 @@ fn widen_to_f32<'a>(decoded: &'a DecodedOutputsRef<'a>) -> WidenedF32<'a> {
         BufferRef::F32(_) => "f32_borrow",
         BufferRef::F16(_) => "f16_widen",
     };
-    let _span = trace_span!("per_scale_bridge::widen_to_f32", kind = kind).entered();
+    let _span = trace_span!("decoder.per_scale.widen_f32", kind = kind).entered();
 
     let n = decoded.total_anchors;
     let nc = decoded.num_classes;
@@ -119,7 +119,7 @@ pub(super) fn per_scale_to_proto_data<'a>(
     normalized: Option<bool>,
     input_dims: Option<(usize, usize)>,
 ) -> Result<Option<ProtoData>, DecoderError> {
-    let _span = trace_span!("per_scale_bridge::per_scale_to_proto_data").entered();
+    let _span = trace_span!("decoder.per_scale.to_proto_data").entered();
     let widened = widen_to_f32(decoded);
     let n = widened.n;
     let nc = widened.nc;
@@ -133,7 +133,7 @@ pub(super) fn per_scale_to_proto_data<'a>(
     output_boxes.clear();
 
     let mut det_indices = {
-        let _s = trace_span!("per_scale_bridge::nms_get_boxes").entered();
+        let _s = trace_span!("decoder.per_scale.bridge_get_boxes").entered();
         impl_yolo_segdet_get_boxes::<XYWH, _, _>(
             boxes_view,
             scores_view,
@@ -151,7 +151,7 @@ pub(super) fn per_scale_to_proto_data<'a>(
 
     match (widened.mask_coefs.as_ref(), widened.protos.as_ref()) {
         (Some(mc), Some(pr)) => {
-            let _s = trace_span!("per_scale_bridge::extract_proto_data").entered();
+            let _s = trace_span!("decoder.per_scale.bridge_extract_proto").entered();
             let mc_view = ArrayView2::<f32>::from_shape((n, nm), mc.as_ref())
                 .map_err(|e| DecoderError::Internal(format!("per_scale mc view: {e}")))?;
             let pr_view = pr.view();
@@ -184,7 +184,7 @@ pub(super) fn per_scale_to_masks<'a>(
     normalized: Option<bool>,
     input_dims: Option<(usize, usize)>,
 ) -> Result<(), DecoderError> {
-    let _span = trace_span!("per_scale_bridge::per_scale_to_masks").entered();
+    let _span = trace_span!("decoder.per_scale.to_masks").entered();
     let widened = widen_to_f32(decoded);
     let n = widened.n;
     let nc = widened.nc;
@@ -199,7 +199,7 @@ pub(super) fn per_scale_to_masks<'a>(
     output_masks.clear();
 
     let mut det_indices = {
-        let _s = trace_span!("per_scale_bridge::nms_get_boxes").entered();
+        let _s = trace_span!("decoder.per_scale.bridge_get_boxes").entered();
         impl_yolo_segdet_get_boxes::<XYWH, _, _>(
             boxes_view,
             scores_view,
@@ -218,7 +218,7 @@ pub(super) fn per_scale_to_masks<'a>(
 
     match (widened.mask_coefs.as_ref(), widened.protos.as_ref()) {
         (Some(mc), Some(pr)) => {
-            let _s = trace_span!("per_scale_bridge::process_masks").entered();
+            let _s = trace_span!("decoder.per_scale.bridge_process_masks").entered();
             let mc_view = ArrayView2::<f32>::from_shape((n, nm), mc.as_ref())
                 .map_err(|e| DecoderError::Internal(format!("per_scale mc view: {e}")))?;
             let pr_view = pr.view();

--- a/crates/decoder/src/per_scale/pipeline.rs
+++ b/crates/decoder/src/per_scale/pipeline.rs
@@ -165,7 +165,7 @@ pub(crate) fn run<'a>(
     // Perfetto's flame graph; per-level / per-role child spans below
     // give the per-stage decomposition we need to find hotspots.
     let _outer = tracing::trace_span!(
-        "per_scale_decode",
+        "decoder.per_scale.run",
         n_levels = plan.levels.len(),
         encoding = ?plan.box_encoding,
         nc = plan.num_classes,
@@ -173,7 +173,7 @@ pub(crate) fn run<'a>(
     )
     .entered();
     let bind = {
-        let _s = tracing::trace_span!("resolve_bindings").entered();
+        let _s = tracing::trace_span!("decoder.per_scale.resolve_bindings").entered();
         resolve_bindings(plan, inputs)?
     };
 
@@ -194,7 +194,7 @@ pub(crate) fn run<'a>(
     // When the schema declares NCHW protos, we transpose into the NHWC
     // scratch before dequant, matching the per-level NCHW strategy.
     if let (Some(proto_input), Some(proto_dispatch)) = (bind.protos, plan.proto_dispatch) {
-        let _s = tracing::trace_span!("protos").entered();
+        let _s = tracing::trace_span!("decoder.per_scale.protos").entered();
         let q = quant_from_tensor(proto_input, "protos", 0)?;
         let proto_layout = plan.proto_layout.unwrap_or(Layout::Nhwc);
         // Destructure to get disjoint borrows on `protos` and
@@ -261,7 +261,7 @@ fn run_levels_sequential(
         // Per-level span groups all role work (box / score / mc) for one
         // FPN scale. `h*w` is the dominant cost factor.
         let _level_span = tracing::trace_span!(
-            "level",
+            "decoder.per_scale.level",
             li = li,
             stride = lvl.stride,
             h = lvl.h,
@@ -283,7 +283,8 @@ fn run_levels_sequential(
         // bottleneck on Cortex-A53; this span isolates the cost from
         // score / mc.
         {
-            let _s = tracing::trace_span!("box", encoding = ?plan.box_encoding).entered();
+            let _s = tracing::trace_span!("decoder.per_scale.boxes", encoding = ?plan.box_encoding)
+                .entered();
             let q = quant_from_tensor(lvl_bind.boxes, "boxes", li)?;
             let dst = boxes_level_slice_of(boxes, lvl.anchor_offset, lvl.h * lvl.w);
             let box_channels = box_channel_count_for_level(lvl);
@@ -304,7 +305,7 @@ fn run_levels_sequential(
         // the per-stage estimate; isolating it lets us see whether the
         // dequant or sigmoid dominates after NEON wiring.
         {
-            let _s = tracing::trace_span!("score", activation = ?plan.score_activation).entered();
+            let _s = tracing::trace_span!("decoder.per_scale.scores", activation = ?plan.score_activation).entered();
             let q = quant_from_tensor(lvl_bind.scores, "scores", li)?;
             let dst =
                 scores_level_slice_of(scores, lvl.anchor_offset, lvl.h * lvl.w, plan.num_classes);
@@ -337,7 +338,7 @@ fn run_levels_sequential(
             plan.mc_dispatch,
             Some(plan.num_mask_coefs).filter(|&n| n > 0),
         ) {
-            let _s = tracing::trace_span!("mc").entered();
+            let _s = tracing::trace_span!("decoder.per_scale.mask_coefs").entered();
             let q = quant_from_tensor(mc_input, "mask_coefs", li)?;
             let mc_buf = mask_coefs.as_mut().ok_or_else(|| {
                 DecoderError::Internal(
@@ -502,7 +503,7 @@ fn process_one_level_nhwc(
     mc_dst: Option<crate::per_scale::kernels::dispatch::DstSliceMut<'_>>,
 ) -> DecoderResult<()> {
     let _level_span = tracing::trace_span!(
-        "level",
+        "decoder.per_scale.level",
         li = li,
         stride = lvl.stride,
         h = lvl.h,
@@ -513,7 +514,8 @@ fn process_one_level_nhwc(
     .entered();
 
     {
-        let _s = tracing::trace_span!("box", encoding = ?plan.box_encoding).entered();
+        let _s = tracing::trace_span!("decoder.per_scale.boxes", encoding = ?plan.box_encoding)
+            .entered();
         let q = quant_from_tensor(lvl_bind.boxes, "boxes", li)?;
         with_mapped_input(lvl_bind.boxes, "boxes", li, |input| {
             plan.box_dispatch.run(input, q, lvl, box_dst)
@@ -521,7 +523,9 @@ fn process_one_level_nhwc(
     }
 
     {
-        let _s = tracing::trace_span!("score", activation = ?plan.score_activation).entered();
+        let _s =
+            tracing::trace_span!("decoder.per_scale.scores", activation = ?plan.score_activation)
+                .entered();
         let q = quant_from_tensor(lvl_bind.scores, "scores", li)?;
         with_mapped_input(lvl_bind.scores, "scores", li, |input| {
             plan.score_dispatch.run(
@@ -541,7 +545,7 @@ fn process_one_level_nhwc(
         Some(plan.num_mask_coefs).filter(|&n| n > 0),
         mc_dst,
     ) {
-        let _s = tracing::trace_span!("mc").entered();
+        let _s = tracing::trace_span!("decoder.per_scale.mask_coefs").entered();
         let q = quant_from_tensor(mc_input, "mask_coefs", li)?;
         with_mapped_input(mc_input, "mask_coefs", li, |input| {
             mc_dispatch.run(input, q, num_mc_gt0, lvl, mc_dst)

--- a/crates/decoder/src/per_scale/pipeline.rs
+++ b/crates/decoder/src/per_scale/pipeline.rs
@@ -165,7 +165,7 @@ pub(crate) fn run<'a>(
     // Perfetto's flame graph; per-level / per-role child spans below
     // give the per-stage decomposition we need to find hotspots.
     let _outer = tracing::trace_span!(
-        "decoder.per_scale.run",
+        "decoder.per_scale_run",
         n_levels = plan.levels.len(),
         encoding = ?plan.box_encoding,
         nc = plan.num_classes,
@@ -173,7 +173,7 @@ pub(crate) fn run<'a>(
     )
     .entered();
     let bind = {
-        let _s = tracing::trace_span!("decoder.per_scale.resolve_bindings").entered();
+        let _s = tracing::trace_span!("decoder.per_scale_run.resolve_bindings").entered();
         resolve_bindings(plan, inputs)?
     };
 
@@ -194,7 +194,7 @@ pub(crate) fn run<'a>(
     // When the schema declares NCHW protos, we transpose into the NHWC
     // scratch before dequant, matching the per-level NCHW strategy.
     if let (Some(proto_input), Some(proto_dispatch)) = (bind.protos, plan.proto_dispatch) {
-        let _s = tracing::trace_span!("decoder.per_scale.protos").entered();
+        let _s = tracing::trace_span!("decoder.per_scale_run.protos").entered();
         let q = quant_from_tensor(proto_input, "protos", 0)?;
         let proto_layout = plan.proto_layout.unwrap_or(Layout::Nhwc);
         // Destructure to get disjoint borrows on `protos` and
@@ -261,7 +261,7 @@ fn run_levels_sequential(
         // Per-level span groups all role work (box / score / mc) for one
         // FPN scale. `h*w` is the dominant cost factor.
         let _level_span = tracing::trace_span!(
-            "decoder.per_scale.level",
+            "decoder.per_scale_run.level",
             li = li,
             stride = lvl.stride,
             h = lvl.h,
@@ -283,7 +283,7 @@ fn run_levels_sequential(
         // bottleneck on Cortex-A53; this span isolates the cost from
         // score / mc.
         {
-            let _s = tracing::trace_span!("decoder.per_scale.boxes", encoding = ?plan.box_encoding)
+            let _s = tracing::trace_span!("decoder.per_scale_run.level.boxes", encoding = ?plan.box_encoding)
                 .entered();
             let q = quant_from_tensor(lvl_bind.boxes, "boxes", li)?;
             let dst = boxes_level_slice_of(boxes, lvl.anchor_offset, lvl.h * lvl.w);
@@ -305,7 +305,7 @@ fn run_levels_sequential(
         // the per-stage estimate; isolating it lets us see whether the
         // dequant or sigmoid dominates after NEON wiring.
         {
-            let _s = tracing::trace_span!("decoder.per_scale.scores", activation = ?plan.score_activation).entered();
+            let _s = tracing::trace_span!("decoder.per_scale_run.level.scores", activation = ?plan.score_activation).entered();
             let q = quant_from_tensor(lvl_bind.scores, "scores", li)?;
             let dst =
                 scores_level_slice_of(scores, lvl.anchor_offset, lvl.h * lvl.w, plan.num_classes);
@@ -338,7 +338,7 @@ fn run_levels_sequential(
             plan.mc_dispatch,
             Some(plan.num_mask_coefs).filter(|&n| n > 0),
         ) {
-            let _s = tracing::trace_span!("decoder.per_scale.mask_coefs").entered();
+            let _s = tracing::trace_span!("decoder.per_scale_run.level.mask_coefs").entered();
             let q = quant_from_tensor(mc_input, "mask_coefs", li)?;
             let mc_buf = mask_coefs.as_mut().ok_or_else(|| {
                 DecoderError::Internal(
@@ -503,7 +503,7 @@ fn process_one_level_nhwc(
     mc_dst: Option<crate::per_scale::kernels::dispatch::DstSliceMut<'_>>,
 ) -> DecoderResult<()> {
     let _level_span = tracing::trace_span!(
-        "decoder.per_scale.level",
+        "decoder.per_scale_run.level",
         li = li,
         stride = lvl.stride,
         h = lvl.h,
@@ -514,7 +514,7 @@ fn process_one_level_nhwc(
     .entered();
 
     {
-        let _s = tracing::trace_span!("decoder.per_scale.boxes", encoding = ?plan.box_encoding)
+        let _s = tracing::trace_span!("decoder.per_scale_run.level.boxes", encoding = ?plan.box_encoding)
             .entered();
         let q = quant_from_tensor(lvl_bind.boxes, "boxes", li)?;
         with_mapped_input(lvl_bind.boxes, "boxes", li, |input| {
@@ -524,7 +524,7 @@ fn process_one_level_nhwc(
 
     {
         let _s =
-            tracing::trace_span!("decoder.per_scale.scores", activation = ?plan.score_activation)
+            tracing::trace_span!("decoder.per_scale_run.level.scores", activation = ?plan.score_activation)
                 .entered();
         let q = quant_from_tensor(lvl_bind.scores, "scores", li)?;
         with_mapped_input(lvl_bind.scores, "scores", li, |input| {
@@ -545,7 +545,7 @@ fn process_one_level_nhwc(
         Some(plan.num_mask_coefs).filter(|&n| n > 0),
         mc_dst,
     ) {
-        let _s = tracing::trace_span!("decoder.per_scale.mask_coefs").entered();
+        let _s = tracing::trace_span!("decoder.per_scale_run.level.mask_coefs").entered();
         let q = quant_from_tensor(mc_input, "mask_coefs", li)?;
         with_mapped_input(mc_input, "mask_coefs", li, |input| {
             mc_dispatch.run(input, q, num_mc_gt0, lvl, mc_dst)

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -739,7 +739,7 @@ pub(crate) fn impl_yolo_quant<B: BBoxTypeTrait, T: PrimInt + AsPrimitive<f32> + 
 ) where
     f32: AsPrimitive<T>,
 {
-    let _span = tracing::trace_span!("decoder.yolo.decode_quant_flat").entered();
+    let _span = tracing::trace_span!("decoder.decode.yolo_quant_flat").entered();
     let (boxes, quant_boxes) = output;
     let (boxes_tensor, scores_tensor) = postprocess_yolo(&boxes);
 
@@ -777,7 +777,7 @@ pub(crate) fn impl_yolo_float<B: BBoxTypeTrait, T: Float + AsPrimitive<f32> + Se
 ) where
     f32: AsPrimitive<T>,
 {
-    let _span = tracing::trace_span!("decoder.yolo.decode_float_flat").entered();
+    let _span = tracing::trace_span!("decoder.decode.yolo_float_flat").entered();
     let (boxes_tensor, scores_tensor) = postprocess_yolo(&output);
     let boxes =
         postprocess_boxes_float::<B, _, _>(score_threshold.as_(), boxes_tensor, scores_tensor);
@@ -815,7 +815,7 @@ pub(crate) fn impl_yolo_split_quant<
 ) where
     f32: AsPrimitive<SCORE>,
 {
-    let _span = tracing::trace_span!("decoder.yolo.decode_quant_split").entered();
+    let _span = tracing::trace_span!("decoder.decode.yolo_quant_split").entered();
     let (boxes_tensor, quant_boxes) = boxes;
     let (scores_tensor, quant_scores) = scores;
 
@@ -865,7 +865,7 @@ pub(crate) fn impl_yolo_split_float<
 ) where
     f32: AsPrimitive<SCORE>,
 {
-    let _span = tracing::trace_span!("decoder.yolo.decode_float_split").entered();
+    let _span = tracing::trace_span!("decoder.decode.yolo_float_split").entered();
     let boxes_tensor = boxes_tensor.reversed_axes();
     let scores_tensor = scores_tensor.reversed_axes();
     let boxes =
@@ -1029,7 +1029,7 @@ where
     f32: AsPrimitive<SCORE>,
 {
     let span = tracing::trace_span!(
-        "decoder.nms.get_boxes",
+        "decoder.nms_get_boxes",
         n_candidates = tracing::field::Empty,
         n_after_topk = tracing::field::Empty,
         n_after_nms = tracing::field::Empty,
@@ -1038,19 +1038,19 @@ where
     let _guard = span.enter();
 
     let mut boxes = {
-        let _s = tracing::trace_span!("decoder.nms.score_filter").entered();
+        let _s = tracing::trace_span!("decoder.nms_get_boxes.score_filter").entered();
         postprocess_boxes_index_float::<B, _, _>(score_threshold.as_(), boxes_tensor, scores_tensor)
     };
     span.record("n_candidates", boxes.len());
 
     if nms.is_some() {
-        let _s = tracing::trace_span!("decoder.nms.top_k", k = pre_nms_top_k).entered();
+        let _s = tracing::trace_span!("decoder.nms_get_boxes.top_k", k = pre_nms_top_k).entered();
         truncate_to_top_k_by_score(&mut boxes, pre_nms_top_k);
     }
     span.record("n_after_topk", boxes.len());
 
     let mut boxes = {
-        let _s = tracing::trace_span!("decoder.nms.suppress").entered();
+        let _s = tracing::trace_span!("decoder.nms_get_boxes.suppress").entered();
         dispatch_nms_extra_float(nms, iou_threshold, Some(max_det), boxes)
     };
     span.record("n_after_nms", boxes.len());
@@ -1097,8 +1097,12 @@ pub(crate) fn impl_yolo_split_segdet_process_masks<
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError> {
-    let _span =
-        tracing::trace_span!("decoder.process_masks", n = boxes.len(), mode = "float").entered();
+    let _span = tracing::trace_span!(
+        "decoder.decode.process_masks",
+        n = boxes.len(),
+        mode = "float"
+    )
+    .entered();
     // Boxes are already bounded by the upstream `max_det` cap from
     // `_get_boxes`; no second cap is needed here (EDGEAI-1302).
 
@@ -1140,7 +1144,7 @@ where
     let (scores_tensor, quant_scores) = scores;
 
     let span = tracing::trace_span!(
-        "decoder.nms.get_boxes",
+        "decoder.nms_get_boxes",
         n_candidates = tracing::field::Empty,
         n_after_topk = tracing::field::Empty,
         n_after_nms = tracing::field::Empty,
@@ -1149,7 +1153,7 @@ where
     let _guard = span.enter();
 
     let mut boxes = {
-        let _s = tracing::trace_span!("decoder.nms.score_filter").entered();
+        let _s = tracing::trace_span!("decoder.nms_get_boxes.score_filter").entered();
         let score_threshold = quantize_score_threshold(score_threshold, quant_scores);
         postprocess_boxes_index_quant::<B, _, _>(
             score_threshold,
@@ -1161,13 +1165,13 @@ where
     span.record("n_candidates", boxes.len());
 
     if nms.is_some() {
-        let _s = tracing::trace_span!("decoder.nms.top_k", k = pre_nms_top_k).entered();
+        let _s = tracing::trace_span!("decoder.nms_get_boxes.top_k", k = pre_nms_top_k).entered();
         truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
     }
     span.record("n_after_topk", boxes.len());
 
     let mut boxes = {
-        let _s = tracing::trace_span!("decoder.nms.suppress").entered();
+        let _s = tracing::trace_span!("decoder.nms_get_boxes.suppress").entered();
         dispatch_nms_extra_int(nms, iou_threshold, Some(max_det), boxes)
     };
     span.record("n_after_nms", boxes.len());
@@ -1177,7 +1181,8 @@ where
     boxes.sort_unstable_by_key(|b| std::cmp::Reverse(b.0.score));
     boxes.truncate(max_det);
     let result: Vec<_> = {
-        let _s = tracing::trace_span!("decoder.nms.dequant_boxes", n = boxes.len()).entered();
+        let _s =
+            tracing::trace_span!("decoder.nms_get_boxes.dequant_boxes", n = boxes.len()).entered();
         boxes
             .into_iter()
             .map(|(b, i)| (dequant_detect_box(&b, quant_scores), i))
@@ -1198,8 +1203,12 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError> {
-    let _span =
-        tracing::trace_span!("decoder.process_masks", n = boxes.len(), mode = "quant").entered();
+    let _span = tracing::trace_span!(
+        "decoder.decode.process_masks",
+        n = boxes.len(),
+        mode = "quant"
+    )
+    .entered();
     let (masks, quant_masks) = mask_coeff;
     let (protos, quant_protos) = protos;
 
@@ -1497,7 +1506,7 @@ pub(super) fn extract_proto_data_float<
     output_boxes: &mut Vec<DetectBox>,
 ) -> ProtoData {
     let _span = tracing::trace_span!(
-        "decoder.extract_proto_data",
+        "decoder.decode_proto.extract_proto_data",
         mode = "float",
         n = det_indices.len(),
         num_protos = mask_tensor.ncols(),
@@ -1554,7 +1563,7 @@ pub(crate) fn extract_proto_data_quant<
     use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
 
     let span = tracing::trace_span!(
-        "decoder.extract_proto_data",
+        "decoder.decode_proto.extract_proto_data",
         mode = "quant",
         n = det_indices.len(),
         num_protos = tracing::field::Empty,

--- a/crates/decoder/src/yolo.rs
+++ b/crates/decoder/src/yolo.rs
@@ -739,7 +739,7 @@ pub(crate) fn impl_yolo_quant<B: BBoxTypeTrait, T: PrimInt + AsPrimitive<f32> + 
 ) where
     f32: AsPrimitive<T>,
 {
-    let _span = tracing::trace_span!("decode", mode = "quant_det").entered();
+    let _span = tracing::trace_span!("decoder.yolo.decode_quant_flat").entered();
     let (boxes, quant_boxes) = output;
     let (boxes_tensor, scores_tensor) = postprocess_yolo(&boxes);
 
@@ -777,7 +777,7 @@ pub(crate) fn impl_yolo_float<B: BBoxTypeTrait, T: Float + AsPrimitive<f32> + Se
 ) where
     f32: AsPrimitive<T>,
 {
-    let _span = tracing::trace_span!("decode", mode = "float_det").entered();
+    let _span = tracing::trace_span!("decoder.yolo.decode_float_flat").entered();
     let (boxes_tensor, scores_tensor) = postprocess_yolo(&output);
     let boxes =
         postprocess_boxes_float::<B, _, _>(score_threshold.as_(), boxes_tensor, scores_tensor);
@@ -815,7 +815,7 @@ pub(crate) fn impl_yolo_split_quant<
 ) where
     f32: AsPrimitive<SCORE>,
 {
-    let _span = tracing::trace_span!("decode", mode = "split_quant_det").entered();
+    let _span = tracing::trace_span!("decoder.yolo.decode_quant_split").entered();
     let (boxes_tensor, quant_boxes) = boxes;
     let (scores_tensor, quant_scores) = scores;
 
@@ -865,7 +865,7 @@ pub(crate) fn impl_yolo_split_float<
 ) where
     f32: AsPrimitive<SCORE>,
 {
-    let _span = tracing::trace_span!("decode", mode = "split_float_det").entered();
+    let _span = tracing::trace_span!("decoder.yolo.decode_float_split").entered();
     let boxes_tensor = boxes_tensor.reversed_axes();
     let scores_tensor = scores_tensor.reversed_axes();
     let boxes =
@@ -1029,7 +1029,7 @@ where
     f32: AsPrimitive<SCORE>,
 {
     let span = tracing::trace_span!(
-        "decode",
+        "decoder.nms.get_boxes",
         n_candidates = tracing::field::Empty,
         n_after_topk = tracing::field::Empty,
         n_after_nms = tracing::field::Empty,
@@ -1038,19 +1038,19 @@ where
     let _guard = span.enter();
 
     let mut boxes = {
-        let _s = tracing::trace_span!("score_filter").entered();
+        let _s = tracing::trace_span!("decoder.nms.score_filter").entered();
         postprocess_boxes_index_float::<B, _, _>(score_threshold.as_(), boxes_tensor, scores_tensor)
     };
     span.record("n_candidates", boxes.len());
 
     if nms.is_some() {
-        let _s = tracing::trace_span!("top_k", k = pre_nms_top_k).entered();
+        let _s = tracing::trace_span!("decoder.nms.top_k", k = pre_nms_top_k).entered();
         truncate_to_top_k_by_score(&mut boxes, pre_nms_top_k);
     }
     span.record("n_after_topk", boxes.len());
 
     let mut boxes = {
-        let _s = tracing::trace_span!("nms").entered();
+        let _s = tracing::trace_span!("decoder.nms.suppress").entered();
         dispatch_nms_extra_float(nms, iou_threshold, Some(max_det), boxes)
     };
     span.record("n_after_nms", boxes.len());
@@ -1097,7 +1097,8 @@ pub(crate) fn impl_yolo_split_segdet_process_masks<
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError> {
-    let _span = tracing::trace_span!("process_masks", n = boxes.len(), mode = "float").entered();
+    let _span =
+        tracing::trace_span!("decoder.process_masks", n = boxes.len(), mode = "float").entered();
     // Boxes are already bounded by the upstream `max_det` cap from
     // `_get_boxes`; no second cap is needed here (EDGEAI-1302).
 
@@ -1139,7 +1140,7 @@ where
     let (scores_tensor, quant_scores) = scores;
 
     let span = tracing::trace_span!(
-        "decode",
+        "decoder.nms.get_boxes",
         n_candidates = tracing::field::Empty,
         n_after_topk = tracing::field::Empty,
         n_after_nms = tracing::field::Empty,
@@ -1148,7 +1149,7 @@ where
     let _guard = span.enter();
 
     let mut boxes = {
-        let _s = tracing::trace_span!("score_filter").entered();
+        let _s = tracing::trace_span!("decoder.nms.score_filter").entered();
         let score_threshold = quantize_score_threshold(score_threshold, quant_scores);
         postprocess_boxes_index_quant::<B, _, _>(
             score_threshold,
@@ -1160,13 +1161,13 @@ where
     span.record("n_candidates", boxes.len());
 
     if nms.is_some() {
-        let _s = tracing::trace_span!("top_k", k = pre_nms_top_k).entered();
+        let _s = tracing::trace_span!("decoder.nms.top_k", k = pre_nms_top_k).entered();
         truncate_to_top_k_by_score_quant(&mut boxes, pre_nms_top_k);
     }
     span.record("n_after_topk", boxes.len());
 
     let mut boxes = {
-        let _s = tracing::trace_span!("nms").entered();
+        let _s = tracing::trace_span!("decoder.nms.suppress").entered();
         dispatch_nms_extra_int(nms, iou_threshold, Some(max_det), boxes)
     };
     span.record("n_after_nms", boxes.len());
@@ -1176,7 +1177,7 @@ where
     boxes.sort_unstable_by_key(|b| std::cmp::Reverse(b.0.score));
     boxes.truncate(max_det);
     let result: Vec<_> = {
-        let _s = tracing::trace_span!("box_dequant", n = boxes.len()).entered();
+        let _s = tracing::trace_span!("decoder.nms.dequant_boxes", n = boxes.len()).entered();
         boxes
             .into_iter()
             .map(|(b, i)| (dequant_detect_box(&b, quant_scores), i))
@@ -1197,7 +1198,8 @@ pub(crate) fn impl_yolo_split_segdet_quant_process_masks<
     output_boxes: &mut Vec<DetectBox>,
     output_masks: &mut Vec<Segmentation>,
 ) -> Result<(), crate::DecoderError> {
-    let _span = tracing::trace_span!("process_masks", n = boxes.len(), mode = "quant").entered();
+    let _span =
+        tracing::trace_span!("decoder.process_masks", n = boxes.len(), mode = "quant").entered();
     let (masks, quant_masks) = mask_coeff;
     let (protos, quant_protos) = protos;
 
@@ -1495,7 +1497,8 @@ pub(super) fn extract_proto_data_float<
     output_boxes: &mut Vec<DetectBox>,
 ) -> ProtoData {
     let _span = tracing::trace_span!(
-        "extract_proto",
+        "decoder.extract_proto_data",
+        mode = "float",
         n = det_indices.len(),
         num_protos = mask_tensor.ncols(),
         layout = "nhwc",
@@ -1551,7 +1554,8 @@ pub(crate) fn extract_proto_data_quant<
     use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
 
     let span = tracing::trace_span!(
-        "extract_proto",
+        "decoder.extract_proto_data",
+        mode = "quant",
         n = det_indices.len(),
         num_protos = tracing::field::Empty,
         layout = tracing::field::Empty,

--- a/crates/hal/src/trace.rs
+++ b/crates/hal/src/trace.rs
@@ -185,7 +185,7 @@ mod tests {
 
         // Emit a span to ensure the file gets content
         {
-            let _span = tracing::trace_span!("test_span", key = "value").entered();
+            let _span = tracing::trace_span!("hal.test_span", key = "value").entered();
         }
 
         // Stop should deactivate

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -570,6 +570,73 @@ Future work could relax to init/teardown-only serialization on drivers
 known to be safe for concurrent runtime ops (e.g. Mali), but the current
 approach prioritizes correctness across all targets.
 
+## Tracing Spans
+
+`ImageProcessor::convert()` and `materialize_masks()` / `draw_decoded_masks()`
+emit a [`tracing::trace_span!`] tree describing the backend-dispatch decision
+and every internal pass. Spans are captured by
+[`edgefirst_hal::trace::start_tracing`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs)
+into Chrome JSON for Perfetto and cost a single relaxed atomic load per call
+site when no subscriber is active.
+
+Span names follow `<crate>.<subsystem>.<operation>`; inner spans keep the full
+prefix so a Perfetto cell makes sense without its parent track.
+
+### Span tree
+
+```text
+image.convert                                           [orchestrator]
+│ fields: src_fmt, dst_fmt, src_memory, dst_memory, rotation, flip
+│
+├── image.gl.convert                                    [OpenGL backend, picked first]
+│   │ fields: src_fmt, dst_fmt, is_int8, src_memory, dst_memory
+│   ├── image.gl.pack_rgb.pass1_rgba                    ← NV12 → intermediate RGBA (resize + crop + flip)
+│   ├── image.gl.pack_rgb.pass2_pack                    ← intermediate RGBA → packed RGB (3:4 width ratio)
+│   ├── image.gl.nv12_to_planar.pass1_rgba              ← Vivante 2-pass: NV12 → intermediate RGBA
+│   └── image.gl.nv12_to_planar.pass2_deinterleave      ← Vivante 2-pass: RGBA → PlanarRgb planes
+│
+├── image.g2d.convert                                   [NXP i.MX G2D backend, picked second]
+│   fields: src_fmt, dst_fmt
+│
+└── image.cpu.convert                                   [universal fallback]
+    ├── image.cpu.format_convert                        ← per-pixel format conversion
+    │   fields: from, to, pass = "pre_resize" | "direct" | "post_resize"
+    └── image.cpu.resize_flip_rotate                    ← fast_image_resize + rayon
+
+image.draw_decoded_masks                                [mask overlay onto image]
+fields: n_detections, n_segmentations
+
+image.materialize_masks                                 [proto data → mask matrices]
+│ fields: n_detections, mode = "proto" | "scaled", width?, height?
+├── image.masks.kernel_i8                               ← i8 coeff × i8 proto, proto-resolution
+├── image.masks.kernel_i16xi8                           ← i16 coeff × i8 proto, proto-resolution
+├── image.masks.kernel_i8_scaled                        ← i8 coeff × i8 proto, scaled to dst W×H
+└── image.masks.kernel_i16xi8_scaled                    ← i16 coeff × i8 proto, scaled to dst W×H
+    fields: n, proto_h, proto_w, num_protos, layout, (width, height for *_scaled)
+```
+
+### What each span measures (mapped to the `convert()` inner workings)
+
+| Span                                | What is happening inside | Key observations |
+|-------------------------------------|--------------------------|------------------|
+| `image.convert`                     | Orchestration: probe backends, pick OpenGL → G2D → CPU, dispatch. | The `src_memory` and `dst_memory` fields reveal whether you're on a zero-copy DMA-buf path, the PBO path, or the heap fallback. Cache-miss EGLImage imports show up as outliers here when callers reuse fds without reusing tensors. |
+| `image.gl.convert`                  | The chosen GL backend's full shader pipeline: bind/import source, set up FBO/renderbuffer, run conversion shader, optional `glFinish`. | First call at a new (src_fmt, dst_fmt, dims) tuple includes shader compile/link cost. Steady-state cost is dominated by the GPU draw and any `glFinish` at the end. |
+| `image.gl.pack_rgb.pass1_rgba`      | NV12 → intermediate RGBA texture (full geometry: resize, crop, rotation, flip, letterbox). | Reused for the "packed RGB" output path (DMA destination with 3-byte-per-pixel width × 3 / 4 render geometry). |
+| `image.gl.pack_rgb.pass2_pack`      | Intermediate RGBA → RGB DMA destination via the packed shader. | Only the second pass touches the DMA buffer; the first pass renders into the cached intermediate texture. |
+| `image.gl.nv12_to_planar.pass1_rgba`| NV12 → intermediate RGBA (the Vivante GC7000UL workaround for the GPU hang on single-pass NV12 → PlanarRgb). | Selected automatically when `is_vivante && src == Nv12 && dst.layout == Planar`. |
+| `image.gl.nv12_to_planar.pass2_deinterleave` | RGBA → PlanarRgb / PlanarRgba via `sampler2D` deinterleave shader. | Includes the optional `XOR 0x80` int8-bias step when the destination is `DType::I8`. |
+| `image.g2d.convert`                 | NXP 2D hardware engine doing format conversion + resize + rotation + flip + letterbox in one DMA-DMA blit. | Only available on i.MX 8M Plus / 8M Mini. Synchronous on the G2D driver; the span includes the driver's blocking wait. |
+| `image.cpu.format_convert`          | Per-pixel format conversion (e.g. NV12 → RGB, RGBA → BGRA). The `pass` field tells you whether this ran before, after, or instead of resize. | `pre_resize` indicates the source needed conversion to RGB/RGBA/GREY before `fast_image_resize` could run; `direct` indicates no resize was needed; `post_resize` indicates the destination format differed from the intermediate. |
+| `image.cpu.resize_flip_rotate`      | `fast_image_resize::Resizer` + rayon parallel slice, with composed flip/rotate/letterbox geometry. | The bulk of CPU `convert()` cost. The CPU backend is selected only when neither GL nor G2D accepts the (src, dst) format pair. |
+| `image.draw_decoded_masks`          | Per-detection alpha-blend of `Segmentation` mask onto the destination image (CPU or GL depending on backend). | When backend == GL, this dispatches to the shader-based mask blit. |
+| `image.materialize_masks`           | Wrapper around the four `image.masks.kernel_*` kernels, paired with letterbox inversion and bbox-clipped row iteration. `mode = "proto"` returns proto-resolution masks; `mode = "scaled"` resamples to `(width, height)`. | Use the proto-resolution mode when you only need IoU computation against ground truth at the proto grid (the default Ultralytics evaluation mode). |
+| `image.masks.kernel_i8`             | Fused i8 dequant + i8 × i8 → i32 matmul + sigmoid at proto resolution. NEON FP16 on aarch64. | The fastest path; avoids producing an intermediate f32 protos buffer. |
+| `image.masks.kernel_i16xi8`         | i16 coeff dequant + i16 × i8 → i32 matmul. Used when mask coefficients are stored at i16. | Preserves the i16 dynamic range that an i8 coeff dequant would lose. |
+| `image.masks.kernel_i8_scaled`      | Same fused i8 path as above, but per-output-pixel bilinear sample of the proto field (no intermediate proto-resolution mask). | Algebraically equivalent to `process_mask_native` from Ultralytics (`retina_masks=True`); empirical mask IoU 0.993 vs. Ultralytics on COCO val2017. |
+| `image.masks.kernel_i16xi8_scaled`  | i16 variant of the above scaled kernel. | Same shape and algorithm; different coefficient dtype. |
+
+[`tracing::trace_span!`]: https://docs.rs/tracing/latest/tracing/macro.trace_span.html
+
 ## Performance Considerations
 
 | Optimization | Why it matters |

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -572,68 +572,87 @@ approach prioritizes correctness across all targets.
 
 ## Tracing Spans
 
-`ImageProcessor::convert()` and `materialize_masks()` / `draw_decoded_masks()`
+`ImageProcessor::convert()`, `materialize_masks()`, and `draw_decoded_masks()`
 emit a [`tracing::trace_span!`] tree describing the backend-dispatch decision
 and every internal pass. Spans are captured by
 [`edgefirst_hal::trace::start_tracing`](https://github.com/EdgeFirstAI/hal/blob/main/crates/hal/src/trace.rs)
 into Chrome JSON for Perfetto and cost a single relaxed atomic load per call
 site when no subscriber is active.
 
-Span names follow `<crate>.<subsystem>.<operation>`; inner spans keep the full
-prefix so a Perfetto cell makes sense without its parent track.
+### Naming convention
+
+Span names follow `<crate>.<function>[.<operation>[.<sub-operation>]]`:
+
+- **`<crate>.<function>`** — top-level span: the public function the user
+  invoked (`image.convert`, `image.materialize_masks`, `image.draw_decoded_masks`).
+- **`<crate>.<function>.<operation>`** — meaningful internal work; backend
+  dispatch within `convert()` lives at this level
+  (`image.convert.gl`, `image.convert.g2d`, `image.convert.cpu`).
+- **`<crate>.<function>.<operation>.<sub-operation>`** — further
+  decomposition where it aids optimisation (`image.convert.gl.pack_rgb.pass1_rgba`,
+  `image.convert.cpu.format_convert`).
+
+A span is worth adding when the work inside it is meaningful for
+optimisation and has enough complexity to justify the overhead — roughly
+500 µs on Cortex-A53 as a guideline.
 
 ### Span tree
 
 ```text
-image.convert                                           [orchestrator]
+image.convert                                           [user-facing fn, orchestrator]
 │ fields: src_fmt, dst_fmt, src_memory, dst_memory, rotation, flip
 │
-├── image.gl.convert                                    [OpenGL backend, picked first]
+├── image.convert.gl                                    [OpenGL backend, picked first]
 │   │ fields: src_fmt, dst_fmt, is_int8, src_memory, dst_memory
-│   ├── image.gl.pack_rgb.pass1_rgba                    ← NV12 → intermediate RGBA (resize + crop + flip)
-│   ├── image.gl.pack_rgb.pass2_pack                    ← intermediate RGBA → packed RGB (3:4 width ratio)
-│   ├── image.gl.nv12_to_planar.pass1_rgba              ← Vivante 2-pass: NV12 → intermediate RGBA
-│   └── image.gl.nv12_to_planar.pass2_deinterleave      ← Vivante 2-pass: RGBA → PlanarRgb planes
+│   ├── image.convert.gl.pack_rgb.pass1_rgba            ← NV12 → intermediate RGBA (resize + crop + flip)
+│   ├── image.convert.gl.pack_rgb.pass2_pack            ← intermediate RGBA → packed RGB (3:4 width ratio)
+│   ├── image.convert.gl.nv12_to_planar.pass1_rgba      ← Vivante 2-pass: NV12 → intermediate RGBA
+│   └── image.convert.gl.nv12_to_planar.pass2_deinterleave ← Vivante 2-pass: RGBA → PlanarRgb planes
 │
-├── image.g2d.convert                                   [NXP i.MX G2D backend, picked second]
+├── image.convert.g2d                                   [NXP i.MX G2D backend, picked second]
 │   fields: src_fmt, dst_fmt
 │
-└── image.cpu.convert                                   [universal fallback]
-    ├── image.cpu.format_convert                        ← per-pixel format conversion
+└── image.convert.cpu                                   [universal fallback, parent implicit]
+    ├── image.convert.cpu.format_convert                ← per-pixel format conversion
     │   fields: from, to, pass = "pre_resize" | "direct" | "post_resize"
-    └── image.cpu.resize_flip_rotate                    ← fast_image_resize + rayon
+    └── image.convert.cpu.resize_flip_rotate            ← fast_image_resize + rayon
 
-image.draw_decoded_masks                                [mask overlay onto image]
+image.draw_decoded_masks                                [user-facing fn]
 fields: n_detections, n_segmentations
 
-image.materialize_masks                                 [proto data → mask matrices]
+image.materialize_masks                                 [user-facing fn]
 │ fields: n_detections, mode = "proto" | "scaled", width?, height?
-├── image.masks.kernel_i8                               ← i8 coeff × i8 proto, proto-resolution
-├── image.masks.kernel_i16xi8                           ← i16 coeff × i8 proto, proto-resolution
-├── image.masks.kernel_i8_scaled                        ← i8 coeff × i8 proto, scaled to dst W×H
-└── image.masks.kernel_i16xi8_scaled                    ← i16 coeff × i8 proto, scaled to dst W×H
+├── image.materialize_masks.kernel_i8                   ← i8 coeff × i8 proto, proto-resolution
+├── image.materialize_masks.kernel_i16xi8               ← i16 coeff × i8 proto, proto-resolution
+├── image.materialize_masks.kernel_i8_scaled            ← i8 coeff × i8 proto, scaled to dst W×H
+└── image.materialize_masks.kernel_i16xi8_scaled        ← i16 coeff × i8 proto, scaled to dst W×H
     fields: n, proto_h, proto_w, num_protos, layout, (width, height for *_scaled)
 ```
 
+> The CPU backend has no top-level `image.convert.cpu` span of its own; the
+> CPU dispatch enters via `image.convert.cpu.format_convert` and/or
+> `image.convert.cpu.resize_flip_rotate` directly. Parent in the trace is
+> `image.convert`.
+
 ### What each span measures (mapped to the `convert()` inner workings)
 
-| Span                                | What is happening inside | Key observations |
-|-------------------------------------|--------------------------|------------------|
-| `image.convert`                     | Orchestration: probe backends, pick OpenGL → G2D → CPU, dispatch. | The `src_memory` and `dst_memory` fields reveal whether you're on a zero-copy DMA-buf path, the PBO path, or the heap fallback. Cache-miss EGLImage imports show up as outliers here when callers reuse fds without reusing tensors. |
-| `image.gl.convert`                  | The chosen GL backend's full shader pipeline: bind/import source, set up FBO/renderbuffer, run conversion shader, optional `glFinish`. | First call at a new (src_fmt, dst_fmt, dims) tuple includes shader compile/link cost. Steady-state cost is dominated by the GPU draw and any `glFinish` at the end. |
-| `image.gl.pack_rgb.pass1_rgba`      | NV12 → intermediate RGBA texture (full geometry: resize, crop, rotation, flip, letterbox). | Reused for the "packed RGB" output path (DMA destination with 3-byte-per-pixel width × 3 / 4 render geometry). |
-| `image.gl.pack_rgb.pass2_pack`      | Intermediate RGBA → RGB DMA destination via the packed shader. | Only the second pass touches the DMA buffer; the first pass renders into the cached intermediate texture. |
-| `image.gl.nv12_to_planar.pass1_rgba`| NV12 → intermediate RGBA (the Vivante GC7000UL workaround for the GPU hang on single-pass NV12 → PlanarRgb). | Selected automatically when `is_vivante && src == Nv12 && dst.layout == Planar`. |
-| `image.gl.nv12_to_planar.pass2_deinterleave` | RGBA → PlanarRgb / PlanarRgba via `sampler2D` deinterleave shader. | Includes the optional `XOR 0x80` int8-bias step when the destination is `DType::I8`. |
-| `image.g2d.convert`                 | NXP 2D hardware engine doing format conversion + resize + rotation + flip + letterbox in one DMA-DMA blit. | Only available on i.MX 8M Plus / 8M Mini. Synchronous on the G2D driver; the span includes the driver's blocking wait. |
-| `image.cpu.format_convert`          | Per-pixel format conversion (e.g. NV12 → RGB, RGBA → BGRA). The `pass` field tells you whether this ran before, after, or instead of resize. | `pre_resize` indicates the source needed conversion to RGB/RGBA/GREY before `fast_image_resize` could run; `direct` indicates no resize was needed; `post_resize` indicates the destination format differed from the intermediate. |
-| `image.cpu.resize_flip_rotate`      | `fast_image_resize::Resizer` + rayon parallel slice, with composed flip/rotate/letterbox geometry. | The bulk of CPU `convert()` cost. The CPU backend is selected only when neither GL nor G2D accepts the (src, dst) format pair. |
-| `image.draw_decoded_masks`          | Per-detection alpha-blend of `Segmentation` mask onto the destination image (CPU or GL depending on backend). | When backend == GL, this dispatches to the shader-based mask blit. |
-| `image.materialize_masks`           | Wrapper around the four `image.masks.kernel_*` kernels, paired with letterbox inversion and bbox-clipped row iteration. `mode = "proto"` returns proto-resolution masks; `mode = "scaled"` resamples to `(width, height)`. | Use the proto-resolution mode when you only need IoU computation against ground truth at the proto grid (the default Ultralytics evaluation mode). |
-| `image.masks.kernel_i8`             | Fused i8 dequant + i8 × i8 → i32 matmul + sigmoid at proto resolution. NEON FP16 on aarch64. | The fastest path; avoids producing an intermediate f32 protos buffer. |
-| `image.masks.kernel_i16xi8`         | i16 coeff dequant + i16 × i8 → i32 matmul. Used when mask coefficients are stored at i16. | Preserves the i16 dynamic range that an i8 coeff dequant would lose. |
-| `image.masks.kernel_i8_scaled`      | Same fused i8 path as above, but per-output-pixel bilinear sample of the proto field (no intermediate proto-resolution mask). | Algebraically equivalent to `process_mask_native` from Ultralytics (`retina_masks=True`); empirical mask IoU 0.993 vs. Ultralytics on COCO val2017. |
-| `image.masks.kernel_i16xi8_scaled`  | i16 variant of the above scaled kernel. | Same shape and algorithm; different coefficient dtype. |
+| Span                                                   | What is happening inside | Key observations |
+|--------------------------------------------------------|--------------------------|------------------|
+| `image.convert`                                        | Orchestration: probe backends, pick OpenGL → G2D → CPU, dispatch. | The `src_memory` and `dst_memory` fields reveal whether you're on a zero-copy DMA-buf path, the PBO path, or the heap fallback. Cache-miss EGLImage imports show up as outliers here when callers reuse fds without reusing tensors. |
+| `image.convert.gl`                                     | The chosen GL backend's full shader pipeline: bind/import source, set up FBO/renderbuffer, run conversion shader, optional `glFinish`. | First call at a new (src_fmt, dst_fmt, dims) tuple includes shader compile/link cost. Steady-state cost is dominated by the GPU draw and any `glFinish` at the end. |
+| `image.convert.gl.pack_rgb.pass1_rgba`                 | NV12 → intermediate RGBA texture (full geometry: resize, crop, rotation, flip, letterbox). | Reused for the "packed RGB" output path (DMA destination with 3-byte-per-pixel width × 3 / 4 render geometry). |
+| `image.convert.gl.pack_rgb.pass2_pack`                 | Intermediate RGBA → RGB DMA destination via the packed shader. | Only the second pass touches the DMA buffer; the first pass renders into the cached intermediate texture. |
+| `image.convert.gl.nv12_to_planar.pass1_rgba`           | NV12 → intermediate RGBA (the Vivante GC7000UL workaround for the GPU hang on single-pass NV12 → PlanarRgb). | Selected automatically when `is_vivante && src == Nv12 && dst.layout == Planar`. |
+| `image.convert.gl.nv12_to_planar.pass2_deinterleave`   | RGBA → PlanarRgb / PlanarRgba via `sampler2D` deinterleave shader. | Includes the optional `XOR 0x80` int8-bias step when the destination is `DType::I8`. |
+| `image.convert.g2d`                                    | NXP 2D hardware engine doing format conversion + resize + rotation + flip + letterbox in one DMA-DMA blit. | Only available on i.MX 8M Plus / 8M Mini. Synchronous on the G2D driver; the span includes the driver's blocking wait. |
+| `image.convert.cpu.format_convert`                     | Per-pixel format conversion (e.g. NV12 → RGB, RGBA → BGRA). The `pass` field tells you whether this ran before, after, or instead of resize. | `pre_resize` indicates the source needed conversion to RGB/RGBA/GREY before `fast_image_resize` could run; `direct` indicates no resize was needed; `post_resize` indicates the destination format differed from the intermediate. |
+| `image.convert.cpu.resize_flip_rotate`                 | `fast_image_resize::Resizer` + rayon parallel slice, with composed flip/rotate/letterbox geometry. | The bulk of CPU `convert()` cost. The CPU backend is selected only when neither GL nor G2D accepts the (src, dst) format pair. |
+| `image.draw_decoded_masks`                             | Per-detection alpha-blend of `Segmentation` mask onto the destination image (CPU or GL depending on backend). | When backend == GL, this dispatches to the shader-based mask blit. |
+| `image.materialize_masks`                              | Wrapper around the four `kernel_*` spans, paired with letterbox inversion and bbox-clipped row iteration. `mode = "proto"` returns proto-resolution masks; `mode = "scaled"` resamples to `(width, height)`. | Use the proto-resolution mode when you only need IoU computation against ground truth at the proto grid (the default Ultralytics evaluation mode). |
+| `image.materialize_masks.kernel_i8`                    | Fused i8 dequant + i8 × i8 → i32 matmul + sigmoid at proto resolution. NEON FP16 on aarch64. | The fastest path; avoids producing an intermediate f32 protos buffer. |
+| `image.materialize_masks.kernel_i16xi8`                | i16 coeff dequant + i16 × i8 → i32 matmul. Used when mask coefficients are stored at i16. | Preserves the i16 dynamic range that an i8 coeff dequant would lose. |
+| `image.materialize_masks.kernel_i8_scaled`             | Same fused i8 path, but per-output-pixel bilinear sample of the proto field (no intermediate proto-resolution mask). | Algebraically equivalent to `process_mask_native` from Ultralytics (`retina_masks=True`); empirical mask IoU 0.993 vs. Ultralytics on COCO val2017. |
+| `image.materialize_masks.kernel_i16xi8_scaled`         | i16 variant of the above scaled kernel. | Same shape and algorithm; different coefficient dtype. |
 
 [`tracing::trace_span!`]: https://docs.rs/tracing/latest/tracing/macro.trace_span.html
 

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -229,7 +229,7 @@ impl CPUProcessor {
         use edgefirst_tensor::{DType, TensorMapTrait, TensorTrait};
 
         let _span = tracing::trace_span!(
-            "materialize_masks",
+            "image.materialize_masks",
             mode = "proto",
             n_detections = detect.len(),
         )
@@ -604,7 +604,7 @@ impl CPUProcessor {
         use edgefirst_tensor::{DType, TensorMapTrait, TensorTrait};
 
         let _span = tracing::trace_span!(
-            "materialize_masks",
+            "image.materialize_masks",
             mode = "scaled",
             n_detections = detect.len(),
             width,
@@ -982,7 +982,7 @@ fn proto_segmentations_i8_i8(
     use edgefirst_tensor::QuantMode;
 
     let _span = tracing::trace_span!(
-        "mask_i8_fastpath",
+        "image.masks.kernel_i8",
         n = detect.len(),
         proto_h,
         proto_w,
@@ -1199,7 +1199,7 @@ fn proto_segmentations_i16_i8(
     use edgefirst_tensor::QuantMode;
 
     let _span = tracing::trace_span!(
-        "mask_i16_i8_fastpath",
+        "image.masks.kernel_i16xi8",
         n = detect.len(),
         proto_h,
         proto_w,
@@ -2024,7 +2024,7 @@ fn scaled_segmentations_i8_i8(
     use edgefirst_tensor::QuantMode;
 
     let _span = tracing::trace_span!(
-        "mask_i8_fastpath",
+        "image.masks.kernel_i8_scaled",
         n = detect.len(),
         proto_h,
         proto_w,
@@ -2326,7 +2326,7 @@ fn scaled_segmentations_i16_i8(
     use edgefirst_tensor::QuantMode;
 
     let _span = tracing::trace_span!(
-        "mask_i16_i8_fastpath",
+        "image.masks.kernel_i16xi8_scaled",
         n = detect.len(),
         proto_h,
         proto_w,

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -982,7 +982,7 @@ fn proto_segmentations_i8_i8(
     use edgefirst_tensor::QuantMode;
 
     let _span = tracing::trace_span!(
-        "image.masks.kernel_i8",
+        "image.materialize_masks.kernel_i8",
         n = detect.len(),
         proto_h,
         proto_w,
@@ -1199,7 +1199,7 @@ fn proto_segmentations_i16_i8(
     use edgefirst_tensor::QuantMode;
 
     let _span = tracing::trace_span!(
-        "image.masks.kernel_i16xi8",
+        "image.materialize_masks.kernel_i16xi8",
         n = detect.len(),
         proto_h,
         proto_w,

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -2024,7 +2024,7 @@ fn scaled_segmentations_i8_i8(
     use edgefirst_tensor::QuantMode;
 
     let _span = tracing::trace_span!(
-        "image.masks.kernel_i8_scaled",
+        "image.materialize_masks.kernel_i8_scaled",
         n = detect.len(),
         proto_h,
         proto_w,
@@ -2326,7 +2326,7 @@ fn scaled_segmentations_i16_i8(
     use edgefirst_tensor::QuantMode;
 
     let _span = tracing::trace_span!(
-        "image.masks.kernel_i16xi8_scaled",
+        "image.materialize_masks.kernel_i16xi8_scaled",
         n = detect.len(),
         proto_h,
         proto_w,

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -599,7 +599,7 @@ impl CPUProcessor {
         let tmp_fmt;
         if intermediate != src_fmt {
             let _s = tracing::trace_span!(
-                "image.cpu.format_convert",
+                "image.convert.cpu.format_convert",
                 from = ?src_fmt,
                 to = ?intermediate,
                 pass = "pre_resize",
@@ -618,11 +618,11 @@ impl CPUProcessor {
         // format must be RGB/RGBA/GREY
         debug_assert!(matches!(tmp_fmt, Rgb | Rgba | Grey));
         if tmp_fmt == dst_fmt {
-            let _s = tracing::trace_span!("image.cpu.resize_flip_rotate").entered();
+            let _s = tracing::trace_span!("image.convert.cpu.resize_flip_rotate").entered();
             self.resize_flip_rotate_pf(tmp, dst, dst_fmt, rotation, flip, crop)?;
         } else if !need_resize_flip_rotation {
             let _s = tracing::trace_span!(
-                "image.cpu.format_convert",
+                "image.convert.cpu.format_convert",
                 from = ?tmp_fmt,
                 to = ?dst_fmt,
                 pass = "direct",
@@ -643,12 +643,12 @@ impl CPUProcessor {
                 Self::convert_format_pf(dst, &mut tmp2, dst_fmt, tmp_fmt)?;
             }
             {
-                let _s = tracing::trace_span!("image.cpu.resize_flip_rotate").entered();
+                let _s = tracing::trace_span!("image.convert.cpu.resize_flip_rotate").entered();
                 self.resize_flip_rotate_pf(tmp, &mut tmp2, tmp_fmt, rotation, flip, crop)?;
             }
             {
                 let _s = tracing::trace_span!(
-                    "image.cpu.format_convert",
+                    "image.convert.cpu.format_convert",
                     from = ?tmp_fmt,
                     to = ?dst_fmt,
                     pass = "post_resize",

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -599,7 +599,7 @@ impl CPUProcessor {
         let tmp_fmt;
         if intermediate != src_fmt {
             let _s = tracing::trace_span!(
-                "cpu_format_convert",
+                "image.cpu.format_convert",
                 from = ?src_fmt,
                 to = ?intermediate,
                 pass = "pre_resize",
@@ -618,11 +618,11 @@ impl CPUProcessor {
         // format must be RGB/RGBA/GREY
         debug_assert!(matches!(tmp_fmt, Rgb | Rgba | Grey));
         if tmp_fmt == dst_fmt {
-            let _s = tracing::trace_span!("cpu_resize").entered();
+            let _s = tracing::trace_span!("image.cpu.resize_flip_rotate").entered();
             self.resize_flip_rotate_pf(tmp, dst, dst_fmt, rotation, flip, crop)?;
         } else if !need_resize_flip_rotation {
             let _s = tracing::trace_span!(
-                "cpu_format_convert",
+                "image.cpu.format_convert",
                 from = ?tmp_fmt,
                 to = ?dst_fmt,
                 pass = "direct",
@@ -643,12 +643,12 @@ impl CPUProcessor {
                 Self::convert_format_pf(dst, &mut tmp2, dst_fmt, tmp_fmt)?;
             }
             {
-                let _s = tracing::trace_span!("cpu_resize").entered();
+                let _s = tracing::trace_span!("image.cpu.resize_flip_rotate").entered();
                 self.resize_flip_rotate_pf(tmp, &mut tmp2, tmp_fmt, rotation, flip, crop)?;
             }
             {
                 let _s = tracing::trace_span!(
-                    "cpu_format_convert",
+                    "image.cpu.format_convert",
                     from = ?tmp_fmt,
                     to = ?dst_fmt,
                     pass = "post_resize",

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -61,7 +61,7 @@ impl G2DProcessor {
         crop: Crop,
     ) -> Result<()> {
         let _span = tracing::trace_span!(
-            "g2d_convert",
+            "image.g2d.convert",
             src_fmt = ?src_dyn.format(),
             dst_fmt = ?dst_dyn.format(),
         )

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -61,7 +61,7 @@ impl G2DProcessor {
         crop: Crop,
     ) -> Result<()> {
         let _span = tracing::trace_span!(
-            "image.g2d.convert",
+            "image.convert.g2d",
             src_fmt = ?src_dyn.format(),
             dst_fmt = ?dst_dyn.format(),
         )

--- a/crates/image/src/gl/processor.rs
+++ b/crates/image/src/gl/processor.rs
@@ -686,7 +686,7 @@ impl GLProcessorST {
         crop: Crop,
     ) -> crate::Result<()> {
         let _span = tracing::trace_span!(
-            "image.gl.convert",
+            "image.convert.gl",
             ?src_fmt,
             ?dst_fmt,
             is_int8,
@@ -2805,7 +2805,8 @@ impl GLProcessorST {
         );
 
         // --- Pass 1: Render source → intermediate RGBA texture ---
-        let _pass1 = tracing::trace_span!("image.gl.pack_rgb.pass1_rgba", dst_w, dst_h).entered();
+        let _pass1 =
+            tracing::trace_span!("image.convert.gl.pack_rgb.pass1_rgba", dst_w, dst_h).entered();
         self.ensure_packed_rgb_intermediate(dst_w, dst_h)?;
         self.packed_rgb_fbo.bind();
         unsafe {
@@ -2827,7 +2828,8 @@ impl GLProcessorST {
 
         // --- Pass 2: Pack intermediate RGBA → RGB DMA destination ---
         let _pass2 =
-            tracing::trace_span!("image.gl.pack_rgb.pass2_pack", render_w, render_h).entered();
+            tracing::trace_span!("image.convert.gl.pack_rgb.pass2_pack", render_w, render_h)
+                .entered();
         self.convert_fbo.bind();
         let dest_egl = self.get_or_create_egl_image_rgb(
             dst,
@@ -2954,7 +2956,8 @@ impl GLProcessorST {
         // --- Pass 1: NV12→RGBA into intermediate texture ---
         // No int8 bias here — bias is applied in pass 2's planar shader.
         let _pass1 =
-            tracing::trace_span!("image.gl.nv12_to_planar.pass1_rgba", dst_w, dst_h).entered();
+            tracing::trace_span!("image.convert.gl.nv12_to_planar.pass1_rgba", dst_w, dst_h)
+                .entered();
         self.ensure_packed_rgb_intermediate(dst_w, dst_h)?;
         self.packed_rgb_fbo.bind();
         unsafe {
@@ -2979,9 +2982,12 @@ impl GLProcessorST {
         // setup_renderbuffer_dma rebinds convert_fbo with the DMA destination EGLImage,
         // replacing packed_rgb_fbo that was active during pass 1. It also sets the viewport
         // to (dst_w, dst_h * 3) for the tall R8 planar renderbuffer.
-        let _pass2 =
-            tracing::trace_span!("image.gl.nv12_to_planar.pass2_deinterleave", dst_w, dst_h)
-                .entered();
+        let _pass2 = tracing::trace_span!(
+            "image.convert.gl.nv12_to_planar.pass2_deinterleave",
+            dst_w,
+            dst_h
+        )
+        .entered();
         self.setup_renderbuffer_dma(dst, dst_fmt)?;
 
         // Bias letterbox clear color for int8 — glClear bypasses the shader.

--- a/crates/image/src/gl/processor.rs
+++ b/crates/image/src/gl/processor.rs
@@ -686,7 +686,7 @@ impl GLProcessorST {
         crop: Crop,
     ) -> crate::Result<()> {
         let _span = tracing::trace_span!(
-            "gl_convert",
+            "image.gl.convert",
             ?src_fmt,
             ?dst_fmt,
             is_int8,
@@ -2805,7 +2805,7 @@ impl GLProcessorST {
         );
 
         // --- Pass 1: Render source → intermediate RGBA texture ---
-        let _pass1 = tracing::trace_span!("gl_pass1_to_rgba", dst_w, dst_h).entered();
+        let _pass1 = tracing::trace_span!("image.gl.pack_rgb.pass1_rgba", dst_w, dst_h).entered();
         self.ensure_packed_rgb_intermediate(dst_w, dst_h)?;
         self.packed_rgb_fbo.bind();
         unsafe {
@@ -2826,7 +2826,8 @@ impl GLProcessorST {
         drop(_pass1);
 
         // --- Pass 2: Pack intermediate RGBA → RGB DMA destination ---
-        let _pass2 = tracing::trace_span!("gl_pass2_pack_rgb", render_w, render_h).entered();
+        let _pass2 =
+            tracing::trace_span!("image.gl.pack_rgb.pass2_pack", render_w, render_h).entered();
         self.convert_fbo.bind();
         let dest_egl = self.get_or_create_egl_image_rgb(
             dst,
@@ -2952,7 +2953,8 @@ impl GLProcessorST {
 
         // --- Pass 1: NV12→RGBA into intermediate texture ---
         // No int8 bias here — bias is applied in pass 2's planar shader.
-        let _pass1 = tracing::trace_span!("gl_pass1_to_rgba", dst_w, dst_h).entered();
+        let _pass1 =
+            tracing::trace_span!("image.gl.nv12_to_planar.pass1_rgba", dst_w, dst_h).entered();
         self.ensure_packed_rgb_intermediate(dst_w, dst_h)?;
         self.packed_rgb_fbo.bind();
         unsafe {
@@ -2977,7 +2979,9 @@ impl GLProcessorST {
         // setup_renderbuffer_dma rebinds convert_fbo with the DMA destination EGLImage,
         // replacing packed_rgb_fbo that was active during pass 1. It also sets the viewport
         // to (dst_w, dst_h * 3) for the tall R8 planar renderbuffer.
-        let _pass2 = tracing::trace_span!("gl_pass2_to_planar", dst_w, dst_h).entered();
+        let _pass2 =
+            tracing::trace_span!("image.gl.nv12_to_planar.pass2_deinterleave", dst_w, dst_h)
+                .entered();
         self.setup_renderbuffer_dma(dst, dst_fmt)?;
 
         // Bias letterbox clear color for int8 — glClear bypasses the shader.

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -1693,7 +1693,7 @@ impl ImageProcessorTrait for ImageProcessor {
         let src_fmt = src.format();
         let dst_fmt = dst.format();
         let _span = tracing::trace_span!(
-            "image_convert",
+            "image.convert",
             ?src_fmt,
             ?dst_fmt,
             src_memory = ?src.memory(),
@@ -1817,7 +1817,7 @@ impl ImageProcessorTrait for ImageProcessor {
         overlay: MaskOverlay<'_>,
     ) -> Result<()> {
         let _span = tracing::trace_span!(
-            "draw_masks",
+            "image.draw_decoded_masks",
             n_detections = detect.len(),
             n_segmentations = segmentation.len(),
         )

--- a/crates/python/pyproject.toml
+++ b/crates/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "edgefirst_hal"
-version = "0.23.1"
+version = "0.23.2"
 description = "Hardware Abstraction Layer for edge AI with zero-copy tensors, image processing, and YOLO decoding"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -758,7 +758,8 @@ impl PyDecoder {
         max_boxes: usize,
     ) -> PyResult<PySegDetOutput<'py>> {
         let _span =
-            tracing::trace_span!("py_decode", n_tensors = model_output.len(), max_boxes).entered();
+            tracing::trace_span!("python.decode", n_tensors = model_output.len(), max_boxes)
+                .entered();
         let tensor_refs: Vec<&edgefirst_hal::tensor::TensorDyn> =
             model_output.iter().map(|t| &t.0).collect();
         let mut output_boxes = Vec::with_capacity(max_boxes);
@@ -784,7 +785,7 @@ impl PyDecoder {
         max_boxes: usize,
     ) -> PyResult<PySegDetTrackedOutput<'py>> {
         let _span = tracing::trace_span!(
-            "py_decode_tracked",
+            "python.decode_tracked",
             n_tensors = model_output.len(),
             max_boxes,
             timestamp,
@@ -849,9 +850,12 @@ impl PyDecoder {
         model_output: Vec<PyRef<'py, crate::tensor::PyTensor>>,
         max_boxes: usize,
     ) -> PyResult<PyProtoDetOutput<'py>> {
-        let _span =
-            tracing::trace_span!("py_decode_proto", n_tensors = model_output.len(), max_boxes,)
-                .entered();
+        let _span = tracing::trace_span!(
+            "python.decode_proto",
+            n_tensors = model_output.len(),
+            max_boxes,
+        )
+        .entered();
         let tensor_refs: Vec<&edgefirst_hal::tensor::TensorDyn> =
             model_output.iter().map(|t| &t.0).collect();
         let mut output_boxes = Vec::with_capacity(max_boxes);

--- a/crates/python/src/image.rs
+++ b/crates/python/src/image.rs
@@ -975,7 +975,7 @@ impl PyImageProcessor {
         dst_crop: Option<PyRect>,
         dst_color: Option<[u8; 4]>,
     ) -> Result<()> {
-        let _span = tracing::trace_span!("py_convert").entered();
+        let _span = tracing::trace_span!("python.convert").entered();
         let rotation = rotation.into();
         let flip = flip.into();
         let crop = Crop {
@@ -1111,7 +1111,7 @@ impl PyImageProcessor {
         resolution: Option<PyMaskResolution>,
         py: Python<'py>,
     ) -> Result<Vec<Bound<'py, numpy::PyArray3<u8>>>> {
-        let _span = tracing::trace_span!("py_materialize_masks").entered();
+        let _span = tracing::trace_span!("python.materialize_masks").entered();
         let detect = numpy_to_detect_boxes(&bbox, &scores, &classes)?;
         let resolution = resolution.map(|r| r.0).unwrap_or(MaskResolution::Proto);
         let mut l = self
@@ -1152,7 +1152,7 @@ impl PyImageProcessor {
         py: Python<'py>,
     ) -> PyResult<Py<PyAny>> {
         let _span = tracing::trace_span!(
-            "py_draw_masks",
+            "python.draw_masks",
             n_tensors = model_output.len(),
             tracked = tracker.is_some(),
         )

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -1173,7 +1173,7 @@ where
     /// ```
     pub fn new(shape: &[usize], memory: Option<TensorMemory>, name: Option<&str>) -> Result<Self> {
         let _span = tracing::trace_span!(
-            "tensor_alloc",
+            "tensor.alloc",
             ?shape,
             memory = ?memory,
             dtype = std::any::type_name::<T>(),
@@ -1778,7 +1778,7 @@ where
 
     fn map(&self) -> Result<TensorMap<T>> {
         let _span = tracing::trace_span!(
-            "tensor_map",
+            "tensor.map",
             memory = ?self.storage.memory(),
         )
         .entered();

--- a/crates/tracker/src/bytetrack.rs
+++ b/crates/tracker/src/bytetrack.rs
@@ -346,7 +346,7 @@ where
 {
     fn update(&mut self, boxes: &[T], timestamp: u64) -> Vec<Option<TrackInfo>> {
         let span = tracing::trace_span!(
-            "tracker_update",
+            "tracker.update",
             n_detections = boxes.len(),
             n_tracklets = self.tracklets.len(),
             timestamp,
@@ -369,14 +369,14 @@ where
 
         // First pass: match high-confidence detections
         if !self.tracklets.is_empty() {
-            let _s = tracing::trace_span!("predict").entered();
+            let _s = tracing::trace_span!("tracker.predict").entered();
             for track in &mut self.tracklets {
                 track.filter.predict();
             }
         }
 
         if !self.tracklets.is_empty() {
-            let _s = tracing::trace_span!("match_high_conf").entered();
+            let _s = tracing::trace_span!("tracker.match_high_conf").entered();
             let costs = self.compute_costs(
                 boxes,
                 self.track_high_conf,
@@ -400,7 +400,7 @@ where
 
         // Second pass: match remaining tracklets to low-confidence detections
         if !self.tracklets.is_empty() {
-            let _s = tracing::trace_span!("match_low_conf").entered();
+            let _s = tracing::trace_span!("tracker.match_low_conf").entered();
             let costs = self.compute_costs(boxes, 0.0, self.track_iou, &matched, &tracked);
             if let Ok(ans) = lapjv(&costs) {
                 self.process_assignments(

--- a/crates/tracker/src/bytetrack.rs
+++ b/crates/tracker/src/bytetrack.rs
@@ -369,14 +369,14 @@ where
 
         // First pass: match high-confidence detections
         if !self.tracklets.is_empty() {
-            let _s = tracing::trace_span!("tracker.predict").entered();
+            let _s = tracing::trace_span!("tracker.update.predict").entered();
             for track in &mut self.tracklets {
                 track.filter.predict();
             }
         }
 
         if !self.tracklets.is_empty() {
-            let _s = tracing::trace_span!("tracker.match_high_conf").entered();
+            let _s = tracing::trace_span!("tracker.update.match_high_conf").entered();
             let costs = self.compute_costs(
                 boxes,
                 self.track_high_conf,
@@ -400,7 +400,7 @@ where
 
         // Second pass: match remaining tracklets to low-confidence detections
         if !self.tracklets.is_empty() {
-            let _s = tracing::trace_span!("tracker.match_low_conf").entered();
+            let _s = tracing::trace_span!("tracker.update.match_low_conf").entered();
             let costs = self.compute_costs(boxes, 0.0, self.track_iou, &matched, &tracked);
             if let Ok(ans) = lapjv(&costs) {
                 self.process_assignments(


### PR DESCRIPTION
## Summary

Adopts a uniform `<crate>.<subsystem>.<operation>` naming convention for every `tracing::trace_span!` call site across the workspace (65 sites in 5 crates, plus 7 new sites in `edgefirst-codec` which previously had none).

Resolves multiple span-name collisions where six `"decode"` spans (four flat-YOLO entry points plus two inner segdet `get_boxes` kernels) only differed by a `mode = ...` field — visually ambiguous in Perfetto flame graphs and impossible to filter cleanly. Also fixes the `"box"` / `"score"` / `"mc"` shorthand inside the per-scale path (cryptic outside its parent span), unifies the mixed prefix conventions (`cpu_*`, `gl_*`, `g2d_*`, `py_*`, `tensor_*`, `tracker_*`, `Decoder::*`, `per_scale_bridge::*`), and adds the previously-missing codec spans.

The "Tracing Spans" section that `README.md` line 573 already advertises now exists in `decoder/ARCHITECTURE.md`, `image/ARCHITECTURE.md`, and `codec/ARCHITECTURE.md` — each carries an authoritative span tree, per-span operation descriptions, and a mapping to the reference implementation (Ultralytics for the decoder; the `convert()` inner pipeline for image; libjpeg/libpng for codec).

## Behavioural impact

- Span names are **observable surface** (visible in any Perfetto / Chrome trace produced by `edgefirst_hal::trace::start_tracing`). Anyone with saved Perfetto queries, dashboards, or filters targeting the old names will need to update them — the full rename table is in `CHANGELOG.md` under `## [0.23.2]`.
- No public Rust / Python / C API change. No runtime behaviour change.
- `tracing` workspace dep added to `edgefirst-codec` (was missing).

## Test plan

- [x] `make format` — workspace reformatted
- [x] `make lint` — clippy strict + ruff clean
- [x] `make test` — `test-rust` + `test-python` + `test-capi` all pass (66/66 capi tests, rust tests pass)
- [x] `cargo check --workspace` — clean
- [ ] Reviewer: spot-check Perfetto trace from a sample inference to confirm new span tree renders as expected
- [ ] Reviewer: confirm no internal tooling (CI dashboards, perf regressions board) filters on old span names