### PR TITLE
Reset TEXTURE_SWIZZLE_R after RGBA->PlanarRgb conversion

### DIFF
--- a/crates/image/src/gl/processor.rs
+++ b/crates/image/src/gl/processor.rs
@@ -3304,6 +3304,21 @@ impl GLProcessorST {
                     vertices_index.as_ptr() as *const c_void,
                 );
             }
+            // Reset the texture swizzle to identity before returning. The
+            // loop above left `TEXTURE_SWIZZLE_R` pointing at GL_BLUE (the
+            // last iteration's value) so that pass 3 would write the blue
+            // plane. The GLES spec says `GL_TEXTURE_SWIZZLE_*` is undefined
+            // for `GL_TEXTURE_EXTERNAL_OES`, but NXP Vivante and Mali drivers
+            // honor it on external textures and the swizzle persists across
+            // subsequent samples — including the bg blit in
+            // `draw_decoded_masks`, which then channel-permutes the entire
+            // overlay's background (`canvas.R := src.B`). Restoring identity
+            // before any later sampler sees this texture is the safe move.
+            gls::gl::TexParameteri(
+                texture_target,
+                gls::gl::TEXTURE_SWIZZLE_R,
+                gls::gl::RED as i32,
+            );
             check_gl_error(function!(), line!())?;
         }
         Ok(())
@@ -3432,6 +3447,16 @@ impl GLProcessorST {
                     vertices_index.as_ptr() as *const c_void,
                 );
             }
+            // Reset the texture swizzle to identity (see the matching
+            // comment in `draw_camera_texture_to_rgb_planar` above). This
+            // path operates on a `TEXTURE_2D` intermediate, which honors the
+            // swizzle per spec — leaving `TEXTURE_SWIZZLE_R = GL_BLUE`
+            // poisons every later sampler bound to this texture object.
+            gls::gl::TexParameteri(
+                texture_target,
+                gls::gl::TEXTURE_SWIZZLE_R,
+                gls::gl::RED as i32,
+            );
             check_gl_error(function!(), line!())?;
         }
         Ok(())

--- a/crates/image/src/gl/processor.rs
+++ b/crates/image/src/gl/processor.rs
@@ -3305,15 +3305,15 @@ impl GLProcessorST {
                 );
             }
             // Reset the texture swizzle to identity before returning. The
-            // loop above left `TEXTURE_SWIZZLE_R` pointing at GL_BLUE (the
-            // last iteration's value) so that pass 3 would write the blue
-            // plane. The GLES spec says `GL_TEXTURE_SWIZZLE_*` is undefined
-            // for `GL_TEXTURE_EXTERNAL_OES`, but NXP Vivante and Mali drivers
-            // honor it on external textures and the swizzle persists across
-            // subsequent samples — including the bg blit in
+            // loop above left `TEXTURE_SWIZZLE_R` pointing at the last
+            // requested planar channel (`GL_BLUE` for RGB, `GL_ALPHA` when
+            // `alpha` is true). The GLES spec says `GL_TEXTURE_SWIZZLE_*` is
+            // undefined for `GL_TEXTURE_EXTERNAL_OES`, but NXP Vivante and
+            // Mali drivers honor it on external textures and the swizzle
+            // persists across subsequent samples — including the bg blit in
             // `draw_decoded_masks`, which then channel-permutes the entire
-            // overlay's background (`canvas.R := src.B`). Restoring identity
-            // before any later sampler sees this texture is the safe move.
+            // overlay's background. Restoring identity before any later
+            // sampler sees this texture is the safe move.
             gls::gl::TexParameteri(
                 texture_target,
                 gls::gl::TEXTURE_SWIZZLE_R,
@@ -3450,8 +3450,10 @@ impl GLProcessorST {
             // Reset the texture swizzle to identity (see the matching
             // comment in `draw_camera_texture_to_rgb_planar` above). This
             // path operates on a `TEXTURE_2D` intermediate, which honors the
-            // swizzle per spec — leaving `TEXTURE_SWIZZLE_R = GL_BLUE`
-            // poisons every later sampler bound to this texture object.
+            // swizzle per spec — leaving `TEXTURE_SWIZZLE_R` set to the last
+            // planar channel selected (for example `GL_BLUE` for RGB or
+            // `GL_ALPHA` for RGBA) poisons every later sampler bound to this
+            // texture object.
             gls::gl::TexParameteri(
                 texture_target,
                 gls::gl::TEXTURE_SWIZZLE_R,


### PR DESCRIPTION
## Summary

`draw_camera_texture_to_rgb_planar` and its `_2d` intermediate variant iterate over the three colour planes and, before each `DrawElements`, set `GL_TEXTURE_SWIZZLE_R` to `GL_RED`, `GL_GREEN`, `GL_BLUE` in turn so the single-channel R8 output of each pass picks up the corresponding component of the RGB(A) source. Both functions returned with the swizzle left at `GL_BLUE` — the value from the loop's final iteration.

`camera_eglimage_texture` is a long-lived texture object reused by the next `draw_decoded_masks` call, whose background blit samples it through `texture_program_yuv`. **NXP Vivante GC7000 (i.MX 8M Plus) and Mali Valhall (i.MX 95) drivers honour `GL_TEXTURE_SWIZZLE_*` on `GL_TEXTURE_EXTERNAL_OES` even though the GLES spec leaves the behaviour undefined**, so the `BLUE` swizzle on the `.r` component persisted into the overlay path: every overlay pixel came out with `canvas.R := src.B` while G/B/A stayed correct. Visually this read as a green tint on warm tones and a magenta tint on cool tones in the saved JPEG. The bounding-box outlines for the default person-class colour `(R = B = 0)` were unaffected, which hid the corruption from a casual eye but still produced visibly wrong overlay backgrounds on i.MX targets.

Mesa happens to ignore the swizzle on external textures, so the golden CI image (`testdata/output_render_gl.jpg`) was clean and `test_decoded_overlay` did not catch this.

Restoring `TEXTURE_SWIZZLE_R` to `GL_RED` at the end of each routine keeps the texture's per-channel swizzle at the GLES identity, so any later sampler reads the source channels in their natural order. `TEXTURE_SWIZZLE_G`/`B`/`A` are not touched inside either function, so a single `TexParameteri` call is enough to restore identity.

## Byte-level evidence (imx8mp-frdm, ara2-rs yolov8 example before fix)

| Pixel | `src` (RGBA) | `canvas` after `draw_decoded_masks` with ≥1 detection |
|---|---|---|
| (0, 0) | [77, 53, 45, 255] | **[45, 53, 45, 255]** |
| (640, 360) | [102, 70, 45, 255] | **[45, 70, 45, 255]** |
| (1279, 719) | [40, 52, 52, 255] | **[52, 52, 52, 255]** |

After the fix every byte matches `src` and the bbox outlines render correctly green.

## Test plan
- [x] `make format lint` — clean
- [x] `cargo zigbuild --target aarch64-unknown-linux-gnu --release --workspace --exclude edgefirst_hal` — clean
- [x] `make sbom` — no NOTICE drift
- [x] Verified end-to-end through ara2-rs yolov8 example on imx8mp-frdm (Vivante GC7000Lite) — overlay JPG now shows natural skin tones, pink crowd, clean green bounding boxes
- [x] Verified end-to-end on imx95-frdm (Mali Valhall) — same correct overlay
- [x] Existing GL unit tests still pass on x86 Mesa (the bug never manifested there since Mesa ignores swizzle on external textures)