### PR TITLE
refactor(colorimetry): single source for YUV<->RGB matrix/range constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Single source for the YUV↔RGB matrix/range constants** (`edgefirst-tensor`,
+  `edgefirst-image`). The BT.601/709/2020 luma weights `(kr, kb)` and the
+  full/limited-range luma/chroma swings are now defined once, as
+  `ColorEncoding::luma_weights()` (→ `MatrixWeights`) and
+  `ColorRange::scaling()` (→ `RangeScaling`) on the core colorimetry types. The
+  in-shader GL coefficients (`yuv_to_rgb_coeffs`) and the hand-rolled
+  fixed-point CPU YUYV encoders both derive from this source instead of carrying
+  private duplicate tables, so a coefficient change is made in exactly one
+  place. Output is byte-identical (verified by the existing encode goldens and a
+  new absolute-value coefficient test).
+- **Documented colorimetry transfer-function limitation.** The `ColorTransfer`
+  (gamma / TRC) axis is stored, propagated, and round-tripped but is **not
+  applied** by any conversion backend; all YUV↔RGB paths operate on the matrix
+  and range only and assume the platform-native transfer curve. HDR curves
+  (PQ / HLG) are therefore not tone-mapped. This is now called out on the type.
 - `convert()` now honors each tensor's `Colorimetry`, resolving unknown axes at
   use-time via an SD/HD height heuristic (height ≥ 720 → BT.709, else BT.601;
   limited range when unknown) without mutating the tensor. CPU and OpenGL backends

