### PR TITLE
DE-2651: Fix ModelPack segmentation decoder rejecting valid models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for any pixel-format pair. Resize is performed at u8 precision before
   widening to F16/F32; normalization is `[0, 1]`.
 
+### Fixed
+
+- **ModelPack segmentation decoder rejected valid models** (DE-2651, DE-2628):
+  `Decoder` construction failed with `InvalidConfig("Segmentation dshape missing
+  required dimension NumClasses")` — and, when the segmentation output was
+  consequently dropped, `InvalidConfig("Invalid ModelPack model outputs")` — for
+  ModelPack models whose segmentation `dshape` tagged the canonical NHWC channel
+  axis with something other than `num_classes` (e.g. `num_protos`, the cloud
+  validator's shape-inference fallback for `.keras` exports). `verify_modelpack_seg`
+  now requires only the spatial dshape axes by name and infers the class count
+  from the canonical NHWC channel axis (`shape[3]`) when `num_classes` is absent,
+  preferring an explicit `num_classes` tag when present. Structural dshape
+  integrity remains enforced by `validate_output_layout`. (Back-ported to the
+  0.22.x line as 0.22.2.)
+- **Unknown dshape axis names no longer fail metadata parsing** (DE-2651):
+  `DimName` gained a catch-all `Unknown` variant, so an unrecognised axis name
+  (e.g. older ModelPack exports tagging the input dshape channel axis
+  `channels`) is preserved as `Unknown` — keeping the dshape length aligned with
+  the shape and sorting the axis to the canonical tail — instead of rejecting the
+  entire decoder build.
+
 ## [0.24.2] - 2026-05-28
 
 ### Fixed

--- a/crates/decoder/src/decoder/builder.rs
+++ b/crates/decoder/src/decoder/builder.rs
@@ -1986,24 +1986,36 @@ impl DecoderBuilder {
                 segmentation.shape
             )));
         }
