### PR TITLE
Jetson/CUDA zero-copy: PBO stride parity + convert→cuda_map output path for TensorRT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,27 @@ test-capi:
 	@$(MAKE) -C crates/capi/tests test
 	@echo "✓ C API tests passed"
 
+# Optional CUDA device-pointer tests (convert -> cuda_map -> cudaMemcpy). Not
+# part of `make test`: they need a CUDA-capable GPU + libcudart at runtime.
+# On a dev PC with only the driver, install the CUDA runtime into the local
+# venv (`pip install nvidia-cuda-runtime-cu12`) and this target points the HAL's
+# dlopen at it via LD_LIBRARY_PATH. On Jetson/Orin libcudart is already on the
+# system path so the venv lookup is simply skipped. Runtime-skips cleanly when
+# no GPU/libcudart is present.
+.PHONY: test-cuda
+test-cuda:
+	@echo "Running CUDA device-pointer tests..."
+	@CUDART_LIB=$$( \
+		if [ -d venv ]; then \
+			find venv -name 'libcudart.so*' -printf '%h\n' 2>/dev/null | head -1; \
+		fi); \
+	if [ -n "$$CUDART_LIB" ]; then \
+		echo "  using venv libcudart at $$CUDART_LIB"; \
+	fi; \
+	LD_LIBRARY_PATH="$$CUDART_LIB:$$LD_LIBRARY_PATH" \
+		cargo test --features opengl -p edgefirst-image --lib cuda_map -- --nocapture
+	@echo "✓ CUDA device-pointer tests complete"
+
 .PHONY: bench
 bench:
 	@echo "Running benchmarks..."

--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ test-cuda:
 		echo "  using venv libcudart at $$CUDART_LIB"; \
 	fi; \
 	LD_LIBRARY_PATH="$$CUDART_LIB:$$LD_LIBRARY_PATH" \
-		cargo test --features opengl -p edgefirst-image --lib cuda_map -- --nocapture
+		cargo test --features opengl -p edgefirst-image --lib cuda -- --nocapture
 	@echo "✓ CUDA device-pointer tests complete"
 
 .PHONY: bench

