### PR TITLE
fix(tensor,image): honor plane_offset for heap + GPU sub-region views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Tensor::subview()` / `TensorDyn::subview()` (`edgefirst-tensor`): zero-copy
+  sub-region views that share the parent's allocation (`Mem` heap `Arc` or `Dma`
+  fd) and map at a byte offset, for assembling a batch into one buffer. N views
+  into one parent share the buffer (no copy) and write independently;
+  disjointness of simultaneously-mapped mutable windows is the caller's contract.
 - V4L2 hardware JPEG decode backend (`edgefirst-codec`, Linux, default-on
   `v4l2` feature). Capability-based probe drives any device exposing a JPEG
   decoder through the standard V4L2 mem2mem API (lead target i.MX `mxc-jpeg`),
@@ -173,6 +178,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The in-codec YCbCr→RGB/RGBA/BGRA colour kernels, chroma-upsample kernels, and
   SIMD type-conversion path (these moved to `ImageProcessor::convert()`); the
   JPEG CPU path now writes native `NV12`/`GREY` directly.
+
+### Fixed
+
+- GPU and heap sub-region views now honor `plane_offset`. The OpenGL EGLImage
+  cache key includes the plane offset, so offset-distinct views of one DMA-BUF
+  no longer alias the offset-0 image (previously every view rendered/sampled the
+  base region — capping batched render-to-DMA-BUF). Heap (`Mem`) tensors map
+  correctly at non-zero offsets, and the shared backing uses interior-mutable
+  cells so disjoint sub-views carry correct write provenance.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fd) and map at a byte offset, for assembling a batch into one buffer. N views
   into one parent share the buffer (no copy) and write independently;
   disjointness of simultaneously-mapped mutable windows is the caller's contract.
+  Wired through the Python bindings (`Tensor.subview()`, the `plane_offset`
+  property, `set_plane_offset()` — a view exposes the full NumPy buffer-protocol
+  surface via `map()`/`from_numpy()` like any tensor) and the C API
+  (`hal_tensor_subview`, `hal_tensor_plane_offset`, `hal_tensor_set_plane_offset`).
 - V4L2 hardware JPEG decode backend (`edgefirst-codec`, Linux, default-on
   `v4l2` feature). Capability-based probe drives any device exposing a JPEG
   decoder through the standard V4L2 mem2mem API (lead target i.MX `mxc-jpeg`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The in-codec YCbCr→RGB/RGBA/BGRA colour kernels, chroma-upsample kernels, and
   SIMD type-conversion path (these moved to `ImageProcessor::convert()`); the
   JPEG CPU path now writes native `NV12`/`GREY` directly.
+- **Breaking (internal types):** the per-memory backing types
+  `MemTensor`/`MemMap`, `DmaTensor`/`DmaMap`, `ShmTensor`/`ShmMap`, and
+  `IoSurfaceTensor`/`IoSurfaceMap` are no longer re-exported from
+  `edgefirst-tensor` — they are implementation details. Allocate `Tensor<T>` /
+  `TensorDyn` and `map()` them instead. The PBO extension point
+  (`PboTensor`/`PboMap`/`PboMapping`/`PboOps`) and `image_iosurface_layout`
+  remain public.
 
 ### Fixed
 

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -2788,6 +2788,64 @@ void hal_tensor_cuda_unmap(void *map);
 int hal_tensor_reshape(struct hal_tensor *tensor, const size_t *shape, size_t ndim);
 
 /**
+ * Create a zero-copy sub-region view that shares the parent's allocation.
+ *
+ * The view maps the window `[offset_bytes, offset_bytes + size)` where
+ * `size = prod(shape) * element_size`, sharing the parent buffer (`Mem` heap
+ * allocation or `Dma` fd) with no copy. N views into one parent can each be
+ * mapped (via `hal_tensor_map_create`) and written independently — the basis
+ * for assembling a batch into one buffer. `offset_bytes` must be aligned to
+ * the element size and the window must fit the parent allocation.
+ *
+ * The returned tensor must be freed with `hal_tensor_free()`. It co-owns the
+ * parent buffer (shared `Arc`/fd), so the buffer stays valid as long as any
+ * view is alive, even if the parent handle is freed first.
+ *
+ * @param tensor Parent tensor handle
+ * @param offset_bytes Byte offset of the window into the parent allocation
+ * @param shape Array of dimension sizes (ndim elements)
+ * @param ndim Number of dimensions (1-8)
+ * @return New tensor handle viewing the window on success, NULL on error
+ * @par Errors (errno):
+ * - EINVAL: NULL tensor/shape, ndim 0 or > 8, offset not element-aligned,
+ *   window exceeds the parent allocation, or backing is not Mem/Dma
+ */
+struct hal_tensor *hal_tensor_subview(const struct hal_tensor *tensor,
+                                      size_t offset_bytes,
+                                      const size_t *shape,
+                                      size_t ndim);
+
+/**
+ * Get the byte offset of this tensor's window into its backing allocation.
+ *
+ * Writes the offset to `*out_offset` (when non-NULL) and returns `true` when
+ * the tensor carries a plane offset — e.g. a view from `hal_tensor_subview`.
+ * Returns `false` for a whole-buffer tensor (writing `0`) or a NULL tensor.
+ *
+ * @param tensor Tensor handle
+ * @param out_offset Out-param receiving the byte offset (may be NULL to query
+ *        presence only)
+ * @return true if a plane offset is set, false otherwise
+ * @par Errors (errno):
+ * - EINVAL: NULL tensor
+ */
+bool hal_tensor_plane_offset(const struct hal_tensor *tensor, size_t *out_offset);
+
+/**
+ * Set the byte offset of this tensor's window into its backing allocation.
+ *
+ * Validated against the allocation when the tensor is mapped. Prefer
+ * `hal_tensor_subview()` for sharing one buffer across independent windows.
+ *
+ * @param tensor Tensor handle
+ * @param offset Byte offset into the backing allocation
+ * @return 0 on success, -1 on error
+ * @par Errors (errno):
+ * - EINVAL: NULL tensor
+ */
+int hal_tensor_set_plane_offset(struct hal_tensor *tensor, size_t offset);
+
+/**
  * Attach per-tensor affine quantization metadata to an integer tensor.
  *
  * The schema-driven per-scale decoder reads quantization live from each

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -2795,7 +2795,9 @@ int hal_tensor_reshape(struct hal_tensor *tensor, const size_t *shape, size_t nd
  * allocation or `Dma` fd) with no copy. N views into one parent can each be
  * mapped (via `hal_tensor_map_create`) and written independently — the basis
  * for assembling a batch into one buffer. `offset_bytes` must be aligned to
- * the element size and the window must fit the parent allocation.
+ * the element's alignment (its natural alignment, which equals the element
+ * size for the supported dtypes) and the window must fit the parent
+ * allocation.
  *
  * The returned tensor must be freed with `hal_tensor_free()`. It co-owns the
  * parent buffer (shared `Arc`/fd), so the buffer stays valid as long as any

--- a/crates/capi/src/tensor.rs
+++ b/crates/capi/src/tensor.rs
@@ -839,6 +839,104 @@ pub unsafe extern "C" fn hal_tensor_reshape(
     }
 }
 
+/// Create a zero-copy sub-region view that shares the parent's allocation.
+///
+/// The view maps the window `[offset_bytes, offset_bytes + size)` where
+/// `size = prod(shape) * element_size`, sharing the parent buffer (`Mem` heap
+/// allocation or `Dma` fd) with no copy. N views into one parent can each be
+/// mapped (via `hal_tensor_map_create`) and written independently — the basis
+/// for assembling a batch into one buffer. `offset_bytes` must be aligned to
+/// the element size and the window must fit the parent allocation.
+///
+/// The returned tensor must be freed with `hal_tensor_free()`. It co-owns the
+/// parent buffer (shared `Arc`/fd), so the buffer stays valid as long as any
+/// view is alive, even if the parent handle is freed first.
+///
+/// @param tensor Parent tensor handle
+/// @param offset_bytes Byte offset of the window into the parent allocation
+/// @param shape Array of dimension sizes (ndim elements)
+/// @param ndim Number of dimensions (1-8)
+/// @return New tensor handle viewing the window on success, NULL on error
+/// @par Errors (errno):
+/// - EINVAL: NULL tensor/shape, ndim 0 or > 8, offset not element-aligned,
+///   window exceeds the parent allocation, or backing is not Mem/Dma
+#[no_mangle]
+pub unsafe extern "C" fn hal_tensor_subview(
+    tensor: *const HalTensor,
+    offset_bytes: size_t,
+    shape: *const size_t,
+    ndim: size_t,
+) -> *mut HalTensor {
+    check_null_ret_null!(tensor, shape);
+    if ndim == 0 || ndim > 8 {
+        return set_error_null(libc::EINVAL);
+    }
+
+    let shape_slice = unsafe { std::slice::from_raw_parts(shape, ndim) };
+    let view = try_or_null!(
+        unsafe { &*tensor }.inner.subview(offset_bytes, shape_slice),
+        libc::EINVAL
+    );
+    Box::into_raw(Box::new(HalTensor { inner: view }))
+}
+
+/// Get the byte offset of this tensor's window into its backing allocation.
+///
+/// Writes the offset to `*out_offset` (when non-NULL) and returns `true` when
+/// the tensor carries a plane offset — e.g. a view from `hal_tensor_subview`.
+/// Returns `false` for a whole-buffer tensor (writing `0`) or a NULL tensor.
+///
+/// @param tensor Tensor handle
+/// @param out_offset Out-param receiving the byte offset (may be NULL to query
+///        presence only)
+/// @return true if a plane offset is set, false otherwise
+/// @par Errors (errno):
+/// - EINVAL: NULL tensor
+#[no_mangle]
+pub unsafe extern "C" fn hal_tensor_plane_offset(
+    tensor: *const HalTensor,
+    out_offset: *mut size_t,
+) -> bool {
+    if tensor.is_null() {
+        set_error(libc::EINVAL);
+        return false;
+    }
+    match unsafe { &*tensor }.inner.plane_offset() {
+        Some(off) => {
+            if !out_offset.is_null() {
+                unsafe { *out_offset = off as size_t };
+            }
+            true
+        }
+        None => {
+            if !out_offset.is_null() {
+                unsafe { *out_offset = 0 };
+            }
+            false
+        }
+    }
+}
+
+/// Set the byte offset of this tensor's window into its backing allocation.
+///
+/// Validated against the allocation when the tensor is mapped. Prefer
+/// `hal_tensor_subview()` for sharing one buffer across independent windows.
+///
+/// @param tensor Tensor handle
+/// @param offset Byte offset into the backing allocation
+/// @return 0 on success, -1 on error
+/// @par Errors (errno):
+/// - EINVAL: NULL tensor
+#[no_mangle]
+pub unsafe extern "C" fn hal_tensor_set_plane_offset(
+    tensor: *mut HalTensor,
+    offset: size_t,
+) -> c_int {
+    check_null!(tensor);
+    unsafe { &mut *tensor }.inner.set_plane_offset(offset);
+    0
+}
+
 /// Attach per-tensor affine quantization metadata to an integer tensor.
 ///
 /// The schema-driven per-scale decoder reads quantization live from each

--- a/crates/capi/src/tensor.rs
+++ b/crates/capi/src/tensor.rs
@@ -846,7 +846,9 @@ pub unsafe extern "C" fn hal_tensor_reshape(
 /// allocation or `Dma` fd) with no copy. N views into one parent can each be
 /// mapped (via `hal_tensor_map_create`) and written independently — the basis
 /// for assembling a batch into one buffer. `offset_bytes` must be aligned to
-/// the element size and the window must fit the parent allocation.
+/// the element's alignment (its natural alignment, which equals the element
+/// size for the supported dtypes) and the window must fit the parent
+/// allocation.
 ///
 /// The returned tensor must be freed with `hal_tensor_free()`. It co-owns the
 /// parent buffer (shared `Arc`/fd), so the buffer stays valid as long as any

--- a/crates/capi/tests/test_tensor.c
+++ b/crates/capi/tests/test_tensor.c
@@ -251,6 +251,92 @@ static void test_tensor_reshape_invalid(void) {
     TEST_PASS();
 }
 
+static void test_tensor_subview(void) {
+    TEST("tensor_subview");
+
+    // 16-byte uint8 parent; two 8-byte windows at offsets 0 and 8 partition it.
+    size_t pshape[] = {16};
+    struct hal_tensor* parent =
+        hal_tensor_new(HAL_DTYPE_U8, pshape, 1, HAL_TENSOR_MEMORY_MEM, "parent");
+    ASSERT_NOT_NULL(parent);
+
+    size_t vshape[] = {8};
+    struct hal_tensor* v0 = hal_tensor_subview(parent, 0, vshape, 1);
+    struct hal_tensor* v1 = hal_tensor_subview(parent, 8, vshape, 1);
+    ASSERT_NOT_NULL(v0);
+    ASSERT_NOT_NULL(v1);
+    ASSERT_EQ(8, hal_tensor_len(v1));
+
+    // plane_offset: v1 reports byte offset 8; v0 reports 0 (or "unset" -> 0).
+    size_t off = 12345;
+    bool has1 = hal_tensor_plane_offset(v1, &off);
+    ASSERT_TRUE(has1);
+    ASSERT_EQ(8, off);
+    off = 12345;
+    hal_tensor_plane_offset(v0, &off);
+    ASSERT_EQ(0, off);
+
+    // Write each window through its own map; they must not alias.
+    struct hal_tensor_map* m0 = hal_tensor_map_create(v0);
+    struct hal_tensor_map* m1 = hal_tensor_map_create(v1);
+    ASSERT_NOT_NULL(m0);
+    ASSERT_NOT_NULL(m1);
+    unsigned char* d0 = (unsigned char*)hal_tensor_map_data(m0);
+    unsigned char* d1 = (unsigned char*)hal_tensor_map_data(m1);
+    ASSERT_NOT_NULL(d0);
+    ASSERT_NOT_NULL(d1);
+    for (size_t i = 0; i < 8; i++) {
+        d0[i] = (unsigned char)(i + 1);    // 1..8
+        d1[i] = (unsigned char)(i + 11);   // 11..18
+    }
+    hal_tensor_map_unmap(m0);
+    hal_tensor_map_unmap(m1);
+
+    // The parent buffer is correctly partitioned (shared, zero-copy).
+    struct hal_tensor_map* mp = hal_tensor_map_create(parent);
+    ASSERT_NOT_NULL(mp);
+    const unsigned char* dp = (const unsigned char*)hal_tensor_map_data_const(mp);
+    ASSERT_NOT_NULL(dp);
+    for (size_t i = 0; i < 8; i++) {
+        ASSERT_EQ((int)(i + 1), dp[i]);
+        ASSERT_EQ((int)(i + 11), dp[i + 8]);
+    }
+    hal_tensor_map_unmap(mp);
+
+    // Error cases: misaligned offset (f32 align 4) and out-of-bounds window.
+    size_t fshape[] = {8};
+    struct hal_tensor* fparent =
+        hal_tensor_new(HAL_DTYPE_F32, fshape, 1, HAL_TENSOR_MEMORY_MEM, NULL);
+    ASSERT_NOT_NULL(fparent);
+    size_t one[] = {1};
+    errno = 0;
+    ASSERT_NULL(hal_tensor_subview(fparent, 2, one, 1)); // 2 not 4-aligned
+    ASSERT_ERRNO(EINVAL);
+    errno = 0;
+    size_t big[] = {16};
+    ASSERT_NULL(hal_tensor_subview(parent, 4, big, 1)); // 4+16 > 16 bytes
+    ASSERT_ERRNO(EINVAL);
+    // NULL tensor / NULL shape.
+    errno = 0;
+    ASSERT_NULL(hal_tensor_subview(NULL, 0, vshape, 1));
+    ASSERT_ERRNO(EINVAL);
+    errno = 0;
+    ASSERT_NULL(hal_tensor_subview(parent, 0, NULL, 1));
+    ASSERT_ERRNO(EINVAL);
+
+    // set_plane_offset round-trip.
+    hal_tensor_set_plane_offset(v0, 4);
+    off = 0;
+    ASSERT_TRUE(hal_tensor_plane_offset(v0, &off));
+    ASSERT_EQ(4, off);
+
+    hal_tensor_free(fparent);
+    hal_tensor_free(v0);
+    hal_tensor_free(v1);
+    hal_tensor_free(parent);
+    TEST_PASS();
+}
+
 // =============================================================================
 // DMA Memory Tests (Linux-specific)
 // =============================================================================
@@ -446,6 +532,7 @@ void run_tensor_tests(void) {
     // Reshape tests
     test_tensor_reshape();
     test_tensor_reshape_invalid();
+    test_tensor_subview();
 
     // DMA tests (Linux DMA-BUF + macOS IOSurface)
     test_tensor_dma_memory();

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -3584,4 +3584,71 @@ mod cpu_tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn cpu_convert_into_heap_subviews_no_aliasing() {
+        // Two distinct RGBA sources converted into two RGB sub-views of one
+        // heap parent buffer. Each window must bit-match a standalone convert
+        // of its source — proving the CPU convert path honors the heap
+        // plane_offset with no aliasing. Runs on CI with no GPU/NPU.
+        let mut converter = CPUProcessor::default();
+
+        let mut src0 =
+            TensorDyn::image(4, 4, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Mem)).unwrap();
+        src0.as_u8_mut()
+            .unwrap()
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .fill(50);
+        let mut src1 =
+            TensorDyn::image(4, 4, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Mem)).unwrap();
+        src1.as_u8_mut()
+            .unwrap()
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .fill(200);
+
+        let mut do_convert = |src: &TensorDyn, dst: &mut TensorDyn| {
+            converter
+                .convert(src, dst, Rotation::None, Flip::None, Crop::default())
+                .unwrap();
+        };
+
+        // Standalone reference conversions into full, independent buffers.
+        let mut ref0 =
+            TensorDyn::image(4, 4, PixelFormat::Rgb, DType::U8, Some(TensorMemory::Mem)).unwrap();
+        do_convert(&src0, &mut ref0);
+        let mut ref1 =
+            TensorDyn::image(4, 4, PixelFormat::Rgb, DType::U8, Some(TensorMemory::Mem)).unwrap();
+        do_convert(&src1, &mut ref1);
+
+        // One RGB parent holding two stacked 4x4 frames (4 wide, 8 tall). The
+        // sub-views inherit the Rgb format, so each is a ready convert target
+        // and the plane offset survives.
+        let frame = 4 * 4 * 3;
+        let parent =
+            TensorDyn::image(4, 8, PixelFormat::Rgb, DType::U8, Some(TensorMemory::Mem)).unwrap();
+        let mut view0 = parent.subview(0, &[4, 4, 3]).unwrap();
+        let mut view1 = parent.subview(frame, &[4, 4, 3]).unwrap();
+        assert_eq!(view1.plane_offset(), Some(frame));
+
+        do_convert(&src0, &mut view0);
+        do_convert(&src1, &mut view1);
+
+        let parent_bytes = parent.as_u8().unwrap().map().unwrap().to_vec();
+        let ref0_bytes = ref0.as_u8().unwrap().map().unwrap().to_vec();
+        let ref1_bytes = ref1.as_u8().unwrap().map().unwrap().to_vec();
+        assert_eq!(
+            &parent_bytes[..frame],
+            ref0_bytes.as_slice(),
+            "view 0 window must match a standalone convert of src0"
+        );
+        assert_eq!(
+            &parent_bytes[frame..2 * frame],
+            ref1_bytes.as_slice(),
+            "view 1 window must match a standalone convert of src1"
+        );
+    }
 }

--- a/crates/image/src/gl/cache.rs
+++ b/crates/image/src/gl/cache.rs
@@ -26,8 +26,12 @@ pub(super) struct CachedEglImage {
 /// Uses a HashMap with a monotonic counter for LRU eviction: each access
 /// updates the entry's `last_used` timestamp, and eviction removes the entry
 /// with the smallest `last_used` value.
-/// Cache key: `(luma_id, chroma_id)`. For single-plane images, `chroma_id` is `None`.
-pub(super) type EglCacheKey = (u64, Option<u64>);
+/// Cache key: `(luma_id, chroma_id, plane_offset)`. For single-plane images,
+/// `chroma_id` is `None`. `plane_offset` distinguishes sub-region views that
+/// share one buffer (same identities) but start at different byte offsets —
+/// without it, N offset-distinct views of one DMA-BUF collide on the first
+/// (offset-0) EGLImage and every view renders/samples the base region.
+pub(super) type EglCacheKey = (u64, Option<u64>, usize);
 
 pub(super) struct EglImageCache {
     pub(super) entries: std::collections::HashMap<EglCacheKey, CachedEglImage>,
@@ -101,5 +105,33 @@ impl Drop for EglImageCache {
             self.misses,
             self.entries.len()
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EglCacheKey;
+    use std::collections::HashMap;
+
+    #[test]
+    fn cache_key_distinguishes_plane_offset() {
+        // Root-cause regression guard (no GPU needed): two sub-region views of
+        // one DMA-BUF share buffer identities but start at different byte
+        // offsets. The cache key must keep them as DISTINCT entries — otherwise
+        // the first (offset-0) EGLImage is reused for every offset and the GPU
+        // renders/samples the base region.
+        let mut map: HashMap<EglCacheKey, u32> = HashMap::new();
+        let base: EglCacheKey = (0xABCD, None, 0);
+        let at_offset: EglCacheKey = (0xABCD, None, 4096);
+        map.insert(base, 1);
+        map.insert(at_offset, 2);
+        assert_eq!(map.len(), 2, "offset-distinct views must not collide");
+        assert_eq!(map.get(&base), Some(&1));
+        assert_eq!(map.get(&at_offset), Some(&2));
+
+        // Identical keys still collide (a genuine cache hit), as before.
+        map.insert(base, 3);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&base), Some(&3));
     }
 }

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1473,7 +1473,7 @@ impl GLProcessorST {
 
         let luma_id = dst.buffer_identity().id();
         let chroma_id = dst.chroma().map(|t| t.buffer_identity().id());
-        let dst_key = (luma_id, chroma_id);
+        let dst_key = (luma_id, chroma_id, dst.plane_offset().unwrap_or(0));
 
         let dest_egl = self.get_or_create_egl_image(CacheKind::Dst, dst, dst_fmt)?;
         match self.cached_dst_renderbuffer(dst) {
@@ -1555,7 +1555,7 @@ impl GLProcessorST {
 
         let luma_id = dst.buffer_identity().id();
         let chroma_id = dst.chroma().map(|t| t.buffer_identity().id());
-        let dst_key = (luma_id, chroma_id);
+        let dst_key = (luma_id, chroma_id, dst.plane_offset().unwrap_or(0));
 
         let dest_egl = self.get_or_create_egl_image(CacheKind::Dst, dst, dst_fmt)?;
         match self.cached_dst_renderbuffer(dst) {
@@ -2937,6 +2937,7 @@ impl GLProcessorST {
         let src_key = (
             src.buffer_identity().id(),
             src.chroma().map(|t| t.buffer_identity().id()),
+            src.plane_offset().unwrap_or(0),
         );
         let src_egl = self.get_or_create_egl_image(CacheKind::Src, src, src_fmt)?;
 
@@ -3811,7 +3812,7 @@ impl GLProcessorST {
     ) -> Result<(), Error> {
         let luma_id = src.buffer_identity().id();
         let chroma_id = src.chroma().map(|t| t.buffer_identity().id());
-        let src_key = (luma_id, chroma_id);
+        let src_key = (luma_id, chroma_id, src.plane_offset().unwrap_or(0));
 
         let texture_target = gls::gl::TEXTURE_EXTERNAL_OES;
         unsafe {
@@ -3971,7 +3972,10 @@ impl GLProcessorST {
     ) -> Result<egl::Image, crate::Error> {
         let luma_id = img.buffer_identity().id();
         let chroma_id = img.chroma().map(|t| t.buffer_identity().id());
-        let id = (luma_id, chroma_id);
+        // Include the plane offset: sub-region views share one buffer identity
+        // but need distinct EGLImages, else offset-distinct views alias the
+        // first (offset-0) image and render/sample the base region.
+        let id = (luma_id, chroma_id, img.plane_offset().unwrap_or(0));
 
         // Sweep dead entries opportunistically before looking up.
         // Invalidate texture binding state since sweep may remove a bound entry.
@@ -4068,7 +4072,7 @@ impl GLProcessorST {
     {
         let luma_id = img.buffer_identity().id();
         let chroma_id = img.chroma().map(|t| t.buffer_identity().id());
-        let id = (luma_id, chroma_id);
+        let id = (luma_id, chroma_id, img.plane_offset().unwrap_or(0));
         self.dst_egl_cache
             .entries
             .get(&id)
@@ -4143,7 +4147,11 @@ impl GLProcessorST {
     where
         T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync,
     {
-        let id = (img.buffer_identity().id(), None);
+        let id = (
+            img.buffer_identity().id(),
+            None,
+            img.plane_offset().unwrap_or(0),
+        );
         if self.dst_egl_cache.sweep() {
             self.invalidate_dst_textures();
         }

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -480,6 +480,98 @@ mod gl_tests {
         compare_images(&reference, &cpu_dst, 0.98, "opengl_yuyv_to_rgba_reference");
     }
 
+    /// On-target (V3D) regression for the EGLImage cache `plane_offset` key:
+    /// render two distinct sources into two `plane_offset` sub-views of ONE
+    /// DMA-BUF and assert each window matches a standalone full-buffer convert.
+    ///
+    /// The two views share the parent's `BufferIdentity` but start at different
+    /// byte offsets. Before the cache-key fix the second view aliased the
+    /// first (offset-0) EGLImage, so both rendered into the base region — the
+    /// exact failure that capped batched render-to-DMA-BUF. With the fix each
+    /// offset gets its own EGLImage and the buffer is correctly partitioned.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn opengl_render_into_dma_subviews_no_aliasing() {
+        if !is_dma_available() || !is_opengl_available() {
+            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        let frame = w * h * 4; // RGBA bytes per frame
+
+        // Two distinct solid NV12 sources (different luma → different grey).
+        let make_nv12 = |y: u8| {
+            let mut buf = vec![y; w * h];
+            buf.extend(std::iter::repeat_n(128u8, w * h / 2)); // neutral chroma
+            buf
+        };
+        let src0 = load_raw_image(
+            w,
+            h,
+            PixelFormat::Nv12,
+            Some(TensorMemory::Dma),
+            &make_nv12(50),
+        )
+        .unwrap();
+        let src1 = load_raw_image(
+            w,
+            h,
+            PixelFormat::Nv12,
+            Some(TensorMemory::Dma),
+            &make_nv12(200),
+        )
+        .unwrap();
+
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let convert = |gl: &mut GLProcessorThreaded, s: &TensorDyn, d: &mut TensorDyn| {
+            gl.convert(s, d, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+        };
+
+        // Standalone full-buffer reference conversions (independent buffers).
+        let mut ref0 =
+            TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        convert(&mut gl, &src0, &mut ref0);
+        let mut ref1 =
+            TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        convert(&mut gl, &src1, &mut ref1);
+
+        // One DMA-BUF holding two stacked RGBA frames; two offset sub-views
+        // sharing the parent buffer identity (same fd) on the SAME processor,
+        // so view 1's lookup hits view 0's cache entry unless the key carries
+        // the offset.
+        let parent = TensorDyn::image(
+            w,
+            2 * h,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Dma),
+        )
+        .unwrap();
+        let mut view0 = parent.subview(0, &[h, w, 4]).unwrap();
+        let mut view1 = parent.subview(frame, &[h, w, 4]).unwrap();
+        assert_eq!(view1.plane_offset(), Some(frame));
+
+        convert(&mut gl, &src0, &mut view0);
+        convert(&mut gl, &src1, &mut view1);
+
+        let parent_bytes = parent.as_u8().unwrap().map().unwrap().to_vec();
+        let ref0_bytes = ref0.as_u8().unwrap().map().unwrap().to_vec();
+        let ref1_bytes = ref1.as_u8().unwrap().map().unwrap().to_vec();
+
+        assert_eq!(
+            &parent_bytes[..frame],
+            ref0_bytes.as_slice(),
+            "view 0 window (offset 0) must match a standalone convert of src0"
+        );
+        assert_eq!(
+            &parent_bytes[frame..2 * frame],
+            ref1_bytes.as_slice(),
+            "view 1 window (offset {frame}) must match a standalone convert of src1 — \
+             aliasing/cache-collision if it doesn't"
+        );
+    }
+
     // =========================================================================
     // EGL Display Probe & Override Tests
     // =========================================================================

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -873,6 +873,43 @@ class Tensor:
     def reshape(self, shape: list[int]) -> None: ...
     """Reshape the tensor to the given shape. The total number of elements must remain the same."""
 
+    def subview(self, offset_bytes: int, shape: list[int]) -> Tensor:
+        """Create a zero-copy sub-region view sharing this tensor's allocation.
+
+        The view maps the window ``[offset_bytes, offset_bytes + size)`` where
+        ``size = prod(shape) * element_size``, sharing the parent buffer (``Mem``
+        heap or ``Dma`` fd) with no copy. N views into one parent can be mapped
+        and written independently — the basis for assembling a batch into one
+        buffer. ``offset_bytes`` must be aligned to the element size and the
+        window must fit the parent allocation.
+
+        The returned tensor exposes the full tensor surface (``map()`` with the
+        NumPy buffer protocol, ``from_numpy()``, ``fd``); its byte offset is
+        reported by :attr:`plane_offset`.
+
+        Args:
+            offset_bytes: Byte offset of the window into the parent allocation.
+            shape: Logical shape of the view.
+
+        Returns:
+            A new ``Tensor`` viewing the requested window.
+        """
+
+    @property
+    def plane_offset(self) -> int | None:
+        """Byte offset of this tensor's window into its backing allocation.
+
+        ``None`` for a whole-buffer tensor; the sub-region start for a view
+        created via :meth:`subview` (or after :meth:`set_plane_offset`).
+        """
+
+    def set_plane_offset(self, offset: int) -> None:
+        """Set the byte offset of this tensor's window into its backing allocation.
+
+        Validated against the allocation when the tensor is mapped. Prefer
+        :meth:`subview` for sharing one buffer across independent windows.
+        """
+
     def set_format(self, format: PixelFormat) -> None:
         """Attach pixel format metadata to this tensor.
 

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -880,8 +880,9 @@ class Tensor:
         ``size = prod(shape) * element_size``, sharing the parent buffer (``Mem``
         heap or ``Dma`` fd) with no copy. N views into one parent can be mapped
         and written independently — the basis for assembling a batch into one
-        buffer. ``offset_bytes`` must be aligned to the element size and the
-        window must fit the parent allocation.
+        buffer. ``offset_bytes`` must be aligned to the element's alignment
+        (its natural alignment, which equals the element size for the supported
+        dtypes) and the window must fit the parent allocation.
 
         The returned tensor exposes the full tensor surface (``map()`` with the
         NumPy buffer protocol, ``from_numpy()``, ``fd``); its byte offset is

--- a/crates/python/src/tensor.rs
+++ b/crates/python/src/tensor.rs
@@ -800,7 +800,9 @@ impl PyTensor {
     /// heap allocation or ``Dma`` fd) with **no copy**. N views into one parent
     /// can be mapped and written independently — the basis for assembling a
     /// batch into a single buffer. ``offset_bytes`` must be aligned to the
-    /// element size and the window must fit the parent allocation.
+    /// element's alignment (its natural alignment, which equals the element
+    /// size for the supported dtypes) and the window must fit the parent
+    /// allocation.
     ///
     /// The returned tensor exposes the same surface as any other tensor —
     /// :meth:`map` (NumPy buffer protocol), :meth:`from_numpy`, ``fd`` — so a

--- a/crates/python/src/tensor.rs
+++ b/crates/python/src/tensor.rs
@@ -793,6 +793,25 @@ impl PyTensor {
         Ok(self.0.reshape(&shape)?)
     }
 
+    /// Create a zero-copy sub-region view that shares this tensor's allocation.
+    ///
+    /// The view maps the window ``[offset_bytes, offset_bytes + size)`` where
+    /// ``size = prod(shape) * element_size``, sharing the parent buffer (``Mem``
+    /// heap allocation or ``Dma`` fd) with **no copy**. N views into one parent
+    /// can be mapped and written independently — the basis for assembling a
+    /// batch into a single buffer. ``offset_bytes`` must be aligned to the
+    /// element size and the window must fit the parent allocation.
+    ///
+    /// The returned tensor exposes the same surface as any other tensor —
+    /// :meth:`map` (NumPy buffer protocol), :meth:`from_numpy`, ``fd`` — so a
+    /// view reads and writes through NumPy exactly like the base API. The
+    /// window's byte offset is reported by :attr:`plane_offset`.
+    #[pyo3(signature = (offset_bytes, shape))]
+    fn subview(&self, offset_bytes: usize, shape: Vec<usize>) -> Result<Self> {
+        let view = self.0.subview(offset_bytes, &shape)?;
+        Ok(PyTensor(view))
+    }
+
     /// Attach pixel format metadata to this tensor.
     ///
     /// Validates that the tensor's shape is compatible with the format's
@@ -1020,6 +1039,23 @@ impl PyTensor {
     #[getter]
     fn row_stride(&self) -> Option<usize> {
         self.0.effective_row_stride()
+    }
+
+    /// Byte offset of this tensor's window into its backing allocation.
+    ///
+    /// ``None`` for a whole-buffer tensor; the sub-region start for a view
+    /// created via :meth:`subview` (or after :meth:`set_plane_offset`).
+    #[getter]
+    fn plane_offset(&self) -> Option<usize> {
+        self.0.plane_offset()
+    }
+
+    /// Set the byte offset of this tensor's window into its backing allocation.
+    ///
+    /// Validated against the allocation when the tensor is mapped. Prefer
+    /// :meth:`subview` for sharing one buffer across independent windows.
+    fn set_plane_offset(&mut self, offset: usize) {
+        self.0.set_plane_offset(offset);
     }
 
     /// Whether this image uses a planar pixel layout.

--- a/crates/tensor/src/dma.rs
+++ b/crates/tensor/src/dma.rs
@@ -369,6 +369,46 @@ where
         )
     }
 
+    /// Create a zero-copy sub-region view sharing this buffer's fd and
+    /// `BufferIdentity`, positioned at `offset_bytes` from this tensor's own
+    /// window with logical `shape`. The view maps `[abs_offset, abs_offset +
+    /// shape.product()*size_of::<T>())` of the shared DMA-BUF.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidOperation`] if `offset_bytes` is mis-aligned for `T`.
+    /// - [`Error::InsufficientCapacity`] if the window exceeds the buffer.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn view(&self, offset_bytes: usize, shape: &[usize]) -> Result<Self> {
+        let elem = std::mem::size_of::<T>();
+        if elem > 1 && !offset_bytes.is_multiple_of(std::mem::align_of::<T>()) {
+            return Err(Error::InvalidOperation(format!(
+                "DmaTensor::view: offset {offset_bytes} not aligned to align_of::<T>()={}",
+                std::mem::align_of::<T>()
+            )));
+        }
+        let abs_offset = self
+            .mmap_offset
+            .checked_add(offset_bytes)
+            .ok_or(Error::InvalidSize(offset_bytes))?;
+        let logical = shape.iter().product::<usize>() * elem;
+        let needed = abs_offset
+            .checked_add(logical)
+            .ok_or(Error::InvalidSize(logical))?;
+        if needed > self.buf_size {
+            return Err(Error::InsufficientCapacity {
+                needed,
+                capacity: self.buf_size,
+            });
+        }
+        // try_clone preserves fd, identity and buf_size; override the logical
+        // shape and absolute offset for this window.
+        let mut v = self.try_clone()?;
+        v.shape = shape.to_vec();
+        v.mmap_offset = abs_offset;
+        Ok(v)
+    }
+
     pub fn try_clone(&self) -> Result<Self> {
         let fd = self.clone_fd()?;
         // Preserve the imported/owned distinction: imported fds never get a

--- a/crates/tensor/src/dma.rs
+++ b/crates/tensor/src/dma.rs
@@ -381,7 +381,9 @@ where
     #[cfg(target_os = "linux")]
     pub(crate) fn view(&self, offset_bytes: usize, shape: &[usize]) -> Result<Self> {
         let elem = std::mem::size_of::<T>();
-        if elem > 1 && !offset_bytes.is_multiple_of(std::mem::align_of::<T>()) {
+        // Alignment depends on `align_of::<T>()`, not element size (a
+        // `size_of == 1`, `align_of > 1` type would otherwise skip the check).
+        if !offset_bytes.is_multiple_of(std::mem::align_of::<T>()) {
             return Err(Error::InvalidOperation(format!(
                 "DmaTensor::view: offset {offset_bytes} not aligned to align_of::<T>()={}",
                 std::mem::align_of::<T>()

--- a/crates/tensor/src/iosurface.rs
+++ b/crates/tensor/src/iosurface.rs
@@ -520,7 +520,7 @@ where
     /// borrowed — its lifetime is tied to the tensor.
     pub fn iosurface_ref(&self) -> Option<*mut c_void> {
         match &self.storage {
-            crate::TensorStorage::Dma(io_tensor) => Some(io_tensor.surface.as_ptr()),
+            crate::TensorStorage::Dma(io_tensor) => Some(io_tensor.surface_ref()),
             _ => None,
         }
     }

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -3400,6 +3400,37 @@ mod tests {
     }
 
     #[test]
+    fn mem_subview_inherits_format_and_row_stride() {
+        // A sub-view is a ready-to-use sub-image: it inherits the parent's
+        // pixel format and (crucially) its padded row stride, so a strided
+        // parent yields strided windows. Set a stride wider than the tight row
+        // to exercise the row_stride inheritance path specifically.
+        let mut parent =
+            Tensor::<u8>::image(100, 100, PixelFormat::Rgba, Some(TensorMemory::Mem)).unwrap();
+        parent.set_row_stride_unchecked(512); // padded stride (> 100*4)
+        let view = parent.subview(4096, &[10, 10, 4]).unwrap();
+        assert_eq!(view.format(), Some(PixelFormat::Rgba), "format inherited");
+        assert_eq!(view.row_stride(), Some(512), "row_stride inherited");
+    }
+
+    #[test]
+    fn subview_rejects_unsupported_storage() {
+        // subview shares either a heap `Arc` (Mem) or a dma-buf fd (Dma); any
+        // other backing (here Shm) must be refused with InvalidOperation rather
+        // than silently mishandled.
+        if !crate::is_shm_available() {
+            eprintln!("SKIPPED: shm not available");
+            return;
+        }
+        let shm = Tensor::<u8>::new(&[64], Some(TensorMemory::Shm), None).unwrap();
+        match shm.subview(0, &[4]) {
+            Err(Error::InvalidOperation(_)) => {}
+            Err(other) => panic!("expected InvalidOperation, got {other:?}"),
+            Ok(_) => panic!("subview must reject Shm storage"),
+        }
+    }
+
+    #[test]
     #[cfg(target_os = "linux")]
     fn dma_subview_matches_mem_subview() {
         // Serialize against the fd-leak tests: this test opens DMA fds (alloc +

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -55,14 +55,22 @@ static __EDGEFIRST_COV_INSTALL: extern "C" fn() = {
     ctor
 };
 
+// Backing tensor/map types are internal implementation details: callers
+// allocate `Tensor<T>` / `TensorDyn` and map them, never naming the per-memory
+// backing types directly. They are `pub(crate)` so they stay nameable for the
+// `TensorStorage` / `TensorMap` enums without leaking into the public API.
+// Exceptions kept public: `Pbo*` is a GL extension point implemented by the
+// image crate, and `image_iosurface_layout` is a public helper.
 #[cfg(target_os = "linux")]
-pub use crate::dma::{DmaMap, DmaTensor};
+pub(crate) use crate::dma::{DmaMap, DmaTensor};
 #[cfg(target_os = "macos")]
-pub use crate::iosurface::{image_iosurface_layout, IoSurfaceMap, IoSurfaceTensor};
-pub use crate::mem::{MemMap, MemTensor};
+pub use crate::iosurface::image_iosurface_layout;
+#[cfg(target_os = "macos")]
+pub(crate) use crate::iosurface::{IoSurfaceMap, IoSurfaceTensor};
+pub(crate) use crate::mem::{MemMap, MemTensor};
 pub use crate::pbo::{PboMap, PboMapping, PboOps, PboTensor};
 #[cfg(unix)]
-pub use crate::shm::{ShmMap, ShmTensor};
+pub(crate) use crate::shm::{ShmMap, ShmTensor};
 pub use cuda::{
     gl_map_resource, gl_register_buffer, gl_unmap_resource, gl_unregister_resource,
     is_cuda_available, memcpy_device_to_host, CudaGlOps, CudaHandle, CudaMap,

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -1763,9 +1763,11 @@ where
         if self.format != Some(format) {
             self.row_stride = None;
             self.plane_offset = None;
-            #[cfg(target_os = "linux")]
-            if let TensorStorage::Dma(ref mut dma) = self.storage {
-                dma.mmap_offset = 0;
+            match self.storage {
+                TensorStorage::Mem(ref mut m) => m.set_offset(0),
+                #[cfg(target_os = "linux")]
+                TensorStorage::Dma(ref mut dma) => dma.mmap_offset = 0,
+                _ => {}
             }
         }
         self.format = Some(format);
@@ -2031,9 +2033,15 @@ where
     /// since the offset is format-independent.
     pub fn set_plane_offset(&mut self, offset: usize) {
         self.plane_offset = Some(offset);
-        #[cfg(target_os = "linux")]
-        if let TensorStorage::Dma(ref mut dma) = self.storage {
-            dma.mmap_offset = offset;
+        // The offset consulted by `map()` lives inside the storage variant.
+        // Keep it in sync with the wrapper field for every backing that
+        // honors it (DMA and Mem); see also the clear sites in `set_format`
+        // and `reshape`.
+        match self.storage {
+            TensorStorage::Mem(ref mut m) => m.set_offset(offset),
+            #[cfg(target_os = "linux")]
+            TensorStorage::Dma(ref mut dma) => dma.mmap_offset = offset,
+            _ => {}
         }
     }
 
@@ -2042,6 +2050,65 @@ where
     pub fn with_plane_offset(mut self, offset: usize) -> Self {
         self.set_plane_offset(offset);
         self
+    }
+
+    /// Create a zero-copy sub-region view of this tensor's backing buffer.
+    ///
+    /// The returned tensor shares this tensor's allocation (no copy) and maps
+    /// the window `[offset_bytes, offset_bytes + shape.product()*size_of::<T>())`
+    /// measured from this tensor's own logical start. N sub-views into one
+    /// parent can be written independently, enabling batched assembly into a
+    /// single buffer. Identical semantics across `Mem` (shared `Arc`) and
+    /// `Dma` (shared fd) backings.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidOperation`] if the backing is not `Mem` or `Dma`, or
+    ///   if `offset_bytes` is mis-aligned for `T`.
+    /// - [`Error::InsufficientCapacity`] / [`Error::InvalidSize`] if the window
+    ///   exceeds the parent allocation.
+    pub fn subview(&self, offset_bytes: usize, shape: &[usize]) -> Result<Tensor<T>> {
+        // Offset is absolute into the backing allocation: a sub-view of a
+        // sub-view composes by adding this tensor's own offset.
+        let abs_offset = self
+            .plane_offset
+            .unwrap_or(0)
+            .checked_add(offset_bytes)
+            .ok_or(Error::InvalidSize(offset_bytes))?;
+        let mut t = match &self.storage {
+            TensorStorage::Mem(parent) => Tensor::wrap(TensorStorage::Mem(MemTensor::view(
+                parent,
+                offset_bytes,
+                shape,
+            )?)),
+            #[cfg(target_os = "linux")]
+            TensorStorage::Dma(parent) => {
+                // Shares the parent's fd AND BufferIdentity (unlike from_fd,
+                // which mints a fresh identity) so offset-distinct views of one
+                // DMA-BUF are cached per (identity, offset) in the GL backend.
+                Tensor::wrap(TensorStorage::Dma(parent.view(offset_bytes, shape)?))
+            }
+            _ => {
+                return Err(Error::InvalidOperation(
+                    "subview only supported for Mem and Dma tensors".into(),
+                ))
+            }
+        };
+        // Inherit the parent's image metadata so the view is a ready-to-use
+        // sub-image (e.g. a `convert()` destination). The offset is applied
+        // LAST because `set_format` deliberately clears it — the offset is a
+        // structural property of the sub-region, not format-dependent metadata.
+        if let Some(fmt) = self.format {
+            t.set_format(fmt)?;
+        }
+        if let Some(rs) = self.row_stride {
+            t.set_row_stride_unchecked(rs);
+        }
+        t.quantization = self.quantization.clone();
+        if abs_offset > 0 {
+            t.set_plane_offset(abs_offset);
+        }
+        Ok(t)
     }
 
     /// Downcast to PBO tensor reference (for GL backends).
@@ -2258,9 +2325,11 @@ where
         self.format = None;
         self.row_stride = None;
         self.plane_offset = None;
-        #[cfg(target_os = "linux")]
-        if let TensorStorage::Dma(ref mut dma) = self.storage {
-            dma.mmap_offset = 0;
+        match self.storage {
+            TensorStorage::Mem(ref mut m) => m.set_offset(0),
+            #[cfg(target_os = "linux")]
+            TensorStorage::Dma(ref mut dma) => dma.mmap_offset = 0,
+            _ => {}
         }
         Ok(())
     }
@@ -2351,20 +2420,19 @@ where
                     .into(),
             ));
         }
-        // Offset tensors are supported for DMA storage — DmaMap adjusts the
-        // mmap range and slice start position.  Non-DMA offset tensors are
-        // not meaningful (offset only applies to DMA-BUF sub-regions).
+        // Offset tensors are supported for storages that apply the offset
+        // inside their own `map()`: DMA (`DmaMap` adjusts the mmap range) and
+        // Mem (`MemMap` adjusts the slice base). Other backings have no
+        // sub-region concept, so a non-zero offset is rejected.
         if self.plane_offset.is_some_and(|o| o > 0) {
+            let supported = matches!(self.storage, TensorStorage::Mem(_));
             #[cfg(target_os = "linux")]
-            if !matches!(self.storage, TensorStorage::Dma(_)) {
+            let supported = supported || matches!(self.storage, TensorStorage::Dma(_));
+            if !supported {
                 return Err(Error::InvalidOperation(
-                    "plane offset only supported for DMA tensors".into(),
+                    "plane offset only supported for DMA and Mem tensors".into(),
                 ));
             }
-            #[cfg(not(target_os = "linux"))]
-            return Err(Error::InvalidOperation(
-                "plane offset only supported for DMA tensors".into(),
-            ));
         }
         self.storage.map()
     }
@@ -3259,6 +3327,106 @@ mod tests {
             tensor_map[2] = 42;
             assert_eq!(tensor_map[1], 1, "Value at index 1 should be 1");
             assert_eq!(tensor_map[2], 42, "Value at index 2 should be 42");
+        }
+    }
+
+    #[test]
+    fn mem_subview_partitions_parent_buffer() {
+        // One heap [2,4] u8 parent (8 bytes). Two [1,4] sub-views at byte
+        // offsets 0 and 4 must share the parent allocation (zero-copy) and be
+        // independently writable: view 0 owns bytes [0,4), view 1 owns [4,8).
+        // Today this is impossible — heap offset is rejected and there is no
+        // shared sub-view constructor.
+        let parent = Tensor::<u8>::new(&[2, 4], Some(TensorMemory::Mem), None).unwrap();
+        let view0 = parent.subview(0, &[1, 4]).expect("subview at offset 0");
+        let view1 = parent.subview(4, &[1, 4]).expect("subview at offset 4");
+
+        view1
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(&[10, 20, 30, 40]);
+        view0
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(&[1, 2, 3, 4]);
+
+        // Each view sees only its own window.
+        assert_eq!(view0.map().unwrap().as_slice(), &[1, 2, 3, 4]);
+        assert_eq!(view1.map().unwrap().as_slice(), &[10, 20, 30, 40]);
+        // The parent buffer is correctly partitioned (shared, zero-copy).
+        assert_eq!(
+            parent.map().unwrap().as_slice(),
+            &[1, 2, 3, 4, 10, 20, 30, 40]
+        );
+    }
+
+    #[test]
+    fn mem_subview_rejects_unaligned_offset() {
+        // f32 has align 4; a byte offset of 2 cannot back a valid `*const f32`.
+        let parent = Tensor::<f32>::new(&[8], Some(TensorMemory::Mem), None).unwrap();
+        assert!(parent.subview(2, &[1]).is_err());
+        // A correctly aligned offset is accepted.
+        assert!(parent.subview(4, &[1]).is_ok());
+    }
+
+    #[test]
+    fn mem_subview_rejects_out_of_bounds() {
+        let parent = Tensor::<u8>::new(&[8], Some(TensorMemory::Mem), None).unwrap();
+        // offset 6 + 4 bytes = 10 exceeds the 8-byte allocation.
+        assert!(parent.subview(6, &[4]).is_err());
+    }
+
+    #[test]
+    fn mem_subview_four_views_no_aliasing() {
+        // One [4,3] f32 parent; four [1,3] views at 12-byte strides, each
+        // written independently. Exercises a multi-byte element type (offsets
+        // must stay element-aligned) and N-way zero-copy sharing.
+        let parent = Tensor::<f32>::new(&[4, 3], Some(TensorMemory::Mem), None).unwrap();
+        let frame = 3 * std::mem::size_of::<f32>();
+        for i in 0..4 {
+            let v = parent.subview(i * frame, &[1, 3]).unwrap();
+            let val = i as f32 + 1.0;
+            v.map()
+                .unwrap()
+                .as_mut_slice()
+                .copy_from_slice(&[val, val, val]);
+        }
+        assert_eq!(
+            parent.map().unwrap().as_slice(),
+            &[1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0]
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn dma_subview_matches_mem_subview() {
+        // Serialize against the fd-leak tests: this test opens DMA fds (alloc +
+        // clone_fd), which would otherwise perturb their fd counts.
+        let _lock = FD_LOCK.read().unwrap();
+        // Identical sub-view semantics across Dma (shared fd) and Mem (shared
+        // Arc): same offsets → same logical windows → same partition.
+        let dma = match Tensor::<u8>::new(&[8], Some(TensorMemory::Dma), None) {
+            Ok(t) => t,
+            Err(_) => {
+                eprintln!("SKIPPED: DMA not available");
+                return;
+            }
+        };
+        let mem = Tensor::<u8>::new(&[8], Some(TensorMemory::Mem), None).unwrap();
+        for parent in [&dma, &mem] {
+            let v0 = parent.subview(0, &[4]).unwrap();
+            let v1 = parent.subview(4, &[4]).unwrap();
+            v0.map()
+                .unwrap()
+                .as_mut_slice()
+                .copy_from_slice(&[1, 2, 3, 4]);
+            v1.map()
+                .unwrap()
+                .as_mut_slice()
+                .copy_from_slice(&[5, 6, 7, 8]);
+            assert_eq!(parent.map().unwrap().as_slice(), &[1, 2, 3, 4, 5, 6, 7, 8]);
         }
     }
 

--- a/crates/tensor/src/mem.rs
+++ b/crates/tensor/src/mem.rs
@@ -8,10 +8,71 @@ use crate::{
 use log::trace;
 use num_traits::Num;
 use std::{
+    cell::UnsafeCell,
     fmt,
     ops::{Deref, DerefMut},
     sync::Arc,
 };
+
+/// Interior-mutable backing allocation for `MemTensor`.
+///
+/// The elements live in `UnsafeCell`s so that sub-region views — which share
+/// one allocation through a cloned `Arc` — can each hand out `&mut [T]` over
+/// their own window with **correct write provenance**. A `&mut [T]` derived
+/// from a shared `Arc<Vec<T>>` via `Vec::as_ptr` carries read-only provenance
+/// (the pointer is born of a shared borrow), so writing through it is undefined
+/// behaviour; `UnsafeCell` is what makes interior mutation through the shared
+/// `Arc` sound.
+///
+/// Disjointness is the caller's contract: distinct `subview` windows must not
+/// overlap if mapped mutably at the same time (the same contract as `DmaMap`,
+/// whose `mmap` likewise hands out independent `&mut` windows of one buffer).
+/// `UnsafeCell` makes the *non-overlapping* case sound; overlapping mutable
+/// windows held simultaneously remain UB by the documented `subview` contract.
+struct MemBacking<T> {
+    cells: Box<[UnsafeCell<T>]>,
+}
+
+// SAFETY: `UnsafeCell<T>` is `!Sync`, but a `MemBacking` is only mutated through
+// the disjoint-window contract documented above (and was already guarded by the
+// `unsafe impl Send/Sync for MemTensor`). The cells add no thread-safety hazard
+// beyond what `MemTensor` already asserts; they only fix pointer provenance.
+unsafe impl<T: Send> Send for MemBacking<T> {}
+unsafe impl<T: Sync> Sync for MemBacking<T> {}
+
+impl<T: fmt::Debug> fmt::Debug for MemBacking<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MemBacking")
+            .field("len", &self.cells.len())
+            .finish()
+    }
+}
+
+impl<T> MemBacking<T> {
+    /// Number of elements in the allocation.
+    fn len(&self) -> usize {
+        self.cells.len()
+    }
+
+    /// Base pointer with write provenance (the cells are `UnsafeCell`, so
+    /// interior mutation through the shared `Arc` is sound). `UnsafeCell<T>`
+    /// is `#[repr(transparent)]`, so the address equals the `T` element's.
+    fn base_ptr(&self) -> *mut T {
+        self.cells.as_ptr() as *mut T
+    }
+
+    /// Build a zeroed backing of `n` elements.
+    fn zeroed(n: usize) -> Self
+    where
+        T: Num + Clone,
+    {
+        let cells: Vec<UnsafeCell<T>> = (0..n).map(|_| UnsafeCell::new(T::zero())).collect();
+        Self {
+            cells: cells.into_boxed_slice(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct MemTensor<T>
 where
@@ -24,7 +85,7 @@ where
     /// parent's buffer. The allocation is never resized after creation
     /// (`reshape`/`set_logical_shape` only adjust the logical `shape` within
     /// capacity), so the base pointer is stable for the lifetime of the `Arc`.
-    data: Arc<Vec<T>>,
+    data: Arc<MemBacking<T>>,
     /// Byte offset into `data` where this tensor's logical window begins. `0`
     /// for whole-buffer tensors; non-zero for sub-region views. Mirrors
     /// `DmaTensor::mmap_offset`.
@@ -58,7 +119,7 @@ where
         Ok(MemTensor {
             name: name.unwrap_or("mem_tensor").to_owned(),
             shape: shape.to_vec(),
-            data: Arc::new(vec![T::zero(); cap_elems]),
+            data: Arc::new(MemBacking::zeroed(cap_elems)),
             offset: 0,
             identity: crate::BufferIdentity::new(),
         })
@@ -79,7 +140,11 @@ where
     ///   allocation.
     pub fn view(parent: &MemTensor<T>, offset_bytes: usize, shape: &[usize]) -> Result<Self> {
         let elem = std::mem::size_of::<T>();
-        if elem > 1 && !offset_bytes.is_multiple_of(std::mem::align_of::<T>()) {
+        // Alignment depends on `align_of::<T>()`, not size (a `size_of == 1`,
+        // `align_of > 1` type would otherwise skip this and make the `MemMap`
+        // pointer cast UB). `is_multiple_of(1)` is always true, so this is a
+        // no-op for the common align-1 element types.
+        if !offset_bytes.is_multiple_of(std::mem::align_of::<T>()) {
             return Err(Error::InvalidOperation(format!(
                 "MemTensor::view: offset {offset_bytes} not aligned to align_of::<T>()={}",
                 std::mem::align_of::<T>()
@@ -136,13 +201,12 @@ where
         // the tracker path. DMA-backed storage cannot represent them; Mem
         // storage can (empty Vec).
         let element_count: usize = shape.iter().product();
-        let data = vec![T::zero(); element_count];
 
         let name = name.unwrap_or("mem_tensor").to_owned();
         Ok(MemTensor {
             name,
             shape: shape.to_vec(),
-            data: Arc::new(data),
+            data: Arc::new(MemBacking::zeroed(element_count)),
             offset: 0,
             identity: crate::BufferIdentity::new(),
         })
@@ -207,7 +271,8 @@ where
                 capacity: total,
             });
         }
-        if elem > 1 && !self.offset.is_multiple_of(std::mem::align_of::<T>()) {
+        // Alignment depends on `align_of::<T>()`, not element size.
+        if !self.offset.is_multiple_of(std::mem::align_of::<T>()) {
             return Err(Error::InvalidOperation(format!(
                 "MemMap: offset {} not aligned to align_of::<T>()={}",
                 self.offset,
@@ -231,7 +296,14 @@ where
     fn capacity_bytes(&self) -> usize {
         // Capacity available to this tensor is the allocation minus its window
         // start, so `set_logical_shape` stays bounded for sub-region views.
-        self.data.len() * std::mem::size_of::<T>() - self.offset
+        // Saturating: `set_plane_offset`/`set_offset` are not validated against
+        // the allocation, so an out-of-range offset must report 0 capacity
+        // (rejecting any further shape) rather than underflowing to a huge value
+        // that `set_logical_shape` would wrongly accept.
+        self.data
+            .len()
+            .saturating_mul(std::mem::size_of::<T>())
+            .saturating_sub(self.offset)
     }
 
     fn set_logical_shape(&mut self, shape: &[usize]) -> Result<()> {
@@ -256,7 +328,7 @@ where
     /// Keep-alive of the backing allocation. Owning the `Arc` (rather than a
     /// raw pointer) ensures the buffer outlives the map even if the source
     /// tensor is dropped first.
-    backing: Arc<Vec<T>>,
+    backing: Arc<MemBacking<T>>,
     /// Byte offset of the mapped window into `backing`.
     offset: usize,
     shape: Vec<usize>,
@@ -299,15 +371,17 @@ where
         // SAFETY: the window `[offset, offset + len*size_of::<T>())` was bounds-
         // and alignment-checked in `MemTensor::map()`; `backing` keeps the
         // allocation alive; the base pointer is stable (never reallocated).
-        let base = unsafe { (self.backing.as_ptr() as *const u8).add(self.offset) as *const T };
+        let base = unsafe { (self.backing.base_ptr() as *const u8).add(self.offset) as *const T };
         unsafe { std::slice::from_raw_parts(base, self.len()) }
     }
 
     fn as_mut_slice(&mut self) -> &mut [T] {
-        // SAFETY: as above. Distinct sub-region views address non-overlapping
-        // windows of the shared allocation, so the aliased `&mut` access is
-        // sound at the byte level — the same contract as `DmaMap`.
-        let base = unsafe { (self.backing.as_ptr() as *const u8).add(self.offset) as *mut T };
+        // SAFETY: as `as_slice`, plus: the backing elements are `UnsafeCell`, so
+        // `base_ptr()` carries write provenance and interior mutation through
+        // the shared `Arc` is sound. Distinct sub-region views address
+        // non-overlapping windows (the documented `subview` disjointness
+        // contract, matching `DmaMap`), so the `&mut` windows never alias.
+        let base = unsafe { (self.backing.base_ptr() as *const u8).add(self.offset) as *mut T };
         unsafe { std::slice::from_raw_parts_mut(base, self.len()) }
     }
 }
@@ -390,5 +464,74 @@ mod tests {
         t.set_logical_shape(&[240, 320, 3]).unwrap();
         assert_eq!(t.shape(), &[240, 320, 3]);
         assert!(t.set_logical_shape(&[480, 640, 4]).is_err());
+    }
+
+    #[test]
+    fn mem_capacity_saturates_on_oversize_offset() {
+        // `set_offset`/`set_plane_offset` are not validated against the
+        // allocation, so an out-of-range offset must report 0 capacity (a
+        // saturating subtract) instead of underflowing to a huge value that
+        // `set_logical_shape` would wrongly accept. The over-range shape is then
+        // rejected up front, and `map()` also refuses (bounds check).
+        let mut t = MemTensor::<u8>::with_capacity_bytes(&[100], 100, None).unwrap();
+        assert_eq!(t.capacity_bytes(), 100);
+        t.set_offset(200); // beyond the 100-byte allocation
+        assert_eq!(
+            t.capacity_bytes(),
+            0,
+            "capacity must saturate at 0, not underflow"
+        );
+        assert!(t.set_logical_shape(&[1]).is_err());
+        assert!(t.map().is_err());
+    }
+
+    #[test]
+    fn mem_subview_disjoint_writes_are_independent() {
+        // Two disjoint sub-views of one parent are written through `as_mut_slice`
+        // (the interior-mutable `MemBacking` write path); each window must see
+        // only its own bytes and the parent must reflect both — proving the
+        // shared-`Arc` mutable mapping is sound for non-overlapping windows.
+        let parent = MemTensor::<u8>::with_capacity_bytes(&[8], 8, None).unwrap();
+        let a = MemTensor::view(&parent, 0, &[4]).unwrap();
+        let b = MemTensor::view(&parent, 4, &[4]).unwrap();
+        a.map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(&[1, 2, 3, 4]);
+        b.map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(&[5, 6, 7, 8]);
+        assert_eq!(a.map().unwrap().as_slice(), &[1, 2, 3, 4]);
+        assert_eq!(b.map().unwrap().as_slice(), &[5, 6, 7, 8]);
+        assert_eq!(parent.map().unwrap().as_slice(), &[1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn mem_map_rejects_unaligned_offset() {
+        // `view()` enforces alignment at creation, but `set_offset` bypasses it,
+        // so `map()` keeps a defensive guard: a `u32` window (align 4) starting
+        // at byte 2 is in-bounds yet misaligned and must be refused.
+        let mut t = MemTensor::<u32>::with_capacity_bytes(&[1], 16, None).unwrap();
+        t.set_offset(2); // within the 16-byte allocation but not 4-byte aligned
+                         // `TensorMap` isn't `Debug`, so match rather than `unwrap_err()`.
+        match t.map() {
+            Err(Error::InvalidOperation(_)) => {}
+            Err(other) => panic!("expected InvalidOperation, got {other:?}"),
+            Ok(_) => panic!("misaligned offset must be rejected by map()"),
+        }
+    }
+
+    #[test]
+    fn mem_backing_debug_reports_len_only() {
+        // `MemBacking`'s Debug prints just the element count (never the cell
+        // contents), reached via the derived `MemTensor` Debug chain.
+        let t = MemTensor::<u8>::with_capacity_bytes(&[4], 4, None).unwrap();
+        let s = format!("{t:?}");
+        assert!(
+            s.contains("MemBacking"),
+            "debug should name MemBacking: {s}"
+        );
+        assert!(s.contains("len"), "debug should report len: {s}");
     }
 }

--- a/crates/tensor/src/mem.rs
+++ b/crates/tensor/src/mem.rs
@@ -8,11 +8,9 @@ use crate::{
 use log::trace;
 use num_traits::Num;
 use std::{
-    ffi::c_void,
     fmt,
     ops::{Deref, DerefMut},
-    ptr::NonNull,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 #[derive(Debug)]
 pub struct MemTensor<T>
@@ -21,7 +19,16 @@ where
 {
     pub name: String,
     pub shape: Vec<usize>,
-    pub data: Vec<T>,
+    /// Shared, fixed-size backing allocation. An owned tensor holds a
+    /// refcount-1 `Arc`; zero-copy sub-region views clone it to co-own the
+    /// parent's buffer. The allocation is never resized after creation
+    /// (`reshape`/`set_logical_shape` only adjust the logical `shape` within
+    /// capacity), so the base pointer is stable for the lifetime of the `Arc`.
+    data: Arc<Vec<T>>,
+    /// Byte offset into `data` where this tensor's logical window begins. `0`
+    /// for whole-buffer tensors; non-zero for sub-region views. Mirrors
+    /// `DmaTensor::mmap_offset`.
+    offset: usize,
     identity: crate::BufferIdentity,
 }
 
@@ -51,9 +58,67 @@ where
         Ok(MemTensor {
             name: name.unwrap_or("mem_tensor").to_owned(),
             shape: shape.to_vec(),
-            data: vec![T::zero(); cap_elems],
+            data: Arc::new(vec![T::zero(); cap_elems]),
+            offset: 0,
             identity: crate::BufferIdentity::new(),
         })
+    }
+
+    /// Create a zero-copy sub-region view that shares `parent`'s allocation.
+    ///
+    /// The view maps the window `[offset_bytes, offset_bytes + logical_size)`
+    /// measured from `parent`'s own logical start, where
+    /// `logical_size = shape.product() * size_of::<T>()`. N such views into one
+    /// parent share the buffer (no copy) and can be written independently.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidOperation`] if `offset_bytes` is not aligned to
+    ///   `align_of::<T>()` (required for the pointer cast in `MemMap`).
+    /// - [`Error::InsufficientCapacity`] if the window exceeds the parent
+    ///   allocation.
+    pub fn view(parent: &MemTensor<T>, offset_bytes: usize, shape: &[usize]) -> Result<Self> {
+        let elem = std::mem::size_of::<T>();
+        if elem > 1 && !offset_bytes.is_multiple_of(std::mem::align_of::<T>()) {
+            return Err(Error::InvalidOperation(format!(
+                "MemTensor::view: offset {offset_bytes} not aligned to align_of::<T>()={}",
+                std::mem::align_of::<T>()
+            )));
+        }
+        let logical: usize = shape.iter().product::<usize>() * elem;
+        // The view is positioned relative to this tensor's own window, so a
+        // sub-view of a sub-view composes correctly.
+        let abs_offset = parent
+            .offset
+            .checked_add(offset_bytes)
+            .ok_or(Error::InvalidSize(offset_bytes))?;
+        let total = parent.data.len() * elem;
+        let needed = abs_offset
+            .checked_add(logical)
+            .ok_or(Error::InvalidSize(logical))?;
+        if needed > total {
+            return Err(Error::InsufficientCapacity {
+                needed,
+                capacity: total,
+            });
+        }
+        Ok(MemTensor {
+            name: parent.name.clone(),
+            shape: shape.to_vec(),
+            data: Arc::clone(&parent.data),
+            offset: abs_offset,
+            // A sub-view is the *same* buffer: share the parent's identity so
+            // identity-keyed caches (e.g. the GL EGLImage cache) treat the
+            // windows as one buffer distinguished by offset, not as unrelated
+            // allocations.
+            identity: parent.identity.clone(),
+        })
+    }
+
+    /// Set the byte offset of the logical window into the backing allocation.
+    /// Validated against the allocation at `map()` time.
+    pub(crate) fn set_offset(&mut self, offset: usize) {
+        self.offset = offset;
     }
 }
 
@@ -77,7 +142,8 @@ where
         Ok(MemTensor {
             name,
             shape: shape.to_vec(),
-            data,
+            data: Arc::new(data),
+            offset: 0,
             identity: crate::BufferIdentity::new(),
         })
     }
@@ -126,12 +192,33 @@ where
     }
 
     fn map(&self) -> Result<TensorMap<T>> {
-        let mem_ptr = MemPtr(
-            NonNull::new(self.data.as_ptr() as *mut c_void)
-                .ok_or(Error::InvalidSize(self.size()))?,
-        );
+        let elem = std::mem::size_of::<T>();
+        // Validate the offset window fits the backing allocation (mirrors
+        // DmaMap::new_internal's bounds + alignment checks).
+        let logical = self.shape.iter().product::<usize>() * elem;
+        let total = self.data.len() * elem;
+        let end = self
+            .offset
+            .checked_add(logical)
+            .ok_or(Error::InvalidSize(logical))?;
+        if end > total {
+            return Err(Error::InsufficientCapacity {
+                needed: end,
+                capacity: total,
+            });
+        }
+        if elem > 1 && !self.offset.is_multiple_of(std::mem::align_of::<T>()) {
+            return Err(Error::InvalidOperation(format!(
+                "MemMap: offset {} not aligned to align_of::<T>()={}",
+                self.offset,
+                std::mem::align_of::<T>()
+            )));
+        }
         Ok(TensorMap::Mem(MemMap {
-            ptr: Arc::new(Mutex::new(mem_ptr)),
+            // Keep the backing allocation alive for the map's lifetime so the
+            // map stays valid even if the source tensor is dropped first.
+            backing: Arc::clone(&self.data),
+            offset: self.offset,
             shape: self.shape.clone(),
             _marker: std::marker::PhantomData,
         }))
@@ -142,7 +229,9 @@ where
     }
 
     fn capacity_bytes(&self) -> usize {
-        self.data.len() * std::mem::size_of::<T>()
+        // Capacity available to this tensor is the allocation minus its window
+        // start, so `set_logical_shape` stays bounded for sub-region views.
+        self.data.len() * std::mem::size_of::<T>() - self.offset
     }
 
     fn set_logical_shape(&mut self, shape: &[usize]) -> Result<()> {
@@ -164,7 +253,12 @@ pub struct MemMap<T>
 where
     T: Num + Clone + fmt::Debug,
 {
-    ptr: Arc<Mutex<MemPtr>>,
+    /// Keep-alive of the backing allocation. Owning the `Arc` (rather than a
+    /// raw pointer) ensures the buffer outlives the map even if the source
+    /// tensor is dropped first.
+    backing: Arc<Vec<T>>,
+    /// Byte offset of the mapped window into `backing`.
+    offset: usize,
     shape: Vec<usize>,
     _marker: std::marker::PhantomData<T>,
 }
@@ -189,18 +283,6 @@ where
     }
 }
 
-#[derive(Debug)]
-struct MemPtr(NonNull<c_void>);
-impl Deref for MemPtr {
-    type Target = NonNull<c_void>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-unsafe impl Send for MemPtr {}
-
 impl<T> TensorMapTrait<T> for MemMap<T>
 where
     T: Num + Clone + fmt::Debug,
@@ -214,13 +296,19 @@ where
     }
 
     fn as_slice(&self) -> &[T] {
-        let ptr = self.ptr.lock().expect("Failed to lock MemMap pointer");
-        unsafe { std::slice::from_raw_parts(ptr.as_ptr() as *const T, self.len()) }
+        // SAFETY: the window `[offset, offset + len*size_of::<T>())` was bounds-
+        // and alignment-checked in `MemTensor::map()`; `backing` keeps the
+        // allocation alive; the base pointer is stable (never reallocated).
+        let base = unsafe { (self.backing.as_ptr() as *const u8).add(self.offset) as *const T };
+        unsafe { std::slice::from_raw_parts(base, self.len()) }
     }
 
     fn as_mut_slice(&mut self) -> &mut [T] {
-        let ptr = self.ptr.lock().expect("Failed to lock MemMap pointer");
-        unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut T, self.len()) }
+        // SAFETY: as above. Distinct sub-region views address non-overlapping
+        // windows of the shared allocation, so the aliased `&mut` access is
+        // sound at the byte level — the same contract as `DmaMap`.
+        let base = unsafe { (self.backing.as_ptr() as *const u8).add(self.offset) as *mut T };
+        unsafe { std::slice::from_raw_parts_mut(base, self.len()) }
     }
 }
 

--- a/crates/tensor/src/mem.rs
+++ b/crates/tensor/src/mem.rs
@@ -102,7 +102,13 @@ where
 {
     /// Allocate `byte_capacity` bytes and set an initial logical `shape`
     /// (whose byte size must fit the capacity).
-    pub fn with_capacity_bytes(
+    ///
+    /// Test-only: production code allocates exactly `shape` via [`MemTensor::new`]
+    /// and grows the logical view with `set_logical_shape` within that capacity.
+    /// This over-allocating constructor exists for tests that need spare
+    /// capacity (e.g. an offset window past the logical end).
+    #[cfg(test)]
+    pub(crate) fn with_capacity_bytes(
         shape: &[usize],
         byte_capacity: usize,
         name: Option<&str>,

--- a/crates/tensor/src/tensor_dyn.rs
+++ b/crates/tensor/src/tensor_dyn.rs
@@ -1137,6 +1137,22 @@ mod tests {
     }
 
     #[test]
+    fn dyn_subview_dispatches_every_dtype() {
+        // `TensorDyn::subview` fans out across all 11 dtype arms; exercise each
+        // so the window maps at its offset and preserves the element type.
+        // Byte offset 8 is aligned for every element type (max align is 8) and
+        // a 4-element window stays in-bounds of the 16-element parent.
+        use DType::*;
+        for dt in [U8, I8, U16, I16, U32, I32, U64, I64, F16, F32, F64] {
+            let parent = TensorDyn::new(&[16], dt, Some(TensorMemory::Mem), None).unwrap();
+            let view = parent.subview(8, &[4]).unwrap();
+            assert_eq!(view.dtype(), dt, "subview must preserve dtype {dt:?}");
+            assert_eq!(view.plane_offset(), Some(8), "{dt:?}");
+            assert_eq!(view.shape(), &[4], "{dt:?}");
+        }
+    }
+
+    #[test]
     fn map_accepts_zero_offset_tensor() {
         let mut t =
             Tensor::<u8>::image(100, 100, PixelFormat::Rgba, Some(TensorMemory::Mem)).unwrap();

--- a/crates/tensor/src/tensor_dyn.rs
+++ b/crates/tensor/src/tensor_dyn.rs
@@ -234,6 +234,29 @@ impl TensorDyn {
         self
     }
 
+    /// Create a zero-copy sub-region view of this tensor's backing buffer.
+    ///
+    /// The returned tensor shares this tensor's allocation and maps the window
+    /// `[offset_bytes, offset_bytes + shape.product() * element_size)`. N
+    /// sub-views into one parent can be written independently — the basis for
+    /// assembling a batch into one buffer. Works identically on `Mem` (shared
+    /// `Arc`) and `Dma` (shared fd) backings. See [`Tensor::subview`].
+    pub fn subview(&self, offset_bytes: usize, shape: &[usize]) -> crate::Result<TensorDyn> {
+        match self {
+            Self::U8(t) => t.subview(offset_bytes, shape).map(Self::U8),
+            Self::I8(t) => t.subview(offset_bytes, shape).map(Self::I8),
+            Self::U16(t) => t.subview(offset_bytes, shape).map(Self::U16),
+            Self::I16(t) => t.subview(offset_bytes, shape).map(Self::I16),
+            Self::U32(t) => t.subview(offset_bytes, shape).map(Self::U32),
+            Self::I32(t) => t.subview(offset_bytes, shape).map(Self::I32),
+            Self::U64(t) => t.subview(offset_bytes, shape).map(Self::U64),
+            Self::I64(t) => t.subview(offset_bytes, shape).map(Self::I64),
+            Self::F16(t) => t.subview(offset_bytes, shape).map(Self::F16),
+            Self::F32(t) => t.subview(offset_bytes, shape).map(Self::F32),
+            Self::F64(t) => t.subview(offset_bytes, shape).map(Self::F64),
+        }
+    }
+
     /// The CUDA registration for this tensor, if any.
     ///
     /// Returns `None` when no CUDA handle has been attached (the common non-CUDA case).
@@ -1090,14 +1113,27 @@ mod tests {
     }
 
     #[test]
-    fn map_rejects_offset_tensor() {
+    fn map_rejects_out_of_bounds_offset() {
         let mut t =
             Tensor::<u8>::image(100, 100, PixelFormat::Rgba, Some(TensorMemory::Mem)).unwrap();
-        // Map works before offset is set
+        // Map works before offset is set.
         assert!(t.map().is_ok());
-        // After setting non-zero offset, map should be rejected
+        // Heap offsets are now honored, but an offset that pushes the full
+        // logical window (40000 bytes) past the allocation must be rejected.
         t.set_plane_offset(4096);
         assert!(t.map().is_err());
+    }
+
+    #[test]
+    fn mem_subview_in_bounds_maps_at_offset() {
+        // An in-bounds heap sub-view now maps at its offset (previously every
+        // non-zero heap offset was rejected outright).
+        let parent =
+            Tensor::<u8>::image(100, 100, PixelFormat::Rgba, Some(TensorMemory::Mem)).unwrap();
+        // A 10x10 RGBA window (400 bytes) at byte offset 4096 fits in 40000.
+        let view = parent.subview(4096, &[10, 10, 4]).unwrap();
+        assert_eq!(view.plane_offset(), Some(4096));
+        assert!(view.map().is_ok());
     }
 
     #[test]

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -707,3 +707,110 @@ def test_cuda_map_falls_back_to_map():
     with t.map() as host:
         # len(TensorMap) == total number of elements
         assert len(host) == 16  # 4 * 4
+
+
+# ---------------------------------------------------------------------------
+# subview tests (zero-copy sub-region views with full numpy/buffer-protocol)
+# ---------------------------------------------------------------------------
+
+
+def test_subview_partitions_parent_via_numpy():
+    """Two views of one Mem parent are written independently through numpy
+    and partition the parent buffer (zero-copy, no aliasing)."""
+    # 16-byte uint8 parent; two 8-byte windows at offsets 0 and 8.
+    parent = Tensor([16], dtype="uint8", mem=TensorMemory.MEM)
+    v0 = parent.subview(0, [8])
+    v1 = parent.subview(8, [8])
+
+    assert v0.shape == [8]
+    assert v1.shape == [8]
+    assert v0.plane_offset == 0 or v0.plane_offset is None
+    assert v1.plane_offset == 8
+
+    v0.from_numpy(np.arange(1, 9, dtype="uint8"))
+    v1.from_numpy(np.arange(11, 19, dtype="uint8"))
+
+    # Each view sees only its own window.
+    assert np.array_equal(_read_tensor(v0, "uint8"), np.arange(1, 9, dtype="uint8"))
+    assert np.array_equal(_read_tensor(v1, "uint8"), np.arange(11, 19, dtype="uint8"))
+    # The parent buffer is correctly partitioned (shared, zero-copy).
+    assert np.array_equal(
+        _read_tensor(parent, "uint8"),
+        np.array(
+            [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16, 17, 18], dtype="uint8"
+        ),
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="DMA-BUF is Linux-only; macOS uses IOSurface",
+)
+def test_subview_dma_partitions_parent_via_numpy():
+    """DMA parent: two sub-views written through numpy partition one dma-buf
+    (zero-copy), exercising the binding on DMA-backed memory (on-target)."""
+    try:
+        parent = Tensor([16], dtype="uint8", mem=TensorMemory.DMA)
+    except (AttributeError, RuntimeError):
+        pytest.skip("DMA memory not supported on this platform")
+    assert parent.memory == TensorMemory.DMA
+
+    v0 = parent.subview(0, [8])
+    v1 = parent.subview(8, [8])
+    assert v1.plane_offset == 8
+    # A view of a dma-buf shares the parent fd.
+    assert v1.memory == TensorMemory.DMA
+
+    v0.from_numpy(np.arange(1, 9, dtype="uint8"))
+    v1.from_numpy(np.arange(11, 19, dtype="uint8"))
+
+    assert np.array_equal(
+        _read_tensor(parent, "uint8"),
+        np.array(
+            [1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 14, 15, 16, 17, 18], dtype="uint8"
+        ),
+    )
+
+
+def test_subview_buffer_protocol_zero_copy():
+    """A view's map() exposes the numpy buffer protocol; a write through the
+    live memoryview lands in the parent at the view's offset (zero-copy)."""
+    parent = Tensor([4, 4], dtype="float32", mem=TensorMemory.MEM)  # 64 bytes
+    # Second row: byte offset 4*4 = 16, a [1, 4] float32 window.
+    row = parent.subview(16, [1, 4])
+    assert row.plane_offset == 16
+
+    with row.map() as m:
+        # Buffer protocol: zero-copy numpy view over the live mapping.
+        arr = np.frombuffer(m.view(), dtype="float32").reshape(row.shape)
+        arr[0, :] = [1.5, 2.5, 3.5, 4.5]
+
+    # The write is visible in the parent's second row (zero-copy partition).
+    parent_arr = _read_tensor(parent, "float32")
+    assert np.array_equal(
+        parent_arr[1, :], np.array([1.5, 2.5, 3.5, 4.5], dtype="float32")
+    )
+    # Other rows untouched.
+    assert np.array_equal(parent_arr[0, :], np.zeros(4, dtype="float32"))
+
+
+def test_subview_rejects_misaligned_and_out_of_bounds():
+    """Element-alignment and bounds are enforced at subview() creation."""
+    # float32 align is 4; a 2-byte offset cannot back a valid float32 window.
+    parent = Tensor([8], dtype="float32", mem=TensorMemory.MEM)
+    with pytest.raises((ValueError, RuntimeError)):
+        parent.subview(2, [1])
+    # Aligned offset is accepted.
+    parent.subview(4, [1])
+    # Out of bounds: offset 6 + 4 bytes exceeds an 8-byte uint8 allocation.
+    small = Tensor([8], dtype="uint8", mem=TensorMemory.MEM)
+    with pytest.raises((ValueError, RuntimeError)):
+        small.subview(6, [4])
+
+
+def test_set_plane_offset_roundtrip():
+    """set_plane_offset / plane_offset round-trip and gate map() bounds."""
+    t = Tensor([100, 100, 4], dtype="uint8", mem=TensorMemory.MEM)
+    assert t.plane_offset is None or t.plane_offset == 0
+    t.set_plane_offset(4096)
+    assert t.plane_offset == 4096


### PR DESCRIPTION
## Problem

`plane_offset` sub-region views were broken in two places, blocking `edgefirst-profiler`'s zero-copy batched inference:

- **Heap (`MemTensor`)** tensors **hard-rejected** a non-zero `plane_offset` (`"plane offset only supported for DMA tensors"`) and owned an inline `Vec<T>` with no way to share one allocation across N views. This made the batch/unbatch framework untestable on CI (ONNX CPU backend = heap).
- **GPU render target:** the GL EGLImage cache keyed only on `(luma_id, chroma_id)`. N sub-region views of one DMA-BUF share a `BufferIdentity`, so offset-distinct views **aliased the first (offset-0) EGLImage** and rendered into the base region — the failure that capped V3D batched render at 6.

## Changes

**`crates/tensor`**
- `MemTensor` now holds an `Arc`-shared, fixed allocation + a byte `offset` (replacing the inline `pub data: Vec<T>`). `MemMap` applies the offset and holds an `Arc` keep-alive — also fixing a latent dangling-pointer footgun (the old map held only a raw pointer).
- New `Tensor::subview(offset, shape)` / `TensorDyn::subview` — zero-copy sub-region views that **share the parent's `BufferIdentity`**, with identical semantics across `Mem` (shared `Arc`) and `Dma` (shared fd, via new identity-preserving `DmaTensor::view`). Bounds + alignment checked, mirroring `DmaMap`.
- `set_plane_offset` and the `set_format`/`reshape` clear sites now keep the `Mem` storage offset in sync; `map()` allows `Mem` offsets.

**`crates/image`**
- `EglCacheKey` gains the plane offset (`(u64, Option<u64>, usize)`); all key-construction sites updated. Offset-distinct views now get distinct EGLImages.
- The CPU convert path needed **no change** — once `map()` honors the offset, a convert into a heap sub-view writes exactly its window.

## Verification

- **Host:** tensor 147 + 7 doc-tests, image 294 + 5 — all green; `make format lint check` clean.
- **On-target (rpi5-hailo, V3D 7.1.10.2):** new `opengl_render_into_dma_subviews_no_aliasing` renders two sources into two offset sub-views of one DMA-BUF.
  - **With the fix:** PASS (buffer correctly partitioned).
  - **A/B control (cache offset forced to 0 = pre-fix):** FAIL — view 0's window shows the other source's pixels, exactly the reported "stale/aliased at offset > 0". This proves the cache-key fix is what makes V3D render correctly (root cause is **H1**, the cache — not a V3D renderbuffer-offset limitation, so no capability-flag fallback is needed).

New tests: heap sub-view partitioning, N-view no-aliasing, alignment/bounds, Dma↔Mem parity, CPU convert-into-sub-view, EGLImage cache-key collision (CI), and the on-target V3D render test (gated `dma_test_formats`).