--- a/crates/image/src/colorimetry.rs
+++ b/crates/image/src/colorimetry.rs
@@ -98,24 +98,20 @@ pub(crate) struct YuvToRgbCoeffs {
 /// Compute the in-shader YUV→RGB coefficients for a resolved
 /// `(ColorEncoding, ColorRange)`. Pure; platform-neutral.
 pub(crate) fn yuv_to_rgb_coeffs(encoding: ColorEncoding, range: ColorRange) -> YuvToRgbCoeffs {
-    // Luma weights (kr, kb) per encoding matrix.
-    let (kr, kb) = match encoding {
-        ColorEncoding::Bt601 => (0.299_f32, 0.114_f32),
-        ColorEncoding::Bt709 => (0.2126_f32, 0.0722_f32),
-        ColorEncoding::Bt2020 => (0.2627_f32, 0.0593_f32),
-        // Future encodings default to BT.709 (HD broadcast).
-        _ => (0.2126_f32, 0.0722_f32),
-    };
+    // Luma weights (kr, kb) and range swings come from the canonical source in
+    // `edgefirst_tensor::colorimetry` so the GL coefficients stay in lockstep
+    // with the CPU encoders. The arithmetic below is kept in `f32` (the GL
+    // uniform type) for bit-stable shader output.
+    let w = encoding.luma_weights();
+    let (kr, kb) = (w.kr as f32, w.kb as f32);
     let kg = 1.0 - kr - kb;
 
-    // Range scaling. Limited: luma spans 16..235 (gain 255/219), chroma
-    // spans 16..240 (gain 255/224). Full: both unity.
-    let (y_offset, y_scale, c_scale) = match range {
-        ColorRange::Full => (0.0, 1.0, 1.0),
-        ColorRange::Limited => (16.0 / 255.0, 255.0 / 219.0, 255.0 / 224.0),
-        // Future ranges default to limited (broadcast convention).
-        _ => (16.0 / 255.0, 255.0 / 219.0, 255.0 / 224.0),
-    };
+    // Limited: luma spans 16..235 (gain 255/219), chroma spans 16..240 (gain
+    // 255/224). Full: both unity.
+    let s = range.scaling();
+    let y_offset = s.y_offset as f32 / 255.0;
+    let y_scale = 255.0 / s.y_swing as f32;
+    let c_scale = 255.0 / s.c_swing as f32;
 
     YuvToRgbCoeffs {
         y_offset,
@@ -158,6 +154,39 @@ mod tests {
         let t = TensorDyn::image(1280, 720, PixelFormat::Nv12, DType::U8, None).unwrap();
         let _ = effective_colorimetry(&t);
         assert_eq!(t.colorimetry(), None); // unchanged
+    }
+
+    #[test]
+    fn yuv_to_rgb_coeffs_match_reference_values() {
+        // Reference YCbCr→RGB cross-terms (well-known broadcast constants). The
+        // shader applies `r = y' + c_vr*v'`, `b = y' + c_ub*u'`, etc.
+        fn close(a: f32, b: f32, what: &str) {
+            assert!((a - b).abs() < 2e-3, "{what}: {a} vs expected {b}");
+        }
+
+        // BT.601 limited range — the canonical SD decode.
+        let c = yuv_to_rgb_coeffs(ColorEncoding::Bt601, ColorRange::Limited);
+        close(c.y_offset, 16.0 / 255.0, "601L y_offset");
+        close(c.y_scale, 255.0 / 219.0, "601L y_scale");
+        close(c.c_vr, 1.596, "601L c_vr");
+        close(c.c_ub, 2.017, "601L c_ub");
+        close(c.c_ug, 0.391, "601L c_ug");
+        close(c.c_vg, 0.813, "601L c_vg");
+
+        // BT.709 limited range — the canonical HD decode.
+        let c = yuv_to_rgb_coeffs(ColorEncoding::Bt709, ColorRange::Limited);
+        close(c.c_vr, 1.793, "709L c_vr");
+        close(c.c_ub, 2.113, "709L c_ub");
+        close(c.c_ug, 0.213, "709L c_ug");
+        close(c.c_vg, 0.533, "709L c_vg");
+
+        // Full range zeroes the luma offset and unity-scales luma; the chroma
+        // cross-terms drop the 255/224 gain.
+        let c = yuv_to_rgb_coeffs(ColorEncoding::Bt601, ColorRange::Full);
+        close(c.y_offset, 0.0, "601F y_offset");
+        close(c.y_scale, 1.0, "601F y_scale");
+        close(c.c_vr, 2.0 * (1.0 - 0.299), "601F c_vr");
+        close(c.c_ub, 2.0 * (1.0 - 0.114), "601F c_ub");
     }
 
     #[test]

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -53,8 +53,9 @@ fn luma_encoder(full_range: bool) -> fn(u8) -> u8 {
 }
 
 /// Fixed-point RGB→YUV coefficient table for the hand-rolled YUYV encoders,
-/// resolved from the destination tensor's matrix + range. All terms are
-/// `Q(BIAS)` fixed-point; `y_off`/`c_off` are the post-shift integer offsets.
+/// resolved from the destination tensor's encoding (`cp.encoding`) and range
+/// (`cp.range_kind`). All terms are `Q(BIAS)` fixed-point; `y_off`/`c_off` are
+/// the post-shift integer offsets.
 struct YuyvEncodeCoeffs {
     y_r: i32,
     y_g: i32,
@@ -70,14 +71,15 @@ struct YuyvEncodeCoeffs {
 }
 
 impl YuyvEncodeCoeffs {
-    /// `BIAS` matches the original hand-rolled tables (Q20 fixed point).
+    /// `BIAS` is Q20 fixed point — retained from the pre-refactor hand-coded
+    /// tables to keep encoder output byte-identical.
     const BIAS: i32 = 20;
     const ROUND: i32 = 1 << (Self::BIAS - 1);
     const ROUND2: i32 = 1 << Self::BIAS;
 
     /// Build the table from the resolved `ColorParams`. The luma/chroma swings
-    /// are full-range (255/255) or limited-range (219/224) per `cp.range`; the
-    /// `KR`/`KB` luma weights come from `cp.matrix` (BT.601 / 709 / 2020).
+    /// are full-range (255/255) or limited-range (219/224) per `cp.range_kind`;
+    /// the `KR`/`KB` luma weights come from `cp.encoding` (BT.601 / 709 / 2020).
     fn from_params(cp: ColorParams) -> Self {
         // KR/KB luma weights and luma/chroma swings come from the canonical
         // source in `edgefirst_tensor::colorimetry`, shared with the in-shader

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -79,21 +79,16 @@ impl YuyvEncodeCoeffs {
     /// are full-range (255/255) or limited-range (219/224) per `cp.range`; the
     /// `KR`/`KB` luma weights come from `cp.matrix` (BT.601 / 709 / 2020).
     fn from_params(cp: ColorParams) -> Self {
-        // KR/KB luma weights per standard matrix.
-        let (kr, kb) = match cp.matrix {
-            yuv::YuvStandardMatrix::Bt601 => (0.299_f64, 0.114_f64),
-            yuv::YuvStandardMatrix::Bt2020 => (0.2627_f64, 0.0593_f64),
-            // BT.709 and any future/unknown matrix default to 709 weights.
-            _ => (0.2126_f64, 0.0722_f64),
-        };
-        let kg = 1.0 - kr - kb;
-        let full = matches!(cp.range, yuv::YuvRange::Full);
-        // Luma swing / chroma swing and offsets for the selected range.
-        let (y_swing, c_swing, y_off, c_off) = if full {
-            (255.0_f64, 255.0_f64, 0, 128)
-        } else {
-            (219.0_f64, 224.0_f64, 16, 128)
-        };
+        // KR/KB luma weights and luma/chroma swings come from the canonical
+        // source in `edgefirst_tensor::colorimetry`, shared with the in-shader
+        // GL coefficients (see `crate::colorimetry::yuv_to_rgb_coeffs`).
+        let w = cp.encoding.luma_weights();
+        let (kr, kb) = (w.kr, w.kb);
+        let kg = w.kg();
+        let s = cp.range_kind.scaling();
+        // Chroma is always centred on 128; the luma black level (`y_off`) and
+        // the swings come from the resolved range.
+        let (y_swing, c_swing, y_off, c_off) = (s.y_swing, s.c_swing, s.y_offset as i32, 128);
         let b = Self::BIAS;
         let yscale = (1_i64 << b) as f64 * y_swing / 255.0;
         let cscale = (1_i64 << b) as f64 * c_swing / 255.0;

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -29,6 +29,12 @@ pub(crate) struct ColorParams {
     pub matrix: yuv::YuvStandardMatrix,
     /// Range resolved from the YUV side (src for decode, dst for encode).
     pub range: yuv::YuvRange,
+    /// The same matrix/range in HAL's own terms, so the hand-rolled fixed-point
+    /// encoders draw their `(kr, kb)` weights and luma/chroma swings from the
+    /// canonical [`edgefirst_tensor::colorimetry`] source rather than a private
+    /// duplicate table.
+    pub encoding: edgefirst_tensor::ColorEncoding,
+    pub range_kind: edgefirst_tensor::ColorRange,
     /// True when the **source** tensor's resolved range is full (decode-side
     /// luma extraction: copy luma directly instead of limited→full expansion).
     pub src_full_range: bool,
@@ -441,6 +447,8 @@ impl CPUProcessor {
         let cp = ColorParams {
             matrix: crate::colorimetry::yuv_matrix(cm.encoding.unwrap()),
             range: crate::colorimetry::yuv_range(cm.range.unwrap()),
+            encoding: cm.encoding.unwrap(),
+            range_kind: cm.range.unwrap(),
             src_full_range: cm.range == Some(edgefirst_tensor::ColorRange::Full),
             dst_full_range: cm.range == Some(edgefirst_tensor::ColorRange::Full),
         };
@@ -580,12 +588,16 @@ impl CPUProcessor {
         let src_params = ColorParams {
             matrix: crate::colorimetry::yuv_matrix(src_cm.encoding.unwrap()),
             range: crate::colorimetry::yuv_range(src_cm.range.unwrap()),
+            encoding: src_cm.encoding.unwrap(),
+            range_kind: src_cm.range.unwrap(),
             src_full_range: src_full,
             dst_full_range: dst_full,
         };
         let dst_params = ColorParams {
             matrix: crate::colorimetry::yuv_matrix(dst_cm.encoding.unwrap()),
             range: crate::colorimetry::yuv_range(dst_cm.range.unwrap()),
+            encoding: dst_cm.encoding.unwrap(),
+            range_kind: dst_cm.range.unwrap(),
             src_full_range: src_full,
             dst_full_range: dst_full,
         };

--- a/crates/tensor/src/colorimetry.rs
+++ b/crates/tensor/src/colorimetry.rs
@@ -42,6 +42,14 @@ pub enum ColorSpace {
 }
 
 /// Transfer function (`color_transfer` in the EdgeFirst schema).
+///
+/// **Limitation:** this axis is stored, propagated, and round-tripped, but it is
+/// **not applied** by any conversion backend. All YUV↔RGB paths operate only on
+/// the matrix ([`ColorEncoding`]) and range ([`ColorRange`]); the transfer
+/// function (gamma / TRC) is assumed to be the platform-native curve and is left
+/// unchanged. HDR transfer curves ([`Self::Pq`] / [`Self::Hlg`]) are therefore
+/// *not* tone-mapped — consumers needing linear-light or HDR handling must apply
+/// the curve themselves.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ColorTransfer {
@@ -187,6 +195,79 @@ macro_rules! display_via_as_str {
     )*};
 }
 display_via_as_str!(ColorSpace, ColorTransfer, ColorEncoding, ColorRange);
+
+/// YCbCr matrix luma weights `(kr, kb)`; the green weight is `kg = 1 - kr - kb`.
+///
+/// This is the single source of the BT.601/709/2020 coefficients. Every
+/// YUV↔RGB path (the in-shader GL coefficients and the hand-rolled fixed-point
+/// CPU encoders) derives its matrix from here so a coefficient change is made
+/// in exactly one place.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MatrixWeights {
+    pub kr: f64,
+    pub kb: f64,
+}
+
+impl MatrixWeights {
+    /// Green luma weight, `1 - kr - kb`.
+    pub fn kg(self) -> f64 {
+        1.0 - self.kr - self.kb
+    }
+}
+
+impl ColorEncoding {
+    /// The matrix luma weights `(kr, kb)` for this encoding — the canonical
+    /// BT.601/709/2020 coefficients shared by every YUV↔RGB conversion path.
+    pub fn luma_weights(self) -> MatrixWeights {
+        match self {
+            Self::Bt601 => MatrixWeights {
+                kr: 0.299,
+                kb: 0.114,
+            },
+            Self::Bt709 => MatrixWeights {
+                kr: 0.2126,
+                kb: 0.0722,
+            },
+            Self::Bt2020 => MatrixWeights {
+                kr: 0.2627,
+                kb: 0.0593,
+            },
+        }
+    }
+}
+
+/// Quantization swings (out of 255) for a YCbCr range: the luma black offset and
+/// the luma/chroma excursions. Full range is `0 / 255 / 255`; limited (studio)
+/// range is `16 / 219 / 224`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RangeScaling {
+    /// Luma black level (0 for full range, 16 for limited).
+    pub y_offset: f64,
+    /// Luma excursion (255 for full range, 219 for limited).
+    pub y_swing: f64,
+    /// Chroma excursion (255 for full range, 224 for limited).
+    pub c_swing: f64,
+}
+
+impl ColorRange {
+    /// The luma/chroma quantization swings for this range — the canonical
+    /// 0/255/255 (full) or 16/219/224 (limited) studio-swing constants shared
+    /// by every YUV↔RGB conversion path.
+    pub fn scaling(self) -> RangeScaling {
+        match self {
+            Self::Full => RangeScaling {
+                y_offset: 0.0,
+                y_swing: 255.0,
+                c_swing: 255.0,
+            },
+            Self::Limited => RangeScaling {
+                y_offset: 16.0,
+                y_swing: 219.0,
+                c_swing: 224.0,
+            },
+        }
+    }
+}
 
 /// Full 4-axis colorimetry. Each axis is `Option`; `None` means "undefined"
 /// and is never auto-filled — consumers (e.g. `convert()`) resolve missing
@@ -381,6 +462,55 @@ mod tests {
         let unknown_enc = Colorimetry::from_v4l2(7, 0, 99, 0);
         assert_eq!(unknown_enc.encoding, None);
         assert_eq!(unknown_enc.range, Some(ColorRange::Full)); // quant still defaulted from JPEG
+    }
+
+    #[test]
+    fn luma_weights_are_the_canonical_bt_constants() {
+        assert_eq!(
+            ColorEncoding::Bt601.luma_weights(),
+            MatrixWeights {
+                kr: 0.299,
+                kb: 0.114
+            }
+        );
+        assert_eq!(
+            ColorEncoding::Bt709.luma_weights(),
+            MatrixWeights {
+                kr: 0.2126,
+                kb: 0.0722
+            }
+        );
+        assert_eq!(
+            ColorEncoding::Bt2020.luma_weights(),
+            MatrixWeights {
+                kr: 0.2627,
+                kb: 0.0593
+            }
+        );
+        // kg = 1 - kr - kb (BT.709 green weight ≈ 0.7152).
+        assert!((ColorEncoding::Bt709.luma_weights().kg() - 0.7152).abs() < 1e-9);
+    }
+
+    #[test]
+    fn range_scaling_is_full_or_studio_swing() {
+        let full = ColorRange::Full.scaling();
+        assert_eq!(
+            full,
+            RangeScaling {
+                y_offset: 0.0,
+                y_swing: 255.0,
+                c_swing: 255.0
+            }
+        );
+        let limited = ColorRange::Limited.scaling();
+        assert_eq!(
+            limited,
+            RangeScaling {
+                y_offset: 16.0,
+                y_swing: 219.0,
+                c_swing: 224.0
+            }
+        );
     }
 
     #[test]

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -42,7 +42,9 @@ mod pbo;
 #[cfg(unix)]
 mod shm;
 mod tensor_dyn;
-pub use colorimetry::{ColorEncoding, ColorRange, ColorSpace, ColorTransfer, Colorimetry};
+pub use colorimetry::{
+    ColorEncoding, ColorRange, ColorSpace, ColorTransfer, Colorimetry, MatrixWeights, RangeScaling,
+};
 
 /// Retained constructor: installs the coverage flush-on-abort handler for this
 /// crate's instrumented test binary. See `covguard`. Only present under


### PR DESCRIPTION
## Summary

WS1-core of the post-0.24.2 cleanup: unify the BT.601/709/2020 matrix/range constants that were hand-written in three places.

> #96 (WS0) is **merged**; this PR is rebased onto `main`. A small follow-up commit (`27120f3`) corrects three `YuyvEncodeCoeffs` doc comments per review feedback (doc-only, no behavior change).

The luma weights `(kr, kb)` and full/limited-range luma/chroma swings now live once, as `ColorEncoding::luma_weights()` → `MatrixWeights` and `ColorRange::scaling()` → `RangeScaling` on the core colorimetry types. Both consumers derive from this source:

- **GL** `yuv_to_rgb_coeffs` (in-shader uniforms) — arithmetic kept in `f32` for bit-stable shader output.
- **CPU** `YuyvEncodeCoeffs` (fixed-point RGB→YUV encoders) — `ColorParams` now carries HAL's own encoding/range so the encoder reads the canonical weights.

A coefficient change is now made in exactly one place.

## Correctness

Output is **byte-identical**:
- Existing RGB→YUYV encode goldens pass unchanged.
- New absolute-value test pins `yuv_to_rgb_coeffs` to the known BT.601/709 broadcast constants (`c_vr≈1.596`, `c_ub≈2.017`, …).
- New unit tests pin `luma_weights()`/`scaling()` to the canonical constants.

Also documents that the `ColorTransfer` (gamma/TRC) axis is stored/propagated but **applied by no backend** (HDR PQ/HLG not tone-mapped).

## Follow-up (hardware-in-loop, not in this PR)

This unification is the prerequisite that lets the **macOS YUYV** and **G2D** BT.601 stop-gaps call the shared coefficients. Removing those stop-gaps and re-tightening the relaxed cross-backend (CPU-vs-GL/G2D/macOS) test tolerances requires the on-target GPU/G2D/macOS CI lanes and lands separately.

## Verification

Rebased onto `main` (post-#96). `make format lint check` clean · full Rust suite green (1166 pass / 7 skipped), including image colorimetry + cpu (127) + tensor colorimetry; working tree clean after the run (no golden churn → byte-identical confirmed).

🤖 Generated as part of the post-0.24.2 cleanup review.
