### PR TITLE
Support maintenance-line CI and back-version release tagging

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -201,6 +201,47 @@ git tag -a -s v0.6.0rc1 -m "Version 0.6.0 Release Candidate 1"
 
 Release candidates are published to PyPI but marked as pre-release.
 
+### Maintenance / Back-Port Patch Release
+
+Use this when patching an **older, superseded release line** — e.g. shipping
+`0.22.2` while `main` has already advanced to `0.24.x`. The patch is **not**
+merged into `main`; it is released by tagging a maintenance branch directly.
+
+1. **Branch from the previous release tag**, not from `main`:
+
+   ```bash
+   git checkout -b release/0.22.2 v0.22.1
+   ```
+
+2. Apply the fix, bump the **patch** version (`make verify-version` must pass),
+   add a CHANGELOG entry, and run the normal pre-release checks
+   (`make format lint verify-version sbom`).
+
+3. **Push the branch.** CI (`test.yml`, `sbom.yml`) now runs on `release/**`
+   branches and on PRs targeting them, so the back-port is validated before it
+   is tagged. Wait for green checks.
+
+4. **Tag to release.** The `release.yml` workflow runs from the tagged commit
+   and builds/publishes as usual. A back-version is published as a normal,
+   **non-latest** release — the GitHub "Latest" badge stays on the highest
+   semver tag (`make_latest` is computed from `git tag` at release time), and
+   PyPI/crates.io keep the highest version as the default. So tagging `v0.22.2`
+   after `v0.24.x` will not displace the current line.
+
+   ```bash
+   git push origin release/0.22.2
+   git push origin v0.22.2   # triggers the release workflow
+   ```
+
+   > **Important:** a tag runs the workflow files **as they exist at the tagged
+   > commit**. If a maintenance branch predates a workflow change, port the
+   > relevant `.github/workflows/` edits onto that branch (adapted to its own
+   > files — do not wholesale-copy `main`'s) and re-create the tag, or the
+   > release runs the stale workflow.
+
+5. **Forward-port the fix to `main`** in a separate `bugfix/` PR (the
+   maintenance line and `main` diverge, so the same fix is needed on both).
+
 ---
 
 ## Code Quality

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history + all tags so the make_latest comparison below can see
+          # every released version, not just the one being tagged.
+          fetch-depth: 0
 
       - name: Download wheel artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -279,6 +283,25 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           awk "/## \[$VERSION\]/,/^## \[/{if (/^## \[/ && !found) {found=1; next} if (/^## \[/ && found) exit; if (found) print}" CHANGELOG.md > RELEASE_NOTES.md || echo "Release $VERSION" > RELEASE_NOTES.md
 
+      - name: Determine 'Latest' eligibility
+        id: latest
+        # Only the highest stable semver tag is marked as the repo's "Latest"
+        # release. A back-version maintenance patch (e.g. v0.22.2 tagged after
+        # v0.24.x already shipped) is published as a normal, non-latest release
+        # so it never displaces the current line's badge. rc tags are excluded
+        # from the comparison and never become Latest. GITHUB_REF is the tag
+        # ref (trusted, matches the workflow's tag trigger pattern).
+        run: |
+          CURRENT="${GITHUB_REF#refs/tags/}"
+          HIGHEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          if [ "$CURRENT" = "$HIGHEST" ]; then
+            echo "make_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Tag $CURRENT (highest stable: $HIGHEST) -> make_latest=$([ "$CURRENT" = "$HIGHEST" ] && echo true || echo false)"
+
       - name: Create Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
@@ -286,3 +309,4 @@ jobs:
           body_path: RELEASE_NOTES.md
           draft: false
           prerelease: ${{ contains(github.ref, 'rc') }}
+          make_latest: ${{ steps.latest.outputs.make_latest }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -18,9 +18,9 @@ name: SBOM Generation & License Compliance
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
   release:
     types: [published]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,9 @@ name: Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'release/**']
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## Summary

Makes the CI/CD workflows support **back-version (maintenance) patch releases** — e.g. shipping `0.22.2` from `release/0.22.2` while `main` is already at `0.24.x`. Discovered while preparing the 0.22.2 DE-2651/DE-2628 fix, which is a patch on a superseded line.

Two gaps were blocking this:

1. **Maintenance branches got zero CI.** `test.yml` and `sbom.yml` only triggered on `branches: [main, develop]` (push + PR base), so a `release/**` branch — and PRs targeting it — ran nothing, and a support patch can't PR into `main` to get validated.
2. **A back-version tag would steal the "Latest" badge.** A pushed tag runs the workflow at its own commit; `softprops/action-gh-release` defaults to marking the new release "Latest", so tagging `v0.22.2` after `v0.24.x` would displace the current line's GitHub Release badge.

## Changes

- **`test.yml` / `sbom.yml`** — add `'release/**'` to `push.branches` and `pull_request.branches`, so maintenance branches and PRs targeting them get the full test + SBOM validation before tagging.
- **`release.yml`** (`create-release` job) — fetch all tags (`fetch-depth: 0`) and compute `make_latest` by comparing the pushed tag to the highest stable semver tag; pass it to `action-gh-release`. A back-version publishes as a normal, **non-latest** release; the highest version keeps the badge. rc tags are excluded and never become Latest. PyPI (`skip-existing`) and crates.io already keep the highest version as the default, so no change needed there.
- **`copilot-instructions.md`** — document the maintenance / back-port release procedure, including the key gotcha that a tag runs the workflow files **as they exist at the tagged commit** (so workflow fixes must be ported onto the maintenance branch and the tag recreated).

## Notes

- No secrets/permissions/environment changes (reuses the existing `pypi` / `crates-io` trusted-publisher environments).
- `make_latest` logic verified locally: `v0.22.2 -> false`, `v0.24.2 (highest) -> true`.
- The same fixes are being applied directly onto `release/0.22.2` (adapted to that branch's older workflow files) so the in-flight 0.22.2 release benefits; this PR covers `main` and all future maintenance releases.