-        Self::verify_dshapes(
-            &segmentation.dshape,
-            &segmentation.shape,
-            "Segmentation",
-            &[
-                DimName::Batch,
-                DimName::Height,
-                DimName::Width,
-                DimName::NumClasses,
-            ],
-        )?;
+        // ModelPack segmentation is canonical NHWC: [Batch, Height, Width,
+        // NumClasses]. Structural integrity of the dshape (rank, per-axis size
+        // agreement with `shape`, no duplicate axes) is already enforced for
+        // every output by `Decoder::validate_output_layout` at build entry, so
+        // here we only require the spatial axes to be named and recover the
+        // class count from the channel axis below.
+        //
+        // Metadata producers that lack embedded metadata (the validator's
+        // shape-inference fallback for ModelPack `.keras` models) tag the
+        // channel axis as `num_protos` or omit its name, which previously
+        // hard-failed here with "Segmentation dshape missing required
+        // dimension NumClasses" (DE-2651 / DE-2628). That is unnecessarily
+        // strict: an unnamed or mis-named channel axis at position 3 is sorted
+        // to the canonical tail by `swap_axes_if_needed`, so the physical NHWC
+        // order — and therefore decode — is unaffected. Infer the class count
+        // from the NHWC shape instead of rejecting the model.
+        if !segmentation.dshape.is_empty() {
+            let names =
+                HashSet::<DimName>::from_iter(segmentation.dshape.iter().map(|(name, _)| *name));
+            for dim in [DimName::Batch, DimName::Height, DimName::Width] {
+                if !names.contains(&dim) {
+                    return Err(DecoderError::InvalidConfig(format!(
+                        "Segmentation dshape missing required dimension {dim:?}"
+                    )));
+                }
+            }
+        }
 
         if let Some(classes) = classes {
-            let seg_classes = if !segmentation.dshape.is_empty() {
-                Self::get_class_count(&segmentation.dshape, None, None)?
-            } else {
-                Self::get_class_count_no_dshape(segmentation.into(), None)?
-            };
+            let seg_classes = Self::modelpack_seg_num_classes(segmentation);
 
             if seg_classes != classes + 1 {
                 return Err(DecoderError::InvalidConfig(format!(
@@ -2013,6 +2025,23 @@ impl DecoderBuilder {
             }
         }
         Ok(())
+    }
+
+    /// Number of segmentation classes for a ModelPack segmentation output.
+    ///
+    /// Prefers an explicit `NumClasses` dshape dimension when present;
+    /// otherwise falls back to the canonical NHWC channel axis (`shape[3]`).
+    /// This tolerates metadata that omits or mis-tags the class axis while
+    /// still honouring a correctly-tagged dshape. Only called after
+    /// `verify_modelpack_seg` has validated that `shape` is rank-4 (it returns
+    /// `InvalidConfig` otherwise), so `shape[3]` cannot panic.
+    fn modelpack_seg_num_classes(segmentation: &configs::Segmentation) -> usize {
+        for (dim_name, dim_size) in &segmentation.dshape {
+            if *dim_name == DimName::NumClasses {
+                return *dim_size;
+            }
+        }
+        segmentation.shape[3]
     }
 
     // verifies that dshapes match the given shape
@@ -2139,7 +2168,6 @@ impl DecoderBuilder {
                 DecoderType::Ultralytics => Ok(scores.shape[1]),
                 DecoderType::ModelPack => Ok(scores.shape[2]),
             },
-            ConfigOutputRef::Segmentation(seg) => Ok(seg.shape[3]),
             _ => Err(DecoderError::Internal(
                 "Attempted to get class count from unsupported config output".to_owned(),
             )),

--- a/crates/decoder/src/decoder/configs.rs
+++ b/crates/decoder/src/decoder/configs.rs
@@ -190,6 +190,14 @@ pub enum DimName {
     Padding,
     #[serde(rename = "box_coords")]
     BoxCoords,
+    /// Any axis name the HAL does not recognise (e.g. a producer's
+    /// `channels` on the input dshape). Preserved so the dshape length still
+    /// matches the shape and the axis sorts to the canonical tail in
+    /// `swap_axes_if_needed`, but it never satisfies a required-dimension
+    /// check. Keeps metadata parsing tolerant of unknown axis names instead
+    /// of failing the whole decoder build (DE-2651).
+    #[serde(other)]
+    Unknown,
 }
 
 impl Display for DimName {
@@ -214,6 +222,7 @@ impl Display for DimName {
             DimName::NumAnchorsXFeatures => write!(f, "num_anchors_x_features"),
             DimName::Padding => write!(f, "padding"),
             DimName::BoxCoords => write!(f, "box_coords"),
+            DimName::Unknown => write!(f, "unknown"),
         }
     }
 }

--- a/crates/decoder/src/decoder/merge.rs
+++ b/crates/decoder/src/decoder/merge.rs
@@ -924,7 +924,7 @@ fn child_to_batch_feature_spatial(
             | DimName::NumProtos
             | DimName::BoxCoords
             | DimName::NumAnchorsXFeatures => features = size,
-            DimName::NumBoxes | DimName::Padding => {}
+            DimName::NumBoxes | DimName::Padding | DimName::Unknown => {}
         }
     }
 

--- a/crates/decoder/src/decoder/tests.rs
+++ b/crates/decoder/src/decoder/tests.rs
@@ -1188,6 +1188,250 @@ mod decoder_builder_tests {
     }
 
     #[test]
+    fn test_modelpack_seg_infers_classes_without_numclasses_dshape() {
+        // Regression for DE-2651 / DE-2628: a ModelPack segmentation output
+        // whose canonical NHWC channel axis is not tagged `NumClasses` (the
+        // validator's shape-inference fallback tags it `NumProtos`) must still
+        // build. HAL infers the class count from the NHWC shape and relies on
+        // `swap_axes_if_needed` to keep the physical layout intact at decode.
+
+        // Segmentation-only: channel axis mis-tagged as NumProtos.
+        let result = DecoderBuilder::new()
+            .with_config(ConfigOutputs {
+                outputs: vec![ConfigOutput::Segmentation(configs::Segmentation {
+                    decoder: configs::DecoderType::ModelPack,
+                    shape: vec![1, 160, 160, 5],
+                    quantization: None,
+                    dshape: vec![
+                        (DimName::Batch, 1),
+                        (DimName::Height, 160),
+                        (DimName::Width, 160),
+                        (DimName::NumProtos, 5),
+                    ],
+                })],
+                ..Default::default()
+            })
+            .build();
+        assert!(
+            result.is_ok(),
+            "seg-only ModelPack with mis-tagged channel should build, got {result:?}"
+        );
+
+        // Multitask (boxes + scores + segmentation): the seg/detection
+        // `classes + 1` cross-check must use the NHWC channel count (shape[3])
+        // when the dshape lacks NumClasses. Detection declares 3 classes, so
+        // the seg channel axis must be 4.
+        let result = DecoderBuilder::new()
+            .with_config(ConfigOutputs {
+                outputs: vec![
+                    ConfigOutput::Boxes(configs::Boxes {
+                        decoder: configs::DecoderType::ModelPack,
+                        shape: vec![1, 8400, 1, 4],
+                        quantization: None,
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::NumBoxes, 8400),
+                            (DimName::Padding, 1),
+                            (DimName::BoxCoords, 4),
+                        ],
+                        normalized: Some(true),
+                    }),
+                    ConfigOutput::Scores(configs::Scores {
+                        decoder: configs::DecoderType::ModelPack,
+                        shape: vec![1, 8400, 3],
+                        quantization: None,
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::NumBoxes, 8400),
+                            (DimName::NumClasses, 3),
+                        ],
+                    }),
+                    ConfigOutput::Segmentation(configs::Segmentation {
+                        decoder: configs::DecoderType::ModelPack,
+                        shape: vec![1, 160, 160, 4],
+                        quantization: None,
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::Height, 160),
+                            (DimName::Width, 160),
+                            (DimName::NumProtos, 4),
+                        ],
+                    }),
+                ],
+                ..Default::default()
+            })
+            .build();
+        assert!(
+            result.is_ok(),
+            "multitask ModelPack with mis-tagged seg channel should build, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_modelpack_seg_inferred_count_mismatch_is_rejected() {
+        // DE-2651 follow-up: when the seg channel axis is mis-tagged (NumProtos)
+        // the `classes + 1` cross-check must still fire using the *inferred*
+        // NHWC channel count (shape[3]). Detection declares 3 classes, so a seg
+        // channel count of 6 (≠ 3 + 1) must be rejected — exercising the
+        // inference failure branch, not just the happy path.
+        let result = DecoderBuilder::new()
+            .with_config(ConfigOutputs {
+                outputs: vec![
+                    ConfigOutput::Boxes(configs::Boxes {
+                        decoder: configs::DecoderType::ModelPack,
+                        shape: vec![1, 8400, 1, 4],
+                        quantization: None,
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::NumBoxes, 8400),
+                            (DimName::Padding, 1),
+                            (DimName::BoxCoords, 4),
+                        ],
+                        normalized: Some(true),
+                    }),
+                    ConfigOutput::Scores(configs::Scores {
+                        decoder: configs::DecoderType::ModelPack,
+                        shape: vec![1, 8400, 3],
+                        quantization: None,
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::NumBoxes, 8400),
+                            (DimName::NumClasses, 3),
+                        ],
+                    }),
+                    ConfigOutput::Segmentation(configs::Segmentation {
+                        decoder: configs::DecoderType::ModelPack,
+                        shape: vec![1, 160, 160, 6],
+                        quantization: None,
+                        dshape: vec![
+                            (DimName::Batch, 1),
+                            (DimName::Height, 160),
+                            (DimName::Width, 160),
+                            (DimName::NumProtos, 6),
+                        ],
+                    }),
+                ],
+                ..Default::default()
+            })
+            .build();
+        assert!(
+            matches!(
+                &result,
+                Err(DecoderError::InvalidConfig(s))
+                    if s == "ModelPack Segmentation channels 6 incompatible with number of classes 3"
+            ),
+            "mis-tagged seg channel count must fail the classes+1 check, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_modelpack_seg_explicit_numclasses_tag_drives_cross_check() {
+        // Regression guard for the refactor: an explicitly-tagged `NumClasses`
+        // seg axis must still drive the detection `classes + 1` check —
+        // `modelpack_seg_num_classes` prefers the tag. Detection declares 3
+        // classes, so a tagged seg channel of 4 builds and 5 is rejected.
+        let build = |seg_channels: usize| {
+            DecoderBuilder::new()
+                .with_config(ConfigOutputs {
+                    outputs: vec![
+                        ConfigOutput::Boxes(configs::Boxes {
+                            decoder: configs::DecoderType::ModelPack,
+                            shape: vec![1, 8400, 1, 4],
+                            quantization: None,
+                            dshape: vec![
+                                (DimName::Batch, 1),
+                                (DimName::NumBoxes, 8400),
+                                (DimName::Padding, 1),
+                                (DimName::BoxCoords, 4),
+                            ],
+                            normalized: Some(true),
+                        }),
+                        ConfigOutput::Scores(configs::Scores {
+                            decoder: configs::DecoderType::ModelPack,
+                            shape: vec![1, 8400, 3],
+                            quantization: None,
+                            dshape: vec![
+                                (DimName::Batch, 1),
+                                (DimName::NumBoxes, 8400),
+                                (DimName::NumClasses, 3),
+                            ],
+                        }),
+                        ConfigOutput::Segmentation(configs::Segmentation {
+                            decoder: configs::DecoderType::ModelPack,
+                            shape: vec![1, 160, 160, seg_channels],
+                            quantization: None,
+                            dshape: vec![
+                                (DimName::Batch, 1),
+                                (DimName::Height, 160),
+                                (DimName::Width, 160),
+                                (DimName::NumClasses, seg_channels),
+                            ],
+                        }),
+                    ],
+                    ..Default::default()
+                })
+                .build()
+        };
+        assert!(
+            build(4).is_ok(),
+            "explicit NumClasses == classes + 1 must build, got {:?}",
+            build(4)
+        );
+        assert!(
+            matches!(
+                build(5),
+                Err(DecoderError::InvalidConfig(s))
+                    if s == "ModelPack Segmentation channels 5 incompatible with number of classes 3"
+            ),
+            "explicit NumClasses ≠ classes + 1 must be rejected, got {:?}",
+            build(5)
+        );
+    }
+
+    #[test]
+    fn test_modelpack_seg_missing_spatial_axis_is_rejected() {
+        // The relaxation made only the *channel* axis optional; the spatial
+        // axes (Batch/Height/Width) must still be named. A seg dshape that omits
+        // Height (an Unknown axis fills the slot) must still be rejected — the
+        // relaxation must not have over-loosened.
+        let result = DecoderBuilder::new()
+            .with_config(ConfigOutputs {
+                outputs: vec![ConfigOutput::Segmentation(configs::Segmentation {
+                    decoder: configs::DecoderType::ModelPack,
+                    shape: vec![1, 160, 160, 5],
+                    quantization: None,
+                    dshape: vec![
+                        (DimName::Batch, 1),
+                        (DimName::Unknown, 160),
+                        (DimName::Width, 160),
+                        (DimName::NumProtos, 5),
+                    ],
+                })],
+                ..Default::default()
+            })
+            .build();
+        assert!(
+            matches!(
+                &result,
+                Err(DecoderError::InvalidConfig(s))
+                    if s == "Segmentation dshape missing required dimension Height"
+            ),
+            "seg dshape missing the Height axis must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_unknown_dshape_axis_name_deserializes_to_unknown() {
+        // DE-2651: an unrecognised dshape axis name must deserialize to
+        // `DimName::Unknown` (via `#[serde(other)]`) instead of failing the
+        // parse, while recognised names still map to their variant. Locks the
+        // serde contract independently of the seg/decoder pipeline.
+        let mut de = serde_json::Deserializer::from_str(r#"[{"channels": 3}, {"batch": 1}]"#);
+        let dshape = configs::deserialize_dshape(&mut de).expect("unknown axis name must parse");
+        assert_eq!(dshape, vec![(DimName::Unknown, 3), (DimName::Batch, 1)]);
+    }
+
+    #[test]
     fn test_modelpack_invalid_det() {
         let result = DecoderBuilder::new()
             .with_config_modelpack_det(

--- a/crates/decoder/tests/decoder_modelpack_multitask.rs
+++ b/crates/decoder/tests/decoder_modelpack_multitask.rs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-repo contract test for DE-2651: build a [`Decoder`] from the
+//! schema-v2 `edgefirst.json` that ModelPack now embeds for a multitask
+//! (detection + segmentation) model.
+//!
+//! ModelPack emits, in order: per-FPN-scale `type: detection` anchor grids,
+//! a raw `type: segmentation` per-class map (canonical NHWC `[1, H, W,
+//! num_classes]`), and a decoded `type: masks` argmax class-index map
+//! (`[1, H, W]`). HAL must classify this as `ModelPackSegDetSplit` — the
+//! decoded `masks` head is not consumed by the ModelPack decoder path and must
+//! not prevent the build, and the segmentation class count is taken from the
+//! NHWC channel axis.
+
+use edgefirst_decoder::{schema::SchemaV2, DecoderBuilder};
+
+/// A 2-scale multitask ModelPack model with 2 annotated classes.
+/// Detection: 3 anchors × (5 + 2 classes) = 21 channels per grid cell.
+/// Segmentation: 2 classes + background = 3 channels (NHWC).
+const MODELPACK_MULTITASK_JSON: &str = r#"
+{
+  "schema_version": 2,
+  "input": { "shape": [1, 3, 480, 640] },
+  "dataset": { "classes": ["cup", "saucer"] },
+  "outputs": [
+    {
+      "name": "output_0", "type": "detection", "encoding": "anchor",
+      "decoder": "modelpack", "normalized": true,
+      "shape": [1, 30, 40, 21],
+      "dshape": [{"batch": 1}, {"height": 30}, {"width": 40},
+                 {"num_anchors_x_features": 21}],
+      "stride": [16, 16],
+      "anchors": [[0.05, 0.05], [0.1, 0.1], [0.2, 0.2]],
+      "dtype": "float32", "quantization": null
+    },
+    {
+      "name": "output_1", "type": "detection", "encoding": "anchor",
+      "decoder": "modelpack", "normalized": true,
+      "shape": [1, 15, 20, 21],
+      "dshape": [{"batch": 1}, {"height": 15}, {"width": 20},
+                 {"num_anchors_x_features": 21}],
+      "stride": [32, 32],
+      "anchors": [[0.3, 0.3], [0.5, 0.5], [0.8, 0.8]],
+      "dtype": "float32", "quantization": null
+    },
+    {
+      "name": "output_seg", "type": "segmentation", "decoder": "modelpack",
+      "shape": [1, 480, 640, 3],
+      "dshape": [{"batch": 1}, {"height": 480}, {"width": 640},
+                 {"num_classes": 3}],
+      "dtype": "float32", "quantization": null
+    },
+    {
+      "name": "output_seg_decoded", "type": "masks", "decoder": "modelpack",
+      "shape": [1, 480, 640],
+      "dshape": [{"batch": 1}, {"height": 480}, {"width": 640}],
+      "dtype": "int32", "quantization": null
+    }
+  ]
+}
+"#;
+
+#[test]
+fn build_decoder_from_modelpack_multitask_schema() {
+    let schema = SchemaV2::parse_json(MODELPACK_MULTITASK_JSON)
+        .expect("parse ModelPack multitask edgefirst.json");
+    // The decoded `masks` head must not prevent the build: HAL ignores it in
+    // the ModelPack path and decodes the raw `segmentation` head. Previously
+    // an untagged/mis-tagged or undeclared output produced
+    // InvalidConfig("Invalid ModelPack model outputs") (DE-2651).
+    DecoderBuilder::new()
+        .with_schema(schema)
+        .build()
+        .expect("build ModelPack multitask decoder");
+}
+
+#[test]
+fn parse_tolerates_unknown_input_dshape_axis_name() {
+    // Older ModelPack exports tagged the input dshape channel axis as
+    // `channels`, which HAL's DimName enum does not define. Parsing must not
+    // reject the whole metadata over an unrecognised axis name — the unknown
+    // axis is preserved as `DimName::Unknown` and sorts to the canonical tail
+    // (DE-2651).
+    let json = MODELPACK_MULTITASK_JSON.replace(
+        "\"input\": { \"shape\": [1, 3, 480, 640] }",
+        "\"input\": { \"shape\": [1, 480, 640, 3], \"dshape\": [\
+         {\"batch\": 1}, {\"height\": 480}, {\"width\": 640}, {\"channels\": 3}] }",
+    );
+    let schema =
+        SchemaV2::parse_json(&json).expect("parse metadata with unknown input dshape axis name");
+    DecoderBuilder::new()
+        .with_schema(schema)
+        .build()
+        .expect("build decoder despite unknown input dshape axis name");
+}

--- a/crates/python/src/decoder.rs
+++ b/crates/python/src/decoder.rs
@@ -163,23 +163,6 @@ impl From<PyDimName> for configs::DimName {
     }
 }
 
-impl From<configs::DimName> for PyDimName {
-    fn from(dn: configs::DimName) -> Self {
-        match dn {
-            configs::DimName::Batch => PyDimName::Batch,
-            configs::DimName::Height => PyDimName::Height,
-            configs::DimName::Width => PyDimName::Width,
-            configs::DimName::NumClasses => PyDimName::NumClasses,
-            configs::DimName::NumFeatures => PyDimName::NumFeatures,
-            configs::DimName::NumBoxes => PyDimName::NumBoxes,
-            configs::DimName::NumProtos => PyDimName::NumProtos,
-            configs::DimName::NumAnchorsXFeatures => PyDimName::NumAnchorsXFeatures,
-            configs::DimName::Padding => PyDimName::Padding,
-            configs::DimName::BoxCoords => PyDimName::BoxCoords,
-        }
-    }
-}
-
 /// A model output configuration for programmatic decoder setup.
 ///
 /// Use the static factory methods (`detection`, `boxes`, `scores`, etc.) to


### PR DESCRIPTION
## Summary

Forward-port to the **0.24.x** (`main`) line of the decoder fix released as **0.22.2** on the 0.22.x maintenance line. `main` still carries this bug — `verify_modelpack_seg` hard-requires a `NumClasses`-tagged channel axis, so valid ModelPack segmentation models are rejected at `Decoder` construction.

ModelPack models whose segmentation `dshape` tags the canonical NHWC channel axis with something other than `num_classes` — e.g. `num_protos`, the cloud validator's shape-inference fallback for `.keras` exports — fail with `InvalidConfig("Segmentation dshape missing required dimension NumClasses")` (and, once the seg output is dropped, `InvalidConfig("Invalid ModelPack model outputs")`). Older exports tagging an input axis with an unrecognised name (e.g. `channels`) fail metadata parsing entirely.

## Changes

- **`DimName::Unknown` catch-all** (`#[serde(other)]`) — an unrecognised dshape axis name is preserved (dshape length stays aligned with shape; the axis sorts to the canonical tail via `swap_axes_if_needed`) instead of failing the whole decoder build.
- **Relaxed `verify_modelpack_seg`** — requires only the spatial axes (Batch/Height/Width) by name and infers the seg class count from the canonical NHWC channel axis (`shape[3]`) when `num_classes` is absent, preferring an explicit `num_classes` tag when present. Structural integrity stays enforced by `validate_output_layout`.
- **Dead-code removal** — dropped the unused reverse `From<configs::DimName> for PyDimName` (which `Unknown` would otherwise have made a non-exhaustive compile error in the `python` crate) and the unreachable `Segmentation` arm in `get_class_count_no_dshape`.
- **Tests** — build-level regressions (inferred-count mismatch, explicit-tag cross-check, missing-spatial-axis negative), serde→`Unknown` round-trip, and a schema-v2 multitask integration test.

No version bump (entry added under CHANGELOG `[Unreleased]`); the release process will version this on the 0.24.x line.

## Pre-flight

- `cargo check --workspace` — all crates (incl. `codec`, `python`, `capi`) compile
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `make verify-version` — 0.24.2 consistent
- `make sbom` — license policy compliant, BOM + NOTICE validated
- `cargo test -p edgefirst-decoder` — new build/serde/integration tests pass

## Related

The 0.22.x maintenance back-port ships as `v0.22.2` from `release/0.22.2` (PR #92 closed in favour of tagging that branch directly, since `main` has advanced to 0.24.2).

Refs: DE-2651, DE-2628