--- a/TESTING.md
+++ b/TESTING.md
@@ -641,14 +641,40 @@ Run these on any host (no CUDA hardware required):
 cargo test -p edgefirst-tensor -- --test-threads=1
 ```
 
+### Device-pointer correctness tests (CUDA host — incl. dev PC)
+
+These exercise the real zero-copy output path end to end:
+`convert()` → `cuda_map()` → `cudaMemcpy(D2H)` → bit-compare to a CPU reference.
+They run on any CUDA-capable host and **skip cleanly** when `libcudart`, GL, or a
+PBO allocation is unavailable, so they are *not* part of `make test`.
+
+| Test (`crates/image`) | Covers |
+|------------------------|--------|
+| `gl::tests::convert_f32_pbo_cuda_map_{roundtrip,numeric}` | RGBA→Rgb F32 PBO → device ptr; 256-byte alignment; numeric match |
+| `gl::tests::jpeg_{nv12,nv16,nv24,grey}_convert_cuda_devptr` | full Jetson flow per native format: JPEG decode → NVxx/GREY → convert → PBO → `cuda_map` (colorimetry-correct) |
+| C-API `cuda_devptr_roundtrip` (`crates/capi/tests`) | `hal_tensor_cuda_map` → `hal_tensor_cuda_device_ptr` → `hal_tensor_cuda_unmap` |
+
+A **dev PC** typically has only the NVIDIA driver (no CUDA toolkit). Install the
+runtime into the local venv and run via the Makefile, which points the HAL's
+`libcudart` dlopen at it:
+
+```bash
+. venv/bin/activate
+pip install nvidia-cuda-runtime-cu12   # provides libcudart.so.12
+make test-cuda                         # sets LD_LIBRARY_PATH → runs the cuda tests
+```
+
+On Jetson/Orin `libcudart` is already on the system path, so `make test-cuda`
+(or the cross-built binary) finds it directly — the venv lookup is skipped.
+
 ### On-target validation
 
 Full-pipeline validation was performed on:
 
 | Platform | OS / CUDA / TensorRT | What was validated |
 |----------|----------------------|--------------------|
-| Jetson Orin-nano (O5/O6/O8) | L4T R36.4 / CUDA 12.6 / TRT 10.3 | DMA-import path, TRT `enqueue_v3`, GL-render→CUDA bridge; numeric max\_err 0.00024 vs CPU reference |
-| Desktop RTX 3090 | CUDA 12.6 | PBO→CUDA path (GL host + CUDA device) |
+| Jetson Orin-nano | L4T R36.4 / CUDA 12.6 / TRT 10.3 | PBO→CUDA output path; `convert→cuda_map→cudaMemcpy` device-ptr correctness, all native JPEG formats (NV12/NV16/NV24/GREY) `max_err=0` (CPU-into-PBO), synthetic GL-render path `max_err=2.4e-4`; device ptr 256-byte aligned. No `/dev/dma_heap` → PBO transfers. |
+| Desktop GTX 1080 | CUDA 12.9 (runtime via pip) | Same device-ptr suite `max_err=0`; C-API `cuda_devptr_roundtrip` |
 
 To run the on-target CUDA tests manually:
 

--- a/crates/capi/tests/test_image.c
+++ b/crates/capi/tests/test_image.c
@@ -329,6 +329,67 @@ static void test_image_processor_convert_invalid(void) {
     TEST_PASS();
 }
 
+// Zero-copy CUDA output path through the C API: convert() into a GPU PBO
+// destination, then hal_tensor_cuda_map() -> hal_tensor_cuda_device_ptr() ->
+// hal_tensor_cuda_unmap(). Mirrors the Rust convert_f32_pbo_cuda_map tests; the
+// device pointer is what a TensorRT client binds via setInputTensorAddress.
+// Skips cleanly when CUDA / GL / a PBO allocation is unavailable.
+static void test_cuda_devptr_roundtrip(void) {
+    TEST("cuda_devptr_roundtrip");
+
+    if (!hal_is_cuda_available()) {
+        TEST_SKIP("CUDA not available (libcudart not loaded)");
+        return;
+    }
+    struct hal_image_processor* proc =
+        hal_image_processor_new_with_backend(HAL_COMPUTE_BACKEND_OPENGL);
+    if (proc == NULL) {
+        TEST_SKIP("No OpenGL backend");
+        return;
+    }
+
+    const size_t w = 64, h = 64;
+    struct hal_tensor* src =
+        hal_tensor_new_image(w, h, HAL_PIXEL_FORMAT_RGBA, HAL_DTYPE_U8, HAL_TENSOR_MEMORY_MEM);
+    ASSERT_NOT_NULL(src);
+    // create_image selects the optimal memory (a GPU PBO on the GL backend),
+    // which is what makes the destination CUDA-mappable.
+    struct hal_tensor* dst =
+        hal_image_processor_create_image(proc, w, h, HAL_PIXEL_FORMAT_RGB, HAL_DTYPE_F32);
+    ASSERT_NOT_NULL(dst);
+    if (hal_tensor_memory_type(dst) != HAL_TENSOR_MEMORY_PBO) {
+        TEST_SKIP("dst not a PBO (no CUDA-GL allocation on this host)");
+        hal_tensor_free(src);
+        hal_tensor_free(dst);
+        hal_image_processor_free(proc);
+        return;
+    }
+
+    int rc = hal_image_processor_convert(proc, src, dst, HAL_ROTATION_NONE, HAL_FLIP_NONE, NULL);
+    ASSERT_EQ(0, rc);
+
+    void* map = hal_tensor_cuda_map(dst);
+    if (map == NULL) {
+        TEST_SKIP("cuda_map returned NULL (CUDA-GL interop unavailable for this context)");
+        hal_tensor_free(src);
+        hal_tensor_free(dst);
+        hal_image_processor_free(proc);
+        return;
+    }
+    size_t sz = 0;
+    void* dptr = hal_tensor_cuda_device_ptr(map, &sz);
+    ASSERT_NOT_NULL(dptr);
+    // [H,W,3] f32 device buffer; 256-byte aligned for TensorRT input pointers.
+    ASSERT_EQ(w * h * 3 * sizeof(float), sz);
+    ASSERT_EQ((size_t)0, ((size_t)dptr) % 256);
+
+    hal_tensor_cuda_unmap(map);
+    hal_tensor_free(src);
+    hal_tensor_free(dst);
+    hal_image_processor_free(proc);
+    TEST_PASS();
+}
+
 // =============================================================================
 // DMA Image Tests (Linux/on-target specific)
 // =============================================================================
@@ -664,6 +725,7 @@ void run_image_tests(void) {
     test_image_processor_convert_scale();
     test_image_processor_convert_with_rotation();
     test_image_processor_convert_invalid();
+    test_cuda_devptr_roundtrip();
 
     // DMA tests
     test_tensor_image_dma();

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -465,6 +465,51 @@ For the full CUDA type model, `CudaHandle` variants (GlBuffer vs
 ExternalMem), and DMA-BUF import path, see
 [`crates/tensor/ARCHITECTURE.md § Zero-copy CUDA tensor mapping`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/ARCHITECTURE.md#zero-copy-cuda-tensor-mapping).
 
+### CUDA → TensorRT integration contract
+
+The supported zero-copy hand-off to a CUDA/TensorRT client is the **output**
+path: allocate the convert destination through `create_image()` (a GPU **PBO**),
+`convert()` into it, then `cuda_map()` and bind the device pointer:
+
+```text
+decode/import → src → convert(src → dst = create_image(PlanarRgb|Rgb, F16|F32))
+             → CudaMap m = dst.cuda_map()
+             → trt_context.setInputTensorAddress(name, m.device_ptr())
+             → enqueueV3(stream)
+```
+
+Contract the client must honour:
+
+- **Lifetime.** The destination tensor *and* the live `CudaMap` guard must
+  outlive every `enqueueV3` that reads the pointer. Drop the guard only after
+  the inference stream has synchronised (`cudaStreamSynchronize` or the
+  set-input-consumed event). Dropping it early returns the PBO to GL.
+- **Synchronisation.** `convert()` finishes its GL work before `cuda_map()`
+  returns, so the device buffer is ready when bound. The producer (HAL convert)
+  and the consumer (TRT) are otherwise on independent streams; the guarantee is
+  "convert complete → map → enqueue". Shared-stream / external-semaphore
+  pipelining is a future optimisation.
+- **Layout / alignment.** The output is tight (no row padding) NCHW planar F16
+  (`PlanarRgb`) or NHWC `Rgb` F32 — `CudaMap::len()` equals the logical byte
+  size. The device pointer is **256-byte aligned**, satisfying TensorRT's
+  `setInputTensorAddress` requirement.
+
+**Jetson (Orin) note.** Orin has no `/dev/dma_heap`, so semi-planar YUV sources
+have no GPU convert path (that needs a DMA-BUF EGLImage). The CPU JPEG decoder
+emits native **NV12 / NV16 / NV24 / GREY** into an `mmap`'d PBO; `convert()`
+runs on the **CPU** (colorimetry-correct) and writes the result into the
+CUDA-registered output PBO, which is then `cuda_map`'d — the zero-copy is the
+*output* to TensorRT, not the decode. This is exercised end-to-end per format by
+`gl::tests::jpeg_{nv12,nv16,nv24,grey}_convert_cuda_devptr` (verified on GTX 1080
+and Tegra Orin) and the C-API `cuda_devptr_roundtrip` test.
+
+**DMA-BUF → CUDA import (`cudaImportExternalMemory`, `ExternalMem`)** is a
+separate, **experimental** path used only when a tensor is *both* a self-owned
+DMA-BUF *and* on a CUDA device. NVIDIA documents `cudaImportExternalMemory` on a
+dma-buf/opaque fd as **unsupported on Tegra/Orin** (use the EGLImage interop
+instead); it is left in place for discrete-x86 experimentation but is **not** the
+Jetson path and is not part of the supported contract above.
+
 ### EGL image cache
 
 The OpenGL backend maintains two independent LRU caches of EGLImages —

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -2477,8 +2477,22 @@ impl GLProcessorST {
                 }
             }
 
+            // Honour a padded source row stride: a PBO written by the CPU JPEG
+            // decoder (or any producer) may have 64-byte-aligned rows, so the
+            // bytes between logical rows must be skipped on upload. Mirror the
+            // non-PBO `draw_src_texture` path (GL_UNPACK_ROW_LENGTH in pixels);
+            // 0 means "tightly packed = src_w". Without this a padded PBO source
+            // shears on every row after the first.
+            let src_bpp = src_fmt.channels();
+            let row_len_px = src
+                .effective_row_stride()
+                .map(|s| s / src_bpp)
+                .filter(|&px| px != src_w)
+                .unwrap_or(0);
+
             // Bind source PBO as UNPACK buffer — glTexImage2D reads from it
             gls::gl::BindBuffer(gls::gl::PIXEL_UNPACK_BUFFER, src_buffer_id);
+            gls::gl::PixelStorei(gls::gl::UNPACK_ROW_LENGTH, row_len_px as i32);
             gls::gl::TexImage2D(
                 texture_target,
                 0,
@@ -2490,6 +2504,7 @@ impl GLProcessorST {
                 gls::gl::UNSIGNED_BYTE,
                 std::ptr::null(), // NULL = read from bound UNPACK buffer
             );
+            gls::gl::PixelStorei(gls::gl::UNPACK_ROW_LENGTH, 0);
             gls::gl::BindBuffer(gls::gl::PIXEL_UNPACK_BUFFER, 0);
 
             // Force texture cache state to be rebuilt next call

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -4439,6 +4439,161 @@ mod gl_tests {
         // drop(cm) unmaps
     }
 
+    /// Full Jetson zero-copy OUTPUT flow, per native JPEG format:
+    ///   JPEG decode → NV12/NV16/NV24/GREY source (JFIF/BT.601-full tagged) →
+    ///   `convert()` → `Rgb` `F32` PBO output → `cuda_map()` →
+    ///   `cudaMemcpy(D2H)` → compare to a CPU `convert()` reference.
+    ///
+    /// Proves the device pointer a TensorRT client receives holds the
+    /// correctly-converted, colorimetry-correct pixels for every format the CPU
+    /// JPEG decoder emits — and that the JPEG→NVxx/GREY decode path itself works
+    /// end to end. On a Jetson (no `/dev/dma_heap`) the NV source has no GPU
+    /// path, so `convert()` runs on the CPU and writes into the CUDA-registered
+    /// output PBO; this test exercises exactly that CPU→PBO→CUDA hand-off.
+    #[cfg(target_os = "linux")]
+    fn jpeg_cuda_devptr_check(fixture: &str, expect_fmt: PixelFormat, w: usize, h: usize) {
+        use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
+        use edgefirst_codec::{ImageDecoder, ImageLoad};
+        use edgefirst_tensor::{Tensor, TensorMapTrait, TensorTrait};
+        use std::ffi::c_void;
+
+        if !edgefirst_tensor::is_cuda_available() {
+            eprintln!("SKIP {fixture}: no libcudart");
+            return;
+        }
+        let mut proc = match ImageProcessor::with_config(ImageProcessorConfig {
+            backend: ComputeBackend::OpenGl,
+            ..Default::default()
+        }) {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP {fixture}: no GL");
+                return;
+            }
+        };
+        if !proc.supported_render_dtypes().f32 {
+            eprintln!("SKIP {fixture}: no f32 render");
+            return;
+        }
+
+        // Decode JPEG into its native format; the decoder tags JFIF (BT.601
+        // full-range), which the CPU convert below must honour.
+        let mut src_t = Tensor::<u8>::image(w, h, expect_fmt, Some(TensorMemory::Mem)).unwrap();
+        let mut dec = ImageDecoder::new();
+        let info = src_t
+            .load_image(&mut dec, &edgefirst_bench::testdata::read(fixture))
+            .unwrap();
+        assert_eq!(info.format, expect_fmt, "{fixture}: native decode format");
+        assert_eq!(
+            src_t.colorimetry(),
+            Some(edgefirst_tensor::Colorimetry::jfif()),
+            "{fixture}: decoder must tag JFIF colorimetry"
+        );
+        let src = TensorDyn::from(src_t);
+
+        // CPU reference: convert into a tight Mem Rgb F32.
+        let mut ref_dst =
+            TensorDyn::image(w, h, PixelFormat::Rgb, DType::F32, Some(TensorMemory::Mem)).unwrap();
+        proc.convert(
+            &src,
+            &mut ref_dst,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .unwrap();
+        let ref_map = ref_dst.as_f32().unwrap().map().unwrap();
+        let ref_px = ref_map.as_slice();
+
+        // Rgb F32 PBO output → cuda_map (the buffer a TRT client binds).
+        let mut pbo_dst = proc
+            .create_image(w, h, PixelFormat::Rgb, DType::F32, None)
+            .unwrap();
+        if pbo_dst.memory() != TensorMemory::Pbo {
+            eprintln!("SKIP {fixture}: dst not PBO");
+            return;
+        }
+        proc.convert(
+            &src,
+            &mut pbo_dst,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .unwrap();
+        let cm = match pbo_dst.cuda_map() {
+            Some(cm) => cm,
+            None => {
+                eprintln!("SKIP {fixture}: cuda_map None (CUDA-GL interop unavailable)");
+                return;
+            }
+        };
+        assert!(!cm.device_ptr().is_null(), "{fixture}: null device_ptr");
+        assert_eq!(
+            cm.device_ptr() as usize % 256,
+            0,
+            "{fixture}: device_ptr must be 256-byte aligned for TensorRT"
+        );
+
+        let n = cm.len() / std::mem::size_of::<f32>();
+        let mut host = vec![0f32; n];
+        // SAFETY: `host` has `cm.len()` bytes; device_ptr is valid while `cm` lives.
+        assert!(
+            unsafe {
+                edgefirst_tensor::memcpy_device_to_host(
+                    host.as_mut_ptr() as *mut c_void,
+                    cm.device_ptr() as *const c_void,
+                    cm.len(),
+                )
+            },
+            "{fixture}: cudaMemcpy device->host failed"
+        );
+
+        // Stride-aware compare: the device buffer carries the PBO's row pitch
+        // (`effective_row_stride`), the Mem reference is tight.
+        let dev_stride_elems =
+            pbo_dst.effective_row_stride().unwrap_or(w * 3 * 4) / std::mem::size_of::<f32>();
+        let mut max_err = 0f32;
+        for y in 0..h {
+            for x in 0..w {
+                for c in 0..3 {
+                    let got = host[y * dev_stride_elems + x * 3 + c];
+                    let exp = ref_px[(y * w + x) * 3 + c];
+                    max_err = max_err.max((got - exp).abs());
+                }
+            }
+        }
+        eprintln!("jpeg_cuda_devptr {fixture} ({expect_fmt:?}): max_err={max_err}");
+        assert!(
+            max_err < 1e-3,
+            "{fixture}: cuda_map device buffer != CPU reference (max_err={max_err})"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn jpeg_nv12_convert_cuda_devptr() {
+        jpeg_cuda_devptr_check("zidane.jpg", PixelFormat::Nv12, 1280, 720);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn jpeg_nv16_convert_cuda_devptr() {
+        jpeg_cuda_devptr_check("zidane_422.jpg", PixelFormat::Nv16, 1280, 720);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn jpeg_nv24_convert_cuda_devptr() {
+        jpeg_cuda_devptr_check("zidane_444.jpg", PixelFormat::Nv24, 1280, 720);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn jpeg_grey_convert_cuda_devptr() {
+        jpeg_cuda_devptr_check("grey.jpg", PixelFormat::Grey, 1024, 681);
+    }
+
     // =========================================================================
     // Path B: NV16/NV24 → RGBA GPU round-trip tests
     //

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -2719,13 +2719,18 @@ where
         //   * Self-allocated DMA tensors (Linux) — pitch padding from
         //     `image_with_stride()`; checked against the DMA-BUF `buf_size`.
         //
+        //   * Self-allocated PBO tensors (any platform with GL) — the GL buffer
+        //     is sized by `capacity_bytes()` and may carry 64-byte row padding;
+        //     the JPEG decoder mmaps it and convert() reads it, both iterating
+        //     by `row_stride`. Checked against the PBO capacity below.
+        //
         // Foreign DMA-BUFs (`from_fd()` + `set_row_stride()`, the V4L2 /
-        // GStreamer case), IOSurface, and PBO storages are rejected: their
-        // layout comes from an external allocator / GPU driver the HAL cannot
-        // validate for a strided CPU view, and they are intended for the GPU
-        // path. (Earlier this rejected *all* non-Linux strided maps with
-        // "DMA backing is Linux-only" — that was an unimplemented path, not a
-        // platform limit; HAL-owned Mem/Shm are trivially mappable and now are.)
+        // GStreamer case) and IOSurface are rejected: their layout comes from an
+        // external allocator / GPU driver the HAL cannot validate for a strided
+        // CPU view, and they are intended for the GPU path. (Earlier this
+        // rejected *all* non-Linux strided maps with "DMA backing is Linux-only"
+        // — that was an unimplemented path, not a platform limit; HAL-owned
+        // Mem/Shm/PBO are trivially mappable and now are.)
         if let Some(stride) = self.row_stride {
             // Rows sit at `stride`-byte spacing; the first shape dim is the row
             // count for packed `[H, W, C]` and semi-planar `[H*k, W]` alike.
@@ -2795,10 +2800,12 @@ where
                     return io.map_with_byte_size(total_bytes);
                 }
                 TensorStorage::Pbo(pbo) => {
-                    // PBO: the GPU-side allocation may have a padded stride; the
-                    // map() call maps the full `handle.size` bytes and the caller
-                    // iterates rows via row_stride.  Validate that the strided
-                    // view fits the PBO capacity before mapping.
+                    // PBO: the GPU-side allocation may have a padded row stride
+                    // (e.g. 64-byte aligned). Expose the full padded buffer so a
+                    // CPU producer (JPEG decoder) and a strided convert source
+                    // can iterate rows via `effective_row_stride()` without
+                    // running past the slice — the logical `pbo.map()` view would
+                    // stop after `shape.product()` and lose bytes past row 0.
                     let capacity = pbo.capacity_bytes();
                     if total_bytes > capacity {
                         return Err(Error::InsufficientCapacity {
@@ -2806,7 +2813,7 @@ where
                             capacity,
                         });
                     }
-                    return pbo.map();
+                    return pbo.map_with_byte_size(total_bytes);
                 }
                 // Reachable on Linux for an IMPORTED DMA-BUF (the `Dma` arm above
                 // is guarded `if !dma.is_imported`). On macOS/Windows every

--- a/crates/tensor/src/pbo.rs
+++ b/crates/tensor/src/pbo.rs
@@ -237,9 +237,34 @@ where
     }
 
     fn map(&self) -> Result<TensorMap<T>> {
+        self.map_internal(None)
+    }
+
+    fn buffer_identity(&self) -> &BufferIdentity {
+        &self.identity
+    }
+}
+
+impl<T> PboTensor<T>
+where
+    T: Num + Clone + fmt::Debug + Send + Sync,
+{
+    /// Map the PBO so `as_slice()` exposes the full padded buffer (`byte_size`
+    /// bytes) rather than the shape-derived logical count. Mirrors
+    /// [`DmaTensor::map_with_byte_size`]: a CPU producer (e.g. the JPEG decoder)
+    /// or a strided convert source iterates rows via `effective_row_stride()`
+    /// without running past the slice. Crate-private; the only caller is
+    /// `Tensor::map()`, which already checks `byte_size <= capacity_bytes()`.
+    pub(crate) fn map_with_byte_size(&self, byte_size: usize) -> Result<TensorMap<T>> {
+        self.map_internal(Some(byte_size))
+    }
+
+    fn map_internal(&self, byte_size_override: Option<usize>) -> Result<TensorMap<T>> {
         if self.handle.mapped.swap(true, Ordering::AcqRel) {
             return Err(Error::PboMapped);
         }
+        // Always map the full GL allocation (`handle.size`); the slice length is
+        // narrowed by `byte_size_override` (or the logical shape) at access time.
         match self
             .handle
             .ops
@@ -254,6 +279,7 @@ where
                     ptr: Arc::new(Mutex::new(pbo_ptr)),
                     shape: self.shape.clone(),
                     handle: Arc::clone(&self.handle),
+                    byte_size_override,
                     _marker: PhantomData,
                 }))
             }
@@ -262,10 +288,6 @@ where
                 Err(e)
             }
         }
-    }
-
-    fn buffer_identity(&self) -> &BufferIdentity {
-        &self.identity
     }
 }
 
@@ -290,6 +312,12 @@ where
     ptr: Arc<Mutex<PboPtr>>,
     shape: Vec<usize>,
     handle: Arc<PboHandle>,
+    /// Optional override for `as_slice().len()`. `None` → `shape.product()`
+    /// elements (logical view). `Some(bytes)` → `bytes / sizeof(T)` elements,
+    /// exposing the full padded GL allocation so callers can iterate rows via
+    /// `row_stride` (set by `Tensor::map()` for strided PBO tensors). Mirrors
+    /// `DmaMap::byte_size_override`.
+    byte_size_override: Option<usize>,
     _marker: PhantomData<T>,
 }
 
@@ -323,12 +351,27 @@ where
 
     fn as_slice(&self) -> &[T] {
         let ptr = self.ptr.lock().expect("Failed to lock PboMap pointer");
-        unsafe { std::slice::from_raw_parts(ptr.as_ptr() as *const T, self.len()) }
+        unsafe { std::slice::from_raw_parts(ptr.as_ptr() as *const T, self.slice_len_elems()) }
     }
 
     fn as_mut_slice(&mut self) -> &mut [T] {
         let ptr = self.ptr.lock().expect("Failed to lock PboMap pointer");
-        unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut T, self.len()) }
+        unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut T, self.slice_len_elems()) }
+    }
+}
+
+impl<T> PboMap<T>
+where
+    T: Num + Clone + fmt::Debug,
+{
+    /// Number of `T` elements exposed by `as_slice()`. Honours
+    /// `byte_size_override` (the full padded GL allocation) when set; otherwise
+    /// the shape-derived logical count. Mirrors `DmaMap::slice_len_elems`.
+    fn slice_len_elems(&self) -> usize {
+        match self.byte_size_override {
+            Some(bytes) => bytes / std::mem::size_of::<T>(),
+            None => self.shape.iter().product(),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Wires up and verifies the **zero-copy `convert()` output path** for CUDA/TensorRT clients (the Jetson Orin flow), and brings PBO-backed tensors to stride parity with DMA so a CPU producer can feed them correctly.

The supported Jetson inference flow is: **CPU JPEG decode → mmap'd PBO → `convert()` → `cuda_map()` → CUDA/TensorRT**. There is no `/dev/dma_heap` on Orin, so semi-planar YUV sources have no GPU convert path — `convert()` runs on the **CPU** (colorimetry-correct) and writes into the CUDA-registered output PBO, which is `cuda_map`'d and bound to TensorRT via `setInputTensorAddress`. The zero-copy is the *output* to the inference engine.

## Changes

- **PBO stride parity** (`crates/tensor/src/pbo.rs`, `lib.rs`): `PboMap` gains a `byte_size_override` (mirrors `DmaMap`) so a strided PBO maps over its full padded GL allocation — a CPU JPEG decoder and a strided convert read/write all rows instead of losing everything past row 0.
- **GL PBO source stride** (`gl/processor/mod.rs`): `draw_src_texture_from_pbo` honors `GL_UNPACK_ROW_LENGTH`, matching the non-PBO path — a 64-byte-aligned PBO source no longer shears on upload.
- **Device-pointer coverage** (`crates/image`, `crates/capi/tests`): per-native-format tests `jpeg_{nv12,nv16,nv24,grey}_convert_cuda_devptr` — decode JPEG → native NV12/NV16/NV24/GREY (JFIF-tagged) → convert → `Rgb F32` PBO → `cuda_map` → `cudaMemcpy(D2H)` → bit-compare vs CPU reference; asserts 256-byte alignment for TensorRT. Plus a C-API `cuda_devptr_roundtrip` exercising `hal_tensor_cuda_map`→`hal_tensor_cuda_device_ptr`→`hal_tensor_cuda_unmap`. All skip cleanly without `libcudart` (default `make test` unaffected).
- **PC CUDA enablement** (`Makefile`): `make test-cuda` runs the device-ptr tests, pointing the HAL's `libcudart` dlopen at a venv-installed runtime (`pip install nvidia-cuda-runtime-cu12`) on dev PCs; uses system CUDA on Jetson.
- **Docs** (`ARCHITECTURE.md`, `TESTING.md`): the convert→cuda_map→`setInputTensorAddress`→`enqueueV3` integration contract (lifetime, stream sync, 256-byte alignment, tight NCHW/NHWC output), the Jetson CPU-convert-into-PBO flow, and the test/run guide. The `cudaImportExternalMemory` dma-buf import is marked experimental / unsupported on Tegra.

## Verification

- **GTX 1080** (CUDA runtime via pip): all 6 image CUDA tests `max_err=0`, device ptr 256-aligned; C-API `cuda_devptr_roundtrip` passes; 309 image lib tests green.
- **Jetson Orin** (CUDA 12.6): all 6 CUDA tests pass — JPEG NV12/NV16/NV24/GREY `max_err=0` (CPU-into-PBO is bit-exact), GL→CUDA PBO interop works on Tegra.
- `clippy -D warnings` clean on default + `dma_test_formats`.

## Notes

- The full TensorRT `enqueueV3` end-to-end lives in the profiler (separate repo), so HAL tests stay at CUDA-kernel/device-pointer correctness (`cudaMemcpy` readback).
- Built on the colorimetry work (PR #88, now merged); rebased onto current `main`.