### PR TITLE
docs: refresh stale dependency version, env vars, and CUDA/PBO references

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Rust:
 
 ```toml
 [dependencies]
-edgefirst-hal = "0.22"
+edgefirst-hal = "0.24"
 ```
 
 C: download a release archive from
@@ -68,7 +68,7 @@ processor.draw_masks(decoder, [output0, output1], output)
 **Rust:**
 
 The umbrella `edgefirst-hal` crate re-exports its sub-crates as modules,
-so a single `edgefirst-hal = "0.22"` dependency is enough — no need to
+so a single `edgefirst-hal = "0.24"` dependency is enough — no need to
 list `edgefirst-image` / `edgefirst-tensor` separately in `Cargo.toml`.
 
 ```rust
@@ -639,8 +639,13 @@ For the C library and consumer linking, see
 | `EDGEFIRST_DISABLE_CPU` | Disable CPU backend |
 | `EDGEFIRST_FORCE_BACKEND` | Force one backend: `cpu`, `g2d`, or `opengl` (disables fallback) |
 | `EDGEFIRST_FORCE_TRANSFER` | Force GL transfer: `pbo`, `dmabuf`, or `sync` |
+| `EDGEFIRST_NV_CONVERT_PATH` | NV12/16/24 GPU conversion path: `sampler`, `shader`, or `auto` (default). `auto` prefers the portable, colorimetry-exact in-shader `ShaderR8`, except BT.601-limited single-plane NV12 on Vivante (hardware sampler is ~12× faster and correct). `sampler`/`shader` force a path for benchmarking/bring-up |
+| `EDGEFIRST_EGL_CACHE_CAPACITY` | Override the per-cache EGLImage capacity (default 64) for high-cardinality varied-geometry streams |
+| `EDGEFIRST_ALLOW_SOFTWARE_GL` | `1` opts in to running the GL backend on a software renderer (otherwise rejected); for CI / headless bring-up |
 | `EDGEFIRST_OPENGL_RENDERSURFACE` | `1` enables EGL renderbuffer path for non-`dma_heap` DMA-BUF (i.MX 95 Neutron NPU) |
 | `EDGEFIRST_PROTO_COMPUTE` | `1` enables GLES 3.1 compute shader for HWC→CHW proto repack |
+| `EDGEFIRST_DISABLE_V4L2` | `1` forces the software JPEG decoder, bypassing the V4L2 hardware JPEG backend (Linux) |
+| `EDGEFIRST_CODEC_V4L2_DEVICE` | Probe a specific V4L2 device node for hardware JPEG decode instead of auto-discovery |
 | `EDGEFIRST_ANGLE_PATH` | macOS only: directory containing `libEGL.dylib` / `libGLESv2.dylib`. Overrides the default search (Homebrew → `@loader_path` → `@executable_path` → `libEGL.dylib` on dyld). Set this when deploying a bundled or custom-signed ANGLE alongside the binary. |
 | `EDGEFIRST_TESTDATA_DIR` | Override testdata location (used by benches and CI) |
 | `RUST_LOG` | Standard `env_logger` filter — `RUST_LOG=edgefirst_image=debug` for backend dispatch + cache stats |

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -1996,9 +1996,9 @@ class ImageProcessor:
         """Create an image tensor with the processor's optimal memory backend.
 
         Selects the best available backing storage based on hardware capabilities:
-        DMA-buf > PBO (GPU buffer, byte-sized types: uint8, int8) > system memory.
-        Images created this way benefit from zero-copy GPU paths when used with
-        this processor's ``convert()``.
+        DMA-buf > PBO (GPU buffer) > system memory. Images created this way
+        benefit from zero-copy GPU paths when used with this processor's
+        ``convert()``.
 
         Args:
             width: Image width in pixels.
@@ -2008,9 +2008,11 @@ class ImageProcessor:
                 Supported values: ``"uint8"``, ``"int8"``, ``"uint16"``,
                 ``"int16"``, ``"uint32"``, ``"int32"``, ``"uint64"``,
                 ``"int64"``, ``"float16"``, ``"float32"``, ``"float64"``.
-                PBO is only available for byte-sized types (``"uint8"``,
-                ``"int8"``); other types still prefer DMA-buf when available
-                and otherwise use system memory.
+                PBO backing covers ``"uint8"``/``"int8"`` and, on GL backends
+                advertising float-texture support, ``"float16"`` and
+                ``"float32"`` (for GPU float model-input paths); other types
+                still prefer DMA-buf when available and otherwise use system
+                memory.
 
         Returns:
             A new image ``Tensor`` backed by the optimal memory type.

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -102,7 +102,7 @@ The CUDA zero-copy surface (`cuda_map()`, `is_cuda_available()`, `CudaMap`,
 | Mock `CudaGlOps` — map/unmap/unregister call sequence | `crates/tensor/src/cuda.rs` `#[cfg(test)]` | `CudaMap` construction calls `map`; `Drop` calls `unmap`; handle drop calls `unregister` in the correct order (before PBO storage drops) |
 | `Debug` impl on `CudaMap` / `CudaHandle` | Same | No panics, no format-string UB |
 | Primitive degradation — absent `libcudart` | Same | `is_cuda_available()` returns `false`; `cuda_map()` returns `None`; no crash |
-| ABI layout asserts | `crates/tensor/src/cuda_abi.rs` | `sizeof` / `alignof` of HAL's CUDA type wrappers match CUDA 12.6 `driver_types.h` — verified as static compile-time assertions |
+| ABI layout asserts | `crates/tensor/src/cuda.rs` (`mod ext_mem_layout`) | `sizeof` / `alignof` of HAL's CUDA type wrappers match CUDA 12.6 `driver_types.h` — verified as static compile-time assertions |
 
 Run all CUDA tests on the host (no hardware required):
 


### PR DESCRIPTION
## Summary

WS6 (docs) of the post-0.24.2 cleanup — stale/missing documentation corrected, **each claim verified against source**.

- **README Quick Start**: bump the example dependency `0.22` → `0.24` (two minor releases stale; predates colorimetry/CUDA/float paths).
- **README Environment Variables**: document six variables that exist in source but were undocumented — `EDGEFIRST_NV_CONVERT_PATH`, `EDGEFIRST_EGL_CACHE_CAPACITY`, `EDGEFIRST_ALLOW_SOFTWARE_GL`, `EDGEFIRST_DISABLE_V4L2`, `EDGEFIRST_CODEC_V4L2_DEVICE`.
- **tensor `TESTING.md`**: the CUDA ABI layout asserts live in `cuda.rs` (`mod ext_mem_layout`), not the non-existent `cuda_abi.rs`.
- **python `create_image` `.pyi` docstring**: PBO backing now also covers `float16`/`float32` on float-texture-capable GL backends (`PboF16Nchw`/`PboF32Nhwc` in `gl::float_dispatch`), not just `uint8`/`int8`.

Independent of the other cleanup PRs. ruff clean.

### Repo-hygiene non-finding
The review's "remove root model blobs / `BUG_*`/`FEATURE_*` docs / `.profraw`" items are already handled — `.gitignore` (`/BUG*.md /FIX*.md /FEATURE*.md *.tflite *.onnx *.profraw`) makes them untracked and invisible (`git status` clean). No change needed.

🤖 Generated as part of the post-0.24.2 cleanup review.