### PR TITLE
DE-2447: ModelPack decoder schema + coffeecup parity coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ env.sh
 # C API build artifacts
 crates/capi/build/
 
-# TFLite models (large binaries); testdata/ has its own .gitignore
+# TFLite/ONNX models (large binaries); testdata/ has its own .gitignore
 *.tflite
+*.onnx

--- a/crates/decoder/tests/modelpack_coffeecup_parity.rs
+++ b/crates/decoder/tests/modelpack_coffeecup_parity.rs
@@ -66,6 +66,7 @@ fn assert_coffeecup_parity(fixture_filename: &str, score_tol: f32, iou_floor: f3
         .with_schema(schema)
         .with_iou_threshold(nms.iou_threshold)
         .with_score_threshold(nms.score_threshold)
+        .with_max_det(nms.max_detections as usize)
         .build()
         .expect("build decoder");
 
@@ -74,7 +75,7 @@ fn assert_coffeecup_parity(fixture_filename: &str, score_tol: f32, iou_floor: f3
         .expect("build tensors from fixture");
     let inputs: Vec<&TensorDyn> = owned_tensors.iter().collect();
 
-    let mut hal_boxes: Vec<DetectBox> = Vec::with_capacity(300);
+    let mut hal_boxes: Vec<DetectBox> = Vec::with_capacity(nms.max_detections as usize);
     let mut hal_masks: Vec<Segmentation> = Vec::new();
     decoder
         .decode(&inputs, &mut hal_boxes, &mut hal_masks)

--- a/crates/decoder/tests/modelpack_coffeecup_parity.rs
+++ b/crates/decoder/tests/modelpack_coffeecup_parity.rs
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parity tests: HAL ModelPack anchor-grid decoder vs the canonical
+//! ModelPack Python reference (``deepview/modelpack/demos/models/
+//! inference_no_decoder.py``) on the coffeecup detection model.
+//!
+//! Two fixtures:
+//! * ``coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.safetensors`` —
+//!   TFLite INT8 outputs from the quantized split-decoder export.
+//! * ``coffeecup-mpk-det-relu-t-27d6.safetensors`` — ONNX float32
+//!   outputs from the pre-quantization export.
+//!
+//! Both fixtures embed the ``edgefirst.json`` schema, the raw model
+//! outputs, and the post-NMS reference detections produced by running
+//! ModelPack's reference decode formula in NumPy. The HAL decoder
+//! must reproduce those detections within a small tolerance.
+//!
+//! Fixtures are regenerated with
+//! ``scripts/decoder_generate_modelpack_fixture.py``.
+
+mod common;
+
+use std::path::PathBuf;
+
+use edgefirst_decoder::{schema::SchemaV2, DecoderBuilder, DetectBox, Segmentation};
+use edgefirst_tensor::TensorDyn;
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    workspace_root().join("testdata/decoder").join(name)
+}
+
+fn iou_xyxy(a: &[f32; 4], b: &[f32; 4]) -> f32 {
+    let x1 = a[0].max(b[0]);
+    let y1 = a[1].max(b[1]);
+    let x2 = a[2].min(b[2]);
+    let y2 = a[3].min(b[3]);
+    let inter = (x2 - x1).max(0.0) * (y2 - y1).max(0.0);
+    let area_a = (a[2] - a[0]) * (a[3] - a[1]);
+    let area_b = (b[2] - b[0]) * (b[3] - b[1]);
+    inter / (area_a + area_b - inter + 1e-9)
+}
+
+/// Drive the HAL decoder on the fixture's raw tensors and verify the
+/// post-NMS output matches the embedded Python reference one-for-one.
+fn assert_coffeecup_parity(fixture_filename: &str, score_tol: f32, iou_floor: f32) {
+    let path = fixture_path(fixture_filename);
+    let fix = match common::per_scale_fixture::PerScaleFixture::load(&path) {
+        Ok(f) => f,
+        Err(common::per_scale_fixture::FixtureError::NotPresent(_)) => {
+            eprintln!("skip: fixture {path:?} not present (run `git lfs pull`)");
+            return;
+        }
+        Err(e) => panic!("fixture load failed: {e}"),
+    };
+    let schema: SchemaV2 =
+        serde_json::from_str(fix.schema_json()).expect("schema_json must parse as SchemaV2");
+    let nms = fix.nms_config();
+    let decoder = DecoderBuilder::default()
+        .with_schema(schema)
+        .with_iou_threshold(nms.iou_threshold)
+        .with_score_threshold(nms.score_threshold)
+        .build()
+        .expect("build decoder");
+
+    let owned_tensors = fix
+        .build_tensors_with_quant()
+        .expect("build tensors from fixture");
+    let inputs: Vec<&TensorDyn> = owned_tensors.iter().collect();
+
+    let mut hal_boxes: Vec<DetectBox> = Vec::with_capacity(300);
+    let mut hal_masks: Vec<Segmentation> = Vec::new();
+    decoder
+        .decode(&inputs, &mut hal_boxes, &mut hal_masks)
+        .expect("HAL decode must succeed");
+
+    let reference = fix.decoded().expect("fixture decoded() reference");
+    let ref_n = reference.boxes_xyxy.shape()[0];
+
+    assert_eq!(
+        hal_boxes.len(),
+        ref_n,
+        "{fixture_filename}: HAL produced {} detections, reference {ref_n}",
+        hal_boxes.len()
+    );
+
+    // Greedy IoU match each reference detection to a HAL detection.
+    // With ref_n == 1 (single coffeecup) the match is unambiguous;
+    // the loop generalises for future multi-object fixtures.
+    let mut consumed = vec![false; hal_boxes.len()];
+    for i in 0..ref_n {
+        let ref_box: [f32; 4] = [
+            reference.boxes_xyxy[[i, 0]],
+            reference.boxes_xyxy[[i, 1]],
+            reference.boxes_xyxy[[i, 2]],
+            reference.boxes_xyxy[[i, 3]],
+        ];
+        let ref_score = reference.scores[i];
+        let ref_class = reference.classes[i] as usize;
+
+        let (best_idx, best_iou) = hal_boxes
+            .iter()
+            .enumerate()
+            .filter(|(j, _)| !consumed[*j])
+            .map(|(j, hal)| {
+                let hal_box = [hal.bbox.xmin, hal.bbox.ymin, hal.bbox.xmax, hal.bbox.ymax];
+                (j, iou_xyxy(&ref_box, &hal_box))
+            })
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+            .expect("HAL must have an unconsumed detection to match against");
+
+        assert!(
+            best_iou >= iou_floor,
+            "{fixture_filename}: ref det[{i}] xyxy={ref_box:?} has no HAL match \
+             with IoU≥{iou_floor:.2} (best={best_iou:.4})"
+        );
+
+        let hal = &hal_boxes[best_idx];
+        let score_diff = (hal.score - ref_score).abs();
+        assert!(
+            score_diff <= score_tol,
+            "{fixture_filename}: ref det[{i}] score={ref_score:.4} vs HAL {:.4} \
+             (|diff|={score_diff:.4} > tol={score_tol})",
+            hal.score
+        );
+        assert_eq!(
+            hal.label, ref_class,
+            "{fixture_filename}: ref det[{i}] class={ref_class} vs HAL {}",
+            hal.label
+        );
+
+        consumed[best_idx] = true;
+    }
+}
+
+#[test]
+fn coffeecup_modelpack_int8_smart_parity() {
+    // Same fixture as the float ONNX path, just routed through the int8
+    // dequant→sigmoid kernel. Tolerance is looser because the per-scale
+    // quantization round-trip drifts a few percent at sigmoid boundaries.
+    assert_coffeecup_parity(
+        "coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.safetensors",
+        /* score_tol = */ 0.02,
+        /* iou_floor = */ 0.95,
+    );
+}
+
+#[test]
+fn coffeecup_modelpack_float_onnx_parity() {
+    // Float-to-float: HAL and the NumPy reference should agree to within
+    // floating-point round-off on a single coffeecup detection.
+    assert_coffeecup_parity(
+        "coffeecup-mpk-det-relu-t-27d6.safetensors",
+        /* score_tol = */ 0.001,
+        /* iou_floor = */ 0.99,
+    );
+}

--- a/crates/decoder/tests/modelpack_decoder_schemas.rs
+++ b/crates/decoder/tests/modelpack_decoder_schemas.rs
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Build a [`Decoder`] from the four ModelPack schema-v2 fixtures shipped
+//! by ModelPack 4.0.
+//!
+//! ModelPack always exports raw per-FPN-scale anchor-grid outputs
+//! (``type: detection``, ``encoding: anchor``, ``decoder: modelpack``),
+//! optionally accompanied by a single ``type: segmentation`` output for
+//! multi-task models. Each FPN scale is its own top-level output — both
+//! before and after conversion — so the "smart" layout differs from the
+//! Ultralytics case: converters do NOT introduce per-scale physical
+//! children, they just fill in `quantization` + `dtype` on each scale in
+//! place. The fixtures cover both the float (pre-conversion, no
+//! quantization) and the quantized INT8 (post-conversion) variants for
+//! detection, segmentation, and multi-task.
+//!
+//! [`Decoder`]: edgefirst_decoder::Decoder
+
+use std::path::PathBuf;
+
+use edgefirst_decoder::{schema::SchemaV2, DecoderBuilder};
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+fn fixture_path(stem: &str) -> PathBuf {
+    workspace_root()
+        .join("testdata/decoder")
+        .join(format!("{stem}.json"))
+}
+
+fn build_from_fixture(stem: &str) -> (SchemaV2, edgefirst_decoder::Decoder) {
+    let path = fixture_path(stem);
+    let schema =
+        SchemaV2::parse_file(&path).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    let decoder = DecoderBuilder::new()
+        .with_schema(schema.clone())
+        .build()
+        .unwrap_or_else(|e| panic!("build {}: {e}", path.display()));
+    (schema, decoder)
+}
+
+/// Shared invariants: ModelPack v2 must NOT set `decoder_version`
+/// (that field is Ultralytics-only per the metadata spec), and the
+/// expected 320x320 input geometry comes through unchanged.
+fn assert_modelpack_invariants(
+    stem: &str,
+    schema: &SchemaV2,
+    decoder: &edgefirst_decoder::Decoder,
+) {
+    assert_eq!(
+        schema.decoder_version, None,
+        "{stem}: ModelPack must not set decoder_version (Ultralytics-only field)",
+    );
+    assert_eq!(
+        decoder.input_dims(),
+        Some((320, 320)),
+        "{stem}: expected 320x320 input",
+    );
+}
+
+#[test]
+fn build_decoder_from_modelpack_det_logical() {
+    let stem = "modelpack_det_logical";
+    let (schema, decoder) = build_from_fixture(stem);
+    assert_modelpack_invariants(stem, &schema, &decoder);
+
+    // Detection-only ModelPack: one logical output per FPN scale, no
+    // per-scale children (this is the float / logical layout).
+    assert_eq!(
+        schema.outputs.len(),
+        2,
+        "{stem}: detection-only should expose 2 per-scale logical outputs",
+    );
+    for out in &schema.outputs {
+        assert!(
+            out.outputs.is_empty(),
+            "{stem}: logical layout must not carry per-scale children, found on {:?}",
+            out.name,
+        );
+    }
+}
+
+#[test]
+fn build_decoder_from_modelpack_seg_logical() {
+    let stem = "modelpack_seg_logical";
+    let (schema, decoder) = build_from_fixture(stem);
+    assert_modelpack_invariants(stem, &schema, &decoder);
+
+    // Segmentation-only ModelPack: a single direct logical output.
+    assert_eq!(
+        schema.outputs.len(),
+        1,
+        "{stem}: segmentation-only should expose 1 logical output",
+    );
+    assert!(
+        schema.outputs[0].outputs.is_empty(),
+        "{stem}: segmentation logical layout must not carry per-scale children",
+    );
+}
+
+#[test]
+fn build_decoder_from_modelpack_multitask_logical() {
+    let stem = "modelpack_multitask_logical";
+    let (schema, decoder) = build_from_fixture(stem);
+    assert_modelpack_invariants(stem, &schema, &decoder);
+
+    // Multi-task: 3 FPN-scale detection outputs + 1 segmentation output.
+    assert_eq!(
+        schema.outputs.len(),
+        4,
+        "{stem}: multitask should expose 3 detection + 1 segmentation = 4 logical outputs",
+    );
+    for out in &schema.outputs {
+        assert!(
+            out.outputs.is_empty(),
+            "{stem}: logical layout must not carry per-scale children, found on {:?}",
+            out.name,
+        );
+    }
+}
+
+#[test]
+fn build_decoder_from_modelpack_det_smart() {
+    let stem = "modelpack_det_smart";
+    let (schema, decoder) = build_from_fixture(stem);
+    assert_modelpack_invariants(stem, &schema, &decoder);
+
+    // Post-conversion (INT8 quantized) ModelPack layout: each FPN scale
+    // is still a top-level `type: detection` output (no nested physical
+    // children — ModelPack's anchor-grid outputs are already per-scale,
+    // so converters fill in `quantization` + `dtype` in place rather
+    // than introducing per-scale children). Each output carries a
+    // non-null `quantization` block and `dtype: int8`.
+    assert_eq!(
+        schema.outputs.len(),
+        2,
+        "{stem}: post-conversion layout should expose 2 per-scale outputs",
+    );
+    for out in &schema.outputs {
+        assert!(
+            out.outputs.is_empty(),
+            "{stem}: ModelPack post-conversion layout must not carry per-scale children, found on {:?}",
+            out.name,
+        );
+        assert!(
+            out.quantization.is_some(),
+            "{stem}: post-conversion ModelPack output {:?} must declare quantization",
+            out.name,
+        );
+    }
+}

--- a/scripts/decoder_generate_modelpack_fixture.py
+++ b/scripts/decoder_generate_modelpack_fixture.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""ModelPack decoder reference fixture generator.
+
+PURPOSE
+-------
+Capture a ModelPack anchor-grid model's raw per-FPN-scale outputs plus the
+reference post-NMS detections into a single ``.safetensors`` file for use as
+an oracle in HAL Rust unit tests (``crates/decoder/tests/``).
+
+Supports both TFLite (int8 quantized, zip-wrapped with embedded
+``edgefirst.json``) and ONNX (float32, ``edgefirst`` key in
+``metadata_props``) models produced by ModelPack 4.0+ exports with
+``decoder: modelpack`` and ``encoding: anchor`` per output.
+
+The fixture lets HAL Rust tests load the raw tensors and the embedded
+``edgefirst.json`` schema, run the HAL ModelPack decoder, and assert
+parity against the reference detections — without pulling any inference
+runtime into the Rust test.
+
+REFERENCE DECODE FORMULA
+------------------------
+Per FPN scale with shape ``[1, H, W, num_anchors * (5 + nc)]``::
+
+    g    = sigmoid(raw_or_dequant).reshape(1, H, W, na, 5 + nc)
+    grid = meshgrid(x=0..W, y=0..H)                            # [1, H, W, 1, 2]
+    xy   = (g[..., 0:2] * 2 + grid - 0.5) / [W, H]             # normalized [0, 1]
+    wh   = (g[..., 2:4] * 2) ** 2 * anchors * 0.5              # normalized [0, 1]
+    obj  = g[..., 4:5]
+    cls  = g[..., 5:]
+    scores = obj                  if nc == 1 else obj * cls
+    boxes_xyxy = concat([xy - wh, xy + wh], axis=-1)
+
+Mirrors ``deepview/modelpack/demos/models/inference_no_decoder.py``.
+
+USAGE
+-----
+::
+
+    python scripts/decoder_generate_modelpack_fixture.py \\
+        coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.tflite \\
+        testdata/coffeecup.jpg \\
+        --output testdata/decoder/coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.safetensors
+
+    python scripts/decoder_generate_modelpack_fixture.py \\
+        coffeecup-mpk-det-relu-t-27d6.onnx \\
+        testdata/coffeecup.jpg \\
+        --output testdata/decoder/coffeecup-mpk-det-relu-t-27d6.safetensors
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import subprocess
+import sys
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FixtureConfig:
+    model_path: Path
+    image_path: Path
+    output_path: Path
+    score_threshold: float
+    iou_threshold: float
+    max_output: int
+
+
+def parse_args(argv: list[str] | None = None) -> FixtureConfig:
+    p = argparse.ArgumentParser(
+        prog="decoder_generate_modelpack_fixture",
+        description="Generate a HAL ModelPack decoder reference fixture (.safetensors).",
+    )
+    p.add_argument("model", type=Path, help="Path to .tflite or .onnx model.")
+    p.add_argument("image", type=Path, help="Representative input image.")
+    p.add_argument("--output", required=True, type=Path, help="Output .safetensors path.")
+    p.add_argument("--score-threshold", type=float, default=0.25)
+    p.add_argument("--iou-threshold", type=float, default=0.5)
+    p.add_argument("--max-output", type=int, default=300)
+    args = p.parse_args(argv)
+    return FixtureConfig(
+        model_path=args.model,
+        image_path=args.image,
+        output_path=args.output,
+        score_threshold=args.score_threshold,
+        iou_threshold=args.iou_threshold,
+        max_output=args.max_output,
+    )
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
+        ).decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Schema extraction
+# ──────────────────────────────────────────────────────────────────────
+
+def extract_schema_tflite(model_path: Path) -> dict:
+    """ModelPack TFLite is a zip with edgefirst.json inside."""
+    with zipfile.ZipFile(model_path) as zf:
+        with zf.open("edgefirst.json") as fp:
+            return json.loads(fp.read().decode("utf-8"))
+
+
+def extract_schema_onnx(model_path: Path) -> dict:
+    """ModelPack ONNX stores schema in metadata_props['edgefirst']."""
+    import onnxruntime as ort
+    sess = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    meta = sess.get_modelmeta()
+    js = meta.custom_metadata_map.get("edgefirst")
+    if js is None:
+        raise SystemExit(
+            f"{model_path}: ONNX model has no 'edgefirst' custom metadata "
+            "key — not a ModelPack-exported model?"
+        )
+    return json.loads(js)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Inference
+# ──────────────────────────────────────────────────────────────────────
+
+def detect_input_hw(input_shape: list[int]) -> tuple[int, int, str]:
+    """Return (in_h, in_w, layout) for a 4D model input. ``layout`` is 'NHWC' or 'NCHW'.
+
+    Detection rule: channel axis is whichever of indices 1 or 3 equals 3.
+    """
+    if len(input_shape) != 4 or input_shape[0] != 1:
+        raise SystemExit(f"unexpected input shape {input_shape}; need [1, ...]")
+    if input_shape[3] == 3:
+        return int(input_shape[1]), int(input_shape[2]), "NHWC"
+    if input_shape[1] == 3:
+        return int(input_shape[2]), int(input_shape[3]), "NCHW"
+    raise SystemExit(f"could not locate channel=3 axis in {input_shape}")
+
+
+def preprocess_image(image_path: Path, in_h: int, in_w: int) -> np.ndarray:
+    """Resize to model input, return uint8 NHWC [1, H, W, 3]."""
+    from PIL import Image
+    img = Image.open(image_path).convert("RGB").resize((in_w, in_h))
+    return np.array(img, dtype=np.uint8)[np.newaxis]  # [1, H, W, 3]
+
+
+def infer_tflite(model_path: Path, image_uint8_nhwc: np.ndarray) -> dict[tuple[int, ...], np.ndarray]:
+    """Run TFLite inference; return {shape: raw_int8_tensor}.
+
+    Binds outputs by shape (TFLite output names like ``PartitionedCall:0``
+    don't map to schema names like ``output_0``).
+    """
+    try:
+        from tflite_runtime.interpreter import Interpreter
+    except ImportError:
+        from tensorflow.lite.python.interpreter import Interpreter
+    interp = Interpreter(model_path=str(model_path))
+    interp.allocate_tensors()
+    in_det = interp.get_input_details()[0]
+    interp.set_tensor(in_det["index"], image_uint8_nhwc)
+    interp.invoke()
+    raw = {}
+    quants = {}
+    for od in interp.get_output_details():
+        t = interp.get_tensor(od["index"])
+        raw[tuple(int(x) for x in t.shape)] = t
+        quants[tuple(int(x) for x in t.shape)] = od["quantization"]
+    return raw, quants
+
+
+def infer_onnx(model_path: Path, image_uint8_nhwc: np.ndarray) -> dict[tuple[int, ...], np.ndarray]:
+    """Run ONNX inference; return {shape: float32_tensor} in NHWC layout.
+
+    ModelPack ONNX takes NCHW float32 input but the heads emit NHWC outputs.
+    """
+    import onnxruntime as ort
+    sess = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    in_meta = sess.get_inputs()[0]
+    # NCHW float32 [1, 3, H, W]; normalize uint8/255.0
+    img_nchw = (image_uint8_nhwc.astype(np.float32) / 255.0).transpose(0, 3, 1, 2)
+    outs = sess.run(None, {in_meta.name: img_nchw})
+    raw = {tuple(int(x) for x in t.shape): t for t in outs}
+    return raw, {}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Reference ModelPack decoder (pure numpy)
+# ──────────────────────────────────────────────────────────────────────
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    # Numerically stable sigmoid
+    out = np.empty_like(x, dtype=np.float32)
+    pos = x >= 0
+    out[pos] = 1.0 / (1.0 + np.exp(-x[pos]))
+    e = np.exp(x[~pos])
+    out[~pos] = e / (1.0 + e)
+    return out
+
+
+def decode_modelpack_outputs(
+    outputs_by_name: dict[str, np.ndarray],
+    schema: dict,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Apply ModelPack reference decode to all detection outputs.
+
+    Returns (boxes_xyxy [N, 4], scores [N, num_classes]) — flattened
+    across FPN scales, pre-NMS, normalized [0, 1] coordinates.
+    """
+    num_classes = len(schema.get("dataset", {}).get("classes", [])) or 1
+    all_boxes, all_scores = [], []
+    for spec in schema["outputs"]:
+        if spec.get("type") != "detection":
+            continue
+        name = spec["name"]
+        if name not in outputs_by_name:
+            raise SystemExit(f"output {name!r} not found in model outputs")
+        t = outputs_by_name[name].astype(np.float32)
+        anchors = np.asarray(spec["anchors"], dtype=np.float32)
+        na = len(anchors)
+        _, gh, gw, c = t.shape
+        nc = c // na - 5
+        if nc != num_classes:
+            raise SystemExit(
+                f"output {name!r}: derived nc={nc} from shape, "
+                f"but schema says {num_classes} classes"
+            )
+        g = _sigmoid(t).reshape(1, gh, gw, na, nc + 5)
+        gx, gy = np.meshgrid(np.arange(gw), np.arange(gh))
+        grid = np.stack([gx, gy], axis=-1).astype(np.float32)
+        grid = grid[None, ..., None, :]  # [1, H, W, 1, 2]
+        xy = (g[..., 0:2] * 2.0 + grid - 0.5) / np.array([gw, gh], dtype=np.float32)
+        wh = (g[..., 2:4] * 2.0) ** 2 * anchors * 0.5
+        obj = g[..., 4:5]
+        cls = g[..., 5:]
+        scores = obj if num_classes == 1 else obj * cls
+        boxes = np.concatenate([xy - wh, xy + wh], axis=-1)
+        all_boxes.append(boxes.reshape(-1, 4))
+        all_scores.append(scores.reshape(-1, num_classes))
+    boxes = np.concatenate(all_boxes, axis=0)
+    scores = np.concatenate(all_scores, axis=0)
+    return boxes, scores
+
+
+def nms_class_agnostic(
+    boxes: np.ndarray,
+    scores: np.ndarray,
+    score_threshold: float,
+    iou_threshold: float,
+    max_output: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Greedy class-agnostic NMS. Returns (boxes [K,4], scores [K], classes [K])."""
+    # Reduce per-anchor multi-class to (max_score, argmax_class)
+    max_scores = scores.max(axis=1)
+    classes = scores.argmax(axis=1)
+    keep_mask = max_scores >= score_threshold
+    boxes = boxes[keep_mask]
+    max_scores = max_scores[keep_mask]
+    classes = classes[keep_mask]
+
+    order = np.argsort(-max_scores)
+    keep: list[int] = []
+    while len(order) > 0 and len(keep) < max_output:
+        i = int(order[0])
+        keep.append(i)
+        if len(order) == 1:
+            break
+        rest = order[1:]
+        x1 = np.maximum(boxes[i, 0], boxes[rest, 0])
+        y1 = np.maximum(boxes[i, 1], boxes[rest, 1])
+        x2 = np.minimum(boxes[i, 2], boxes[rest, 2])
+        y2 = np.minimum(boxes[i, 3], boxes[rest, 3])
+        inter = np.clip(x2 - x1, 0, None) * np.clip(y2 - y1, 0, None)
+        area_i = (boxes[i, 2] - boxes[i, 0]) * (boxes[i, 3] - boxes[i, 1])
+        area_r = (boxes[rest, 2] - boxes[rest, 0]) * (boxes[rest, 3] - boxes[rest, 1])
+        iou = inter / (area_i + area_r - inter + 1e-9)
+        order = rest[iou < iou_threshold]
+    keep_idx = np.array(keep, dtype=np.int64)
+    return boxes[keep_idx], max_scores[keep_idx], classes[keep_idx]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Dequantize helpers
+# ──────────────────────────────────────────────────────────────────────
+
+def dequantize_tensors(
+    raw_by_shape: dict[tuple[int, ...], np.ndarray],
+    schema: dict,
+) -> dict[str, np.ndarray]:
+    """Bind raw tensors to schema outputs by shape and dequantize each.
+
+    Returns ``{schema_output_name: float32_ndarray}``.
+    """
+    dequant = {}
+    for spec in schema["outputs"]:
+        shape = tuple(spec["shape"])
+        if shape not in raw_by_shape:
+            raise SystemExit(f"output {spec['name']!r}: shape {shape} not produced by model")
+        t = raw_by_shape[shape]
+        q = spec.get("quantization")
+        if q is not None and t.dtype != np.float32:
+            scale = float(q["scale"])
+            zp = int(q["zero_point"])
+            dequant[spec["name"]] = (t.astype(np.float32) - zp) * scale
+        else:
+            dequant[spec["name"]] = t.astype(np.float32)
+    return dequant
+
+
+def raw_tensors_by_name(
+    raw_by_shape: dict[tuple[int, ...], np.ndarray],
+    schema: dict,
+) -> dict[str, np.ndarray]:
+    """Bind raw (un-dequantized) tensors to schema names by shape."""
+    out = {}
+    for spec in schema["outputs"]:
+        shape = tuple(spec["shape"])
+        if shape in raw_by_shape:
+            out[spec["name"]] = raw_by_shape[shape]
+    return out
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────────────
+
+DOCUMENTATION_TEMPLATE = """\
+# {basename} — HAL ModelPack decoder fixture
+
+Generated by ``scripts/decoder_generate_modelpack_fixture.py``.
+
+## Source
+- Model: ``{model_path}`` (sha256: ``{model_sha}``)
+- Image: ``{image_path}``
+- Generated: ``{generated_at}``
+- Generator git sha: ``{git_sha}``
+
+## Tensor keys
+- ``input.image`` — preprocessed uint8 NHWC [1, {in_h}, {in_w}, 3].
+- ``raw.<output_name>`` — raw model output per FPN scale (dtype matches model).
+- ``intermediate.<output_name>.dequant`` — float32 dequantized output.
+- ``decoded.boxes_xyxy`` — post-NMS reference boxes [N, 4], normalized [0, 1].
+- ``decoded.scores`` — post-NMS reference scores [N].
+- ``decoded.classes`` — post-NMS reference class indices [N].
+
+## Decode formula (per scale)
+```
+g    = sigmoid(dequant).reshape(1, H, W, na, 5 + nc)
+xy   = (g[..., 0:2] * 2 + meshgrid - 0.5) / [W, H]
+wh   = (g[..., 2:4] * 2) ** 2 * anchors * 0.5
+obj  = g[..., 4:5]
+cls  = g[..., 5:]
+score = obj if nc == 1 else obj * cls
+xyxy  = concat([xy - wh, xy + wh])
+```
+NMS: class-agnostic, score≥{score_threshold}, IoU<{iou_threshold},
+max={max_output} detections.
+
+## HAL kernel mapping
+- ``raw.*`` → input to ``DecoderBuilder::with_schema(schema).build()``.
+- ``intermediate.<name>.dequant`` → expected output of
+  ``modelpack::postprocess_modelpack_split_quant`` dequant pass.
+- ``decoded.*`` → expected post-``Decoder::decode`` outputs.
+
+## Consumer tests
+- ``crates/decoder/tests/modelpack_coffeecup_parity.rs``
+"""
+
+
+def main() -> None:
+    cfg = parse_args()
+    model_path = cfg.model_path
+    image_path = cfg.image_path
+
+    # 1. Schema
+    suffix = model_path.suffix.lower()
+    if suffix == ".tflite":
+        schema = extract_schema_tflite(model_path)
+        decoder_family = "modelpack_split_int8"
+    elif suffix == ".onnx":
+        schema = extract_schema_onnx(model_path)
+        decoder_family = "modelpack_split_float"
+    else:
+        raise SystemExit(f"unsupported model suffix {suffix!r}; expect .tflite or .onnx")
+
+    # 2. Preprocess (always feed inference an NHWC uint8 tensor — infer_onnx
+    # transposes to NCHW where needed; in_h/in_w come from whichever layout
+    # the schema declares).
+    in_h, in_w, layout = detect_input_hw(schema["input"]["shape"])
+    image_uint8 = preprocess_image(image_path, in_h, in_w)
+
+    # 3. Inference
+    if suffix == ".tflite":
+        raw_by_shape, _quant_by_shape = infer_tflite(model_path, image_uint8)
+    else:
+        raw_by_shape, _ = infer_onnx(model_path, image_uint8)
+
+    raw_by_name = raw_tensors_by_name(raw_by_shape, schema)
+    dequant_by_name = dequantize_tensors(raw_by_shape, schema)
+
+    # 4. Reference decode + NMS
+    pre_nms_boxes, pre_nms_scores = decode_modelpack_outputs(dequant_by_name, schema)
+    boxes_xyxy, scores, classes = nms_class_agnostic(
+        pre_nms_boxes, pre_nms_scores,
+        cfg.score_threshold, cfg.iou_threshold, cfg.max_output,
+    )
+    print(f"reference pre-NMS detections: {len(pre_nms_boxes)}", file=sys.stderr)
+    print(f"reference post-NMS detections: {len(boxes_xyxy)} (score≥{cfg.score_threshold})",
+          file=sys.stderr)
+
+    # 5. Pack tensors
+    tensors: dict[str, np.ndarray] = {
+        "input.image": image_uint8.squeeze(0),
+    }
+    for name, t in raw_by_name.items():
+        tensors[f"raw.{name}"] = np.ascontiguousarray(t)
+    for name, t in dequant_by_name.items():
+        tensors[f"intermediate.{name}.dequant"] = np.ascontiguousarray(t)
+    tensors["decoded.boxes_xyxy"] = np.ascontiguousarray(boxes_xyxy.astype(np.float32))
+    tensors["decoded.scores"] = np.ascontiguousarray(scores.astype(np.float32))
+    # Use uint32 so PerScaleFixture::decoded() reads it as the u32 it expects.
+    tensors["decoded.classes"] = np.ascontiguousarray(classes.astype(np.uint32))
+
+    # 6. Metadata — keys match testdata/decoder/common/per_scale_fixture.rs
+    # so the existing PerScaleFixture loader can consume modelpack fixtures
+    # without code duplication. For the float ONNX path we emit an empty
+    # ``quantization_json`` map so the loader skips quant attachment.
+    quant_meta = {
+        spec["name"]: spec["quantization"]
+        for spec in schema["outputs"]
+        if spec.get("quantization") is not None
+    }
+    nms_cfg = {
+        "mode": "class_agnostic",
+        "score_threshold": cfg.score_threshold,
+        "iou_threshold": cfg.iou_threshold,
+        "max_output": cfg.max_output,
+    }
+    metadata = {
+        "format_version": "1",
+        "decoder_family": decoder_family,
+        "model_path": str(model_path),
+        "model_basename": model_path.name,
+        "model_sha256": sha256_file(model_path),
+        "image_path": str(image_path),
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "generator_git_sha": git_sha(),
+        "reference_script_sha256": sha256_file(Path(__file__).resolve()),
+        "schema_json": json.dumps(schema, separators=(",", ":")),
+        "edgefirst_json": json.dumps(schema, separators=(",", ":")),  # alias for layout-fixture parity
+        "quantization_json": json.dumps(quant_meta, separators=(",", ":")),
+        "nms_config_json": json.dumps(nms_cfg, separators=(",", ":")),
+        "expected_count_min": str(len(boxes_xyxy)),
+        "documentation_md": DOCUMENTATION_TEMPLATE.format(
+            basename=model_path.name,
+            model_path=model_path,
+            model_sha=sha256_file(model_path),
+            image_path=image_path,
+            generated_at=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            git_sha=git_sha(),
+            in_h=in_h,
+            in_w=in_w,
+            score_threshold=cfg.score_threshold,
+            iou_threshold=cfg.iou_threshold,
+            max_output=cfg.max_output,
+        ),
+    }
+
+    # 7. Save
+    from safetensors.numpy import save_file
+    cfg.output_path.parent.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(cfg.output_path), metadata=metadata)
+    print(f"wrote {cfg.output_path} ({cfg.output_path.stat().st_size} bytes)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/decoder_generate_modelpack_fixture.py
+++ b/scripts/decoder_generate_modelpack_fixture.py
@@ -164,7 +164,9 @@ def infer_tflite(model_path: Path, image_uint8_nhwc: np.ndarray) -> dict[tuple[i
     """Run TFLite inference; return {shape: raw_int8_tensor}.
 
     Binds outputs by shape (TFLite output names like ``PartitionedCall:0``
-    don't map to schema names like ``output_0``).
+    don't map to schema names like ``output_0``). Per-tensor quantization
+    parameters travel via the embedded ``edgefirst.json`` instead of being
+    threaded out of this function.
     """
     try:
         from tflite_runtime.interpreter import Interpreter
@@ -175,13 +177,11 @@ def infer_tflite(model_path: Path, image_uint8_nhwc: np.ndarray) -> dict[tuple[i
     in_det = interp.get_input_details()[0]
     interp.set_tensor(in_det["index"], image_uint8_nhwc)
     interp.invoke()
-    raw = {}
-    quants = {}
+    raw: dict[tuple[int, ...], np.ndarray] = {}
     for od in interp.get_output_details():
         t = interp.get_tensor(od["index"])
         raw[tuple(int(x) for x in t.shape)] = t
-        quants[tuple(int(x) for x in t.shape)] = od["quantization"]
-    return raw, quants
+    return raw
 
 
 def infer_onnx(model_path: Path, image_uint8_nhwc: np.ndarray) -> dict[tuple[int, ...], np.ndarray]:
@@ -195,8 +195,7 @@ def infer_onnx(model_path: Path, image_uint8_nhwc: np.ndarray) -> dict[tuple[int
     # NCHW float32 [1, 3, H, W]; normalize uint8/255.0
     img_nchw = (image_uint8_nhwc.astype(np.float32) / 255.0).transpose(0, 3, 1, 2)
     outs = sess.run(None, {in_meta.name: img_nchw})
-    raw = {tuple(int(x) for x in t.shape): t for t in outs}
-    return raw, {}
+    return {tuple(int(x) for x in t.shape): t for t in outs}
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -406,9 +405,9 @@ def main() -> None:
 
     # 3. Inference
     if suffix == ".tflite":
-        raw_by_shape, _quant_by_shape = infer_tflite(model_path, image_uint8)
+        raw_by_shape = infer_tflite(model_path, image_uint8)
     else:
-        raw_by_shape, _ = infer_onnx(model_path, image_uint8)
+        raw_by_shape = infer_onnx(model_path, image_uint8)
 
     raw_by_name = raw_tensors_by_name(raw_by_shape, schema)
     dequant_by_name = dequantize_tensors(raw_by_shape, schema)
@@ -445,11 +444,14 @@ def main() -> None:
         for spec in schema["outputs"]
         if spec.get("quantization") is not None
     }
+    # Key name ``max_detections`` matches PerScaleFixture::load() so the
+    # Rust test reads the actual fixture-time cap instead of falling back
+    # to the loader's default.
     nms_cfg = {
         "mode": "class_agnostic",
         "score_threshold": cfg.score_threshold,
         "iou_threshold": cfg.iou_threshold,
-        "max_output": cfg.max_output,
+        "max_detections": cfg.max_output,
     }
     metadata = {
         "format_version": "1",

--- a/testdata/decoder/coffeecup-mpk-det-relu-t-27d6.safetensors
+++ b/testdata/decoder/coffeecup-mpk-det-relu-t-27d6.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c03f6d7660158aae1ba6f9dc9e5ba1e1c33971c5b52cd4a8dbc9532fbe5c64f6
-size 490360
+oid sha256:5a4a3b56a44f68860e34090037365201e3174d7841ae966a3d5dccb14337cac7
+size 490368

--- a/testdata/decoder/coffeecup-mpk-det-relu-t-27d6.safetensors
+++ b/testdata/decoder/coffeecup-mpk-det-relu-t-27d6.safetensors
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c03f6d7660158aae1ba6f9dc9e5ba1e1c33971c5b52cd4a8dbc9532fbe5c64f6
+size 490360

--- a/testdata/decoder/coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.safetensors
+++ b/testdata/decoder/coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.safetensors
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b63b2fc8ca6919ddda5422538713a1e8f1129a8787ddeb735035d828bfc77dd8
+oid sha256:408104623c0b980e1be0352c7e1ce5fca9931a557610b9d0c727dbb98104c1ad
 size 456682

--- a/testdata/decoder/coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.safetensors
+++ b/testdata/decoder/coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.safetensors
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b63b2fc8ca6919ddda5422538713a1e8f1129a8787ddeb735035d828bfc77dd8
+size 456682

--- a/testdata/decoder/modelpack_det_logical.json
+++ b/testdata/decoder/modelpack_det_logical.json
@@ -1,0 +1,113 @@
+{
+  "schema_version": 2,
+  "name": "modelpack-csp19n-320x320-rgb-t-aaa1",
+  "description": "ModelPack detection-only, 2 FPN scales, logical layout",
+  "author": "Au-Zone Technologies",
+  "host": {
+    "studio_server": "test.edgefirst.studio",
+    "project_id": "1123",
+    "session": "t-aaa1",
+    "username": "tester"
+  },
+  "dataset": {
+    "name": "synthetic",
+    "id": "ds-1c8",
+    "classes": [
+      "cat", "dog", "person", "car", "truck",
+      "bus", "bike", "plane", "boat", "traffic_light",
+      "fire_hydrant", "stop_sign", "bird"
+    ]
+  },
+  "input": {
+    "shape": [1, 320, 320, 3],
+    "cameraadaptor": "rgb",
+    "input_channels": 3,
+    "output_channels": 3
+  },
+  "model": {
+    "detection": true,
+    "segmentation": false,
+    "model_name": "nano",
+    "backbone": "cspdarknet19",
+    "model_size": "nano",
+    "task": "detection",
+    "anchors": [
+      [[10, 13], [16, 30], [33, 23]],
+      [[30, 61], [62, 45], [59, 119]]
+    ],
+    "end2end": false
+  },
+  "validation": {
+    "iou": 0.5,
+    "score": 0.25,
+    "nms": "hal",
+    "preprocessing": "resize",
+    "normalization": "unsigned"
+  },
+  "nms": "class_agnostic",
+  "calibration": "calibration-ds-1c8-aaaaaaaa.safetensors",
+  "outputs": [
+    {
+      "name": "output_0",
+      "type": "detection",
+      "encoding": "anchor",
+      "decoder": "modelpack",
+      "normalized": true,
+      "shape": [1, 20, 20, 54],
+      "dshape": [
+        {"batch": 1},
+        {"height": 20},
+        {"width": 20},
+        {"num_anchors_x_features": 54}
+      ],
+      "stride": [16, 16],
+      "anchors": [[0.031, 0.041], [0.050, 0.094], [0.103, 0.072]],
+      "dtype": "float32",
+      "quantization": null
+    },
+    {
+      "name": "output_1",
+      "type": "detection",
+      "encoding": "anchor",
+      "decoder": "modelpack",
+      "normalized": true,
+      "shape": [1, 10, 10, 54],
+      "dshape": [
+        {"batch": 1},
+        {"height": 10},
+        {"width": 10},
+        {"num_anchors_x_features": 54}
+      ],
+      "stride": [32, 32],
+      "anchors": [[0.094, 0.191], [0.194, 0.141], [0.184, 0.372]],
+      "dtype": "float32",
+      "quantization": null
+    }
+  ],
+  "split_hints": [
+    {
+      "type": "quantization_split",
+      "target": "output_0",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "strides": [16],
+      "anchors_per_cell": 3,
+      "description": "ModelPack anchor-grid at stride 16: 3 anchors × (4 box + 1 obj + 13 classes) = 54 channels interleaved",
+      "boundaries": [
+        {"name": "detection_grid", "channels": [0, 54], "activation": "sigmoid"}
+      ]
+    },
+    {
+      "type": "quantization_split",
+      "target": "output_1",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "strides": [32],
+      "anchors_per_cell": 3,
+      "description": "ModelPack anchor-grid at stride 32: 3 anchors × (4 box + 1 obj + 13 classes) = 54 channels interleaved",
+      "boundaries": [
+        {"name": "detection_grid", "channels": [0, 54], "activation": "sigmoid"}
+      ]
+    }
+  ]
+}

--- a/testdata/decoder/modelpack_det_smart.json
+++ b/testdata/decoder/modelpack_det_smart.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 2,
+  "name": "modelpack-csp19n-320x320-rgb-t-aaa1-quant",
+  "description": "ModelPack detection-only, 2 FPN scales, compiled INT8 layout. Each FPN scale is its own physical tensor with `quantization` and `dtype: int8` populated directly on the logical output — ModelPack anchor-grid outputs are already per-scale, so converters do not introduce further per-scale children (no nested `outputs[]`).",
+  "author": "Au-Zone Technologies",
+  "host": {
+    "studio_server": "test.edgefirst.studio",
+    "project_id": "1123",
+    "session": "t-aaa1",
+    "username": "tester"
+  },
+  "dataset": {
+    "name": "synthetic",
+    "id": "ds-1c8",
+    "classes": [
+      "cat", "dog", "person", "car", "truck",
+      "bus", "bike", "plane", "boat", "traffic_light",
+      "fire_hydrant", "stop_sign", "bird"
+    ]
+  },
+  "input": {
+    "shape": [1, 320, 320, 3],
+    "cameraadaptor": "rgb",
+    "input_channels": 3,
+    "output_channels": 3
+  },
+  "model": {
+    "detection": true,
+    "segmentation": false,
+    "model_name": "nano",
+    "backbone": "cspdarknet19",
+    "model_size": "nano",
+    "task": "detection",
+    "anchors": [
+      [[10, 13], [16, 30], [33, 23]],
+      [[30, 61], [62, 45], [59, 119]]
+    ],
+    "end2end": false
+  },
+  "validation": {
+    "iou": 0.5,
+    "score": 0.25,
+    "nms": "hal",
+    "preprocessing": "resize",
+    "normalization": "unsigned"
+  },
+  "nms": "class_agnostic",
+  "calibration": "calibration-ds-1c8-aaaaaaaa.safetensors",
+  "outputs": [
+    {
+      "name": "output_0",
+      "type": "detection",
+      "encoding": "anchor",
+      "decoder": "modelpack",
+      "normalized": true,
+      "shape": [1, 20, 20, 54],
+      "dshape": [
+        {"batch": 1},
+        {"height": 20},
+        {"width": 20},
+        {"num_anchors_x_features": 54}
+      ],
+      "stride": [16, 16],
+      "anchors": [[0.031, 0.041], [0.050, 0.094], [0.103, 0.072]],
+      "dtype": "int8",
+      "quantization": {
+        "scale": 0.05,
+        "zero_point": 0,
+        "dtype": "int8"
+      }
+    },
+    {
+      "name": "output_1",
+      "type": "detection",
+      "encoding": "anchor",
+      "decoder": "modelpack",
+      "normalized": true,
+      "shape": [1, 10, 10, 54],
+      "dshape": [
+        {"batch": 1},
+        {"height": 10},
+        {"width": 10},
+        {"num_anchors_x_features": 54}
+      ],
+      "stride": [32, 32],
+      "anchors": [[0.094, 0.191], [0.194, 0.141], [0.184, 0.372]],
+      "dtype": "int8",
+      "quantization": {
+        "scale": 0.07,
+        "zero_point": 5,
+        "dtype": "int8"
+      }
+    }
+  ]
+}

--- a/testdata/decoder/modelpack_multitask_logical.json
+++ b/testdata/decoder/modelpack_multitask_logical.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": 2,
+  "name": "modelpack-csp53n-multi-320x320-rgb-t-aaa3",
+  "description": "ModelPack multi-task (det+seg), 3 FPN scales, logical layout",
+  "author": "Au-Zone Technologies",
+  "host": {
+    "studio_server": "test.edgefirst.studio",
+    "project_id": "1123",
+    "session": "t-aaa3",
+    "username": "tester"
+  },
+  "dataset": {
+    "name": "synthetic",
+    "id": "ds-1c8",
+    "classes": [
+      "cat", "dog", "person", "car", "truck"
+    ]
+  },
+  "input": {
+    "shape": [1, 320, 320, 3],
+    "cameraadaptor": "rgb",
+    "input_channels": 3,
+    "output_channels": 3
+  },
+  "model": {
+    "detection": true,
+    "segmentation": true,
+    "model_name": "nano",
+    "backbone": "cspdarknet53",
+    "model_size": "nano",
+    "task": "multitask",
+    "anchors": [
+      [[10, 13], [16, 30], [33, 23]],
+      [[30, 61], [62, 45], [59, 119]],
+      [[116, 90], [156, 198], [373, 326]]
+    ],
+    "end2end": false
+  },
+  "validation": {
+    "iou": 0.5,
+    "score": 0.25,
+    "nms": "hal",
+    "preprocessing": "resize",
+    "normalization": "unsigned"
+  },
+  "nms": "class_agnostic",
+  "calibration": "calibration-ds-1c8-cccccccc.safetensors",
+  "outputs": [
+    {
+      "name": "output_0",
+      "type": "detection",
+      "encoding": "anchor",
+      "decoder": "modelpack",
+      "normalized": true,
+      "shape": [1, 40, 40, 30],
+      "dshape": [
+        {"batch": 1},
+        {"height": 40},
+        {"width": 40},
+        {"num_anchors_x_features": 30}
+      ],
+      "stride": [8, 8],
+      "anchors": [[0.031, 0.041], [0.050, 0.094], [0.103, 0.072]],
+      "dtype": "float32",
+      "quantization": null
+    },
+    {
+      "name": "output_1",
+      "type": "detection",
+      "encoding": "anchor",
+      "decoder": "modelpack",
+      "normalized": true,
+      "shape": [1, 20, 20, 30],
+      "dshape": [
+        {"batch": 1},
+        {"height": 20},
+        {"width": 20},
+        {"num_anchors_x_features": 30}
+      ],
+      "stride": [16, 16],
+      "anchors": [[0.094, 0.191], [0.194, 0.141], [0.184, 0.372]],
+      "dtype": "float32",
+      "quantization": null
+    },
+    {
+      "name": "output_2",
+      "type": "detection",
+      "encoding": "anchor",
+      "decoder": "modelpack",
+      "normalized": true,
+      "shape": [1, 10, 10, 30],
+      "dshape": [
+        {"batch": 1},
+        {"height": 10},
+        {"width": 10},
+        {"num_anchors_x_features": 30}
+      ],
+      "stride": [32, 32],
+      "anchors": [[0.363, 0.281], [0.488, 0.619], [1.166, 1.019]],
+      "dtype": "float32",
+      "quantization": null
+    },
+    {
+      "name": "output_3",
+      "type": "segmentation",
+      "decoder": "modelpack",
+      "shape": [1, 160, 160, 6],
+      "dshape": [
+        {"batch": 1},
+        {"height": 160},
+        {"width": 160},
+        {"num_classes": 6}
+      ],
+      "dtype": "float32",
+      "quantization": null
+    }
+  ],
+  "split_hints": [
+    {
+      "type": "quantization_split", "target": "output_0",
+      "input_dtype": "uint8", "output_dtype": "int8",
+      "strides": [8], "anchors_per_cell": 3,
+      "description": "ModelPack anchor-grid at stride 8: 3 anchors × (4 box + 1 obj + 5 classes) = 30 channels interleaved",
+      "boundaries": [{"name": "detection_grid", "channels": [0, 30], "activation": "sigmoid"}]
+    },
+    {
+      "type": "quantization_split", "target": "output_1",
+      "input_dtype": "uint8", "output_dtype": "int8",
+      "strides": [16], "anchors_per_cell": 3,
+      "description": "ModelPack anchor-grid at stride 16: 3 anchors × (4 box + 1 obj + 5 classes) = 30 channels interleaved",
+      "boundaries": [{"name": "detection_grid", "channels": [0, 30], "activation": "sigmoid"}]
+    },
+    {
+      "type": "quantization_split", "target": "output_2",
+      "input_dtype": "uint8", "output_dtype": "int8",
+      "strides": [32], "anchors_per_cell": 3,
+      "description": "ModelPack anchor-grid at stride 32: 3 anchors × (4 box + 1 obj + 5 classes) = 30 channels interleaved",
+      "boundaries": [{"name": "detection_grid", "channels": [0, 30], "activation": "sigmoid"}]
+    },
+    {
+      "type": "quantization_split", "target": "output_3",
+      "input_dtype": "uint8", "output_dtype": "int8",
+      "description": "ModelPack segmentation: 6 classes (5 annotated + background)",
+      "boundaries": [{"name": "segmentation", "channels": [0, 6], "activation": "softmax"}]
+    }
+  ]
+}

--- a/testdata/decoder/modelpack_seg_logical.json
+++ b/testdata/decoder/modelpack_seg_logical.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 2,
+  "name": "modelpack-csp19n-seg-320x320-rgb-t-aaa2",
+  "description": "ModelPack segmentation-only, logical layout",
+  "author": "Au-Zone Technologies",
+  "host": {
+    "studio_server": "test.edgefirst.studio",
+    "project_id": "1123",
+    "session": "t-aaa2",
+    "username": "tester"
+  },
+  "dataset": {
+    "name": "synthetic",
+    "id": "ds-1c8",
+    "classes": ["road", "lane", "sidewalk", "vehicle", "person"]
+  },
+  "input": {
+    "shape": [1, 320, 320, 3],
+    "cameraadaptor": "rgb",
+    "input_channels": 3,
+    "output_channels": 3
+  },
+  "model": {
+    "detection": false,
+    "segmentation": true,
+    "model_name": "nano",
+    "backbone": "cspdarknet19",
+    "model_size": "nano",
+    "task": "segmentation",
+    "anchors": null,
+    "end2end": false
+  },
+  "validation": {
+    "iou": 0.5,
+    "score": 0.25,
+    "nms": "none",
+    "preprocessing": "resize",
+    "normalization": "unsigned"
+  },
+  "calibration": "calibration-ds-1c8-bbbbbbbb.safetensors",
+  "outputs": [
+    {
+      "name": "output_0",
+      "type": "segmentation",
+      "decoder": "modelpack",
+      "shape": [1, 160, 160, 6],
+      "dshape": [
+        {"batch": 1},
+        {"height": 160},
+        {"width": 160},
+        {"num_classes": 6}
+      ],
+      "dtype": "float32",
+      "quantization": null
+    }
+  ],
+  "split_hints": [
+    {
+      "type": "quantization_split",
+      "target": "output_0",
+      "input_dtype": "uint8",
+      "output_dtype": "int8",
+      "description": "ModelPack segmentation: 6 classes (5 annotated + background)",
+      "boundaries": [
+        {"name": "segmentation", "channels": [0, 6], "activation": "softmax"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds end-to-end parity coverage for HAL's ModelPack anchor-grid decoder against the canonical ModelPack Python reference, on a real 270x480 production detection model (`coffeecup-mpk-det-relu-t-27d6`).
- Adds schema-build coverage for ModelPack 4.0 layouts the HAL hadn't been exercised against (det/seg/multitask logical, det smart) via four synthetic fixtures.

## What's included
- **Parity tests** — `crates/decoder/tests/modelpack_coffeecup_parity.rs` runs `Decoder::decode` on raw outputs captured from both the TFLite int8 smart export and the ONNX float export, then asserts the post-NMS detections match the Python reference embedded in each fixture. Tolerances: IoU >= 0.95 + score within 0.02 (int8), IoU >= 0.99 + score within 0.001 (float).
- **Schema tests** — `crates/decoder/tests/modelpack_decoder_schemas.rs` asserts `SchemaV2::parse_file` + `DecoderBuilder::with_schema(...).build()` succeeds on four ModelPack 4.0 schema shapes (det/seg/multitask logical, det smart) with the expected output topology.
- **Fixture generator** — `scripts/decoder_generate_modelpack_fixture.py` runs inference on either a TFLite (int8) or ONNX (float) ModelPack model, executes the canonical reference decode in NumPy, and packs raw + intermediate + reference into a `.safetensors` consumable by the existing `PerScaleFixture` loader.
- **.gitignore** — adds `*.onnx` alongside the existing `*.tflite` rule so source models stay local-only (only the generated fixtures are committed, via LFS).

## Files
- `crates/decoder/tests/modelpack_coffeecup_parity.rs` (new, +163)
- `crates/decoder/tests/modelpack_decoder_schemas.rs` (new, +156)
- `scripts/decoder_generate_modelpack_fixture.py` (new, +492)
- `testdata/decoder/modelpack_{det_logical,det_smart,seg_logical,multitask_logical}.json` (new schema fixtures)
- `testdata/decoder/coffeecup-mpk-det-relu-t-27d6{,_quant-u8-i8_smart}.safetensors` (new, LFS-tracked, ~947 KB total)
- `.gitignore` (+`*.onnx`)

## Why this matters
The existing modelpack tests only exercised synthetic 320x320 schemas. This change is the first proof that HAL's ModelPack runtime (dequant + sigmoid + anchor-grid decode + class-agnostic NMS) reproduces the canonical ModelPack reference on a real model with non-square input and per-tensor int8 quantization.

## Test plan
- [x] `cargo test -p edgefirst-decoder --test modelpack_coffeecup_parity` — 2/2 pass
- [x] `cargo test -p edgefirst-decoder --test modelpack_decoder_schemas` — 4/4 pass
- [x] `cargo test -p edgefirst-decoder` — full suite 480/480 (no regressions)
- [x] `make format lint check` clean

## Regenerating the fixtures
```bash
source venv/bin/activate
python scripts/decoder_generate_modelpack_fixture.py \
  coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.tflite \
  testdata/coffeecup.jpg \
  --output testdata/decoder/coffeecup-mpk-det-relu-t-27d6_quant-u8-i8_smart.safetensors

python scripts/decoder_generate_modelpack_fixture.py \
  coffeecup-mpk-det-relu-t-27d6.onnx \
  testdata/coffeecup.jpg \
  --output testdata/decoder/coffeecup-mpk-det-relu-t-27d6.safetensors
```
The source `.tflite`/`.onnx` are intentionally not committed; they live at the repo root for reviewers who want to reproduce locally.