### PR TITLE
feat(image): portable in-shader NV conversion path + geometry-aware EGLImage cache

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -750,6 +750,7 @@ See [README.md § Benchmarking](../README.md#benchmarking) for full instructions
 |--------|-------|-----------------|
 | `tensor_benchmark` | `edgefirst-tensor` | Allocation and map/unmap latency (Heap, SHM, DMA) |
 | `pipeline_benchmark` | `edgefirst-image` | Letterbox pipeline and format conversion |
+| `nv_path_benchmark` | `edgefirst-image` | NV12/16/24 `ExternalSampler` vs `ShaderR8` A/B (`EDGEFIRST_NV_CONVERT_PATH=sampler\|shader`) |
 | `decode_pipeline_benchmark` | `edgefirst-image` | JPEG decode → letterbox convert (strided input, HWC/CHW) |
 | `mask_benchmark` | `edgefirst-image` | Mask rendering paths (GL, CPU, hybrid) |
 | `image_benchmark` | `edgefirst-image` | JPEG loading, convert, and resize operations |

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -94,6 +94,49 @@ Orthogonally, each compute backend operates on buffers using different memory an
 
 Typically we benchmark DMA-buf and PBO for GPU backends. The Sync (upload/readpixels) path is only benchmarked when PBO is not supported on a platform.
 
+### NV12 / NV16 / NV24 Conversion Paths (sampler vs shader)
+
+Semi-planar YUV (NV12/NV16/NV24) → RGB on the OpenGL backend has two GPU paths,
+selectable via the **`EDGEFIRST_NV_CONVERT_PATH`** environment variable
+(`sampler` | `shader` | `auto`, default `auto`):
+
+| Path | `NvConvertPath` | Mechanism | YUV→RGB by | Notes |
+|------|-----------------|-----------|-----------|-------|
+| **Sampler** | `ExternalSampler` | `samplerExternalOES` EGLImage | the **GPU driver** | NV12 only (incl. multiplane). Colorimetry & chroma upsampling are the driver's. |
+| **Shader** | `ShaderR8` | R8 `texelFetch` + in-shader matrix | **HAL** (exact, per-tensor) | NV12/NV16/NV24, single-plane (combined buffer). Portable & identical across GPUs. |
+
+On a **non-DMA** backend (PBO/Sync, e.g. orin) `ShaderR8` uploads the combined
+buffer as an R8 texture (`glTexImage2D`) and runs the same shader — so the GPU
+NV path is available even without DMA-buf EGLImage import. True-multiplane NV12
+(separate Y/UV fds) has no single-buffer R8 view, so it always uses `Sampler`.
+
+**Correctness (per-pixel Δ vs CPU reference, on-target):** the matrix matches on
+every GPU (solid frames ≤1); the divergence is **chroma upsampling**. `Sampler`
+uses the driver's *bilinear* chroma (≤55 at chroma edges on V3D & Mali);
+`ShaderR8` uses nearest/replicate and matches CPU (≤2). Vivante's sampler is
+nearest-like and also matches CPU.
+
+**Latency (NV12 720p convert, median, on-target A/B via `nv_path_benchmark`):**
+
+| Platform | GPU | Sampler | Shader | Selected by `auto` |
+|----------|-----|---------|--------|--------------------|
+| rpi5-hailo | V3D | 2.1 ms | 2.4 ms | **Shader** (correct, ~equal speed) |
+| imx95-frdm | Mali-G310 | 1.5 ms | 2.3 ms | **Shader** (chroma correctness) |
+| imx8mp-frdm | Vivante GC7000UL | **2.5 ms** | **29.2 ms** | **Sampler** (shader ~12× slower; sampler also correct here) |
+| jetson-orin-nano | Tegra (NVIDIA) | 2.4 ms | 2.1 ms | **Shader** (R8 upload; no DMA-buf import) |
+
+**`auto` policy:** prefer `ShaderR8` (portable, colorimetry-exact) everywhere
+**except** single-plane, BT.601-limited, even-and-4-aligned NV12 on **Vivante**,
+where `ExternalSampler` is both ~12× faster and colorimetry-correct. Full-range /
+BT.709 sources on Vivante still take `ShaderR8` (slower but correct — the fixed
+driver matrix would be wrong). `EDGEFIRST_NV_CONVERT_PATH` overrides this for
+benchmarking and platform bring-up.
+
+Source-width constraint for the `Sampler` (NV12 EGLImage) path: **even width**
+(4:2:0 chroma is W/2). The import uses the 64-byte-aligned row pitch, so widths
+that are even but not 4-aligned (e.g. 1282) take the zero-copy sampler path; a
+driver that still rejects falls back automatically.
+
 ### Buffer Infrastructure Benchmarks
 
 In addition to compute benchmarks, we separately measure:
@@ -170,6 +213,7 @@ See [README.md § Benchmarking](README.md#benchmarking) for full instructions on
 | `tensor_benchmark` | `edgefirst-tensor` | Tensor allocation and map/unmap latency across buffer types (Heap, SHM, DMA) |
 | `image_benchmark` | `edgefirst-image` | JPEG loading, format convert, resize operations across buffer backends |
 | `pipeline_benchmark` | `edgefirst-image` | Letterbox pipeline and format conversion (camera→model input) |
+| `nv_path_benchmark` | `edgefirst-image` | NV12/16/24 sampler-vs-shader A/B (set `EDGEFIRST_NV_CONVERT_PATH=sampler\|shader`); synthesized sources, no testdata |
 | `decode_pipeline_benchmark` | `edgefirst-image` | JPEG decode → letterbox convert end-to-end (strided input, HWC/CHW output) |
 | `mask_benchmark` | `edgefirst-image` | Mask rendering: draw_decoded_masks, draw_proto_masks, hybrid path |
 | `opencv_benchmark` | `edgefirst-image` | OpenCV baseline comparison for same operations |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **GPU NV12/NV16/NV24 conversion on non-DMA (heap/PBO) backends**
+  (`edgefirst-image`): the in-shader R8 (`ShaderR8`) path now also runs when
+  DMA-BUF EGLImage import is unavailable (e.g. NVIDIA Jetson Orin) by uploading
+  the combined semi-planar buffer as an R8 texture, replacing the CPU fallback.
+- **`EDGEFIRST_NV_CONVERT_PATH`** (`sampler` | `shader` | `auto`,
+  `edgefirst-image`): selects the NV12 GPU conversion path. `auto` (default)
+  prefers the portable, colorimetry-exact in-shader `ShaderR8`, except
+  BT.601-limited single-plane NV12 on Vivante (where the hardware sampler is
+  ~12× faster and colorimetry-correct). `sampler`/`shader` force a path for
+  benchmarking and platform bring-up.
+- **`EDGEFIRST_EGL_CACHE_CAPACITY`** (`edgefirst-image`): overrides the per-cache
+  EGLImage capacity (default 64) for high-cardinality varied-geometry streams.
+- `nv_path_benchmark` (`edgefirst-image`): cross-platform `sampler`-vs-`shader`
+  NV12/16/24 A/B benchmark (synthesized sources, no testdata required).
 - `Tensor::subview()` / `TensorDyn::subview()` (`edgefirst-tensor`): zero-copy
   sub-region views that share the parent's allocation (`Mem` heap `Arc` or `Dma`
   fd) and map at a byte offset, for assembling a batch into one buffer. N views
@@ -236,6 +250,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **GPU EGLImage source cache stale-geometry read (recycled DMA-BUF pools).**
+  The OpenGL source EGLImage cache keyed only on buffer identity + plane offset.
+  A pooled DMA-BUF tensor reconfigured between converts (`configure_image`, e.g.
+  a decode pool reused at a new width/format/stride per frame) reused the cached
+  EGLImage imported at the *previous* geometry, so the GPU sampled at the wrong
+  pitch — producing wrong/garbage output (deterministic single-threaded,
+  nondeterministic under parallel decode). The cache key now carries
+  `width`/`height`/`row_stride`/`format`, so a content/geometry change is a
+  distinct entry. Constant-geometry reuse still hits the cache (no perf change).
 - **GPU NV16/NV24 zero-copy convert on Linux/embedded GLES.** NV16 (4:2:2) and
   NV24 (4:4:4) DMA-BUF sources previously had no GPU path and silently fell back
   to the CPU YUV→RGB converter (the dominant cost in preprocessing on embedded

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -285,7 +285,7 @@ Both paths feed the existing, dtype-appropriate output render unchanged: u8/i8
 RGB(A) into a zero-copy DMA target for the quantized NPU targets (imx8mp vx,
 imx95 Neutron), or the RGBA8→PlanarRgb-F16 packer for the F16 targets
 (Tegra/orin, macOS). `last_nv_convert_path` records which path ran
-(`HwYuvA`/`R8ShaderB`/`Cpu`) so tests and the profiler can assert no silent CPU
+(`ExternalSampler`/`ShaderR8`/`Cpu`) so tests and the profiler can assert no silent CPU
 fallback for a DMA NV* source.
 
 ### macOS GL backend (`gl/macos_processor.rs`)

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -67,6 +67,10 @@ name = "pipeline_benchmark"
 harness = false
 
 [[bench]]
+name = "nv_path_benchmark"
+harness = false
+
+[[bench]]
 name = "mask_benchmark"
 harness = false
 

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -19,6 +19,7 @@ crates/image/
     ├── mask_benchmark.rs        # Mask decode + draw paths
     ├── mask_decode_benchmark.rs # Mask materialization vs proto-only
     ├── pipeline_benchmark.rs    # End-to-end pipeline measurements
+    ├── nv_path_benchmark.rs     # NV12/16/24 sampler-vs-shader A/B (EDGEFIRST_NV_CONVERT_PATH)
     ├── decode_pipeline_benchmark.rs  # JPEG decode → letterbox convert pipeline
     ├── opencv_benchmark.rs      # Comparison vs OpenCV reference (optional)
     ├── sanity_check.rs          # Quick smoke tests for bench harness setup
@@ -111,6 +112,8 @@ cargo test -p edgefirst-image --features g2d_test_formats -- --test-threads=1
 | `EDGEFIRST_DISABLE_GL=1` | Disable OpenGL even if available |
 | `EDGEFIRST_DISABLE_G2D=1` | Disable G2D even if available |
 | `EDGEFIRST_FORCE_TRANSFER=dmabuf` / `=pbo` / `=sync` | Force GL transfer backend (the `sync` value pins the non-zero-copy `glReadPixels` baseline used for benchmarking) |
+| `EDGEFIRST_NV_CONVERT_PATH=sampler` / `=shader` / `=auto` | Force the NV12 GPU conversion path (`auto` default; see BENCHMARKS.md) |
+| `EDGEFIRST_EGL_CACHE_CAPACITY=<n>` | Override the per-cache EGLImage capacity (default 64) |
 
 Example — run tests without any GPU backend:
 

--- a/crates/image/benches/nv_path_benchmark.rs
+++ b/crates/image/benches/nv_path_benchmark.rs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! NV12/NV16/NV24 conversion-path A/B benchmark (`ExternalSampler` vs
+//! `ShaderR8`), cross-platform.
+//!
+//! Self-contained: sources are synthesized (Y luma gradient + neutral chroma),
+//! so NO testdata files are required on the target. Run twice per platform,
+//! forcing each path, then compare:
+//!
+//! ```bash
+//! EDGEFIRST_NV_CONVERT_PATH=sampler ./nv_path_benchmark --json sampler.json
+//! EDGEFIRST_NV_CONVERT_PATH=shader  ./nv_path_benchmark --json shader.json
+//! ```
+//!
+//! On non-DMA backends (e.g. orin) NV* takes the R8-upload `ShaderR8` path
+//! regardless of the env var; the run still records its latency.
+
+mod common;
+
+use common::{calculate_letterbox, run_bench, BenchSuite};
+
+use edgefirst_image::{Crop, Flip, ImageProcessor, ImageProcessorTrait, Rect, Rotation};
+use edgefirst_tensor::{DType, PixelFormat, TensorMapTrait, TensorTrait};
+
+const WARMUP: usize = 10;
+const ITERATIONS: usize = 100;
+
+/// Combined semi-planar buffer byte length for a `w x h` image.
+fn nv_len(fmt: PixelFormat, w: usize, h: usize) -> usize {
+    match fmt {
+        PixelFormat::Nv12 => w * h * 3 / 2,
+        PixelFormat::Nv16 => w * h * 2,
+        PixelFormat::Nv24 => w * h * 3,
+        _ => w * h,
+    }
+}
+
+/// Synthesize an NV* source: Y plane = luma gradient, chroma = neutral 128.
+fn fill_nv(buf: &mut [u8], w: usize, h: usize) {
+    for r in 0..h {
+        for c in 0..w {
+            buf[r * w + c] = ((r + c) * 255 / (w + h)) as u8;
+        }
+    }
+    for b in buf.iter_mut().skip(w * h) {
+        *b = 128;
+    }
+}
+
+fn main() {
+    let mut suite = BenchSuite::from_args();
+    let path = std::env::var("EDGEFIRST_NV_CONVERT_PATH").unwrap_or_else(|_| "auto".into());
+    println!("\n== NV conversion-path benchmark (EDGEFIRST_NV_CONVERT_PATH={path}) ==\n");
+
+    let mut proc = match ImageProcessor::new() {
+        Ok(p) => p,
+        Err(e) => {
+            println!("  [skipped: ImageProcessor init failed: {e}]");
+            suite.finish();
+            return;
+        }
+    };
+
+    // Camera 1280x720 → model 640x640 (the profiler's letterbox geometry).
+    let (in_w, in_h) = (1280usize, 720usize);
+    let (out_w, out_h) = (640usize, 640usize);
+    let (lx, ly, lw, lh) = calculate_letterbox(in_w, in_h, out_w, out_h);
+    let lb_crop = Crop::new()
+        .with_dst_rect(Some(Rect::new(lx, ly, lw, lh)))
+        .with_dst_color(Some([114, 114, 114, 255]));
+
+    for fmt in [PixelFormat::Nv12, PixelFormat::Nv16, PixelFormat::Nv24] {
+        let src = match proc.create_image(in_w, in_h, fmt, DType::U8, None) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("  {fmt:?}: [skipped: source alloc failed: {e}]");
+                continue;
+            }
+        };
+        {
+            let mut map = src.as_u8().unwrap().map().unwrap();
+            let n = nv_len(fmt, in_w, in_h);
+            fill_nv(&mut map.as_mut_slice()[..n], in_w, in_h);
+        }
+        let src_bytes = nv_len(fmt, in_w, in_h) as u64;
+
+        // (1) Convert, same size → RGBA (sampling cost, no resize).
+        if let Ok(mut dst) = proc.create_image(in_w, in_h, PixelFormat::Rgba, DType::U8, None) {
+            let name = format!("{path}/{fmt:?}/convert_720p_rgba").to_lowercase();
+            if let Err(e) =
+                proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+            {
+                println!("  {name:50} [unsupported: {e}]");
+            } else {
+                let r = run_bench(&name, WARMUP, ITERATIONS, || {
+                    proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+                        .unwrap();
+                });
+                r.print_summary_with_throughput(src_bytes);
+                suite.record(&r);
+            }
+        }
+
+        // (2) Letterbox 720p → 640x640 packed RGB (the profiler op).
+        if let Ok(mut dst) = proc.create_image(out_w, out_h, PixelFormat::Rgb, DType::U8, None) {
+            let name = format!("{path}/{fmt:?}/letterbox_720p_to_640_rgb").to_lowercase();
+            if let Err(e) = proc.convert(&src, &mut dst, Rotation::None, Flip::None, lb_crop) {
+                println!("  {name:50} [unsupported: {e}]");
+            } else {
+                let r = run_bench(&name, WARMUP, ITERATIONS, || {
+                    proc.convert(&src, &mut dst, Rotation::None, Flip::None, lb_crop)
+                        .unwrap();
+                });
+                r.print_summary_with_throughput(src_bytes);
+                suite.record(&r);
+            }
+        }
+    }
+
+    suite.finish();
+}

--- a/crates/image/src/gl/cache.rs
+++ b/crates/image/src/gl/cache.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::resources::EglImage;
+use edgefirst_tensor::{PixelFormat, Tensor, TensorTrait};
 
 /// Selects which EGLImage cache to use.
 #[derive(Debug, PartialEq)]
@@ -26,12 +27,52 @@ pub(super) struct CachedEglImage {
 /// Uses a HashMap with a monotonic counter for LRU eviction: each access
 /// updates the entry's `last_used` timestamp, and eviction removes the entry
 /// with the smallest `last_used` value.
-/// Cache key: `(luma_id, chroma_id, plane_offset)`. For single-plane images,
-/// `chroma_id` is `None`. `plane_offset` distinguishes sub-region views that
-/// share one buffer (same identities) but start at different byte offsets —
-/// without it, N offset-distinct views of one DMA-BUF collide on the first
-/// (offset-0) EGLImage and every view renders/samples the base region.
-pub(super) type EglCacheKey = (u64, Option<u64>, usize);
+/// Identity + geometry that uniquely determine an imported EGLImage.
+///
+/// `luma_id` / `chroma_id` are the buffer identities; `plane_offset`
+/// distinguishes sub-region views that share one buffer but start at different
+/// byte offsets (without it, N offset-distinct views of one DMA-BUF collide on
+/// the first EGLImage and every view renders/samples the base region).
+///
+/// `width` / `height` / `row_stride` / `format` capture the geometry the
+/// EGLImage was imported with. A pooled buffer reused at a different size via
+/// `Tensor::configure_image` (e.g. a 128-wide pool decoding a 96-wide image)
+/// keeps the same identities and `plane_offset`, but needs a fresh import: the
+/// import's pitch/dimensions/fourcc all derive from these fields. Omitting them
+/// reuses the stale-geometry EGLImage and the GPU samples the buffer at the
+/// wrong pitch — deterministically wrong single-threaded, nondeterministic in
+/// parallel, correct only on a heap source (which never takes this path).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct EglCacheKey {
+    pub(super) luma_id: u64,
+    pub(super) chroma_id: Option<u64>,
+    pub(super) plane_offset: usize,
+    pub(super) width: usize,
+    pub(super) height: usize,
+    pub(super) row_stride: usize,
+    pub(super) format: PixelFormat,
+}
+
+impl EglCacheKey {
+    /// Build the cache key from a tensor and the format it will be imported as.
+    /// Every construction site MUST go through this so the key used to insert
+    /// an EGLImage matches the key used to look it up and to gate the texture
+    /// binding-skip.
+    pub(super) fn from_tensor<T>(img: &Tensor<T>, format: PixelFormat) -> Self
+    where
+        T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync,
+    {
+        Self {
+            luma_id: img.buffer_identity().id(),
+            chroma_id: img.chroma().map(|t| t.buffer_identity().id()),
+            plane_offset: img.plane_offset().unwrap_or(0),
+            width: img.width().unwrap_or(0),
+            height: img.height().unwrap_or(0),
+            row_stride: img.effective_row_stride().unwrap_or(0),
+            format,
+        }
+    }
+}
 
 pub(super) struct EglImageCache {
     pub(super) entries: std::collections::HashMap<EglCacheKey, CachedEglImage>,
@@ -111,7 +152,27 @@ impl Drop for EglImageCache {
 #[cfg(test)]
 mod tests {
     use super::EglCacheKey;
+    use edgefirst_tensor::PixelFormat;
     use std::collections::HashMap;
+
+    fn key(
+        luma_id: u64,
+        plane_offset: usize,
+        width: usize,
+        height: usize,
+        row_stride: usize,
+        format: PixelFormat,
+    ) -> EglCacheKey {
+        EglCacheKey {
+            luma_id,
+            chroma_id: None,
+            plane_offset,
+            width,
+            height,
+            row_stride,
+            format,
+        }
+    }
 
     #[test]
     fn cache_key_distinguishes_plane_offset() {
@@ -121,8 +182,8 @@ mod tests {
         // the first (offset-0) EGLImage is reused for every offset and the GPU
         // renders/samples the base region.
         let mut map: HashMap<EglCacheKey, u32> = HashMap::new();
-        let base: EglCacheKey = (0xABCD, None, 0);
-        let at_offset: EglCacheKey = (0xABCD, None, 4096);
+        let base = key(0xABCD, 0, 64, 64, 64, PixelFormat::Grey);
+        let at_offset = key(0xABCD, 4096, 64, 64, 64, PixelFormat::Grey);
         map.insert(base, 1);
         map.insert(at_offset, 2);
         assert_eq!(map.len(), 2, "offset-distinct views must not collide");
@@ -133,5 +194,47 @@ mod tests {
         map.insert(base, 3);
         assert_eq!(map.len(), 2);
         assert_eq!(map.get(&base), Some(&3));
+    }
+
+    #[test]
+    fn cache_key_distinguishes_geometry() {
+        // Root-cause regression guard for the pool-recycle bug: ONE buffer
+        // (same luma_id + offset) reconfigured to different geometry via
+        // `configure_image` must produce DISTINCT keys — otherwise the EGLImage
+        // imported for the first geometry is reused at the wrong pitch.
+        let mut map: HashMap<EglCacheKey, u32> = HashMap::new();
+        let g0 = key(0xBEEF, 0, 128, 96, 128, PixelFormat::Grey);
+        let g1 = key(0xBEEF, 0, 96, 128, 96, PixelFormat::Grey); // different w/h/stride
+        let g2 = key(0xBEEF, 0, 128, 96, 128, PixelFormat::Nv12); // different format
+        map.insert(g0, 1);
+        map.insert(g1, 2);
+        map.insert(g2, 3);
+        assert_eq!(
+            map.len(),
+            3,
+            "geometry/format-distinct reuses must not collide"
+        );
+
+        // Same identity + same geometry is still a genuine hit.
+        let g0_again = key(0xBEEF, 0, 128, 96, 128, PixelFormat::Grey);
+        map.insert(g0_again, 4);
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.get(&g0), Some(&4));
+    }
+
+    #[test]
+    fn cache_key_distinguishes_stride() {
+        // A stride-only change (same identity/offset/w/h/format, different
+        // row_stride — e.g. a padded vs tight pool buffer) must be a DISTINCT
+        // key. Guards against dropping `row_stride` from the key, which would
+        // reintroduce the wrong-pitch stale read on a re-padded pool.
+        let mut map: HashMap<EglCacheKey, u32> = HashMap::new();
+        let tight = key(0xBEEF, 0, 128, 96, 128, PixelFormat::Grey);
+        let padded = key(0xBEEF, 0, 128, 96, 256, PixelFormat::Grey); // stride differs
+        map.insert(tight, 1);
+        map.insert(padded, 2);
+        assert_eq!(map.len(), 2, "stride-distinct imports must not collide");
+        assert_eq!(map.get(&tight), Some(&1));
+        assert_eq!(map.get(&padded), Some(&2));
     }
 }

--- a/crates/image/src/gl/dma_import.rs
+++ b/crates/image/src/gl/dma_import.rs
@@ -73,9 +73,16 @@ impl DmaImportAttrs {
         let yuv_range = cm.range.unwrap_or(ColorRange::Limited);
 
         let (width, height, drm_fourcc, channels) = if src_fmt == PixelFormat::Nv12 {
-            if !src_w.is_multiple_of(4) {
+            // NV12's genuine floor is even width (4:2:0 chroma is W/2 CbCr pairs).
+            // The historical width%4 gate was for word-aligned row reads of the
+            // tight luma pitch — now moot because the import uses the 64-aligned
+            // `plane0_pitch` (`effective_row_stride`) below, not `width`. Relaxed
+            // to width%2 so even-but-not-4-aligned camera widths take the
+            // zero-copy sampler path; a driver that still rejects falls back via
+            // `egl_create_image_with_fallback`.
+            if !src_w.is_multiple_of(2) {
                 return Err(Error::NotSupported(format!(
-                    "EGLImage requires width divisible by 4 for {src_fmt}, got {src_w}"
+                    "EGLImage requires even width for {src_fmt} (4:2:0 chroma), got {src_w}"
                 )));
             }
             // Luma (plane 0) is full-resolution R8; chroma subsampling
@@ -554,6 +561,44 @@ mod tests {
         assert_eq!(p1.pitch, stride);
         assert_eq!(attrs.width, width);
         assert_eq!(attrs.height, height);
+    }
+
+    /// Phase 5: even-but-not-4-aligned NV12 width imports (relaxed `%4→%2`
+    /// gate); odd width is still rejected (4:2:0 chroma is W/2 — needs even W).
+    /// The import uses the 64-aligned `plane0_pitch`, not `width`, so the old
+    /// word-alignment rationale for `%4` no longer applies.
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn test_nv12_even_width_relaxed_gate() {
+        let (height, stride) = (64usize, 128usize);
+        let total = stride * height + stride * height.div_ceil(2);
+        let buf = match alloc_dma(total, "nv12_even_w") {
+            Some(t) => t,
+            None => {
+                eprintln!("SKIPPED: test_nv12_even_width_relaxed_gate - DMA not available");
+                return;
+            }
+        };
+
+        // 66 is even but NOT 4-aligned — previously rejected by the width%4 gate.
+        let luma_pd = PlaneDescriptor::new(buf.dmabuf().unwrap())
+            .unwrap()
+            .with_stride(stride);
+        let t66 = import_nv12(luma_pd, None, 66, height).unwrap();
+        let attrs = DmaImportAttrs::from_tensor(t66.as_u8().unwrap(), PixelFormat::Nv12)
+            .expect("even-but-not-4-aligned NV12 width must import after the %4→%2 relaxation");
+        assert_eq!(attrs.width, 66);
+
+        // Odd width still rejected (4:2:0 chroma needs even width).
+        let luma_pd2 = PlaneDescriptor::new(buf.dmabuf().unwrap())
+            .unwrap()
+            .with_stride(stride);
+        if let Ok(t65) = import_nv12(luma_pd2, None, 65, height) {
+            assert!(
+                DmaImportAttrs::from_tensor(t65.as_u8().unwrap(), PixelFormat::Nv12).is_err(),
+                "odd-width NV12 must still be rejected by the even-width gate"
+            );
+        }
     }
 
     /// Contiguous single-fd: no chroma descriptor, UV follows Y in buffer.

--- a/crates/image/src/gl/processor/float.rs
+++ b/crates/image/src/gl/processor/float.rs
@@ -737,7 +737,7 @@ impl GLProcessorST {
         // Attach the EGLImage (renderbuffer when supported, else texture) to the
         // FBO, mirroring the u8 packed-RGB DMA destination path.
         unsafe {
-            match self.cached_dst_renderbuffer(dst_f16) {
+            match self.cached_dst_renderbuffer(dst_f16, PixelFormat::PlanarRgb) {
                 Some(rbo) => {
                     gls::gl::BindRenderbuffer(gls::gl::RENDERBUFFER, rbo);
                     gls::gl::FramebufferRenderbuffer(

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -49,14 +49,34 @@ pub(super) use float::dma_f16_packed_layout;
 /// reader observing it after, say, an RGBA convert sees the prior NV* value).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum NvConvertPath {
-    /// Path A: driver-decoded YUV via `samplerExternalOES` EGLImage.
-    HwYuvA,
-    /// Path B: hand-written texelFetch R8 shader (ES 3.0, no extension).
-    R8ShaderB,
+    /// Driver-decoded YUV via `samplerExternalOES` EGLImage. The GPU driver
+    /// performs YUV→RGB (matrix + chroma upsampling); colorimetry is only as
+    /// correct as the driver's EGL hint support. Required for true-multiplane
+    /// NV12 (separate Y/UV fds). Was "Path A".
+    ExternalSampler,
+    /// R8 `texelFetch` shader applying the exact per-tensor YUV→RGB matrix in
+    /// the shader (ES 3.0, no extension). Portable and identical across GPUs;
+    /// no width constraint (uses the 64-aligned stride). Was "Path B".
+    ShaderR8,
     /// CPU fallback (EGLImage creation failed or format not DMA-backed).
     Cpu,
     /// Not yet set (initial state, or non-NV* convert).
     None,
+}
+
+/// Client preference for the NV* GPU conversion path, set via
+/// `EDGEFIRST_NV_CONVERT_PATH` (`sampler` | `shader` | `auto`).
+///
+/// `Auto` prefers [`NvConvertPath::ShaderR8`] (portable, colorimetry-exact)
+/// wherever possible, using [`NvConvertPath::ExternalSampler`] only when the
+/// shader path is impossible (true-multiplane NV12). The forced variants are
+/// for benchmarking and platform bring-up; an impossible force logs a warning
+/// and falls back rather than failing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum NvPathPref {
+    Auto,
+    ForceSampler,
+    ForceShader,
 }
 
 /// OpenGL single-threaded image converter.
@@ -184,6 +204,8 @@ pub struct GLProcessorST {
     nv_r8_egl_cache: EglImageCache,
     /// Which path ran for the most recent NV* convert (instrumentation).
     pub(super) last_nv_convert_path: NvConvertPath,
+    /// Client preference for NV* path selection (`EDGEFIRST_NV_CONVERT_PATH`).
+    nv_path_pref: NvPathPref,
     pub(super) gl_context: GlContext,
 }
 
@@ -631,6 +653,45 @@ impl GLProcessorST {
         let vertex_buffer = Buffer::new(0, 3, 100);
         let texture_buffer = Buffer::new(1, 2, 100);
 
+        // EGLImage cache capacity (per cache: src / dst / nv_r8). The key carries
+        // geometry, so a pool buffer reused at N distinct sizes needs N live
+        // EGLImages to avoid evict/re-import churn; a parallel decode pool wants
+        // headroom for (pool slots × distinct sizes). Capacity is the eviction
+        // bound only — EGLImages are lightweight views into the tensor's existing
+        // DMA-BUF (no pixel copy) and are created on demand, so a large default is
+        // free for fixed-dimension workloads (live camera) that only ever use a
+        // size or two. Override with EDGEFIRST_EGL_CACHE_CAPACITY for high-
+        // cardinality varied-size streams (e.g. dataset validation).
+        const DEFAULT_EGL_CACHE_CAPACITY: usize = 64;
+        let egl_cache_capacity = std::env::var("EDGEFIRST_EGL_CACHE_CAPACITY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&c| c > 0)
+            .unwrap_or(DEFAULT_EGL_CACHE_CAPACITY);
+
+        // NV* conversion-path preference. `auto` (default) prefers the portable,
+        // colorimetry-exact in-shader ShaderR8 path; `sampler`/`shader` force a
+        // path for benchmarking / platform bring-up (an impossible force warns
+        // and falls back). Mirrors the EDGEFIRST_FORCE_TRANSFER idiom below.
+        let nv_path_pref = match std::env::var("EDGEFIRST_NV_CONVERT_PATH") {
+            Ok(v) => match v.to_ascii_lowercase().as_str() {
+                "sampler" | "external" | "a" => NvPathPref::ForceSampler,
+                "shader" | "r8" | "b" => NvPathPref::ForceShader,
+                "auto" | "" => NvPathPref::Auto,
+                other => {
+                    log::warn!(
+                        "EDGEFIRST_NV_CONVERT_PATH={other:?} not recognised \
+                         (expected sampler|shader|auto), using auto"
+                    );
+                    NvPathPref::Auto
+                }
+            },
+            Err(_) => NvPathPref::Auto,
+        };
+        if nv_path_pref != NvPathPref::Auto {
+            log::info!("EDGEFIRST_NV_CONVERT_PATH override: {nv_path_pref:?}");
+        }
+
         let mut converter = GLProcessorST {
             gl_context,
             texture_program,
@@ -666,8 +727,8 @@ impl GLProcessorST {
             convert_fbo: FrameBuffer::new(),
             draw_fbo: FrameBuffer::new(),
             draw_render_texture,
-            src_egl_cache: EglImageCache::new(8),
-            dst_egl_cache: EglImageCache::new(8),
+            src_egl_cache: EglImageCache::new(egl_cache_capacity),
+            dst_egl_cache: EglImageCache::new(egl_cache_capacity),
             bgra_warned: false,
             is_vivante,
             use_renderbuffer: std::env::var("EDGEFIRST_OPENGL_RENDERSURFACE")
@@ -689,8 +750,9 @@ impl GLProcessorST {
             nv_r8_program,
             nv_r8_int8_program,
             nv_r8_texture: Texture::new(),
-            nv_r8_egl_cache: EglImageCache::new(8),
+            nv_r8_egl_cache: EglImageCache::new(egl_cache_capacity),
             last_nv_convert_path: NvConvertPath::None,
+            nv_path_pref,
         };
         check_gl_error(function!(), line!())?;
 
@@ -1395,10 +1457,18 @@ impl GLProcessorST {
                     | PixelFormat::Nv24
             )
         } else {
+            // Non-DMA (PBO/Sync): packed RGB(A)/Grey upload via draw_src_texture,
+            // plus single-plane NV12/NV16/NV24 via the R8-upload ShaderR8 path
+            // (combined buffer uploaded as R8 + in-shader YUV — no DMA-BUF
+            // EGLImage needed; the GPU NV path on e.g. orin). Multiplane NV12
+            // can't be uploaded as one R8 texture and falls to CPU.
             matches!(
                 fmt,
                 PixelFormat::Rgb | PixelFormat::Rgba | PixelFormat::Grey
-            )
+            ) || (matches!(
+                fmt,
+                PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
+            ) && !img.is_multiplane())
         }
     }
 
@@ -1551,12 +1621,11 @@ impl GLProcessorST {
             (dst_w as i32, dst_h as i32)
         };
 
-        let luma_id = dst.buffer_identity().id();
-        let chroma_id = dst.chroma().map(|t| t.buffer_identity().id());
-        let dst_key = (luma_id, chroma_id, dst.plane_offset().unwrap_or(0));
+        let dst_key = EglCacheKey::from_tensor(dst, dst_fmt);
+        let luma_id = dst_key.luma_id;
 
         let dest_egl = self.get_or_create_egl_image(CacheKind::Dst, dst, dst_fmt)?;
-        match self.cached_dst_renderbuffer(dst) {
+        match self.cached_dst_renderbuffer(dst, dst_fmt) {
             Some(rbo) => unsafe {
                 gls::gl::BindRenderbuffer(gls::gl::RENDERBUFFER, rbo);
                 gls::gl::FramebufferRenderbuffer(
@@ -1633,12 +1702,11 @@ impl GLProcessorST {
             (dst_w as i32, dst_h as i32)
         };
 
-        let luma_id = dst.buffer_identity().id();
-        let chroma_id = dst.chroma().map(|t| t.buffer_identity().id());
-        let dst_key = (luma_id, chroma_id, dst.plane_offset().unwrap_or(0));
+        let dst_key = EglCacheKey::from_tensor(dst, dst_fmt);
+        let luma_id = dst_key.luma_id;
 
         let dest_egl = self.get_or_create_egl_image(CacheKind::Dst, dst, dst_fmt)?;
-        match self.cached_dst_renderbuffer(dst) {
+        match self.cached_dst_renderbuffer(dst, dst_fmt) {
             Some(rbo) => unsafe {
                 gls::gl::BindRenderbuffer(gls::gl::RENDERBUFFER, rbo);
                 gls::gl::FramebufferRenderbuffer(
@@ -1712,26 +1780,23 @@ impl GLProcessorST {
             );
             self.convert_to_packed_rgb(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
         } else if dst_fmt.layout() == PixelLayout::Planar {
-            // Vivante two-pass: force RGBA8 intermediate for NV12 → PlanarRgb.
-            // NV16/NV24 use Path B which always produces RGBA8 first — the
-            // `convert_nv_to_planar_two_pass` function calls `convert_to`
-            // internally, which now routes NV16/NV24 through Path B anyway.
-            // So extending the Vivante guard to NV16/NV24 costs nothing extra
-            // and avoids any potential single-pass hang on Vivante for these
-            // formats (untested on Vivante, but safe-by-construction).
-            if self.is_vivante
-                && matches!(
-                    src_fmt,
-                    PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
-                )
-            {
-                // Two-pass workaround: NV*→RGBA intermediate → RGBA→PlanarRgb.
-                // NV12: required (EDGEAI-1180 GPU hang on Vivante GC7000UL).
-                // NV16/NV24: Path B already produces RGBA8, making the "two-pass"
-                // the natural pipeline — no extra cost, just consistent dispatch.
+            // All NV12/NV16/NV24 → Planar go through the two-pass pipeline
+            // (NV*→RGBA8 intermediate → RGBA→PlanarRgb), because the intermediate
+            // pass delegates to `convert_to`, which routes NV* through
+            // `select_nv_path` — giving planar output the SAME colorimetry-exact
+            // `ShaderR8` path (and Vivante carve-out, and multiplane→ExternalSampler)
+            // as the packed path. The old single-pass `convert_to_planar` binds
+            // `samplerExternalOES` directly (driver YUV→RGB): colorimetry-wrong on
+            // hint-ignoring/bilinear-chroma drivers for NV12, and has NO sampler
+            // path at all for NV16/NV24. Two-pass also subsumes the Vivante NV12
+            // single-pass GPU hang (EDGEAI-1180).
+            if matches!(
+                src_fmt,
+                PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
+            ) {
                 log::trace!(
                     "GL DMA dispatch: {src_fmt}→{dst_fmt} int8={is_int8} → two-pass planar \
-                     (Vivante workaround: RGBA intermediate + planar_2d{}shader)",
+                     (RGBA intermediate + planar_2d{}shader; select_nv_path-driven)",
                     if is_int8 { "_int8_" } else { "_" }
                 );
                 self.convert_nv_to_planar_two_pass(
@@ -2837,6 +2902,77 @@ impl GLProcessorST {
         Ok(())
     }
 
+    /// Pick the NV* GPU conversion path for `src`/`src_fmt`, honoring the
+    /// `EDGEFIRST_NV_CONVERT_PATH` preference. Returns the path to *attempt*;
+    /// the caller maps an EGLImage-creation error to the [`NvConvertPath::Cpu`]
+    /// fallback. Forcing an unavailable path logs a warning and falls back to
+    /// the only viable one rather than failing.
+    ///
+    /// Capability:
+    /// - [`NvConvertPath::ShaderR8`] needs a single combined-plane buffer, so it
+    ///   covers single-plane NV12/NV16/NV24 but NOT true-multiplane NV12.
+    /// - [`NvConvertPath::ExternalSampler`] (samplerExternalOES) is wired for
+    ///   NV12 only (incl. multiplane); NV16/NV24 have no sampler path.
+    fn select_nv_path(&self, src: &Tensor<u8>, src_fmt: PixelFormat) -> NvConvertPath {
+        // `ShaderR8` (R8 texelFetch) only applies to SINGLE-PLANE semi-planar
+        // NV12/NV16/NV24. Everything else routed through this picker —
+        // RGBA/Grey/YUYV/RGB and true-multiplane NV12 — uses the
+        // `ExternalSampler` (samplerExternalOES / `draw_camera_texture_eglimage`)
+        // path, so that is the default.
+        let shader_capable = matches!(
+            src_fmt,
+            PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
+        ) && !src.is_multiplane();
+        if !shader_capable {
+            return NvConvertPath::ExternalSampler;
+        }
+        // From here: single-plane NV12/NV16/NV24 — ShaderR8 is viable. Only NV12
+        // also has an ExternalSampler path (NV16/NV24 do not).
+        match self.nv_path_pref {
+            NvPathPref::ForceShader => NvConvertPath::ShaderR8,
+            NvPathPref::ForceSampler => {
+                if src_fmt == PixelFormat::Nv12 {
+                    NvConvertPath::ExternalSampler
+                } else {
+                    log::warn!(
+                        "EDGEFIRST_NV_CONVERT_PATH=sampler unavailable for {src_fmt:?} \
+                         (no external-sampler path); using shader"
+                    );
+                    NvConvertPath::ShaderR8
+                }
+            }
+            // Auto: prefer the portable, colorimetry-exact in-shader ShaderR8.
+            //
+            // EXCEPTION — Vivante (i.MX 8MP): the texelFetch shader is ~12×
+            // slower than the hardware samplerExternalOES (on-target benchmark:
+            // NV12 720p convert 29ms shader vs 2.5ms sampler), and Vivante's
+            // fixed BT.601-limited sampler matrix MATCHES the reference for
+            // BT.601-limited sources (Phase 2 probe: ≤1 vs CPU). So for
+            // single-plane NV12 that is BT.601-limited and 4-aligned (the
+            // sampler import constraint), prefer ExternalSampler on Vivante.
+            // Full-range / BT.709 on Vivante still take ShaderR8 (slow but
+            // colorimetry-correct — the driver would apply the wrong matrix).
+            NvPathPref::Auto => {
+                let vivante_sampler_fast_path = src_fmt == PixelFormat::Nv12
+                    && self.is_vivante
+                    && src.width().is_some_and(|w| w.is_multiple_of(4))
+                    && {
+                        let cm = crate::colorimetry::resolve_colorimetry(
+                            src.colorimetry(),
+                            src.height(),
+                        );
+                        cm.encoding == Some(edgefirst_tensor::ColorEncoding::Bt601)
+                            && cm.range == Some(edgefirst_tensor::ColorRange::Limited)
+                    };
+                if vivante_sampler_fast_path {
+                    NvConvertPath::ExternalSampler
+                } else {
+                    NvConvertPath::ShaderR8
+                }
+            }
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn convert_to(
         &mut self,
@@ -2905,52 +3041,26 @@ impl GLProcessorST {
             crate::Rotation::CounterClockwise90 => 3,
         };
         if self.gl_context.transfer_backend.is_dma() && src.memory() == TensorMemory::Dma {
-            // NV16/NV24: Path B (R8 texelFetch shader, ES 3.0 core).
-            // NV12: Path A (samplerExternalOES YUV EGLImage) is only reliable on
-            // Vivante — on Mali-G310 (i.MX95) it samples garbage (GPU-vs-CPU
-            // max_diff 255), and the YUV EGLImage import also requires width % 4
-            // == 0 on some drivers (e.g. V3D). Restrict NV12 Path A to Vivante at
-            // a 4-aligned width; everything else takes Path B, the portable R8
-            // texelFetch shader (no width constraint; NV12 via chroma_shift=(1,1),
-            // chroma_lines=1). Path B already covers NV16/NV24 on every target.
-            // True-multiplane NV12 (separate Y/UV DMA-BUFs) MUST stay on Path A:
-            // Path B imports a single combined-plane R8 buffer and cannot address
-            // separate planes. For single-plane (combined) NV12, Path A is only
-            // reliable on Vivante (garbage on Mali), so restrict it to Vivante at
-            // a 4-aligned width; everything else takes the portable Path B.
-            // Path A (samplerExternalOES) hands YUV→RGB to the DRIVER. On
-            // hint-ignoring GPUs (Vivante) that is a FIXED BT.601-limited
-            // matrix, so single-plane Path A is only colorimetry-correct when
-            // the resolved colorimetry actually IS BT.601 limited. For any
-            // other colorimetry (full-range — e.g. JFIF JPEG — or BT.709/2020)
-            // force the in-shader Path B, which applies the exact matrix via
-            // the per-tensor uniforms. (True-multiplane NV12 can ONLY use Path
-            // A — Path B imports one combined buffer — but such tensors are
-            // camera BT.601-limited in practice; Path A's merged EGL color
-            // hints cover the hint-honoring drivers.)
-            let cm = crate::colorimetry::resolve_colorimetry(src.colorimetry(), src.height());
-            let driver_default_colorimetry = cm.encoding
-                == Some(edgefirst_tensor::ColorEncoding::Bt601)
-                && cm.range == Some(edgefirst_tensor::ColorRange::Limited);
-            let nv12_path_a_ok = src_fmt == PixelFormat::Nv12
-                && src_w.is_multiple_of(4)
-                && (src.is_multiplane() || (self.is_vivante && driver_default_colorimetry));
-            let use_path_b = matches!(src_fmt, PixelFormat::Nv16 | PixelFormat::Nv24)
-                || (src_fmt == PixelFormat::Nv12 && !nv12_path_a_ok);
+            // Choose the NV* path (ShaderR8 vs ExternalSampler) honoring the
+            // EDGEFIRST_NV_CONVERT_PATH preference. See `select_nv_path`: Auto
+            // prefers the portable, colorimetry-exact in-shader ShaderR8 for
+            // single-plane NV12/NV16/NV24, using the driver ExternalSampler only
+            // for true-multiplane NV12 (which ShaderR8 cannot import).
+            let chosen = self.select_nv_path(src, src_fmt);
 
-            if use_path_b {
+            if chosen == NvConvertPath::ShaderR8 {
                 match self.get_or_create_nv_r8_egl_image(src, src_fmt) {
                     Ok(r8_egl) => {
                         tracing::trace!(
-                            path = "R8ShaderB",
+                            path = "ShaderR8",
                             src_fmt = ?src_fmt,
                             "image.convert.gl.nv_path"
                         );
-                        self.last_nv_convert_path = NvConvertPath::R8ShaderB;
+                        self.last_nv_convert_path = NvConvertPath::ShaderR8;
                         self.draw_nv_texture_2d(
                             src,
                             src_fmt,
-                            r8_egl,
+                            Some(r8_egl),
                             src_roi,
                             dst_roi,
                             rotation_offset,
@@ -2984,12 +3094,14 @@ impl GLProcessorST {
                     }
                 }
             } else {
-                // Path A for NV12 (proven); NV16/NV24 always use Path B above.
+                // ExternalSampler path (samplerExternalOES): NV12 (incl.
+                // multiplane) and all non-shader DMA formats (RGBA/Grey/YUYV);
+                // single-plane NV12/NV16/NV24 take ShaderR8 above.
                 match self.get_or_create_egl_image(CacheKind::Src, src, src_fmt) {
                     Ok(src_egl) => {
                         if src_fmt == PixelFormat::Nv12 {
-                            tracing::trace!(path = "HwYuvA", src_fmt = ?src_fmt, "image.convert.gl.nv_path");
-                            self.last_nv_convert_path = NvConvertPath::HwYuvA;
+                            tracing::trace!(path = "ExternalSampler", src_fmt = ?src_fmt, "image.convert.gl.nv_path");
+                            self.last_nv_convert_path = NvConvertPath::ExternalSampler;
                         }
                         self.draw_camera_texture_eglimage(
                             src,
@@ -3024,10 +3136,22 @@ impl GLProcessorST {
                     }
                 }
             }
+        } else if matches!(
+            src_fmt,
+            PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
+        ) && !src.is_multiplane()
+        {
+            // Non-DMA (PBO/Sync) single-plane NV*: GPU-convert via the SAME
+            // ShaderR8 in-shader path used for DMA, but with the combined buffer
+            // CPU-UPLOADED as R8 instead of EGLImage-imported. This enables the
+            // NV shaders on backends without DMA-BUF EGLImage import (e.g. orin),
+            // replacing the old CPU fallback. Multiplane NV12 (separate Y/UV
+            // buffers) cannot be uploaded as one R8 texture → CPU below.
+            tracing::trace!(path = "ShaderR8-upload", src_fmt = ?src_fmt, "image.convert.gl.nv_path");
+            self.last_nv_convert_path = NvConvertPath::ShaderR8;
+            self.draw_nv_texture_2d(src, src_fmt, None, src_roi, dst_roi, rotation_offset, flip)?;
         } else {
-            // Non-DMA source: any NV* falls back to the CPU texture-upload path
-            // (no zero-copy EGLImage). Record it so tests/profiler see the CPU
-            // fallback rather than a stale path from a prior frame.
+            // Non-DMA source, non-NV (or multiplane NV): CPU texture-upload path.
             if matches!(
                 src_fmt,
                 PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
@@ -3152,11 +3276,7 @@ impl GLProcessorST {
             }
         }
 
-        let src_key = (
-            src.buffer_identity().id(),
-            src.chroma().map(|t| t.buffer_identity().id()),
-            src.plane_offset().unwrap_or(0),
-        );
+        let src_key = EglCacheKey::from_tensor(src, src_fmt);
         let src_egl = self.get_or_create_egl_image(CacheKind::Src, src, src_fmt)?;
 
         self.draw_camera_texture_to_rgb_planar(
@@ -3249,7 +3369,7 @@ impl GLProcessorST {
             4,
         )?;
         unsafe {
-            match self.cached_dst_renderbuffer(dst) {
+            match self.cached_dst_renderbuffer(dst, dst_fmt) {
                 Some(rbo) => {
                     gls::gl::BindRenderbuffer(gls::gl::RENDERBUFFER, rbo);
                     gls::gl::FramebufferRenderbuffer(
@@ -3629,12 +3749,12 @@ impl GLProcessorST {
                 check_gl_error(function!(), line!())?;
                 log::trace!(
                     "draw_camera_planar: bound new src EGLImage id={:#x}",
-                    src_key.0
+                    src_key.luma_id
                 );
             } else {
                 log::trace!(
                     "draw_camera_planar: reusing bound src EGLImage id={:#x}",
-                    src_key.0
+                    src_key.luma_id
                 );
             }
             let y_centers = if alpha {
@@ -4035,16 +4155,15 @@ impl GLProcessorST {
     fn draw_camera_texture_eglimage(
         &mut self,
         src: &Tensor<u8>,
-        _src_fmt: PixelFormat,
+        src_fmt: PixelFormat,
         egl_img: egl::Image,
         src_roi: RegionOfInterest,
         mut dst_roi: RegionOfInterest,
         rotation_offset: usize,
         flip: Flip,
     ) -> Result<(), Error> {
-        let luma_id = src.buffer_identity().id();
-        let chroma_id = src.chroma().map(|t| t.buffer_identity().id());
-        let src_key = (luma_id, chroma_id, src.plane_offset().unwrap_or(0));
+        let src_key = EglCacheKey::from_tensor(src, src_fmt);
+        let luma_id = src_key.luma_id;
 
         let texture_target = gls::gl::TEXTURE_EXTERNAL_OES;
         unsafe {
@@ -4161,12 +4280,18 @@ impl GLProcessorST {
         Ok(())
     }
 
-    /// Path B: render NV12/NV16/NV24 → RGBA8 via the R8 texelFetch shader.
+    /// `ShaderR8`: render NV12/NV16/NV24 → RGBA8 via the R8 texelFetch shader.
     ///
-    /// The combined semi-planar buffer was imported as a single-plane R8
-    /// EGLImage (`create_image_from_dma_nv_r8`) and bound as `TEXTURE_2D`.
-    /// The shader addresses Y and UV bytes directly, parameterised by four
-    /// uniforms derived from the source format.
+    /// The combined semi-planar buffer is presented as a single-plane R8
+    /// `TEXTURE_2D` and the shader addresses Y and UV bytes directly,
+    /// parameterised by four uniforms derived from the source format.
+    ///
+    /// `r8_src` selects how the R8 texture is established:
+    /// - `Some(egl_img)` — zero-copy EGLImage import (DMA-BUF source, the
+    ///   `create_image_from_dma_nv_r8` path).
+    /// - `None` — CPU upload of the combined buffer via `glTexImage2D` (the
+    ///   non-DMA / PBO path, e.g. orin where DMA-BUF EGLImage import is
+    ///   unavailable). Same shader, same exact in-shader matrix.
     ///
     /// Renders into the currently-bound FBO (the RGBA8 intermediate or the
     /// DMA destination) — identical output slot to `draw_camera_texture_eglimage`.
@@ -4175,7 +4300,7 @@ impl GLProcessorST {
         &mut self,
         src: &Tensor<u8>,
         src_fmt: PixelFormat,
-        egl_img: egl::Image,
+        r8_src: Option<egl::Image>,
         src_roi: RegionOfInterest,
         mut dst_roi: RegionOfInterest,
         rotation_offset: usize,
@@ -4201,9 +4326,8 @@ impl GLProcessorST {
         let chroma_shift_y = layout.shift_y as i32;
         let chroma_lines = layout.uv_rows_per_luma as i32;
 
-        let luma_id = src.buffer_identity().id();
-        let chroma_id = src.chroma().map(|t| t.buffer_identity().id());
-        let src_key = (luma_id, chroma_id, src.plane_offset().unwrap_or(0));
+        let src_key = EglCacheKey::from_tensor(src, src_fmt);
+        let luma_id = src_key.luma_id;
 
         // `nv_r8_program` may have been swapped to the int8 variant by
         // `convert_dest_dma` for int8 destinations — always use the current
@@ -4236,11 +4360,73 @@ impl GLProcessorST {
                 gls::gl::CLAMP_TO_EDGE as i32,
             );
 
-            if self.nv_r8_texture.bind_egl_image(src_key, egl_img.as_ptr()) {
-                check_gl_error(function!(), line!())?;
-                log::trace!("draw_nv_texture_2d: bound new R8 EGLImage id={luma_id:#x}");
-            } else {
-                log::trace!("draw_nv_texture_2d: reusing bound R8 EGLImage id={luma_id:#x}");
+            match r8_src {
+                Some(egl_img) => {
+                    if self.nv_r8_texture.bind_egl_image(src_key, egl_img.as_ptr()) {
+                        check_gl_error(function!(), line!())?;
+                        log::trace!("draw_nv_texture_2d: bound new R8 EGLImage id={luma_id:#x}");
+                    } else {
+                        log::trace!(
+                            "draw_nv_texture_2d: reusing bound R8 EGLImage id={luma_id:#x}"
+                        );
+                    }
+                }
+                None => {
+                    // Non-DMA upload path: upload the combined semi-planar buffer
+                    // as an R8 texture (tex_width × combined_plane_height). The
+                    // shader addresses it identically to the EGLImage case, so
+                    // the in-shader YUV matrix is byte-for-byte the same as the
+                    // DMA ShaderR8 path. Used where DMA-BUF EGLImage import is
+                    // unavailable (e.g. orin) or the source is heap-backed.
+                    //
+                    // A PBO source MUST NOT reach here: `map()` on a PBO tensor on
+                    // the GL thread deadlocks (the buffer is GL-owned). PBO sources
+                    // go through `draw_src_texture_from_pbo`; guard the invariant
+                    // locally rather than relying solely on the dispatch call graph.
+                    if src.as_pbo().is_some() {
+                        return Err(Error::NotSupported(
+                            "NV R8 upload cannot map a PBO source on the GL thread; \
+                             route PBO sources through the PBO upload path"
+                                .into(),
+                        ));
+                    }
+                    let combined_h = src_fmt.combined_plane_height(src_h).ok_or_else(|| {
+                        Error::NotSupported(format!(
+                            "draw_nv_texture_2d upload: {src_fmt:?} is not semi-planar"
+                        ))
+                    })?;
+                    let offset = src.plane_offset().unwrap_or(0);
+                    let needed = tex_width as usize * combined_h;
+                    let map = src.map()?;
+                    let bytes = map.as_slice();
+                    if offset + needed > bytes.len() {
+                        return Err(Error::InvalidShape(format!(
+                            "NV R8 upload: need {needed} bytes at offset {offset} but buffer is {}",
+                            bytes.len()
+                        )));
+                    }
+                    // `UNPACK_ALIGNMENT` is 1 (set once in `new`), so any row width
+                    // is valid — no 4-aligned-pitch requirement on the upload.
+                    // (TODO/EDGEAI: reuse storage via glTexSubImage2D when dims are
+                    // unchanged instead of reallocating every frame — tracked
+                    // follow-up; needs EGLImage-vs-upload storage tracking to be safe.)
+                    gls::gl::TexImage2D(
+                        gls::gl::TEXTURE_2D,
+                        0,
+                        gls::gl::R8 as i32,
+                        tex_width,
+                        combined_h as i32,
+                        0,
+                        gls::gl::RED,
+                        gls::gl::UNSIGNED_BYTE,
+                        bytes[offset..].as_ptr() as *const c_void,
+                    );
+                    check_gl_error(function!(), line!())?;
+                    // The texture now holds uploaded pixels, not an EGLImage —
+                    // clear the EGLImage binding key so a later DMA convert rebinds.
+                    self.nv_r8_texture.invalidate_egl_binding();
+                    log::trace!("draw_nv_texture_2d: uploaded R8 ({tex_width}x{combined_h})");
+                }
             }
 
             // Set uniforms (img_size, tex_width, chroma_shift, chroma_lines).
@@ -4389,9 +4575,8 @@ impl GLProcessorST {
         img: &Tensor<u8>,
         img_fmt: PixelFormat,
     ) -> Result<egl::Image, crate::Error> {
-        let luma_id = img.buffer_identity().id();
-        let chroma_id = img.chroma().map(|t| t.buffer_identity().id());
-        let id = (luma_id, chroma_id, img.plane_offset().unwrap_or(0));
+        let id = EglCacheKey::from_tensor(img, img_fmt);
+        let luma_id = id.luma_id;
 
         if self.nv_r8_egl_cache.sweep() {
             self.nv_r8_texture.invalidate_egl_binding();
@@ -4471,12 +4656,12 @@ impl GLProcessorST {
         img: &Tensor<u8>,
         img_fmt: PixelFormat,
     ) -> Result<egl::Image, crate::Error> {
-        let luma_id = img.buffer_identity().id();
-        let chroma_id = img.chroma().map(|t| t.buffer_identity().id());
-        // Include the plane offset: sub-region views share one buffer identity
-        // but need distinct EGLImages, else offset-distinct views alias the
-        // first (offset-0) image and render/sample the base region.
-        let id = (luma_id, chroma_id, img.plane_offset().unwrap_or(0));
+        // Identity + offset + geometry: sub-region views share one buffer
+        // identity but need distinct EGLImages (offset), and a pooled buffer
+        // reconfigured to a new size/format/stride needs a fresh import
+        // (geometry) — see EglCacheKey.
+        let id = EglCacheKey::from_tensor(img, img_fmt);
+        let luma_id = id.luma_id;
 
         // Sweep dead entries opportunistically before looking up.
         // Invalidate texture binding state since sweep may remove a bound entry.
@@ -4567,13 +4752,11 @@ impl GLProcessorST {
     }
 
     /// Look up the renderbuffer ID for a cached destination EGLImage.
-    fn cached_dst_renderbuffer<T>(&self, img: &Tensor<T>) -> Option<u32>
+    fn cached_dst_renderbuffer<T>(&self, img: &Tensor<T>, fmt: PixelFormat) -> Option<u32>
     where
         T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync,
     {
-        let luma_id = img.buffer_identity().id();
-        let chroma_id = img.chroma().map(|t| t.buffer_identity().id());
-        let id = (luma_id, chroma_id, img.plane_offset().unwrap_or(0));
+        let id = EglCacheKey::from_tensor(img, fmt);
         self.dst_egl_cache
             .entries
             .get(&id)
@@ -4639,7 +4822,7 @@ impl GLProcessorST {
     fn get_or_create_egl_image_rgb<T>(
         &mut self,
         img: &Tensor<T>,
-        _img_fmt: PixelFormat,
+        img_fmt: PixelFormat,
         width: usize,
         height: usize,
         drm_format: DrmFourcc,
@@ -4648,11 +4831,10 @@ impl GLProcessorST {
     where
         T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync,
     {
-        let id = (
-            img.buffer_identity().id(),
-            None,
-            img.plane_offset().unwrap_or(0),
-        );
+        // Keyed identically to `cached_dst_renderbuffer` and the logical-dims
+        // dst path: the packed render dims derive deterministically from the
+        // tensor's logical geometry, so `from_tensor` is a consistent key.
+        let id = EglCacheKey::from_tensor(img, img_fmt);
         if self.dst_egl_cache.sweep() {
             self.invalidate_dst_textures();
         }
@@ -4661,11 +4843,11 @@ impl GLProcessorST {
         if let Some(cached) = self.dst_egl_cache.entries.get_mut(&id) {
             self.dst_egl_cache.hits += 1;
             cached.last_used = ts;
-            log::trace!("EglImageCache dst (RGB) hit: id={:#x}", id.0);
+            log::trace!("EglImageCache dst (RGB) hit: id={:#x}", id.luma_id);
             return Ok(cached.egl_image.egl_image);
         }
         self.dst_egl_cache.misses += 1;
-        log::trace!("EglImageCache dst (RGB) miss: id={:#x}", id.0);
+        log::trace!("EglImageCache dst (RGB) miss: id={:#x}", id.luma_id);
         // Invalidate dst texture binding state on cache miss (new EGLImage creation).
         self.invalidate_dst_textures();
 

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -581,6 +581,386 @@ mod gl_tests {
     }
 
     // =========================================================================
+    // Recycled DMA-BUF *source* stale-read regression
+    //
+    // A DMA-BUF-backed source that is CPU-written, GPU-sampled by convert(),
+    // and then RECYCLED across frames must reflect the latest write. The
+    // recycled buffer keeps a stable BufferIdentity, so the source EGLImage
+    // cache (keyed by BufferIdentity + chroma id + plane_offset) hits.
+    //
+    // The defect this guards against: a decode pool reuses ONE oversized buffer
+    // and calls `configure_image()` each frame, so the SAME fd is presented to
+    // convert() with a DIFFERENT geometry/stride every frame (e.g. a 128-wide
+    // pool decoding a 96-wide image). Because the cache key omits geometry, the
+    // cached EGLImage built for the previous frame's stride is reused and the
+    // GPU samples the buffer at the wrong pitch — deterministically wrong
+    // single-threaded, nondeterministic in parallel, correct on a heap source.
+    // (Recycling at CONSTANT geometry is fine — V3D re-fetches the DMA-BUF each
+    // draw — so the constant-geometry tests below pass on buggy and fixed code
+    // alike; the geometry-change test is the one that fails pre-fix.)
+    //
+    // Oracle = a FRESH DMA source of the same content+geometry (new identity →
+    // cache miss → correct convert). Same code path as the recycled source; the
+    // only difference is buffer identity.
+    // =========================================================================
+
+    /// Overwrite an existing tensor's bytes in place (re-map → copy → drop →
+    /// DMA_BUF_IOCTL_SYNC(END)), simulating a pool recycle of one buffer.
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn overwrite_in_place(t: &TensorDyn, bytes: &[u8]) {
+        let mut map = t.as_u8().unwrap().map().unwrap();
+        map.as_mut_slice()[..bytes.len()].copy_from_slice(bytes);
+    }
+
+    /// Write image A into a DMA source, convert, then overwrite the SAME source
+    /// with distinct image B and convert again on the SAME processor. Assert the
+    /// second output matches a fresh-DMA-source convert of B (no stale read).
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn dma_recycle_stale_read_check(
+        w: usize,
+        h: usize,
+        src_fmt: PixelFormat,
+        bytes_a: &[u8],
+        bytes_b: &[u8],
+        tolerance: u8,
+    ) {
+        // ONE recycled DMA-BUF source, reused across two "frames".
+        let src = load_raw_image(w, h, src_fmt, Some(TensorMemory::Dma), bytes_a).unwrap();
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let convert = |gl: &mut GLProcessorThreaded, s: &TensorDyn, d: &mut TensorDyn| {
+            gl.convert(s, d, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+        };
+
+        // Frame A: warms the src EGLImage cache + texture binding.
+        let mut dst_a =
+            TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        convert(&mut gl, &src, &mut dst_a);
+        let dst_a_bytes = dst_a.as_u8().unwrap().map().unwrap().to_vec();
+
+        // Frame B: overwrite the SAME buffer (same fd / BufferIdentity), convert
+        // again. Cache HIT + binding-skip → this is where the stale read fires.
+        overwrite_in_place(&src, bytes_b);
+        let mut dst_b =
+            TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        convert(&mut gl, &src, &mut dst_b);
+        let dst_b_bytes = dst_b.as_u8().unwrap().map().unwrap().to_vec();
+
+        // Oracle: a fresh DMA source of B (new identity → cache miss → correct).
+        let fresh_b = load_raw_image(w, h, src_fmt, Some(TensorMemory::Dma), bytes_b).unwrap();
+        let mut oracle_b =
+            TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        convert(&mut gl, &fresh_b, &mut oracle_b);
+        let oracle_b_bytes = oracle_b.as_u8().unwrap().map().unwrap().to_vec();
+
+        // Guard against bad test data: A and B must produce different output, or
+        // the test could never distinguish stale from correct.
+        assert_ne!(
+            dst_a_bytes, oracle_b_bytes,
+            "test data invalid for {src_fmt:?}: frame A and frame B convert identically"
+        );
+
+        // The bug: dst_b carries frame-A content (stale) instead of frame-B.
+        assert_pixels_match(&oracle_b_bytes, &dst_b_bytes, tolerance);
+    }
+
+    /// Grey source (profiler's decode-pool format; EXTERNAL_OES Path A).
+    /// Grey→Rgba is a scalar luma replicate (no YUV matrix) → byte-exact.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn dma_recycle_grey_stale_read() {
+        if !is_dma_available() || !is_opengl_available() {
+            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        dma_recycle_stale_read_check(
+            w,
+            h,
+            PixelFormat::Grey,
+            &vec![50u8; w * h],
+            &vec![200u8; w * h],
+            0,
+        );
+    }
+
+    /// NV12 source (EXTERNAL_OES Path A on Vivante / R8 texelFetch Path B on
+    /// V3D/Mali). YUV→Rgba carries a small color-matrix rounding → tolerance 4.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn dma_recycle_nv12_stale_read() {
+        if !is_dma_available() || !is_opengl_available() {
+            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        let make_nv12 = |y: u8| {
+            let mut buf = vec![y; w * h];
+            buf.extend(std::iter::repeat_n(128u8, w * h / 2)); // neutral chroma
+            buf
+        };
+        dma_recycle_stale_read_check(w, h, PixelFormat::Nv12, &make_nv12(50), &make_nv12(200), 4);
+    }
+
+    /// NV16 source (full-res chroma; R8 texelFetch Path B). tolerance 4.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn dma_recycle_nv16_stale_read() {
+        if !is_dma_available() || !is_opengl_available() {
+            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        let make_nv16 = |y: u8| {
+            let mut buf = vec![y; w * h];
+            buf.extend(std::iter::repeat_n(128u8, w * h)); // full-res neutral chroma
+            buf
+        };
+        dma_recycle_stale_read_check(w, h, PixelFormat::Nv16, &make_nv16(50), &make_nv16(200), 4);
+    }
+
+    /// Small-pool recycle: 2 DMA-BUF sources round-robined over 5 distinct
+    /// solid-fill frames; every GPU output must equal a fresh-source convert of
+    /// the same frame. Exercises the cache/LRU interaction across more than one
+    /// recycled identity.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn dma_pool_recycle_all_frames_match_oracle() {
+        if !is_dma_available() || !is_opengl_available() {
+            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        let lumas: [u8; 5] = [20, 70, 130, 180, 240];
+
+        let pool = [
+            TensorDyn::image(w, h, PixelFormat::Grey, DType::U8, Some(TensorMemory::Dma)).unwrap(),
+            TensorDyn::image(w, h, PixelFormat::Grey, DType::U8, Some(TensorMemory::Dma)).unwrap(),
+        ];
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let convert = |gl: &mut GLProcessorThreaded, s: &TensorDyn, d: &mut TensorDyn| {
+            gl.convert(s, d, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+        };
+
+        for (frame, &luma) in lumas.iter().enumerate() {
+            let buf = &pool[frame % pool.len()];
+            overwrite_in_place(buf, &vec![luma; w * h]);
+
+            let mut gpu =
+                TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            convert(&mut gl, buf, &mut gpu);
+
+            // Fresh-source oracle for this exact frame.
+            let fresh = load_raw_image(
+                w,
+                h,
+                PixelFormat::Grey,
+                Some(TensorMemory::Dma),
+                &vec![luma; w * h],
+            )
+            .unwrap();
+            let mut oracle =
+                TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            convert(&mut gl, &fresh, &mut oracle);
+
+            let oracle_map = oracle.as_u8().unwrap().map().unwrap();
+            let gpu_map = gpu.as_u8().unwrap().map().unwrap();
+            assert_pixels_match(oracle_map.as_slice(), gpu_map.as_slice(), 0);
+        }
+    }
+
+    /// Fill `[h][w]` of `t`'s buffer with a non-uniform 2D pattern at the
+    /// tensor's effective row stride. Non-uniform content is essential: a solid
+    /// fill survives any stride/geometry misread, so it could not detect the
+    /// cache-key bug.
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn fill_grey_pattern(t: &TensorDyn, w: usize, h: usize, salt: u8) {
+        let stride = t.effective_row_stride().unwrap_or(w);
+        let mut map = t.as_u8().unwrap().map().unwrap();
+        let buf = map.as_mut_slice();
+        for r in 0..h {
+            for c in 0..w {
+                buf[r * stride + c] = ((r * 13 + c * 7) as u8).wrapping_add(salt);
+            }
+        }
+    }
+
+    /// THE faithful profiler repro. One oversized DMA pool buffer is recycled
+    /// across frames of DIFFERENT geometry via `configure_image()` (exactly what
+    /// the JPEG decoder does into `create_decode_source_pool`). Each frame's GPU
+    /// convert must equal a fresh-source convert of the same geometry+content.
+    ///
+    /// Pre-fix: frame N hits the cached EGLImage built for an earlier frame's
+    /// stride and samples the buffer at the wrong pitch → mismatch. This test
+    /// FAILS on buggy main and passes once the cache key carries geometry.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn dma_recycle_geometry_change_stale_read() {
+        if !is_dma_available() || !is_opengl_available() {
+            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+            return;
+        }
+        // Oversized pool (like the profiler's pool_w x 3*max_h R8 surface),
+        // recycled in place via configure_image — keeps ONE BufferIdentity.
+        let mut pool = TensorDyn::image(
+            128,
+            128,
+            PixelFormat::Grey,
+            DType::U8,
+            Some(TensorMemory::Dma),
+        )
+        .unwrap();
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let convert = |gl: &mut GLProcessorThreaded, s: &TensorDyn, d: &mut TensorDyn| {
+            gl.convert(s, d, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+        };
+
+        // A sequence of DISTINCT geometries (varying width → varying stride),
+        // each with distinct content. Reusing the same buffer means every frame
+        // shares the pool's BufferIdentity but needs its own EGLImage geometry.
+        let frames: [(usize, usize, u8); 4] =
+            [(128, 96, 0), (96, 128, 40), (120, 100, 80), (64, 128, 120)];
+
+        for (i, &(w, h, salt)) in frames.iter().enumerate() {
+            // Recycled pool: reconfigure to this frame's geometry, write, convert.
+            pool.configure_image(w, h, PixelFormat::Grey).unwrap();
+            fill_grey_pattern(&pool, w, h, salt);
+            let mut dst_recycled =
+                TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            convert(&mut gl, &pool, &mut dst_recycled);
+            let recycled_bytes = dst_recycled.as_u8().unwrap().map().unwrap().to_vec();
+
+            // Fresh-source oracle: new buffer, same geometry+content.
+            let fresh =
+                TensorDyn::image(w, h, PixelFormat::Grey, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            fill_grey_pattern(&fresh, w, h, salt);
+            let mut dst_fresh =
+                TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            convert(&mut gl, &fresh, &mut dst_fresh);
+            let fresh_bytes = dst_fresh.as_u8().unwrap().map().unwrap().to_vec();
+
+            assert_eq!(
+                recycled_bytes.len(),
+                fresh_bytes.len(),
+                "frame {i} ({w}x{h}): output size mismatch"
+            );
+            assert_pixels_match(&fresh_bytes, &recycled_bytes, 0);
+        }
+    }
+
+    /// Stronger guard for the parallel-decode manifestation: a POOL of pooled
+    /// buffers, each recycled through DIFFERENT geometries, INTERLEAVED on one
+    /// processor — the same shared-cache access pattern parallel decode threads
+    /// produce (which buffer+geometry populates the cache first is what varied
+    /// run-to-run, giving 822–833). With a geometry-aware key every
+    /// (buffer, geometry) has its own entry, so interleaving is order-
+    /// independent and every output must match its fresh-source oracle.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn dma_pool_geometry_interleaved_stale_read() {
+        if !is_dma_available() || !is_opengl_available() {
+            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+            return;
+        }
+        let mut pool = [
+            TensorDyn::image(
+                128,
+                128,
+                PixelFormat::Grey,
+                DType::U8,
+                Some(TensorMemory::Dma),
+            )
+            .unwrap(),
+            TensorDyn::image(
+                128,
+                128,
+                PixelFormat::Grey,
+                DType::U8,
+                Some(TensorMemory::Dma),
+            )
+            .unwrap(),
+        ];
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let convert = |gl: &mut GLProcessorThreaded, s: &TensorDyn, d: &mut TensorDyn| {
+            gl.convert(s, d, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+        };
+
+        // Interleave buffers AND geometries: each step reuses a pool slot at a
+        // new size, so the cache sees the worst-case mix of identities+geometry.
+        let steps: [(usize, usize, usize, u8); 6] = [
+            (0, 128, 96, 0),
+            (1, 96, 128, 30),
+            (0, 64, 100, 60),  // slot 0 reused at a 3rd geometry
+            (1, 120, 64, 90),  // slot 1 reused at a 2nd geometry
+            (0, 128, 96, 120), // slot 0 back to its 1st geometry, new content
+            (1, 96, 128, 150),
+        ];
+
+        for &(slot, w, h, salt) in steps.iter() {
+            pool[slot].configure_image(w, h, PixelFormat::Grey).unwrap();
+            fill_grey_pattern(&pool[slot], w, h, salt);
+            let mut dst =
+                TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            convert(&mut gl, &pool[slot], &mut dst);
+
+            let fresh =
+                TensorDyn::image(w, h, PixelFormat::Grey, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            fill_grey_pattern(&fresh, w, h, salt);
+            let mut oracle =
+                TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            convert(&mut gl, &fresh, &mut oracle);
+
+            let dst_map = dst.as_u8().unwrap().map().unwrap();
+            let oracle_map = oracle.as_u8().unwrap().map().unwrap();
+            assert_pixels_match(oracle_map.as_slice(), dst_map.as_slice(), 0);
+        }
+    }
+
+    /// Regression guard: a single-shot (non-recycled) DMA source must equal a
+    /// fresh-source convert — the fix must not break the first-frame path.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn dma_single_shot_grey_matches_fresh() {
+        if !is_dma_available() || !is_opengl_available() {
+            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        let bytes = vec![128u8; w * h];
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let convert = |gl: &mut GLProcessorThreaded, s: &TensorDyn, d: &mut TensorDyn| {
+            gl.convert(s, d, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+        };
+
+        let src = load_raw_image(w, h, PixelFormat::Grey, Some(TensorMemory::Dma), &bytes).unwrap();
+        let mut dst =
+            TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        convert(&mut gl, &src, &mut dst);
+
+        let fresh =
+            load_raw_image(w, h, PixelFormat::Grey, Some(TensorMemory::Dma), &bytes).unwrap();
+        let mut oracle =
+            TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        convert(&mut gl, &fresh, &mut oracle);
+
+        let oracle_map = oracle.as_u8().unwrap().map().unwrap();
+        let dst_map = dst.as_u8().unwrap().map().unwrap();
+        assert_pixels_match(oracle_map.as_slice(), dst_map.as_slice(), 0);
+    }
+
+    // =========================================================================
     // EGL Display Probe & Override Tests
     // =========================================================================
 
@@ -4647,7 +5027,7 @@ mod gl_tests {
     /// Verify NV16→RGBA via Path B (R8 texelFetch shader) on DMA buffers.
     ///
     /// Checks:
-    ///   (a) `last_nv_convert_path` == `R8ShaderB` — no CPU fallback.
+    ///   (a) `last_nv_convert_path` == `ShaderR8` — no CPU fallback.
     ///   (b) Every output pixel matches the expected BT.601 full-range RGB
     ///       within ±2 (rounding from f32 shader arithmetic).
     #[test]
@@ -4697,8 +5077,8 @@ mod gl_tests {
         // (a) Assert Path B ran — no CPU fallback for a DMA NV16 source.
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
-            "NV16 DMA convert must use Path B (R8ShaderB), got {:?}",
+            NvConvertPath::ShaderR8,
+            "NV16 DMA convert must use Path B (ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -4720,10 +5100,592 @@ mod gl_tests {
         }
     }
 
+    /// RAII guard: sets `EDGEFIRST_NV_CONVERT_PATH` and removes it on drop, so a
+    /// panic in `GLProcessorST::new` cannot leak the override to later tests.
+    /// GL tests run `--test-threads=1` (CI), so there is no concurrent reader.
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    struct NvPathEnvGuard;
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    impl NvPathEnvGuard {
+        fn set(v: &str) -> Self {
+            std::env::set_var("EDGEFIRST_NV_CONVERT_PATH", v);
+            NvPathEnvGuard
+        }
+    }
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    impl Drop for NvPathEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("EDGEFIRST_NV_CONVERT_PATH");
+        }
+    }
+
+    /// `EDGEFIRST_NV_CONVERT_PATH` selects the NV12 GPU conversion path.
+    ///
+    /// - `auto` (default) and `shader` → `ShaderR8` (single-plane NV12 prefers
+    ///   the portable in-shader path).
+    /// - `sampler` → the driver `ExternalSampler` path is selected; the actual
+    ///   recorded path is `ExternalSampler` on success or `Cpu` if the driver
+    ///   rejects the NV12 EGLImage import — never `ShaderR8`.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn test_nv12_path_env_override() {
+        use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize); // width % 4 == 0 so the sampler import is accepted
+        let mut bytes = vec![100u8; w * h]; // Y plane
+        for _ in 0..(w * h / 4) {
+            bytes.push(150); // Cb
+            bytes.push(80); // Cr
+        }
+
+        let run = |env: Option<&str>| -> Option<NvConvertPath> {
+            // The env var is read once in `GLProcessorST::new`; the guard sets it
+            // for exactly that construction and removes it on drop (panic-safe).
+            let gl = {
+                std::env::remove_var("EDGEFIRST_NV_CONVERT_PATH");
+                let _guard = env.map(NvPathEnvGuard::set);
+                GLProcessorST::new(None)
+            };
+            let mut gl = match gl {
+                Ok(g) => g,
+                Err(e) => {
+                    eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                    return None;
+                }
+            };
+            let mut src =
+                load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Dma), &bytes).unwrap();
+            // Tag full-range so the Vivante Auto carve-out (BT.601-LIMITED only)
+            // does NOT engage — keeps `auto → ShaderR8` deterministic on every
+            // platform, including Vivante (where BT.601-limited NV12 would
+            // otherwise correctly prefer ExternalSampler; see select_nv_path).
+            src.set_colorimetry(Some(
+                edgefirst_tensor::Colorimetry::default()
+                    .with_encoding(edgefirst_tensor::ColorEncoding::Bt709)
+                    .with_range(edgefirst_tensor::ColorRange::Full),
+            ));
+            let mut dst =
+                TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+            Some(gl.last_nv_convert_path)
+        };
+
+        if let Some(p) = run(None) {
+            assert_eq!(
+                p,
+                NvConvertPath::ShaderR8,
+                "auto default: single-plane full-range NV12 must prefer ShaderR8"
+            );
+        }
+        if let Some(p) = run(Some("shader")) {
+            assert_eq!(
+                p,
+                NvConvertPath::ShaderR8,
+                "forced shader must use ShaderR8"
+            );
+        }
+        if let Some(p) = run(Some("sampler")) {
+            assert_ne!(
+                p,
+                NvConvertPath::ShaderR8,
+                "forced sampler must NOT use ShaderR8 (got ExternalSampler or Cpu)"
+            );
+        }
+    }
+
+    /// Phase 4b: a NON-DMA (heap/PBO) NV12 source must be GPU-converted via the
+    /// R8-UPLOAD `ShaderR8` path — not the CPU fallback. This is the path that
+    /// gives orin (no DMA-BUF EGLImage import) GPU NV conversion. Gated on
+    /// OpenGL only (NOT DMA), so it runs on orin.
+    ///
+    /// Asserts: (a) `last_nv_convert_path == ShaderR8` for a `Mem` NV12 source;
+    /// (b) the GPU upload output matches the `CPUProcessor` reference within ±2
+    /// (same in-shader matrix as DMA `ShaderR8`).
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn test_nv12_nondma_upload_uses_shader() {
+        use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        // Patterned NV12 (luma gradient + neutral chroma) — exercises the shader.
+        let mut bytes = vec![0u8; w * h];
+        for r in 0..h {
+            for c in 0..w {
+                bytes[r * w + c] = ((r + c) * 255 / (w + h)) as u8;
+            }
+        }
+        bytes.extend(std::iter::repeat_n(128u8, w * h / 2)); // neutral chroma
+
+        let mut gl = match GLProcessorST::new(None) {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                return;
+            }
+        };
+
+        // Non-DMA (Mem) NV12 source → must take the R8-upload ShaderR8 path.
+        let mem_src =
+            load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Mem), &bytes).unwrap();
+        let mut gpu_dst = TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, None).unwrap();
+        gl.convert(
+            &mem_src,
+            &mut gpu_dst,
+            Rotation::None,
+            Flip::None,
+            Crop::no_crop(),
+        )
+        .unwrap();
+        assert_eq!(
+            gl.last_nv_convert_path,
+            NvConvertPath::ShaderR8,
+            "non-DMA NV12 must use the R8-upload ShaderR8 path, not CPU (got {:?})",
+            gl.last_nv_convert_path
+        );
+
+        // CPU reference (same matrix) — outputs must agree within ±2.
+        let cpu_src =
+            load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Mem), &bytes).unwrap();
+        let mut cpu_dst = TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, None).unwrap();
+        crate::cpu::CPUProcessor::new()
+            .convert(
+                &cpu_src,
+                &mut cpu_dst,
+                Rotation::None,
+                Flip::None,
+                Crop::no_crop(),
+            )
+            .unwrap();
+
+        let gpu_map = gpu_dst.as_u8().unwrap().map().unwrap();
+        let cpu_map = cpu_dst.as_u8().unwrap().map().unwrap();
+        assert_pixels_match(cpu_map.as_slice(), gpu_map.as_slice(), 2);
+    }
+
+    /// Regression for the planar `select_nv_path` fix: NV12 (DMA) → PlanarRgb
+    /// must route through the colorimetry-exact `ShaderR8` two-pass — NOT the
+    /// driver `samplerExternalOES` the single-pass `convert_to_planar` used,
+    /// which diverged on chroma edges (V3D/Mali) and had no path for NV16/NV24.
+    /// Full-range tag keeps the path deterministic (avoids the Vivante carve-out).
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn test_nv12_to_planar_rgb_uses_shader_path() {
+        use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        // NV12 with a vertical chroma edge — where the driver sampler diverged.
+        let mut bytes = Vec::with_capacity(w * h * 3 / 2);
+        for r in 0..h {
+            for c in 0..w {
+                bytes.push(((r + c) * 255 / (w + h)) as u8);
+            }
+        }
+        for _ in 0..h / 2 {
+            for c in 0..w / 2 {
+                let (cb, cr) = if c < w / 4 { (90, 160) } else { (200, 40) };
+                bytes.push(cb);
+                bytes.push(cr);
+            }
+        }
+        fn tag(t: &mut TensorDyn) {
+            t.set_colorimetry(Some(
+                edgefirst_tensor::Colorimetry::default()
+                    .with_encoding(edgefirst_tensor::ColorEncoding::Bt709)
+                    .with_range(edgefirst_tensor::ColorRange::Full),
+            ));
+        }
+
+        let mut gl = match GLProcessorST::new(None) {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                return;
+            }
+        };
+        let mut src =
+            load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Dma), &bytes).unwrap();
+        tag(&mut src);
+        let mut dst = TensorDyn::image(
+            w,
+            h,
+            PixelFormat::PlanarRgb,
+            DType::U8,
+            Some(TensorMemory::Dma),
+        )
+        .unwrap();
+        gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+            .unwrap();
+        assert_eq!(
+            gl.last_nv_convert_path,
+            NvConvertPath::ShaderR8,
+            "NV12→PlanarRgb must use the ShaderR8 two-pass (select_nv_path), not the driver sampler"
+        );
+
+        // Correctness: matches the CPU planar reference (the sampler did not).
+        let mut cpu_src =
+            load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Mem), &bytes).unwrap();
+        tag(&mut cpu_src);
+        let mut cpu_dst = TensorDyn::image(w, h, PixelFormat::PlanarRgb, DType::U8, None).unwrap();
+        crate::cpu::CPUProcessor::new()
+            .convert(
+                &cpu_src,
+                &mut cpu_dst,
+                Rotation::None,
+                Flip::None,
+                Crop::no_crop(),
+            )
+            .unwrap();
+        compare_images(&cpu_dst, &dst, 0.95, "nv12_to_planar_rgb_shader");
+    }
+
+    /// Phase 4b coverage: NV16/NV24 (not just NV12) on a non-DMA (heap) source
+    /// must also GPU-convert via the R8-upload `ShaderR8` path and match CPU ≤2.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn test_nv16_nv24_nondma_upload_uses_shader() {
+        use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize);
+        let mut gl = match GLProcessorST::new(None) {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                return;
+            }
+        };
+        // (format, chroma byte count): NV16 4:2:2 = w*h UV; NV24 4:4:4 = 2*w*h UV.
+        for (fmt, uv) in [(PixelFormat::Nv16, w * h), (PixelFormat::Nv24, 2 * w * h)] {
+            let mut bytes = vec![0u8; w * h];
+            for r in 0..h {
+                for c in 0..w {
+                    bytes[r * w + c] = ((r + c) * 255 / (w + h)) as u8; // Y gradient
+                }
+            }
+            bytes.extend(std::iter::repeat_n(128u8, uv)); // neutral chroma
+
+            let mem_src = load_raw_image(w, h, fmt, Some(TensorMemory::Mem), &bytes).unwrap();
+            let mut gpu = TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, None).unwrap();
+            gl.convert(
+                &mem_src,
+                &mut gpu,
+                Rotation::None,
+                Flip::None,
+                Crop::no_crop(),
+            )
+            .unwrap();
+            assert_eq!(
+                gl.last_nv_convert_path,
+                NvConvertPath::ShaderR8,
+                "non-DMA {fmt:?} must use the R8-upload ShaderR8 path (got {:?})",
+                gl.last_nv_convert_path
+            );
+
+            let cpu_src = load_raw_image(w, h, fmt, Some(TensorMemory::Mem), &bytes).unwrap();
+            let mut cpu = TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, None).unwrap();
+            crate::cpu::CPUProcessor::new()
+                .convert(
+                    &cpu_src,
+                    &mut cpu,
+                    Rotation::None,
+                    Flip::None,
+                    Crop::no_crop(),
+                )
+                .unwrap();
+            assert_pixels_match(
+                cpu.as_u8().unwrap().map().unwrap().as_slice(),
+                gpu.as_u8().unwrap().map().unwrap().as_slice(),
+                2,
+            );
+        }
+    }
+
+    /// Diagnostic probe (Phase 2): quantify *why* the driver `ExternalSampler`
+    /// path diverges from the exact reference, separating colorimetry/matrix
+    /// error (flat regions) from chroma-upsampling error (chroma edges).
+    ///
+    /// Converts NV12 three ways — `ExternalSampler` (driver YUV), `ShaderR8`
+    /// (exact in-shader matrix), and CPU (the heap/`Mem` reference, == the
+    /// profiler's 841 path) — and prints per-path deltas vs CPU. Run with
+    /// `--nocapture` and read the `PROBE[...]` lines per platform.
+    ///
+    /// Asserts only that `ShaderR8` matches CPU on a SOLID frame (pure matrix —
+    /// must agree); the `ExternalSampler` divergence is characterised, not
+    /// bounded (it is platform-dependent and is the thing under study).
+    #[test]
+    #[ignore = "diagnostic probe — run manually on-target with --nocapture --ignored"]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn probe_nv12_sampler_vs_shader_divergence() {
+        use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        let (w, h) = (64usize, 64usize); // width % 4 == 0 for the sampler import
+
+        // Build NV12 (Y plane then h/2 rows of w/2 interleaved CbCr pairs). The
+        // chroma closure maps a luma column to (Cb, Cr).
+        let build = |y: u8, chroma: &dyn Fn(usize) -> (u8, u8)| -> Vec<u8> {
+            let mut buf = vec![y; w * h];
+            for _r in 0..h / 2 {
+                for c in 0..w / 2 {
+                    let (cb, cr) = chroma(c * 2);
+                    buf.push(cb);
+                    buf.push(cr);
+                }
+            }
+            buf
+        };
+        let solid = build(120, &|_| (90, 160));
+        let edge = build(120, &|col| if col < w / 2 { (90, 160) } else { (200, 40) });
+
+        // Force a path via the env var (read at construction), then clear it.
+        let convert_dma = |env: &str, bytes: &[u8]| -> Option<(NvConvertPath, Vec<u8>)> {
+            std::env::set_var("EDGEFIRST_NV_CONVERT_PATH", env);
+            let gl = GLProcessorST::new(None);
+            std::env::remove_var("EDGEFIRST_NV_CONVERT_PATH");
+            let mut gl = match gl {
+                Ok(g) => g,
+                Err(e) => {
+                    eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                    return None;
+                }
+            };
+            let src =
+                load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Dma), bytes).unwrap();
+            let mut dst =
+                TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma))
+                    .unwrap();
+            gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+            let out = dst.as_u8().unwrap().map().unwrap().to_vec();
+            Some((gl.last_nv_convert_path, out))
+        };
+        let cpu_ref = |bytes: &[u8]| -> Vec<u8> {
+            let src =
+                load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Mem), bytes).unwrap();
+            let mut dst = TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, None).unwrap();
+            crate::cpu::CPUProcessor::new()
+                .convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+            dst.as_u8().unwrap().map().unwrap().to_vec()
+        };
+        // (max, mean, max in flat regions, max within ±2 cols of the w/2 edge)
+        let stats = |a: &[u8], b: &[u8]| -> (u32, f64, u32, u32) {
+            let (mut maxd, mut sum, mut maxflat, mut maxbound) = (0u32, 0u64, 0u32, 0u32);
+            for i in 0..w * h {
+                let boundary = ((i % w) as i64 - (w as i64 / 2)).abs() <= 2;
+                for ch in 0..3 {
+                    let d = (a[i * 4 + ch] as i32 - b[i * 4 + ch] as i32).unsigned_abs();
+                    maxd = maxd.max(d);
+                    sum += d as u64;
+                    if boundary {
+                        maxbound = maxbound.max(d);
+                    } else {
+                        maxflat = maxflat.max(d);
+                    }
+                }
+            }
+            (maxd, sum as f64 / (w * h * 3) as f64, maxflat, maxbound)
+        };
+
+        for (name, bytes) in [("solid", &solid), ("chroma-edge", &edge)] {
+            let cpu = cpu_ref(bytes);
+            let Some((ps, sampler)) = convert_dma("sampler", bytes) else {
+                return;
+            };
+            let Some((pb, shader)) = convert_dma("shader", bytes) else {
+                return;
+            };
+            let (smax, smean, sflat, sbound) = stats(&sampler, &cpu);
+            let (bmax, bmean, bflat, bbound) = stats(&shader, &cpu);
+            eprintln!(
+                "PROBE[{name}] ExternalSampler({ps:?}) vs CPU: max={smax} mean={smean:.2} \
+                 flat(matrix)={sflat} boundary(chroma)={sbound}"
+            );
+            eprintln!(
+                "PROBE[{name}] ShaderR8({pb:?})       vs CPU: max={bmax} mean={bmean:.2} \
+                 flat(matrix)={bflat} boundary(chroma)={bbound}"
+            );
+            if name == "solid" {
+                assert!(
+                    bmax <= 4,
+                    "ShaderR8 must match CPU reference on a solid frame (pure matrix): max={bmax}"
+                );
+            }
+        }
+    }
+
+    /// Diagnostic probe (Phase 4): isolate where the profiler's NV12→packed-RGB
+    /// DMA path diverges from the CPU reference (the 830-vs-841), using the
+    /// profiler's EXACT letterbox (mirrors `LetterboxTransform::compute`:
+    /// aspect-fit + neutral-grey `[114,114,114,255]` bars).
+    ///
+    /// NV12 sampling already matches CPU at same size (Phase 2). This exercises
+    /// the camera→model letterbox resize. Reports DMA-GL vs `CPUProcessor`:
+    ///   - `same-size`     : no resize → baseline (sampling + pack).
+    ///   - `lb-full`       : whole frame incl. grey bars (catches bar-fill diffs).
+    ///   - `lb-content`    : the resized image region only (pure resize delta).
+    ///   - shader vs sampler shows whether the driver's LINEAR resize is closer.
+    #[test]
+    #[ignore = "diagnostic probe — run manually on-target with --nocapture --ignored"]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn probe_nv12_packed_letterbox_divergence() {
+        use crate::opengl_headless::processor::GLProcessorST;
+        use crate::Rect;
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        // 16:9 source so fitting into a square model produces top/bottom bars.
+        let (sw, sh) = (192usize, 108usize);
+        let model = 96usize;
+
+        // Patterned NV12: luma gradient + a vertical chroma edge.
+        let mut bytes = Vec::with_capacity(sw * sh * 3 / 2);
+        for r in 0..sh {
+            for c in 0..sw {
+                bytes.push(((r + c) * 255 / (sw + sh)) as u8);
+            }
+        }
+        for _r in 0..sh / 2 {
+            for c in 0..sw / 2 {
+                let (cb, cr) = if c < sw / 4 { (90, 160) } else { (200, 40) };
+                bytes.push(cb);
+                bytes.push(cr);
+            }
+        }
+
+        // Mirror LetterboxTransform::compute (profiler/src/pipeline.rs:1648).
+        let scale = (model as f32 / sw as f32).min(model as f32 / sh as f32);
+        let scaled_w = (sw as f32 * scale).round() as usize;
+        let scaled_h = (sh as f32 * scale).round() as usize;
+        let pad_x = (model - scaled_w) / 2;
+        let pad_y = (model - scaled_h) / 2;
+        let letterbox = || {
+            Crop::new()
+                .with_src_rect(Some(Rect::new(0, 0, sw, sh)))
+                .with_dst_rect(Some(Rect::new(pad_x, pad_y, scaled_w, scaled_h)))
+                .with_dst_color(Some([114, 114, 114, 255]))
+        };
+
+        let gl_packed = |env: &str, crop: Crop, dw: usize, dh: usize| -> Option<(usize, Vec<u8>)> {
+            std::env::set_var("EDGEFIRST_NV_CONVERT_PATH", env);
+            let g = GLProcessorST::new(None);
+            std::env::remove_var("EDGEFIRST_NV_CONVERT_PATH");
+            let mut g = match g {
+                Ok(x) => x,
+                Err(e) => {
+                    eprintln!("SKIPPED: {} - GL: {e}", function!());
+                    return None;
+                }
+            };
+            let src =
+                load_raw_image(sw, sh, PixelFormat::Nv12, Some(TensorMemory::Dma), &bytes).unwrap();
+            let mut dst = TensorDyn::image(dw, dh, PixelFormat::Rgb, DType::U8, None).unwrap();
+            g.convert(&src, &mut dst, Rotation::None, Flip::None, crop)
+                .ok()?;
+            let stride = dst
+                .as_u8()
+                .unwrap()
+                .effective_row_stride()
+                .unwrap_or(dw * 3);
+            Some((stride, dst.as_u8().unwrap().map().unwrap().to_vec()))
+        };
+        let cpu_packed = |crop: Crop, dw: usize, dh: usize| -> (usize, Vec<u8>) {
+            let src =
+                load_raw_image(sw, sh, PixelFormat::Nv12, Some(TensorMemory::Mem), &bytes).unwrap();
+            let mut dst = TensorDyn::image(dw, dh, PixelFormat::Rgb, DType::U8, None).unwrap();
+            crate::cpu::CPUProcessor::new()
+                .convert(&src, &mut dst, Rotation::None, Flip::None, crop)
+                .unwrap();
+            let stride = dst
+                .as_u8()
+                .unwrap()
+                .effective_row_stride()
+                .unwrap_or(dw * 3);
+            (stride, dst.as_u8().unwrap().map().unwrap().to_vec())
+        };
+        // Stride-aware delta over a pixel region [r0..r0+rh) × [c0..c0+cw) (RGB).
+        let region = |a: &[u8],
+                      sa: usize,
+                      b: &[u8],
+                      sb: usize,
+                      c0: usize,
+                      r0: usize,
+                      cw: usize,
+                      rh: usize|
+         -> (u32, f64) {
+            let (mut mx, mut sum) = (0u32, 0u64);
+            for r in r0..r0 + rh {
+                for c in (c0 * 3)..((c0 + cw) * 3) {
+                    let d = (a[r * sa + c] as i32 - b[r * sb + c] as i32).unsigned_abs();
+                    mx = mx.max(d);
+                    sum += d as u64;
+                }
+            }
+            (mx, sum as f64 / (cw * 3 * rh) as f64)
+        };
+
+        // same-size baseline (no resize)
+        let cpu0 = cpu_packed(Crop::no_crop(), sw, sh);
+        if let Some(g) = gl_packed("shader", Crop::no_crop(), sw, sh) {
+            let (mx, mean) = region(&g.1, g.0, &cpu0.1, cpu0.0, 0, 0, sw, sh);
+            eprintln!("PROBE2[same-size]   ShaderR8 vs CPU: max={mx} mean={mean:.2}");
+        }
+
+        // letterbox (aspect-fit + grey bars), full frame + content region only
+        let cpu1 = cpu_packed(letterbox(), model, model);
+        // Decisive content-region pixel dump: flip / offset / rescale vs CPU?
+        if let Some(g) = gl_packed("shader", letterbox(), model, model) {
+            let px = |buf: &[u8], stride: usize, r: usize, c: usize| {
+                let o = r * stride + c * 3;
+                (buf[o], buf[o + 1], buf[o + 2])
+            };
+            let (ctop, cleft) = (pad_y, pad_x);
+            let (cbot, cright) = (pad_y + scaled_h - 1, pad_x + scaled_w - 1);
+            eprintln!(
+                "DUMP content TL cpu={:?} gl={:?} | TR cpu={:?} gl={:?} | BL cpu={:?} gl={:?} | BR cpu={:?} gl={:?}",
+                px(&cpu1.1, cpu1.0, ctop, cleft),
+                px(&g.1, g.0, ctop, cleft),
+                px(&cpu1.1, cpu1.0, ctop, cright),
+                px(&g.1, g.0, ctop, cright),
+                px(&cpu1.1, cpu1.0, cbot, cleft),
+                px(&g.1, g.0, cbot, cleft),
+                px(&cpu1.1, cpu1.0, cbot, cright),
+                px(&g.1, g.0, cbot, cright),
+            );
+        }
+        for env in ["shader", "sampler"] {
+            if let Some(g) = gl_packed(env, letterbox(), model, model) {
+                let (fmx, fmean) = region(&g.1, g.0, &cpu1.1, cpu1.0, 0, 0, model, model);
+                let (cmx, cmean) =
+                    region(&g.1, g.0, &cpu1.1, cpu1.0, pad_x, pad_y, scaled_w, scaled_h);
+                eprintln!(
+                    "PROBE2[lb-full/{env:8}] vs CPU: max={fmx} mean={fmean:.2}   \
+                     lb-content: max={cmx} mean={cmean:.2}"
+                );
+            }
+        }
+    }
+
     /// Verify NV24→RGBA via Path B (R8 texelFetch shader) on DMA buffers.
     ///
     /// Checks:
-    ///   (a) `last_nv_convert_path` == `R8ShaderB` — no CPU fallback.
+    ///   (a) `last_nv_convert_path` == `ShaderR8` — no CPU fallback.
     ///   (b) Every output pixel matches the expected BT.601 full-range RGB
     ///       within ±2.
     #[test]
@@ -4772,8 +5734,8 @@ mod gl_tests {
         // (a) Assert Path B ran — no CPU fallback for a DMA NV24 source.
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
-            "NV24 DMA convert must use Path B (R8ShaderB), got {:?}",
+            NvConvertPath::ShaderR8,
+            "NV24 DMA convert must use Path B (ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -4861,7 +5823,7 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
+            NvConvertPath::ShaderR8,
             "NV16 DMA convert must use Path B"
         );
 
@@ -4944,7 +5906,7 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
+            NvConvertPath::ShaderR8,
             "NV24 DMA convert must use Path B"
         );
 
@@ -4964,10 +5926,11 @@ mod gl_tests {
         );
     }
 
-    /// Verify NV12 still uses Path A (samplerExternalOES) — no regression.
+    /// Verify a DMA NV12 source converts on the GPU (ExternalSampler or
+    /// ShaderR8, platform-dependent) and never silently falls back to CPU.
     #[test]
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
-    fn test_nv12_still_uses_path_a() {
+    fn test_nv12_dma_gpu_path_no_cpu_fallback() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
             eprintln!("SKIPPED: {} - DMA not available", function!());
@@ -4995,14 +5958,14 @@ mod gl_tests {
             .unwrap();
 
         // NV12 must stay on a GPU path (no CPU-fallback regression). The exact
-        // path is GPU-dependent: Path A (HwYuvA) on Vivante, Path B (R8ShaderB)
+        // path is GPU-dependent: Path A (ExternalSampler) on Vivante, Path B (ShaderR8)
         // elsewhere — single-plane Path A YUV sampling is unreliable on Mali.
         assert!(
             matches!(
                 gl.last_nv_convert_path,
-                NvConvertPath::HwYuvA | NvConvertPath::R8ShaderB
+                NvConvertPath::ExternalSampler | NvConvertPath::ShaderR8
             ),
-            "NV12 DMA convert must use a GPU path (HwYuvA/R8ShaderB), got {:?}",
+            "NV12 DMA convert must use a GPU path (ExternalSampler/ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
     }
@@ -5081,7 +6044,7 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
+            NvConvertPath::ShaderR8,
             "NV16 int8 DMA convert must use Path B"
         );
 
@@ -5273,7 +6236,7 @@ mod gl_tests {
     /// G-03: NV16 odd-width (65×64) end-to-end GPU vs CPU reference.
     ///
     /// Asserts:
-    ///   (a) `last_nv_convert_path == R8ShaderB` — no CPU fallback.
+    ///   (a) `last_nv_convert_path == ShaderR8` — no CPU fallback.
     ///   (b) GPU output matches CPU reference within ±4 (per-pixel, each RGBA channel).
     ///       Tolerance 4 absorbs f32 shader rounding; identical fill on both sides
     ///       rules out test-infrastructure bias.
@@ -5319,8 +6282,8 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
-            "G-03: NV16 odd-W must use Path B (R8ShaderB), got {:?}",
+            NvConvertPath::ShaderR8,
+            "G-03: NV16 odd-W must use Path B (ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -5379,8 +6342,8 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
-            "G-04: NV24 odd-W must use Path B (R8ShaderB), got {:?}",
+            NvConvertPath::ShaderR8,
+            "G-04: NV24 odd-W must use Path B (ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -5443,8 +6406,8 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
-            "G-05: NV16 odd-both must use Path B (R8ShaderB), got {:?}",
+            NvConvertPath::ShaderR8,
+            "G-05: NV16 odd-both must use Path B (ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -5507,8 +6470,8 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
-            "G-06: NV24 odd-both must use Path B (R8ShaderB), got {:?}",
+            NvConvertPath::ShaderR8,
+            "G-06: NV24 odd-both must use Path B (ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -5645,8 +6608,8 @@ mod gl_tests {
         // NV12 width 65 (not mult-4) routes to Path B (R8 shader).
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
-            "G-01: non-mult-4 NV12 must route to Path B (R8ShaderB), got {:?}",
+            NvConvertPath::ShaderR8,
+            "G-01: non-mult-4 NV12 must route to Path B (ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -5671,7 +6634,7 @@ mod gl_tests {
     /// where width (320) is a multiple of 4 but the height is odd.
     ///
     /// Asserts:
-    ///   (a) `last_nv_convert_path == R8ShaderB` — no CPU fallback for DMA source.
+    ///   (a) `last_nv_convert_path == ShaderR8` — no CPU fallback for DMA source.
     ///   (b) GPU output matches CPU reference within ±4.
     #[test]
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
@@ -5714,17 +6677,17 @@ mod gl_tests {
         )
         .unwrap();
 
-        // Even-width NV12 uses a hardware GPU path: Path A (HwYuvA,
-        // samplerExternalOES) on Vivante, or Path B (R8ShaderB) elsewhere —
+        // Even-width NV12 uses a hardware GPU path: Path A (ExternalSampler,
+        // samplerExternalOES) on Vivante, or Path B (ShaderR8) elsewhere —
         // Path A's YUV-EGLImage sampling is only reliable on Vivante (it samples
         // garbage on Mali-G310). Either is correct here; what matters is that it
         // stays on the GPU rather than falling back to the CPU.
         assert!(
             matches!(
                 gl.last_nv_convert_path,
-                NvConvertPath::HwYuvA | NvConvertPath::R8ShaderB
+                NvConvertPath::ExternalSampler | NvConvertPath::ShaderR8
             ),
-            "G-02: even-W odd-H NV12 should use a GPU path (HwYuvA/R8ShaderB), got {:?}",
+            "G-02: even-W odd-H NV12 should use a GPU path (ExternalSampler/ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -5892,11 +6855,13 @@ mod gl_tests {
         )
         .unwrap();
 
-        // NV12 i8 must still use Path A (HwYuvA).
+        // Odd-width single-plane NV12 routes to ShaderR8 (no width gate); the
+        // driver ExternalSampler requires even/4-aligned width. (This assert only
+        // runs if the #[ignore] is lifted — kept accurate per current routing.)
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::HwYuvA,
-            "G-07: NV12 i8 odd-W must still use Path A (HwYuvA), got {:?}",
+            NvConvertPath::ShaderR8,
+            "G-07: odd-W single-plane NV12 must use ShaderR8, got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -5966,8 +6931,8 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
-            "G-08: NV16 i8 odd-both must use Path B (R8ShaderB), got {:?}",
+            NvConvertPath::ShaderR8,
+            "G-08: NV16 i8 odd-both must use Path B (ShaderR8), got {:?}",
             gl.last_nv_convert_path
         );
 
@@ -6030,7 +6995,7 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
+            NvConvertPath::ShaderR8,
             "even NV16 regression: must use Path B"
         );
         let (max_diff, first_fail) = compare_gpu_vs_cpu_u8(&gpu_dst, &cpu_dst, w, h);
@@ -6084,7 +7049,7 @@ mod gl_tests {
 
         assert_eq!(
             gl.last_nv_convert_path,
-            NvConvertPath::R8ShaderB,
+            NvConvertPath::ShaderR8,
             "even NV24 regression: must use Path B"
         );
         let (max_diff, first_fail) = compare_gpu_vs_cpu_u8(&gpu_dst, &cpu_dst, w, h);


### PR DESCRIPTION
## Summary

Hardens the OpenGL NV12/NV16/NV24 → RGB(A)/Planar conversion paths that the
EdgeFirst profiler's zero-copy DMA-BUF pipeline depends on. One correctness
**fix**, plus a portable in-shader **path** made the default across GPUs.

### Fixed — recycled-pool stale read
The source EGLImage cache keyed only on `(buffer_id, chroma_id, plane_offset)`.
A pooled DMA-BUF tensor reconfigured between converts (`configure_image`, e.g. a
decode pool reused at a new width/format/stride per frame) reused the cached
EGLImage imported at the *previous* geometry, so the GPU sampled at the wrong
pitch → wrong/garbage output (deterministic single-threaded, nondeterministic
under parallel decode). The key now carries `width`/`height`/`row_stride`/`format`.
Constant-geometry reuse still hits the cache (no perf change).

### Changed — prefer the portable in-shader path
- `select_nv_path` centralizes path choice. `auto` prefers the colorimetry-exact
  in-shader **`ShaderR8`** (R8 `texelFetch`) for NV12/16/24, **except**
  BT.601-limited single-plane NV12 on **Vivante**, where the hardware sampler
  (`ExternalSampler`) is ~12× faster *and* colorimetry-correct.
- The driver-sampler divergence is **chroma upsampling** (bilinear), not the
  matrix — ≤55 at chroma edges on V3D/Mali vs ≤2 for `ShaderR8`/CPU.
- **Planar output** (`PlanarRgb`) now uses the same two-pass `ShaderR8` route
  (was the colorimetry-unguarded driver sampler, with no path for NV16/24).
- Rename `NvConvertPath::{HwYuvA→ExternalSampler, R8ShaderB→ShaderR8}`.

### Added
- **GPU NV conversion on non-DMA (heap/PBO) backends** (e.g. Jetson Orin): the
  R8 path now uploads the combined buffer via `glTexImage2D` instead of falling
  back to CPU when DMA-BUF EGLImage import is unavailable.
- `EDGEFIRST_NV_CONVERT_PATH` (`sampler|shader|auto`) and
  `EDGEFIRST_EGL_CACHE_CAPACITY` (default 64) controls.
- `nv_path_benchmark` (synthesized sources, no testdata) + per-platform docs.
- Relax the sampler NV12 width gate `%4 → %2` (NV12's true 4:2:0 floor; the
  import already uses the 64-aligned pitch).

## Validation (on-target)
| Platform | GPU | Result |
|---|---|---|
| rpi5-hailo | V3D | full `gl_tests` 98 passed / 0 failed / 4 ignored |
| imx8mp-frdm | Vivante GC7000UL | PR-fix tests 4/4 (Vivante carve-out engages) |
| imx95-frdm | Mali-G310 | A/B benchmark |
| jetson-orin-nano | Tegra | non-DMA R8-upload path 2/2 |

`make format lint check` clean; `clippy -D warnings` + `cargo fmt --all --check` clean.
New tests: geometry/stride/recycle regressions, planar `ShaderR8` parity, non-DMA
upload (NV12/16/24), env-path override, even-width gate. Two diagnostic probes are
`#[ignore]`d (run manually with `--nocapture --ignored`).

## Follow-ups (tracked, not in this PR)
- `glTexSubImage2D` reuse for the non-DMA upload (avoid per-frame realloc).
- PBO async (double-buffered) upload.
- Pre-existing Vivante multiplane-NV12 driver-colorimetry test deltas (pass on V3D).
- Profiler revert (`Mem`→`None` decode pool) + coco128 841 e2e (needs this merged).

> Note: the `NvConvertPath` rename changes the `image.convert.gl.nv_path` trace
> field value (`HwYuvA`/`R8ShaderB` → `ExternalSampler`/`ShaderR8`); consumers
> should key on the structured field, not the literal string.