### PR TITLE
fix(cpu,cuda): honour stride in YUV/planar CPU converters; fix CUDA ext-mem drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CPU packed-YUV → GREY ignored the source row stride** (`edgefirst-image`).
+  `Yuyv`/`Vyuy` → `Grey` chunked the flat mapped buffer with a fixed 16-byte
+  stride, so a padded source (DMA-BUF, V4L2 hardware decode, or pitch-aligned
+  `create_image`) read luma from per-row padding and produced misaligned/garbage
+  output. Both paths now iterate rows honouring `effective_row_stride`, matching
+  the other `*_to_grey` converters.
+- **CPU planar → packed read-back ignored stride** (`edgefirst-image`).
+  `PlanarRgb`/`PlanarRgba` → `Rgb`/`Rgba` derived plane boundaries from
+  `mapped_len / channels` and walked each plane as if tightly packed, corrupting
+  output for strided/padded planar sources. The four converters now share a
+  single stride-aware `planar_to_packed` helper that derives plane offsets from
+  `height × row_stride` and reads each row at its true offset.
+- **CPU NV24 → GREY truncated multiplane sources** (`edgefirst-image`).
+  `convert_nv24_to_grey` computed the luma height as `shape[0] / 3` before the
+  multiplane check, so a true-multiplane NV24 tensor (separate luma/chroma
+  allocations) produced only the top third of its rows. The height is now
+  resolved inside the multiplane branch, matching `convert_nv24_to_rgb`.
+- **CUDA external-memory handle drop called `cudaFree` on a mapped pointer**
+  (`edgefirst-tensor`). `CudaHandle::Drop` for an imported DMA-BUF (`ExternalMem`)
+  called `cudaFree` on the pointer returned by `cudaExternalMemoryGetMappedBuffer`
+  before destroying the external-memory object. CUDA frees that buffer together
+  with the external-memory object, so the extra `cudaFree` is disallowed and can
+  corrupt driver bookkeeping / double-free. Drop now only calls
+  `cudaDestroyExternalMemory`.
 - **GPU EGLImage source cache stale-geometry read (recycled DMA-BUF pools).**
   The OpenGL source EGLImage cache keyed only on buffer identity + plane offset.
   A pooled DMA-BUF tensor reconfigured between converts (`configure_image`, e.g.

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2025 Au-Zone Technologies
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::Result;
+use crate::{Error, Result};
 use edgefirst_tensor::{Tensor, TensorMapTrait, TensorTrait};
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use rayon::slice::ParallelSliceMut;
@@ -1410,14 +1410,53 @@ impl CPUProcessor {
         let w = src.width().unwrap();
         let h = src.height().unwrap();
         let src_stride = super::tensor_row_stride(src);
-        let plane_stride = src_stride * h;
         let dst_stride = super::tensor_row_stride(dst);
         let has_alpha_plane = dst_ch == 4 && src_planes >= 4;
+        // Planes actually read: R/G/B always, plus the alpha plane when the
+        // destination has one and the source supplies it.
+        let planes_read = if has_alpha_plane { 4 } else { 3 };
 
         let src_map = src.map()?;
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
         let dst_bytes = dst_map.as_mut_slice();
+
+        // Validate the buffers against the derived geometry before indexing.
+        // Like `split_semi_planar`, an imported tensor may carry a stride/shape
+        // that exceeds its actual allocation (untrusted input), so use checked
+        // arithmetic and return `InvalidShape` instead of panicking with an
+        // out-of-bounds slice. `src_stride >= w`, so a plane spans at most
+        // `h * src_stride` bytes and the last row's `w` bytes stay in-plane.
+        let plane_stride = src_stride.checked_mul(h).ok_or_else(|| {
+            Error::InvalidShape(format!(
+                "planar plane size overflow (stride={src_stride}, h={h})"
+            ))
+        })?;
+        let src_need = plane_stride.checked_mul(planes_read).ok_or_else(|| {
+            Error::InvalidShape(format!(
+                "planar source size overflow (plane_stride={plane_stride}, planes={planes_read})"
+            ))
+        })?;
+        if src_bytes.len() < src_need {
+            return Err(Error::InvalidShape(format!(
+                "planar source has {} bytes but needs {src_need} (stride={src_stride}, h={h}, planes={planes_read})",
+                src_bytes.len()
+            )));
+        }
+        let dst_row = w.checked_mul(dst_ch).ok_or_else(|| {
+            Error::InvalidShape(format!("packed dst row overflow (w={w}, ch={dst_ch})"))
+        })?;
+        let dst_need = dst_stride.checked_mul(h).ok_or_else(|| {
+            Error::InvalidShape(format!(
+                "packed dst size overflow (stride={dst_stride}, h={h})"
+            ))
+        })?;
+        if dst_stride < dst_row || dst_bytes.len() < dst_need {
+            return Err(Error::InvalidShape(format!(
+                "packed dst has stride={dst_stride}, {} bytes but needs stride>={dst_row} and {dst_need} bytes (w={w}, h={h}, ch={dst_ch})",
+                dst_bytes.len()
+            )));
+        }
 
         dst_bytes
             .par_chunks_mut(dst_stride)

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -3,9 +3,8 @@
 
 use crate::Result;
 use edgefirst_tensor::{Tensor, TensorMapTrait, TensorTrait};
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
-};
+use rayon::iter::{IndexedParallelIterator, ParallelIterator};
+use rayon::slice::ParallelSliceMut;
 use std::ops::Shr;
 
 use super::{CPUProcessor, ColorParams};
@@ -492,19 +491,29 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
+        // YUYV→GREY keeps the luma samples and drops chroma. Honour the source
+        // row stride so padded/odd-width buffers are not read across row
+        // boundaries (a flat `as_chunks` over the whole map ignores stride and
+        // reads pad bytes as luma — see EDGEAI stride-handling fix).
+        let src_w = src.width().unwrap();
+        let src_h = src.height().unwrap();
+        let src_stride = super::tensor_row_stride(src);
+        let dst_stride = super::tensor_row_stride(dst);
         let luma = luma_mapper(cp.src_full_range);
+
         let src_map = src.map()?;
+        let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
-        let src_chunks = src_map.as_chunks::<16>();
-        let dst_chunks = dst_map.as_chunks_mut::<8>();
-        for (s, d) in src_chunks.0.iter().zip(dst_chunks.0) {
-            s.iter().step_by(2).zip(d).for_each(|(s, d)| *d = luma(*s));
-        }
+        let dst_bytes = dst_map.as_mut_slice();
 
-        for (s, d) in src_chunks.1.iter().step_by(2).zip(dst_chunks.1) {
-            *d = luma(*s);
+        // YUYV byte order per macropixel: [Y0, U, Y1, V] — luma at even offsets.
+        for row in 0..src_h {
+            let s = &src_bytes[row * src_stride..][..src_w * 2];
+            let d = &mut dst_bytes[row * dst_stride..][..src_w];
+            for (x, dx) in d.iter_mut().enumerate() {
+                *dx = luma(s[x * 2]);
+            }
         }
-
         Ok(())
     }
 
@@ -644,22 +653,28 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
+        // VYUY→GREY keeps the luma samples and drops chroma. Honour the source
+        // row stride so padded/odd-width buffers are not read across row
+        // boundaries (a flat `as_chunks` over the whole map ignores stride).
+        let src_w = src.width().unwrap();
+        let src_h = src.height().unwrap();
+        let src_stride = super::tensor_row_stride(src);
+        let dst_stride = super::tensor_row_stride(dst);
         let luma = luma_mapper(cp.src_full_range);
+
         let src_map = src.map()?;
+        let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
-        // VYUY byte order: [V, Y0, U, Y1] — Y at offsets 1, 3
-        let src_chunks = src_map.as_chunks::<16>();
-        let dst_chunks = dst_map.as_chunks_mut::<8>();
-        for (s, d) in src_chunks.0.iter().zip(dst_chunks.0) {
-            for (di, si) in (1..16).step_by(2).enumerate() {
-                d[di] = luma(s[si]);
+        let dst_bytes = dst_map.as_mut_slice();
+
+        // VYUY byte order per macropixel: [V, Y0, U, Y1] — luma at odd offsets.
+        for row in 0..src_h {
+            let s = &src_bytes[row * src_stride..][..src_w * 2];
+            let d = &mut dst_bytes[row * dst_stride..][..src_w];
+            for (x, dx) in d.iter_mut().enumerate() {
+                *dx = luma(s[x * 2 + 1]);
             }
         }
-
-        for (di, si) in (1..src_chunks.1.len()).step_by(2).enumerate() {
-            dst_chunks.1[di] = luma(src_chunks.1[si]);
-        }
-
         Ok(())
     }
 
@@ -1346,7 +1361,16 @@ impl CPUProcessor {
         cp: ColorParams,
     ) -> Result<()> {
         let src_w = src.width().unwrap();
-        let src_h = src.shape()[0] / 3;
+        // The luma plane height: for a true-multiplane NV24 the (luma) tensor's
+        // shape[0] is already the logical height; for the contiguous combined
+        // buffer the shape is [3H, W] so divide by three. Computing this before
+        // the multiplane check (as the previous code did) truncated multiplane
+        // output to one third of its rows.
+        let src_h = if src.is_multiplane() {
+            src.shape()[0]
+        } else {
+            src.shape()[0] / 3
+        };
         let src_stride = super::tensor_row_stride(src);
         let dst_stride = super::tensor_row_stride(dst);
 
@@ -1367,102 +1391,74 @@ impl CPUProcessor {
         Ok(())
     }
 
-    pub(super) fn convert_8bps_to_rgb(src: &Tensor<u8>, dst: &mut Tensor<u8>) -> Result<()> {
+    /// Read a planar `[C, H, W]` source into a packed interleaved destination,
+    /// honouring both the source row stride and the destination row stride.
+    /// Colour planes 0..3 map to destination channels R, G, B. When the
+    /// destination has a fourth channel it is taken from source plane 3 if the
+    /// source has one (`PlanarRgba`), otherwise filled with 255 (`PlanarRgb`).
+    ///
+    /// Plane offsets are derived from `height * row_stride` and rows are walked
+    /// individually, so strided / pitch-aligned sources (DMA, `create_image`)
+    /// are not mis-sliced or read across their per-row padding — a flat
+    /// `mapped_len / channels` split reads pad bytes as pixels on padded buffers.
+    fn planar_to_packed(
+        src: &Tensor<u8>,
+        dst: &mut Tensor<u8>,
+        src_planes: usize,
+        dst_ch: usize,
+    ) -> Result<()> {
+        let w = src.width().unwrap();
+        let h = src.height().unwrap();
+        let src_stride = super::tensor_row_stride(src);
+        let plane_stride = src_stride * h;
+        let dst_stride = super::tensor_row_stride(dst);
+        let has_alpha_plane = dst_ch == 4 && src_planes >= 4;
+
         let src_map = src.map()?;
-        let src_ = src_map.as_slice();
-
-        // Planar [C, H, W] — plane size = H*W = total/3
-        let plane_size = src_.len() / 3;
-        let (src0, src1) = src_.split_at(plane_size);
-        let (src1, src2) = src1.split_at(plane_size);
-
+        let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
-        let dst_ = dst_map.as_mut_slice();
+        let dst_bytes = dst_map.as_mut_slice();
 
-        src0.par_iter()
-            .zip_eq(src1)
-            .zip_eq(src2)
-            .zip_eq(dst_.as_chunks_mut::<3>().0.par_iter_mut())
-            .for_each(|(((s0, s1), s2), d)| {
-                d[0] = *s0;
-                d[1] = *s1;
-                d[2] = *s2;
+        dst_bytes
+            .par_chunks_mut(dst_stride)
+            .take(h)
+            .enumerate()
+            .for_each(|(row, d)| {
+                let off = row * src_stride;
+                let r = &src_bytes[off..][..w];
+                let g = &src_bytes[plane_stride + off..][..w];
+                let b = &src_bytes[2 * plane_stride + off..][..w];
+                for x in 0..w {
+                    let p = &mut d[x * dst_ch..][..dst_ch];
+                    p[0] = r[x];
+                    p[1] = g[x];
+                    p[2] = b[x];
+                    if dst_ch == 4 {
+                        p[3] = if has_alpha_plane {
+                            src_bytes[3 * plane_stride + off + x]
+                        } else {
+                            255
+                        };
+                    }
+                }
             });
         Ok(())
+    }
+
+    pub(super) fn convert_8bps_to_rgb(src: &Tensor<u8>, dst: &mut Tensor<u8>) -> Result<()> {
+        Self::planar_to_packed(src, dst, 3, 3)
     }
 
     pub(super) fn convert_8bps_to_rgba(src: &Tensor<u8>, dst: &mut Tensor<u8>) -> Result<()> {
-        let src_map = src.map()?;
-        let src_ = src_map.as_slice();
-
-        let plane_size = src_.len() / 3;
-        let (src0, src1) = src_.split_at(plane_size);
-        let (src1, src2) = src1.split_at(plane_size);
-
-        let mut dst_map = dst.map()?;
-        let dst_ = dst_map.as_mut_slice();
-
-        src0.par_iter()
-            .zip_eq(src1)
-            .zip_eq(src2)
-            .zip_eq(dst_.as_chunks_mut::<4>().0.par_iter_mut())
-            .for_each(|(((s0, s1), s2), d)| {
-                d[0] = *s0;
-                d[1] = *s1;
-                d[2] = *s2;
-                d[3] = 255;
-            });
-        Ok(())
+        Self::planar_to_packed(src, dst, 3, 4)
     }
 
     pub(super) fn convert_prgba_to_rgb(src: &Tensor<u8>, dst: &mut Tensor<u8>) -> Result<()> {
-        let src_map = src.map()?;
-        let src_ = src_map.as_slice();
-
-        let plane_size = src_.len() / 4;
-        let (src0, src1) = src_.split_at(plane_size);
-        let (src1, src2) = src1.split_at(plane_size);
-        let (src2, _src3) = src2.split_at(plane_size);
-
-        let mut dst_map = dst.map()?;
-        let dst_ = dst_map.as_mut_slice();
-
-        src0.par_iter()
-            .zip_eq(src1)
-            .zip_eq(src2)
-            .zip_eq(dst_.as_chunks_mut::<3>().0.par_iter_mut())
-            .for_each(|(((s0, s1), s2), d)| {
-                d[0] = *s0;
-                d[1] = *s1;
-                d[2] = *s2;
-            });
-        Ok(())
+        Self::planar_to_packed(src, dst, 4, 3)
     }
 
     pub(super) fn convert_prgba_to_rgba(src: &Tensor<u8>, dst: &mut Tensor<u8>) -> Result<()> {
-        let src_map = src.map()?;
-        let src_ = src_map.as_slice();
-
-        let plane_size = src_.len() / 4;
-        let (src0, src1) = src_.split_at(plane_size);
-        let (src1, src2) = src1.split_at(plane_size);
-        let (src2, src3) = src2.split_at(plane_size);
-
-        let mut dst_map = dst.map()?;
-        let dst_ = dst_map.as_mut_slice();
-
-        src0.par_iter()
-            .zip_eq(src1)
-            .zip_eq(src2)
-            .zip_eq(src3)
-            .zip_eq(dst_.as_chunks_mut::<4>().0.par_iter_mut())
-            .for_each(|((((s0, s1), s2), s3), d)| {
-                d[0] = *s0;
-                d[1] = *s1;
-                d[2] = *s2;
-                d[3] = *s3;
-            });
-        Ok(())
+        Self::planar_to_packed(src, dst, 4, 4)
     }
 
     pub(super) fn rgba_to_rgb(rgba: [u8; 4]) -> [u8; 3] {

--- a/crates/image/tests/odd_dim_cpu.rs
+++ b/crates/image/tests/odd_dim_cpu.rs
@@ -1084,3 +1084,173 @@ fn d3_resize_strided_rgb_source() {
         "d3: strided-src resize differs from tight-src resize: max_diff={max_diff}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// WS0 correctness regressions
+// ---------------------------------------------------------------------------
+
+/// Convert a packed-YUV tensor to GREY through the public CPU pipeline and
+/// return the tightly-packed `w*h` luma bytes.
+fn cpu_to_grey_packed(src: Tensor<u8>, w: usize, h: usize) -> Vec<u8> {
+    let mut proc = CPUProcessor::default();
+    let src_dyn = TensorDyn::from(src);
+    let mut dst =
+        TensorDyn::image(w, h, PixelFormat::Grey, DType::U8, Some(TensorMemory::Mem)).unwrap();
+    proc.convert(
+        &src_dyn,
+        &mut dst,
+        Rotation::None,
+        Flip::None,
+        Crop::default(),
+    )
+    .unwrap();
+    let dst_u8 = dst.as_u8().unwrap();
+    let stride = dst_u8.effective_row_stride().unwrap_or(w);
+    let map = dst_u8.map().unwrap();
+    let s = map.as_slice();
+    let mut out = vec![0u8; w * h];
+    for r in 0..h {
+        out[r * w..(r + 1) * w].copy_from_slice(&s[r * stride..r * stride + w]);
+    }
+    out
+}
+
+/// Packed YUYV/VYUY → GREY must read luma honouring the source row stride. A
+/// padded (DMA / V4L2) source previously chunked the flat map and read pad
+/// bytes as luma; the tight and strided sources must now agree. `luma_off` is
+/// the byte offset of the luma sample within each 2-byte unit (0 for YUYV's
+/// `[Y,C]`, 1 for VYUY's `[C,Y]`).
+fn packed_yuv_to_grey_strided_matches_tight(fmt: PixelFormat, luma_off: usize) {
+    let w = 64usize; // even width: one YUYV/VYUY macropixel spans 2 px
+    let h = 16usize;
+
+    let fill = |buf: &mut [u8], stride: usize| {
+        for r in 0..h {
+            for x in 0..w {
+                let base = r * stride + x * 2;
+                buf[base + luma_off] = ((r * 7 + x * 3) % 220 + 16) as u8; // luma
+                buf[base + (1 - luma_off)] = ((r * 5 + x * 11) % 256) as u8; // chroma
+            }
+        }
+    };
+
+    let tight = {
+        let mut s = Tensor::<u8>::image(w, h, fmt, Some(TensorMemory::Mem)).unwrap();
+        let stride = s.effective_row_stride().unwrap_or(w * 2);
+        {
+            let mut m = s.map().unwrap();
+            fill(m.as_mut_slice(), stride);
+        }
+        s
+    };
+    let tight_grey = cpu_to_grey_packed(tight, w, h);
+
+    // Strided source is DMA-backed (Linux only); elsewhere `image_with_stride`
+    // returns NotImplemented and the tight path above is the whole assertion.
+    let padded = 192usize; // 64-aligned, > w*2 = 128
+    if let Ok(mut s) = Tensor::<u8>::image_with_stride(w, h, fmt, padded, None) {
+        let stride = s.effective_row_stride().unwrap_or(padded);
+        assert!(stride > w * 2, "expected a padded stride, got {stride}");
+        {
+            let mut m = s.map().unwrap();
+            fill(m.as_mut_slice(), stride);
+        }
+        let strided_grey = cpu_to_grey_packed(s, w, h);
+        assert_eq!(
+            tight_grey, strided_grey,
+            "{fmt:?}→Grey: strided source diverges from tight source (stride bug)"
+        );
+    }
+}
+
+#[test]
+fn d4_yuyv_to_grey_strided_matches_tight() {
+    packed_yuv_to_grey_strided_matches_tight(PixelFormat::Yuyv, 0);
+}
+
+#[test]
+fn d5_vyuy_to_grey_strided_matches_tight() {
+    packed_yuv_to_grey_strided_matches_tight(PixelFormat::Vyuy, 1);
+}
+
+/// Planar → packed read-back (`convert_8bps_*` / `convert_prgba_*`) round-trips
+/// losslessly. Locks in the stride-aware `planar_to_packed` helper on the tight
+/// path; the strided planar path is not reachable through the public API
+/// (`image_with_stride` rejects planar layouts) but shares the same code.
+#[test]
+fn d6_planar_packed_roundtrip() {
+    let w = 40usize;
+    let h = 24usize;
+
+    let convert = |src: &TensorDyn, dst_fmt: PixelFormat, dst_ch: usize| -> TensorDyn {
+        let mut proc = CPUProcessor::default();
+        let mut dst = TensorDyn::image(w, h, dst_fmt, DType::U8, Some(TensorMemory::Mem)).unwrap();
+        let _ = dst_ch;
+        proc.convert(src, &mut dst, Rotation::None, Flip::None, Crop::default())
+            .unwrap();
+        dst
+    };
+
+    let read_packed = |t: &TensorDyn, ch: usize| -> Vec<u8> {
+        let u8t = t.as_u8().unwrap();
+        let stride = u8t.effective_row_stride().unwrap_or(w * ch);
+        let map = u8t.map().unwrap();
+        let s = map.as_slice();
+        let mut out = vec![0u8; w * h * ch];
+        for r in 0..h {
+            out[r * w * ch..(r + 1) * w * ch].copy_from_slice(&s[r * stride..r * stride + w * ch]);
+        }
+        out
+    };
+
+    // RGB → PlanarRgb → RGB is the identity.
+    let mut rgb = Tensor::<u8>::image(w, h, PixelFormat::Rgb, Some(TensorMemory::Mem)).unwrap();
+    {
+        let stride = rgb.effective_row_stride().unwrap_or(w * 3);
+        let mut m = rgb.map().unwrap();
+        let s = m.as_mut_slice();
+        for r in 0..h {
+            for x in 0..w {
+                let b = r * stride + x * 3;
+                s[b] = ((r * 9 + x * 5) % 256) as u8;
+                s[b + 1] = ((r * 3 + x * 13) % 256) as u8;
+                s[b + 2] = ((r * 17 + x * 2) % 256) as u8;
+            }
+        }
+    }
+    let rgb_dyn = TensorDyn::from(rgb);
+    let rgb_orig = read_packed(&rgb_dyn, 3);
+    let planar = convert(&rgb_dyn, PixelFormat::PlanarRgb, 3);
+    let back = convert(&planar, PixelFormat::Rgb, 3);
+    assert_eq!(
+        rgb_orig,
+        read_packed(&back, 3),
+        "RGB→PlanarRgb→RGB not identity"
+    );
+
+    // RGBA → PlanarRgba → RGBA is the identity (exercises the alpha plane).
+    let mut rgba = Tensor::<u8>::image(w, h, PixelFormat::Rgba, Some(TensorMemory::Mem)).unwrap();
+    {
+        let stride = rgba.effective_row_stride().unwrap_or(w * 4);
+        let mut m = rgba.map().unwrap();
+        let s = m.as_mut_slice();
+        for r in 0..h {
+            for x in 0..w {
+                let b = r * stride + x * 4;
+                s[b] = ((r + x) % 256) as u8;
+                s[b + 1] = ((r * 2 + x * 3) % 256) as u8;
+                s[b + 2] = ((r * 4 + x) % 256) as u8;
+                s[b + 3] = ((r * 6 + x * 7) % 256) as u8;
+            }
+        }
+    }
+    let rgba_dyn = TensorDyn::from(rgba);
+    let rgba_orig = read_packed(&rgba_dyn, 4);
+    let planar_a = convert(&rgba_dyn, PixelFormat::PlanarRgba, 4);
+    let back_a = convert(&planar_a, PixelFormat::Rgba, 4);
+    assert_eq!(
+        rgba_orig,
+        read_packed(&back_a, 4),
+        "RGBA→PlanarRgba→RGBA not identity"
+    );
+}

--- a/crates/tensor/src/cuda.rs
+++ b/crates/tensor/src/cuda.rs
@@ -346,12 +346,14 @@ impl Drop for CudaHandle {
     fn drop(&mut self) {
         match &self.kind {
             CudaBacking::GlBuffer { resource, ops } => ops.unregister(*resource),
-            CudaBacking::ExternalMem { ext_mem, dptr } => {
+            CudaBacking::ExternalMem { ext_mem, dptr: _ } => {
+                // The device pointer comes from `cudaExternalMemoryGetMappedBuffer`,
+                // which CUDA frees together with the external-memory object. Calling
+                // `cudaFree` on such a pointer is explicitly disallowed and corrupts
+                // the driver's bookkeeping (risking a double-free when the handle is
+                // destroyed), so only destroy the external-memory object here.
                 if let Some(t) = table() {
-                    // cudaExternalMemoryGetMappedBuffer's pointer must be freed with
-                    // cudaFree before destroying the external-memory handle.
                     unsafe {
-                        (t.free)(*dptr);
                         (t.destroy_external_memory)(*ext_mem);
                     }
                 }


### PR DESCRIPTION
## Summary

Four verified correctness regressions surfaced by a whole-repository review of the changes since v0.24.2 (WS0 of the cleanup effort). These silently corrupt output on padded sources or risk a CUDA double-free.

| ID | Fix |
|----|-----|
| **C2** | `Yuyv`/`Vyuy` → `Grey` chunked the flat mapped buffer ignoring row stride; padded sources (DMA-BUF, V4L2 HW decode, pitch-aligned `create_image`) read luma from per-row padding. Now iterate rows honouring `effective_row_stride`. |
| **C3** | `PlanarRgb`/`PlanarRgba` → `Rgb`/`Rgba` derived plane boundaries from `mapped_len/channels` and walked planes as tightly packed, corrupting strided sources. Now share a stride-aware `planar_to_packed` helper deriving plane offsets from `height × row_stride`. |
| **H4** | `convert_nv24_to_grey` computed luma height as `shape[0]/3` before the multiplane check, truncating true-multiplane NV24 to a third of its rows; resolved inside the multiplane branch like `convert_nv24_to_rgb` (defensive — multiplane NV24 not yet constructible via the public API). |
| **H1-cuda** | `CudaHandle::Drop` called `cudaFree` on a `cudaExternalMemoryGetMappedBuffer` pointer before destroying the external-memory object; CUDA disallows this (risking driver corruption / double-free). Drop now only calls `cudaDestroyExternalMemory`. |

## Tests

- New strided `Yuyv`/`Vyuy` → `Grey` regression cells (`d4`/`d5`) — exercise the **DMA lane on CI**; tight-path locally (dev host `/dev/dma_heap` is root-only).
- New planar→packed round-trip identity test (`d6`).
- Existing CPU encode/decode golden tests unchanged (byte-identical).

## Verification

`make format lint check` clean · image cpu 127, odd_dim 36, tensor 168 + 7 doc-tests pass (`-j 1`).

🤖 Generated as part of the post-0.24.2 cleanup review.