### PR TITLE
Post-0.24.2 cleanup rollup: CPU/Python dedup, alloc_zeroed perf, doc refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ env.sh
 /docs/
 *.profraw
 .remember
+.mcp.json
 
 # Benchmark intermediate data (JSON results, logs)
 /benchmarks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Heap (`Mem`) tensor allocation no longer eagerly memsets every element**
+  (`edgefirst-tensor`). `MemBacking::zeroed` had regressed to
+  `(0..n).map(UnsafeCell::new).collect()`, which allocates uninitialised then
+  writes every element — committing every page up front. It now allocates via
+  `alloc_zeroed` (calloc) when `T::zero()` is the all-zeros bit pattern (every
+  primitive numeric type), so the kernel returns lazily-zeroed pages. This backs
+  every `Tensor::image(.., Mem)` and the per-call image intermediates the CPU
+  converter allocates, restoring the pre-regression allocation latency.
 - **CPU packed-YUV → GREY ignored the source row stride** (`edgefirst-image`).
   `Yuyv`/`Vyuy` → `Grey` chunked the flat mapped buffer with a fixed 16-byte
   stride, so a padded source (DMA-BUF, V4L2 hardware decode, or pitch-aligned

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Rust:
 
 ```toml
 [dependencies]
-edgefirst-hal = "0.22"
+edgefirst-hal = "0.24"
 ```
 
 C: download a release archive from
@@ -68,7 +68,7 @@ processor.draw_masks(decoder, [output0, output1], output)
 **Rust:**
 
 The umbrella `edgefirst-hal` crate re-exports its sub-crates as modules,
-so a single `edgefirst-hal = "0.22"` dependency is enough — no need to
+so a single `edgefirst-hal = "0.24"` dependency is enough — no need to
 list `edgefirst-image` / `edgefirst-tensor` separately in `Cargo.toml`.
 
 ```rust
@@ -639,8 +639,13 @@ For the C library and consumer linking, see
 | `EDGEFIRST_DISABLE_CPU` | Disable CPU backend |
 | `EDGEFIRST_FORCE_BACKEND` | Force one backend: `cpu`, `g2d`, or `opengl` (disables fallback) |
 | `EDGEFIRST_FORCE_TRANSFER` | Force GL transfer: `pbo`, `dmabuf`, or `sync` |
+| `EDGEFIRST_NV_CONVERT_PATH` | NV12/16/24 GPU conversion path: `sampler`, `shader`, or `auto` (default). `auto` prefers the portable, colorimetry-exact in-shader `ShaderR8`, except BT.601-limited single-plane NV12 on Vivante (hardware sampler is ~12× faster and correct). `sampler`/`shader` force a path for benchmarking/bring-up |
+| `EDGEFIRST_EGL_CACHE_CAPACITY` | Override the per-cache EGLImage capacity (default 64) for high-cardinality varied-geometry streams |
+| `EDGEFIRST_ALLOW_SOFTWARE_GL` | `1` opts in to running the GL backend on a software renderer (otherwise rejected); for CI / headless bring-up |
 | `EDGEFIRST_OPENGL_RENDERSURFACE` | `1` enables EGL renderbuffer path for non-`dma_heap` DMA-BUF (i.MX 95 Neutron NPU) |
 | `EDGEFIRST_PROTO_COMPUTE` | `1` enables GLES 3.1 compute shader for HWC→CHW proto repack |
+| `EDGEFIRST_DISABLE_V4L2` | `1` forces the software JPEG decoder, bypassing the V4L2 hardware JPEG backend (Linux) |
+| `EDGEFIRST_CODEC_V4L2_DEVICE` | Probe a specific V4L2 device node for hardware JPEG decode instead of auto-discovery |
 | `EDGEFIRST_ANGLE_PATH` | macOS only: directory containing `libEGL.dylib` / `libGLESv2.dylib`. Overrides the default search (Homebrew → `@loader_path` → `@executable_path` → `libEGL.dylib` on dyld). Set this when deploying a bundled or custom-signed ANGLE alongside the binary. |
 | `EDGEFIRST_TESTDATA_DIR` | Override testdata location (used by benches and CI) |
 | `RUST_LOG` | Standard `env_logger` filter — `RUST_LOG=edgefirst_image=debug` for backend dispatch + cache stats |

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -501,22 +501,21 @@ impl CPUProcessor {
         let dst_stride = super::tensor_row_stride(dst);
         let luma = luma_mapper(cp.src_full_range);
 
+        // Each macropixel is 2 bytes/px; check the row width for overflow so a
+        // malformed width can't wrap and slip past `guard_plane`.
+        let src_row = src_w.checked_mul(2).ok_or_else(|| {
+            Error::InvalidShape(format!("yuyv→grey src row overflow (w={src_w})"))
+        })?;
         let src_map = src.map()?;
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
         let dst_bytes = dst_map.as_mut_slice();
-        super::guard_plane(
-            src_bytes.len(),
-            src_stride,
-            src_h,
-            src_w * 2,
-            "yuyv→grey src",
-        )?;
+        super::guard_plane(src_bytes.len(), src_stride, src_h, src_row, "yuyv→grey src")?;
         super::guard_plane(dst_bytes.len(), dst_stride, src_h, src_w, "yuyv→grey dst")?;
 
         // YUYV byte order per macropixel: [Y0, U, Y1, V] — luma at even offsets.
         for row in 0..src_h {
-            let s = &src_bytes[row * src_stride..][..src_w * 2];
+            let s = &src_bytes[row * src_stride..][..src_row];
             let d = &mut dst_bytes[row * dst_stride..][..src_w];
             for (x, dx) in d.iter_mut().enumerate() {
                 *dx = luma(s[x * 2]);
@@ -676,22 +675,21 @@ impl CPUProcessor {
         let dst_stride = super::tensor_row_stride(dst);
         let luma = luma_mapper(cp.src_full_range);
 
+        // Each macropixel is 2 bytes/px; check the row width for overflow so a
+        // malformed width can't wrap and slip past `guard_plane`.
+        let src_row = src_w.checked_mul(2).ok_or_else(|| {
+            Error::InvalidShape(format!("vyuy→grey src row overflow (w={src_w})"))
+        })?;
         let src_map = src.map()?;
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
         let dst_bytes = dst_map.as_mut_slice();
-        super::guard_plane(
-            src_bytes.len(),
-            src_stride,
-            src_h,
-            src_w * 2,
-            "vyuy→grey src",
-        )?;
+        super::guard_plane(src_bytes.len(), src_stride, src_h, src_row, "vyuy→grey src")?;
         super::guard_plane(dst_bytes.len(), dst_stride, src_h, src_w, "vyuy→grey dst")?;
 
         // VYUY byte order per macropixel: [V, Y0, U, Y1] — luma at odd offsets.
         for row in 0..src_h {
-            let s = &src_bytes[row * src_stride..][..src_w * 2];
+            let s = &src_bytes[row * src_stride..][..src_row];
             let d = &mut dst_bytes[row * dst_stride..][..src_w];
             for (x, dx) in d.iter_mut().enumerate() {
                 *dx = luma(s[x * 2 + 1]);

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -207,57 +207,14 @@ fn pack_to_planar(
 }
 
 impl CPUProcessor {
-    pub(super) fn convert_nv12_to_rgb(
-        src: &Tensor<u8>,
-        dst: &mut Tensor<u8>,
-        cp: ColorParams,
-    ) -> Result<()> {
-        let src_w = src.width().unwrap();
-        let src_h = src.height().unwrap();
-        if src.is_multiplane() {
-            let y_map = src.map()?;
-            let uv_map = src.chroma().unwrap().map()?;
-            // The chroma plane is a raw tensor (no format), so its
-            // `effective_row_stride()` has no width-based fallback — default to
-            // even(width) so an odd-width odd-stride chroma plane stays aligned.
-            let y_stride = src
-                .effective_row_stride()
-                .unwrap_or(src_w.next_multiple_of(2));
-            let uv_stride = src
-                .chroma()
-                .unwrap()
-                .effective_row_stride()
-                .unwrap_or(src_w.next_multiple_of(2));
-            Self::nv12_to_rgb_kernel(
-                y_map.as_slice(),
-                uv_map.as_slice(),
-                src_w,
-                src_h,
-                y_stride,
-                uv_stride,
-                dst,
-                cp,
-            )
-        } else {
-            // Contiguous NV12: `src_h` luma rows then `ceil(src_h/2)` chroma
-            // rows, every row `stride` bytes (>= even_width for padded buffers).
-            // The chroma plane starts after the luma rows: `stride * src_h`.
-            let map = src.map()?;
-            let stride = src
-                .effective_row_stride()
-                .unwrap_or(src_w.next_multiple_of(2));
-            let (y_plane, uv_plane) = super::split_semi_planar(
-                map.as_slice(),
-                stride,
-                src_h,
-                src.format().expect("semi-planar source has a pixel format"),
-            )?;
-            Self::nv12_to_rgb_kernel(y_plane, uv_plane, src_w, src_h, stride, stride, dst, cp)
-        }
-    }
-
+    /// Shared decode for every semi-planar (NV12/NV16/NV24) → packed
+    /// conversion: wrap the already-resolved planes/strides in a
+    /// `YuvBiPlanarImage` and run the format-specific `yuv` kernel. `decode`
+    /// is a closure that forwards to the right `yuv::yuv_nvXX_to_rgb[a]` with
+    /// the matrix/range bound from `ColorParams`; only the plane geometry
+    /// (resolved by the `convert_nvXX` wrappers) differs between formats.
     #[allow(clippy::too_many_arguments)]
-    fn nv12_to_rgb_kernel(
+    fn semi_planar_decode<F>(
         y_plane: &[u8],
         uv_plane: &[u8],
         width: usize,
@@ -265,8 +222,15 @@ impl CPUProcessor {
         y_stride: usize,
         uv_stride: usize,
         dst: &mut Tensor<u8>,
-        cp: ColorParams,
-    ) -> Result<()> {
+        decode: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(
+            &yuv::YuvBiPlanarImage<u8>,
+            &mut [u8],
+            u32,
+        ) -> std::result::Result<(), yuv::YuvError>,
+    {
         let src = yuv::YuvBiPlanarImage {
             y_plane,
             y_stride: y_stride as u32,
@@ -275,15 +239,74 @@ impl CPUProcessor {
             width: width as u32,
             height: height as u32,
         };
+        let dst_stride = super::tensor_row_stride(dst) as u32;
+        Ok(decode(&src, dst.map()?.as_mut_slice(), dst_stride)?)
+    }
 
-        Ok(yuv::yuv_nv12_to_rgb(
-            &src,
-            dst.map()?.as_mut_slice(),
-            super::tensor_row_stride(dst) as u32,
-            cp.range,
-            cp.matrix,
-            yuv::YuvConversionMode::Balanced,
-        )?)
+    /// Resolve an NV12 (4:2:0) source's planes/strides and decode. The chroma
+    /// plane is half-height with one `(Cb,Cr)` pair per two luma columns ⇒ the
+    /// same row pitch as luma. A true-multiplane source reads the chroma
+    /// plane's own stride (a raw tensor whose `effective_row_stride()` has no
+    /// width fallback — default to even(width)); the contiguous buffer's two
+    /// planes share the one stride.
+    fn convert_nv12<F>(src: &Tensor<u8>, dst: &mut Tensor<u8>, decode: F) -> Result<()>
+    where
+        F: FnOnce(
+            &yuv::YuvBiPlanarImage<u8>,
+            &mut [u8],
+            u32,
+        ) -> std::result::Result<(), yuv::YuvError>,
+    {
+        let src_w = src.width().unwrap();
+        let src_h = src.height().unwrap();
+        let stride = src
+            .effective_row_stride()
+            .unwrap_or(src_w.next_multiple_of(2));
+        if src.is_multiplane() {
+            let y_map = src.map()?;
+            let uv_map = src.chroma().unwrap().map()?;
+            let uv_stride = src
+                .chroma()
+                .unwrap()
+                .effective_row_stride()
+                .unwrap_or(src_w.next_multiple_of(2));
+            Self::semi_planar_decode(
+                y_map.as_slice(),
+                uv_map.as_slice(),
+                src_w,
+                src_h,
+                stride,
+                uv_stride,
+                dst,
+                decode,
+            )
+        } else {
+            let map = src.map()?;
+            let (y_plane, uv_plane) = super::split_semi_planar(
+                map.as_slice(),
+                stride,
+                src_h,
+                src.format().expect("semi-planar source has a pixel format"),
+            )?;
+            Self::semi_planar_decode(y_plane, uv_plane, src_w, src_h, stride, stride, dst, decode)
+        }
+    }
+
+    pub(super) fn convert_nv12_to_rgb(
+        src: &Tensor<u8>,
+        dst: &mut Tensor<u8>,
+        cp: ColorParams,
+    ) -> Result<()> {
+        Self::convert_nv12(src, dst, |img, out, stride| {
+            yuv::yuv_nv12_to_rgb(
+                img,
+                out,
+                stride,
+                cp.range,
+                cp.matrix,
+                yuv::YuvConversionMode::Balanced,
+            )
+        })
     }
 
     // NOTE: The `*_to_rgba` helpers below all accept BGRA destinations.
@@ -294,72 +317,16 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        let src_w = src.width().unwrap();
-        let src_h = src.height().unwrap();
-        if src.is_multiplane() {
-            let y_map = src.map()?;
-            let uv_map = src.chroma().unwrap().map()?;
-            let y_stride = src
-                .effective_row_stride()
-                .unwrap_or(src_w.next_multiple_of(2));
-            let uv_stride = src
-                .chroma()
-                .unwrap()
-                .effective_row_stride()
-                .unwrap_or(src_w.next_multiple_of(2));
-            Self::nv12_to_rgba_kernel(
-                y_map.as_slice(),
-                uv_map.as_slice(),
-                src_w,
-                src_h,
-                y_stride,
-                uv_stride,
-                dst,
-                cp,
-            )
-        } else {
-            let map = src.map()?;
-            let stride = src
-                .effective_row_stride()
-                .unwrap_or(src_w.next_multiple_of(2));
-            let (y_plane, uv_plane) = super::split_semi_planar(
-                map.as_slice(),
+        Self::convert_nv12(src, dst, |img, out, stride| {
+            yuv::yuv_nv12_to_rgba(
+                img,
+                out,
                 stride,
-                src_h,
-                src.format().expect("semi-planar source has a pixel format"),
-            )?;
-            Self::nv12_to_rgba_kernel(y_plane, uv_plane, src_w, src_h, stride, stride, dst, cp)
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn nv12_to_rgba_kernel(
-        y_plane: &[u8],
-        uv_plane: &[u8],
-        width: usize,
-        height: usize,
-        y_stride: usize,
-        uv_stride: usize,
-        dst: &mut Tensor<u8>,
-        cp: ColorParams,
-    ) -> Result<()> {
-        let src = yuv::YuvBiPlanarImage {
-            y_plane,
-            y_stride: y_stride as u32,
-            uv_plane,
-            uv_stride: uv_stride as u32,
-            width: width as u32,
-            height: height as u32,
-        };
-
-        Ok(yuv::yuv_nv12_to_rgba(
-            &src,
-            dst.map()?.as_mut_slice(),
-            super::tensor_row_stride(dst) as u32,
-            cp.range,
-            cp.matrix,
-            yuv::YuvConversionMode::Balanced,
-        )?)
+                cp.range,
+                cp.matrix,
+                yuv::YuvConversionMode::Balanced,
+            )
+        })
     }
 
     pub(super) fn convert_nv12_to_grey(
@@ -1082,73 +1049,64 @@ impl CPUProcessor {
         Ok(())
     }
 
-    pub(super) fn convert_nv16_to_rgb(
-        src: &Tensor<u8>,
-        dst: &mut Tensor<u8>,
-        cp: ColorParams,
-    ) -> Result<()> {
+    /// Resolve an NV16 (4:2:2) source's planes/strides and decode. The UV plane
+    /// is full-height with one `(Cb,Cr)` pair per two luma columns ⇒ `width`
+    /// bytes per chroma row, i.e. the SAME pitch as luma; both planes use the
+    /// buffer's (possibly even-padded) row stride (the logical width would
+    /// corrupt every row past the first for an odd width where stride > width).
+    fn convert_nv16<F>(src: &Tensor<u8>, dst: &mut Tensor<u8>, decode: F) -> Result<()>
+    where
+        F: FnOnce(
+            &yuv::YuvBiPlanarImage<u8>,
+            &mut [u8],
+            u32,
+        ) -> std::result::Result<(), yuv::YuvError>,
+    {
         let src_w = src.width().unwrap();
-        // NV16's UV plane is full-height with one (Cb,Cr) pair per two luma
-        // columns ⇒ `width` bytes per chroma row, i.e. the SAME pitch as luma.
-        // Both planes use the buffer's (possibly even-padded) row stride; using
-        // the logical width here corrupts every row past the first when the
-        // width is odd (stride > width). See the NV24 kernel below.
+        let src_h = src.height().unwrap();
         let stride = src
             .effective_row_stride()
             .unwrap_or(src_w.next_multiple_of(2));
         if src.is_multiplane() {
             let y_map = src.map()?;
             let uv_map = src.chroma().unwrap().map()?;
-            let src_h = src.shape()[0];
-            Self::nv16_to_rgb_kernel(
+            Self::semi_planar_decode(
                 y_map.as_slice(),
                 uv_map.as_slice(),
                 src_w,
                 src_h,
                 stride,
+                stride,
                 dst,
-                cp,
+                decode,
             )
         } else {
             let map = src.map()?;
-            let src_h = src.shape()[0] / 2;
             let (y_plane, uv_plane) = super::split_semi_planar(
                 map.as_slice(),
                 stride,
                 src_h,
                 src.format().expect("semi-planar source has a pixel format"),
             )?;
-            Self::nv16_to_rgb_kernel(y_plane, uv_plane, src_w, src_h, stride, dst, cp)
+            Self::semi_planar_decode(y_plane, uv_plane, src_w, src_h, stride, stride, dst, decode)
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn nv16_to_rgb_kernel(
-        y_plane: &[u8],
-        uv_plane: &[u8],
-        width: usize,
-        height: usize,
-        stride: usize,
+    pub(super) fn convert_nv16_to_rgb(
+        src: &Tensor<u8>,
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        let src = yuv::YuvBiPlanarImage {
-            y_plane,
-            y_stride: stride as u32,
-            uv_plane,
-            uv_stride: stride as u32,
-            width: width as u32,
-            height: height as u32,
-        };
-
-        Ok(yuv::yuv_nv16_to_rgb(
-            &src,
-            dst.map()?.as_mut_slice(),
-            super::tensor_row_stride(dst) as u32,
-            cp.range,
-            cp.matrix,
-            yuv::YuvConversionMode::Balanced,
-        )?)
+        Self::convert_nv16(src, dst, |img, out, stride| {
+            yuv::yuv_nv16_to_rgb(
+                img,
+                out,
+                stride,
+                cp.range,
+                cp.matrix,
+                yuv::YuvConversionMode::Balanced,
+            )
+        })
     }
 
     pub(super) fn convert_nv16_to_rgba(
@@ -1156,134 +1114,80 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
+        Self::convert_nv16(src, dst, |img, out, stride| {
+            yuv::yuv_nv16_to_rgba(
+                img,
+                out,
+                stride,
+                cp.range,
+                cp.matrix,
+                yuv::YuvConversionMode::Balanced,
+            )
+        })
+    }
+
+    /// Resolve an NV24 (4:4:4 semi-planar) source's planes/strides and decode.
+    /// The contiguous layout is `[3H, W]`: the Y plane (H rows) then the
+    /// full-resolution interleaved UV plane (2H rows of W ⇒ `2*W` bytes per
+    /// chroma row), so the UV stride is twice the luma stride. Handles
+    /// true-multiplane (separate Y / CbCr buffers) as well as the contiguous
+    /// buffer so NV24 is not silently mis-sliced when chroma is its own tensor.
+    fn convert_nv24<F>(src: &Tensor<u8>, dst: &mut Tensor<u8>, decode: F) -> Result<()>
+    where
+        F: FnOnce(
+            &yuv::YuvBiPlanarImage<u8>,
+            &mut [u8],
+            u32,
+        ) -> std::result::Result<(), yuv::YuvError>,
+    {
         let src_w = src.width().unwrap();
-        // See `convert_nv16_to_rgb`: both planes share the buffer row stride.
+        let src_h = src.height().unwrap();
         let stride = src
             .effective_row_stride()
             .unwrap_or(src_w.next_multiple_of(2));
+        let uv_stride = stride * 2;
         if src.is_multiplane() {
             let y_map = src.map()?;
             let uv_map = src.chroma().unwrap().map()?;
-            let src_h = src.shape()[0];
-            Self::nv16_to_rgba_kernel(
+            Self::semi_planar_decode(
                 y_map.as_slice(),
                 uv_map.as_slice(),
                 src_w,
                 src_h,
                 stride,
+                uv_stride,
                 dst,
-                cp,
+                decode,
             )
         } else {
             let map = src.map()?;
-            let src_h = src.shape()[0] / 2;
             let (y_plane, uv_plane) = super::split_semi_planar(
                 map.as_slice(),
                 stride,
                 src_h,
                 src.format().expect("semi-planar source has a pixel format"),
             )?;
-            Self::nv16_to_rgba_kernel(y_plane, uv_plane, src_w, src_h, stride, dst, cp)
+            Self::semi_planar_decode(
+                y_plane, uv_plane, src_w, src_h, stride, uv_stride, dst, decode,
+            )
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn nv16_to_rgba_kernel(
-        y_plane: &[u8],
-        uv_plane: &[u8],
-        width: usize,
-        height: usize,
-        stride: usize,
-        dst: &mut Tensor<u8>,
-        cp: ColorParams,
-    ) -> Result<()> {
-        let src = yuv::YuvBiPlanarImage {
-            y_plane,
-            y_stride: stride as u32,
-            uv_plane,
-            uv_stride: stride as u32,
-            width: width as u32,
-            height: height as u32,
-        };
-
-        Ok(yuv::yuv_nv16_to_rgba(
-            &src,
-            dst.map()?.as_mut_slice(),
-            super::tensor_row_stride(dst) as u32,
-            cp.range,
-            cp.matrix,
-            yuv::YuvConversionMode::Balanced,
-        )?)
-    }
-
-    // ── NV24 (4:4:4 semi-planar): full-resolution interleaved Cb/Cr ──
-    // Contiguous layout is `[3H, W]`: Y plane (H rows) then the interleaved UV
-    // plane (2H rows of W ⇒ `2*W` bytes per chroma row). The UV plane stride is
-    // therefore twice the luma stride.
     pub(super) fn convert_nv24_to_rgb(
         src: &Tensor<u8>,
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        let src_w = src.width().unwrap();
-        let stride = src
-            .effective_row_stride()
-            .unwrap_or(src_w.next_multiple_of(2));
-        // Mirror NV16: handle true-multiplane (separate Y / CbCr DMA-BUFs) as
-        // well as the contiguous combined buffer, so NV24 is not silently
-        // mis-sliced when the chroma plane lives in its own tensor.
-        if src.is_multiplane() {
-            let y_map = src.map()?;
-            let uv_map = src.chroma().unwrap().map()?;
-            let src_h = src.shape()[0];
-            Self::nv24_to_rgb_kernel(
-                y_map.as_slice(),
-                uv_map.as_slice(),
-                src_w,
-                src_h,
+        Self::convert_nv24(src, dst, |img, out, stride| {
+            yuv::yuv_nv24_to_rgb(
+                img,
+                out,
                 stride,
-                dst,
-                cp,
+                cp.range,
+                cp.matrix,
+                yuv::YuvConversionMode::Balanced,
             )
-        } else {
-            let src_h = src.shape()[0] / 3;
-            let map = src.map()?;
-            let (y_plane, uv_plane) = super::split_semi_planar(
-                map.as_slice(),
-                stride,
-                src_h,
-                src.format().expect("semi-planar source has a pixel format"),
-            )?;
-            Self::nv24_to_rgb_kernel(y_plane, uv_plane, src_w, src_h, stride, dst, cp)
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn nv24_to_rgb_kernel(
-        y_plane: &[u8],
-        uv_plane: &[u8],
-        width: usize,
-        height: usize,
-        y_stride: usize,
-        dst: &mut Tensor<u8>,
-        cp: ColorParams,
-    ) -> Result<()> {
-        let src = yuv::YuvBiPlanarImage {
-            y_plane,
-            y_stride: y_stride as u32,
-            uv_plane,
-            uv_stride: (y_stride * 2) as u32,
-            width: width as u32,
-            height: height as u32,
-        };
-        Ok(yuv::yuv_nv24_to_rgb(
-            &src,
-            dst.map()?.as_mut_slice(),
-            super::tensor_row_stride(dst) as u32,
-            cp.range,
-            cp.matrix,
-            yuv::YuvConversionMode::Balanced,
-        )?)
+        })
     }
 
     pub(super) fn convert_nv24_to_rgba(
@@ -1291,64 +1195,16 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        let src_w = src.width().unwrap();
-        let stride = src
-            .effective_row_stride()
-            .unwrap_or(src_w.next_multiple_of(2));
-        // Mirror NV16: support true-multiplane (separate Y / CbCr buffers) as
-        // well as the contiguous combined buffer.
-        if src.is_multiplane() {
-            let y_map = src.map()?;
-            let uv_map = src.chroma().unwrap().map()?;
-            let src_h = src.shape()[0];
-            Self::nv24_to_rgba_kernel(
-                y_map.as_slice(),
-                uv_map.as_slice(),
-                src_w,
-                src_h,
+        Self::convert_nv24(src, dst, |img, out, stride| {
+            yuv::yuv_nv24_to_rgba(
+                img,
+                out,
                 stride,
-                dst,
-                cp,
+                cp.range,
+                cp.matrix,
+                yuv::YuvConversionMode::Balanced,
             )
-        } else {
-            let src_h = src.shape()[0] / 3;
-            let map = src.map()?;
-            let (y_plane, uv_plane) = super::split_semi_planar(
-                map.as_slice(),
-                stride,
-                src_h,
-                src.format().expect("semi-planar source has a pixel format"),
-            )?;
-            Self::nv24_to_rgba_kernel(y_plane, uv_plane, src_w, src_h, stride, dst, cp)
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn nv24_to_rgba_kernel(
-        y_plane: &[u8],
-        uv_plane: &[u8],
-        width: usize,
-        height: usize,
-        y_stride: usize,
-        dst: &mut Tensor<u8>,
-        cp: ColorParams,
-    ) -> Result<()> {
-        let src = yuv::YuvBiPlanarImage {
-            y_plane,
-            y_stride: y_stride as u32,
-            uv_plane,
-            uv_stride: (y_stride * 2) as u32,
-            width: width as u32,
-            height: height as u32,
-        };
-        Ok(yuv::yuv_nv24_to_rgba(
-            &src,
-            dst.map()?.as_mut_slice(),
-            super::tensor_row_stride(dst) as u32,
-            cp.range,
-            cp.matrix,
-            yuv::YuvConversionMode::Balanced,
-        )?)
+        })
     }
 
     /// NV24 → GREY: drop chroma, copy the luma plane honouring its row stride.

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -180,8 +180,42 @@ fn pack_to_planar(
     let mut dst_map = dst.map()?;
     let dst_bytes = dst_map.as_mut_slice();
 
+    // Validate the mapped buffers against the derived geometry before indexing,
+    // so a malformed/untrusted tensor yields `InvalidShape` instead of a panic
+    // (mirrors `planar_to_packed` / `split_semi_planar`).
+    let src_row = w.checked_mul(src_ch).ok_or_else(|| {
+        Error::InvalidShape(format!(
+            "pack_to_planar src row overflow (w={w}, ch={src_ch})"
+        ))
+    })?;
     // Each destination plane is `h` rows of `dst_stride` bytes (the row pitch).
-    let plane = dst_stride * h;
+    let plane = dst_stride.checked_mul(h).ok_or_else(|| {
+        Error::InvalidShape(format!(
+            "pack_to_planar plane size overflow (stride={dst_stride}, h={h})"
+        ))
+    })?;
+    let src_need = src_stride.checked_mul(h).ok_or_else(|| {
+        Error::InvalidShape(format!(
+            "pack_to_planar src size overflow (stride={src_stride}, h={h})"
+        ))
+    })?;
+    let dst_need = plane.checked_mul(plane_src.len()).ok_or_else(|| {
+        Error::InvalidShape(format!(
+            "pack_to_planar dst size overflow (plane={plane}, planes={})",
+            plane_src.len()
+        ))
+    })?;
+    if src_row > src_stride || src_bytes.len() < src_need || dst_bytes.len() < dst_need {
+        return Err(Error::InvalidShape(format!(
+            "pack_to_planar geometry exceeds buffers: src {} (need {src_need}), dst {} (need \
+             {dst_need}), row {src_row} vs stride {src_stride} (w={w}, h={h}, src_ch={src_ch})",
+            src_bytes.len(),
+            dst_bytes.len()
+        )));
+    }
+    if plane == 0 {
+        return Ok(()); // zero-height / empty image: nothing to scatter
+    }
     let plane_slices: Vec<&mut [u8]> = dst_bytes.chunks_mut(plane).take(plane_src.len()).collect();
     rayon::scope(|sc| {
         for (pb, &chan) in plane_slices.into_iter().zip(plane_src.iter()) {
@@ -350,6 +384,8 @@ impl CPUProcessor {
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
         let dst_bytes = dst_map.as_mut_slice();
+        super::guard_plane(src_bytes.len(), src_stride, src_h, src_w, "nv12→grey src")?;
+        super::guard_plane(dst_bytes.len(), dst_stride, src_h, src_w, "nv12→grey dst")?;
 
         for row in 0..src_h {
             let s = &src_bytes[row * src_stride..][..src_w];
@@ -469,6 +505,14 @@ impl CPUProcessor {
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
         let dst_bytes = dst_map.as_mut_slice();
+        super::guard_plane(
+            src_bytes.len(),
+            src_stride,
+            src_h,
+            src_w * 2,
+            "yuyv→grey src",
+        )?;
+        super::guard_plane(dst_bytes.len(), dst_stride, src_h, src_w, "yuyv→grey dst")?;
 
         // YUYV byte order per macropixel: [Y0, U, Y1, V] — luma at even offsets.
         for row in 0..src_h {
@@ -495,8 +539,14 @@ impl CPUProcessor {
         let src_map = src.map()?;
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
-        // Split at the stride-aligned luma plane boundary, not the tight one.
-        let (y_plane, uv_plane) = dst_map.split_at_mut(dst_stride * dst_h);
+        // Split at the stride-aligned luma plane boundary, not the tight one,
+        // validating the destination holds the full combined plane first.
+        let (y_plane, uv_plane) = super::split_semi_planar_mut(
+            dst_map.as_mut_slice(),
+            dst_stride,
+            dst_h,
+            edgefirst_tensor::PixelFormat::Nv16,
+        )?;
 
         // YUYV byte order per two-pixel macropixel: [Y0, Cb, Y1, Cr].
         // The NV16 chroma row is `even(dst_w)` bytes wide (one (Cb,Cr) pair per
@@ -630,6 +680,14 @@ impl CPUProcessor {
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
         let dst_bytes = dst_map.as_mut_slice();
+        super::guard_plane(
+            src_bytes.len(),
+            src_stride,
+            src_h,
+            src_w * 2,
+            "vyuy→grey src",
+        )?;
+        super::guard_plane(dst_bytes.len(), dst_stride, src_h, src_w, "vyuy→grey dst")?;
 
         // VYUY byte order per macropixel: [V, Y0, U, Y1] — luma at odd offsets.
         for row in 0..src_h {
@@ -656,8 +714,14 @@ impl CPUProcessor {
         let src_map = src.map()?;
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
-        // Split at the stride-aligned luma plane boundary, not the tight one.
-        let (y_plane, uv_plane) = dst_map.split_at_mut(dst_stride * dst_h);
+        // Split at the stride-aligned luma plane boundary, not the tight one,
+        // validating the destination holds the full combined plane first.
+        let (y_plane, uv_plane) = super::split_semi_planar_mut(
+            dst_map.as_mut_slice(),
+            dst_stride,
+            dst_h,
+            edgefirst_tensor::PixelFormat::Nv16,
+        )?;
 
         // VYUY byte order per two-pixel macropixel: [V, Y0, U, Y1]. The NV16
         // chroma row is `even(dst_w)` bytes wide, so slice UV to the even width.
@@ -777,8 +841,14 @@ impl CPUProcessor {
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
         let dst_bytes = dst_map.as_mut_slice();
-        // NV16 luma plane: dst_h rows, then UV plane: another dst_h rows.
-        let (y_plane, uv_plane) = dst_bytes.split_at_mut(dst_stride * src_h);
+        // NV16 luma plane: src_h rows, then UV plane: another src_h rows.
+        // Validate the destination holds the full combined plane before splitting.
+        let (y_plane, uv_plane) = super::split_semi_planar_mut(
+            dst_bytes,
+            dst_stride,
+            src_h,
+            edgefirst_tensor::PixelFormat::Nv16,
+        )?;
 
         for row in 0..src_h {
             // Copy luma row, respecting source and destination strides.
@@ -894,8 +964,14 @@ impl CPUProcessor {
         let dst_stride = super::tensor_row_stride(dst);
         let mut dst_map = dst.map()?;
 
-        // Split at the stride-aligned luma plane boundary, not the tight one.
-        let (y_plane, uv_plane) = dst_map.split_at_mut(dst_stride * dst_h);
+        // Split at the stride-aligned luma plane boundary, not the tight one,
+        // validating the destination holds the full combined plane first.
+        let (y_plane, uv_plane) = super::split_semi_planar_mut(
+            dst_map.as_mut_slice(),
+            dst_stride,
+            dst_h,
+            edgefirst_tensor::PixelFormat::Nv16,
+        )?;
         let mut bi_planar_image = yuv::YuvBiPlanarImageMut::<u8> {
             y_plane: yuv::BufferStoreMut::Borrowed(y_plane),
             y_stride: dst_stride as u32,
@@ -1013,8 +1089,14 @@ impl CPUProcessor {
         let dst_stride = super::tensor_row_stride(dst);
         let mut dst_map = dst.map()?;
 
-        // Split at the stride-aligned luma plane boundary, not the tight one.
-        let (y_plane, uv_plane) = dst_map.split_at_mut(dst_stride * dst_h);
+        // Split at the stride-aligned luma plane boundary, not the tight one,
+        // validating the destination holds the full combined plane first.
+        let (y_plane, uv_plane) = super::split_semi_planar_mut(
+            dst_map.as_mut_slice(),
+            dst_stride,
+            dst_h,
+            edgefirst_tensor::PixelFormat::Nv16,
+        )?;
         let mut bi_planar_image = yuv::YuvBiPlanarImageMut::<u8> {
             y_plane: yuv::BufferStoreMut::Borrowed(y_plane),
             y_stride: dst_stride as u32,
@@ -1035,7 +1117,19 @@ impl CPUProcessor {
     }
 
     pub(super) fn copy_image(src: &Tensor<u8>, dst: &mut Tensor<u8>) -> Result<()> {
-        dst.map()?.copy_from_slice(&src.map()?);
+        let src_map = src.map()?;
+        let mut dst_map = dst.map()?;
+        let (s, d) = (src_map.as_slice(), dst_map.as_mut_slice());
+        // Guard the length before `copy_from_slice` (which panics on mismatch),
+        // for parity with `prepare_dst_base_cpu`.
+        if s.len() != d.len() {
+            return Err(Error::InvalidShape(format!(
+                "copy_image source/destination size mismatch: {} vs {} bytes",
+                s.len(),
+                d.len()
+            )));
+        }
+        d.copy_from_slice(s);
         Ok(())
     }
 
@@ -1234,6 +1328,8 @@ impl CPUProcessor {
         let src_bytes = src_map.as_slice();
         let mut dst_map = dst.map()?;
         let dst_bytes = dst_map.as_mut_slice();
+        super::guard_plane(src_bytes.len(), src_stride, src_h, src_w, "nv24→grey src")?;
+        super::guard_plane(dst_bytes.len(), dst_stride, src_h, src_w, "nv24→grey dst")?;
         for row in 0..src_h {
             let s = &src_bytes[row * src_stride..][..src_w];
             let d = &mut dst_bytes[row * dst_stride..][..src_w];

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -481,10 +481,15 @@ impl CPUProcessor {
                 let src_slice = m.as_slice();
                 let transposed_storage =
                     if proto_data.layout == edgefirst_decoder::ProtoLayout::Nchw {
-                        let hw = proto_h * proto_w;
-                        // Guard the proto buffer length before the per-plane
-                        // slice so an undersized (e.g. imported `from_fd`) proto
-                        // tensor yields `InvalidShape` instead of a panic/SIGBUS.
+                        // Guard the proto geometry before the per-plane slice so
+                        // an undersized or overflowing (e.g. imported `from_fd`)
+                        // proto tensor yields `InvalidShape` instead of a wrapped
+                        // `hw` slipping past the bounds check (panic/SIGBUS).
+                        let hw = proto_h.checked_mul(proto_w).ok_or_else(|| {
+                            crate::Error::InvalidShape(format!(
+                                "proto plane size overflow (proto_h={proto_h}, proto_w={proto_w})"
+                            ))
+                        })?;
                         let need = hw.checked_mul(num_protos).ok_or_else(|| {
                             crate::Error::InvalidShape(format!(
                                 "proto NCHW size overflow (hw={hw}, n={num_protos})"
@@ -865,10 +870,15 @@ impl CPUProcessor {
                 let src_slice = m.as_slice();
                 let transposed_storage =
                     if proto_data.layout == edgefirst_decoder::ProtoLayout::Nchw {
-                        let hw = proto_h * proto_w;
-                        // Guard the proto buffer length before the per-plane
-                        // slice so an undersized (e.g. imported `from_fd`) proto
-                        // tensor yields `InvalidShape` instead of a panic/SIGBUS.
+                        // Guard the proto geometry before the per-plane slice so
+                        // an undersized or overflowing (e.g. imported `from_fd`)
+                        // proto tensor yields `InvalidShape` instead of a wrapped
+                        // `hw` slipping past the bounds check (panic/SIGBUS).
+                        let hw = proto_h.checked_mul(proto_w).ok_or_else(|| {
+                            crate::Error::InvalidShape(format!(
+                                "proto plane size overflow (proto_h={proto_h}, proto_w={proto_w})"
+                            ))
+                        })?;
                         let need = hw.checked_mul(num_protos).ok_or_else(|| {
                             crate::Error::InvalidShape(format!(
                                 "proto NCHW size overflow (hw={hw}, n={num_protos})"

--- a/crates/image/src/cpu/masks.rs
+++ b/crates/image/src/cpu/masks.rs
@@ -482,7 +482,22 @@ impl CPUProcessor {
                 let transposed_storage =
                     if proto_data.layout == edgefirst_decoder::ProtoLayout::Nchw {
                         let hw = proto_h * proto_w;
-                        let mut nhwc = vec![0i8; hw * num_protos];
+                        // Guard the proto buffer length before the per-plane
+                        // slice so an undersized (e.g. imported `from_fd`) proto
+                        // tensor yields `InvalidShape` instead of a panic/SIGBUS.
+                        let need = hw.checked_mul(num_protos).ok_or_else(|| {
+                            crate::Error::InvalidShape(format!(
+                                "proto NCHW size overflow (hw={hw}, n={num_protos})"
+                            ))
+                        })?;
+                        if src_slice.len() < need {
+                            return Err(crate::Error::InvalidShape(format!(
+                                "proto buffer {} bytes < {need} (proto_h={proto_h}, \
+                                 proto_w={proto_w}, num_protos={num_protos})",
+                                src_slice.len()
+                            )));
+                        }
+                        let mut nhwc = vec![0i8; need];
                         for c in 0..num_protos {
                             let plane = &src_slice[c * hw..(c + 1) * hw];
                             for px in 0..hw {
@@ -851,7 +866,22 @@ impl CPUProcessor {
                 let transposed_storage =
                     if proto_data.layout == edgefirst_decoder::ProtoLayout::Nchw {
                         let hw = proto_h * proto_w;
-                        let mut nhwc = vec![0i8; hw * num_protos];
+                        // Guard the proto buffer length before the per-plane
+                        // slice so an undersized (e.g. imported `from_fd`) proto
+                        // tensor yields `InvalidShape` instead of a panic/SIGBUS.
+                        let need = hw.checked_mul(num_protos).ok_or_else(|| {
+                            crate::Error::InvalidShape(format!(
+                                "proto NCHW size overflow (hw={hw}, n={num_protos})"
+                            ))
+                        })?;
+                        if src_slice.len() < need {
+                            return Err(crate::Error::InvalidShape(format!(
+                                "proto buffer {} bytes < {need} (proto_h={proto_h}, \
+                                 proto_w={proto_w}, num_protos={num_protos})",
+                                src_slice.len()
+                            )));
+                        }
+                        let mut nhwc = vec![0i8; need];
                         for c in 0..num_protos {
                             let plane = &src_slice[c * hw..(c + 1) * hw];
                             for px in 0..hw {

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -185,6 +185,58 @@ fn split_semi_planar(
     Ok(bytes.split_at(stride * src_h))
 }
 
+/// Mutable mirror of [`split_semi_planar`]: split a contiguous semi-planar
+/// destination's mapped bytes into `(luma, chroma)` planes at the
+/// `stride * dst_h` boundary, validating the map holds the full combined plane
+/// first. A bare `split_at_mut` would panic if a caller-supplied (untrusted)
+/// destination's declared dimensions/stride exceed its actual buffer, so this
+/// returns `Error::InvalidShape` instead.
+fn split_semi_planar_mut(
+    bytes: &mut [u8],
+    stride: usize,
+    dst_h: usize,
+    fmt: PixelFormat,
+) -> Result<(&mut [u8], &mut [u8])> {
+    let total_h = fmt.combined_plane_height(dst_h).unwrap_or(dst_h);
+    let need = stride.checked_mul(total_h).ok_or_else(|| {
+        Error::InvalidShape(format!(
+            "{fmt:?} plane size overflow (stride={stride}, h={dst_h})"
+        ))
+    })?;
+    if bytes.len() < need {
+        return Err(Error::InvalidShape(format!(
+            "{fmt:?} destination has {} bytes but needs {need} (stride={stride}, h={dst_h})",
+            bytes.len()
+        )));
+    }
+    Ok(bytes.split_at_mut(stride * dst_h))
+}
+
+/// Validate that a mapped plane buffer of `buf_len` bytes can hold `rows` rows
+/// of `stride` bytes each, with `row_bytes` valid bytes per row. Returns
+/// `Error::InvalidShape` (instead of letting a later row slice panic) when a
+/// caller-supplied stride/shape exceeds the actual allocation. `what` labels the
+/// buffer in the error message.
+fn guard_plane(
+    buf_len: usize,
+    stride: usize,
+    rows: usize,
+    row_bytes: usize,
+    what: &str,
+) -> Result<()> {
+    let need = stride.checked_mul(rows).ok_or_else(|| {
+        Error::InvalidShape(format!(
+            "{what} plane size overflow (stride={stride}, rows={rows})"
+        ))
+    })?;
+    if row_bytes > stride || buf_len < need {
+        return Err(Error::InvalidShape(format!(
+            "{what} buffer too small: {buf_len} bytes, need {need} (stride={stride}, rows={rows}, row_bytes={row_bytes})"
+        )));
+    }
+    Ok(())
+}
+
 /// Apply XOR 0x80 bias to color channels only, preserving alpha.
 ///
 /// Matches GL int8 shader behavior: `vec4(int8_bias(c.rgb), c.a)`.

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -200,12 +200,12 @@ fn split_semi_planar_mut(
     let total_h = fmt.combined_plane_height(dst_h).unwrap_or(dst_h);
     let need = stride.checked_mul(total_h).ok_or_else(|| {
         Error::InvalidShape(format!(
-            "{fmt:?} plane size overflow (stride={stride}, h={dst_h})"
+            "{fmt:?} plane size overflow (stride={stride}, combined_h={total_h})"
         ))
     })?;
     if bytes.len() < need {
         return Err(Error::InvalidShape(format!(
-            "{fmt:?} destination has {} bytes but needs {need} (stride={stride}, h={dst_h})",
+            "{fmt:?} destination has {} bytes but needs {need} (stride={stride}, combined_h={total_h})",
             bytes.len()
         )));
     }

--- a/crates/image/src/cpu/resize.rs
+++ b/crates/image/src/cpu/resize.rs
@@ -417,7 +417,20 @@ impl CPUProcessor {
         uv: [u8; 2],
         mut crop: Rect,
     ) -> Result<()> {
-        let (y_plane, uv_plane) = dst.split_at_mut(dst_width * dst_height);
+        // Validate the buffer holds the luma plane before splitting so a
+        // caller-supplied (untrusted) dst cannot panic the `split_at_mut`.
+        let luma = dst_width.checked_mul(dst_height).ok_or_else(|| {
+            Error::InvalidShape(format!(
+                "semiplanar fill luma size overflow (w={dst_width}, h={dst_height})"
+            ))
+        })?;
+        if dst.len() < luma {
+            return Err(Error::InvalidShape(format!(
+                "semiplanar fill dst {} bytes < luma plane {luma} (w={dst_width}, h={dst_height})",
+                dst.len()
+            )));
+        }
+        let (y_plane, uv_plane) = dst.split_at_mut(luma);
         Self::fill_image_outside_crop_::<1>((y_plane, dst_width, dst_height), [y], crop)?;
         crop.left /= 2;
         crop.width /= 2;

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -12,6 +12,46 @@ mod cpu_tests {
         DType, PixelFormat, Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait,
     };
 
+    /// The buffer-geometry guards reject undersized/overflowing inputs with
+    /// `InvalidShape` instead of panicking. Exercised directly on plain slices
+    /// (the end-to-end malformed-tensor path needs an undersized `from_fd`/DMA
+    /// buffer, which is Linux+DMA-gated).
+    #[test]
+    fn buffer_geometry_guards_reject_bad_input() {
+        use super::super::{guard_plane, split_semi_planar_mut};
+
+        // NV16 combined-plane height = 2*h ⇒ stride 4 × h 2 needs 16 bytes.
+        let mut ok = [0u8; 16];
+        let (y, uv) = split_semi_planar_mut(&mut ok, 4, 2, PixelFormat::Nv16).unwrap();
+        assert_eq!((y.len(), uv.len()), (8, 8)); // luma split at stride*h = 8
+
+        let mut small = [0u8; 12];
+        assert!(matches!(
+            split_semi_planar_mut(&mut small, 4, 2, PixelFormat::Nv16),
+            Err(Error::InvalidShape(_))
+        ));
+        let mut tiny = [0u8; 1];
+        assert!(matches!(
+            split_semi_planar_mut(&mut tiny, usize::MAX, 4, PixelFormat::Nv16),
+            Err(Error::InvalidShape(_))
+        ));
+
+        // guard_plane: ok, row_bytes>stride, buffer too small, overflow.
+        assert!(guard_plane(16, 4, 2, 4, "t").is_ok());
+        assert!(matches!(
+            guard_plane(16, 4, 2, 5, "t"),
+            Err(Error::InvalidShape(_))
+        ));
+        assert!(matches!(
+            guard_plane(7, 4, 2, 4, "t"),
+            Err(Error::InvalidShape(_))
+        ));
+        assert!(matches!(
+            guard_plane(1, usize::MAX, 4, 1, "t"),
+            Err(Error::InvalidShape(_))
+        ));
+    }
+
     macro_rules! function {
         () => {{
             fn f() {}

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -970,7 +970,15 @@ mod g2d_tests {
     ) -> Result<TensorDyn, crate::Error> {
         let img = TensorDyn::image(width, height, format, DType::U8, memory)?;
         let mut map = img.as_u8().unwrap().map()?;
-        map.as_mut_slice()[..bytes.len()].copy_from_slice(bytes);
+        let dst = map.as_mut_slice();
+        if bytes.len() > dst.len() {
+            return Err(crate::Error::InvalidShape(format!(
+                "load_raw_image: {} input bytes exceed {}-byte image buffer",
+                bytes.len(),
+                dst.len()
+            )));
+        }
+        dst[..bytes.len()].copy_from_slice(bytes);
         Ok(img)
     }
 

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -1996,9 +1996,9 @@ class ImageProcessor:
         """Create an image tensor with the processor's optimal memory backend.
 
         Selects the best available backing storage based on hardware capabilities:
-        DMA-buf > PBO (GPU buffer, byte-sized types: uint8, int8) > system memory.
-        Images created this way benefit from zero-copy GPU paths when used with
-        this processor's ``convert()``.
+        DMA-buf > PBO (GPU buffer) > system memory. Images created this way
+        benefit from zero-copy GPU paths when used with this processor's
+        ``convert()``.
 
         Args:
             width: Image width in pixels.
@@ -2008,9 +2008,11 @@ class ImageProcessor:
                 Supported values: ``"uint8"``, ``"int8"``, ``"uint16"``,
                 ``"int16"``, ``"uint32"``, ``"int32"``, ``"uint64"``,
                 ``"int64"``, ``"float16"``, ``"float32"``, ``"float64"``.
-                PBO is only available for byte-sized types (``"uint8"``,
-                ``"int8"``); other types still prefer DMA-buf when available
-                and otherwise use system memory.
+                PBO backing covers ``"uint8"``/``"int8"`` and, on GL backends
+                advertising float-texture support, ``"float16"`` and
+                ``"float32"`` (for GPU float model-input paths); other types
+                still prefer DMA-buf when available and otherwise use system
+                memory.
 
         Returns:
             A new image ``Tensor`` backed by the optimal memory type.

--- a/crates/python/src/colorimetry.rs
+++ b/crates/python/src/colorimetry.rs
@@ -13,137 +13,61 @@ use pyo3::prelude::*;
 
 // ─── Axis enums ──────────────────────────────────────────────────────────────
 
-/// Color primaries (`color_space` in the EdgeFirst schema).
-#[pyclass(name = "ColorSpace", eq, eq_int, from_py_object)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PyColorSpace {
-    Bt709,
-    Bt2020,
-    Srgb,
-    Smpte170m,
-}
-
-impl From<PyColorSpace> for ColorSpace {
-    fn from(v: PyColorSpace) -> Self {
-        match v {
-            PyColorSpace::Bt709 => ColorSpace::Bt709,
-            PyColorSpace::Bt2020 => ColorSpace::Bt2020,
-            PyColorSpace::Srgb => ColorSpace::Srgb,
-            PyColorSpace::Smpte170m => ColorSpace::Smpte170m,
+/// Generate a PyO3 mirror of a core `edgefirst_tensor` colorimetry enum plus
+/// the bidirectional conversions. `From<Py> for Rs` is total; `TryFrom<Rs> for
+/// Py` is fallible because the core enums are `#[non_exhaustive]` — a variant
+/// added in a newer core has no Python binding, so it maps to `Err(())` (the
+/// getters surface that as `None` rather than panicking).
+macro_rules! bridge_enum {
+    (
+        $(#[$meta:meta])*
+        $py:ident <=> $rs:ident as $name:literal { $($variant:ident),+ $(,)? }
+    ) => {
+        $(#[$meta])*
+        #[pyclass(name = $name, eq, eq_int, from_py_object)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum $py {
+            $($variant),+
         }
-    }
-}
 
-// Rs→Py is fallible: the Rust enums are `#[non_exhaustive]`, so a variant added
-// in a newer core may have no Python binding. Map it to `Err` and let the
-// getters surface it as `None` (unknown) rather than panicking.
-impl TryFrom<ColorSpace> for PyColorSpace {
-    type Error = ();
-    fn try_from(v: ColorSpace) -> Result<Self, ()> {
-        match v {
-            ColorSpace::Bt709 => Ok(PyColorSpace::Bt709),
-            ColorSpace::Bt2020 => Ok(PyColorSpace::Bt2020),
-            ColorSpace::Srgb => Ok(PyColorSpace::Srgb),
-            ColorSpace::Smpte170m => Ok(PyColorSpace::Smpte170m),
-            _ => Err(()),
+        impl From<$py> for $rs {
+            fn from(v: $py) -> Self {
+                match v {
+                    $($py::$variant => $rs::$variant),+
+                }
+            }
         }
-    }
-}
 
-/// Transfer function (`color_transfer` in the EdgeFirst schema).
-#[pyclass(name = "ColorTransfer", eq, eq_int, from_py_object)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PyColorTransfer {
-    Bt709,
-    Srgb,
-    Pq,
-    Hlg,
-    Linear,
-}
-
-impl From<PyColorTransfer> for ColorTransfer {
-    fn from(v: PyColorTransfer) -> Self {
-        match v {
-            PyColorTransfer::Bt709 => ColorTransfer::Bt709,
-            PyColorTransfer::Srgb => ColorTransfer::Srgb,
-            PyColorTransfer::Pq => ColorTransfer::Pq,
-            PyColorTransfer::Hlg => ColorTransfer::Hlg,
-            PyColorTransfer::Linear => ColorTransfer::Linear,
+        impl TryFrom<$rs> for $py {
+            type Error = ();
+            fn try_from(v: $rs) -> Result<Self, ()> {
+                match v {
+                    $($rs::$variant => Ok($py::$variant),)+
+                    _ => Err(()),
+                }
+            }
         }
-    }
+    };
 }
 
-impl TryFrom<ColorTransfer> for PyColorTransfer {
-    type Error = ();
-    fn try_from(v: ColorTransfer) -> Result<Self, ()> {
-        match v {
-            ColorTransfer::Bt709 => Ok(PyColorTransfer::Bt709),
-            ColorTransfer::Srgb => Ok(PyColorTransfer::Srgb),
-            ColorTransfer::Pq => Ok(PyColorTransfer::Pq),
-            ColorTransfer::Hlg => Ok(PyColorTransfer::Hlg),
-            ColorTransfer::Linear => Ok(PyColorTransfer::Linear),
-            _ => Err(()),
-        }
-    }
+bridge_enum! {
+    /// Color primaries (`color_space` in the EdgeFirst schema).
+    PyColorSpace <=> ColorSpace as "ColorSpace" { Bt709, Bt2020, Srgb, Smpte170m }
 }
 
-/// YCbCr encoding matrix (`color_encoding` in the EdgeFirst schema).
-#[pyclass(name = "ColorEncoding", eq, eq_int, from_py_object)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PyColorEncoding {
-    Bt601,
-    Bt709,
-    Bt2020,
+bridge_enum! {
+    /// Transfer function (`color_transfer` in the EdgeFirst schema).
+    PyColorTransfer <=> ColorTransfer as "ColorTransfer" { Bt709, Srgb, Pq, Hlg, Linear }
 }
 
-impl From<PyColorEncoding> for ColorEncoding {
-    fn from(v: PyColorEncoding) -> Self {
-        match v {
-            PyColorEncoding::Bt601 => ColorEncoding::Bt601,
-            PyColorEncoding::Bt709 => ColorEncoding::Bt709,
-            PyColorEncoding::Bt2020 => ColorEncoding::Bt2020,
-        }
-    }
+bridge_enum! {
+    /// YCbCr encoding matrix (`color_encoding` in the EdgeFirst schema).
+    PyColorEncoding <=> ColorEncoding as "ColorEncoding" { Bt601, Bt709, Bt2020 }
 }
 
-impl TryFrom<ColorEncoding> for PyColorEncoding {
-    type Error = ();
-    fn try_from(v: ColorEncoding) -> Result<Self, ()> {
-        match v {
-            ColorEncoding::Bt601 => Ok(PyColorEncoding::Bt601),
-            ColorEncoding::Bt709 => Ok(PyColorEncoding::Bt709),
-            ColorEncoding::Bt2020 => Ok(PyColorEncoding::Bt2020),
-            _ => Err(()),
-        }
-    }
-}
-
-/// Quantization range (`color_range` in the EdgeFirst schema).
-#[pyclass(name = "ColorRange", eq, eq_int, from_py_object)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PyColorRange {
-    Full,
-    Limited,
-}
-
-impl From<PyColorRange> for ColorRange {
-    fn from(v: PyColorRange) -> Self {
-        match v {
-            PyColorRange::Full => ColorRange::Full,
-            PyColorRange::Limited => ColorRange::Limited,
-        }
-    }
-}
-
-impl TryFrom<ColorRange> for PyColorRange {
-    type Error = ();
-    fn try_from(v: ColorRange) -> Result<Self, ()> {
-        match v {
-            ColorRange::Full => Ok(PyColorRange::Full),
-            ColorRange::Limited => Ok(PyColorRange::Limited),
-            _ => Err(()),
-        }
-    }
+bridge_enum! {
+    /// Quantization range (`color_range` in the EdgeFirst schema).
+    PyColorRange <=> ColorRange as "ColorRange" { Full, Limited }
 }
 
 // ─── Colorimetry ─────────────────────────────────────────────────────────────

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -102,7 +102,7 @@ The CUDA zero-copy surface (`cuda_map()`, `is_cuda_available()`, `CudaMap`,
 | Mock `CudaGlOps` — map/unmap/unregister call sequence | `crates/tensor/src/cuda.rs` `#[cfg(test)]` | `CudaMap` construction calls `map`; `Drop` calls `unmap`; handle drop calls `unregister` in the correct order (before PBO storage drops) |
 | `Debug` impl on `CudaMap` / `CudaHandle` | Same | No panics, no format-string UB |
 | Primitive degradation — absent `libcudart` | Same | `is_cuda_available()` returns `false`; `cuda_map()` returns `None`; no crash |
-| ABI layout asserts | `crates/tensor/src/cuda_abi.rs` | `sizeof` / `alignof` of HAL's CUDA type wrappers match CUDA 12.6 `driver_types.h` — verified as static compile-time assertions |
+| ABI layout asserts | `crates/tensor/src/cuda.rs` (`mod ext_mem_layout`) | `sizeof` / `alignof` of HAL's CUDA type wrappers match CUDA 12.6 `driver_types.h` — verified as static compile-time assertions |
 
 Run all CUDA tests on the host (no hardware required):
 

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -1101,49 +1101,35 @@ where
                 {
                     MemTensor::<T>::new(shape, name).map(TensorStorage::Mem)
                 } else {
+                    // Auto-select priority: Dma > Mem. Shm is intentionally NOT
+                    // auto-selected — it offers no advantage over Mem for an
+                    // in-process tensor and Mem always succeeds, so Shm below Mem
+                    // is effectively never reached. Request Shm explicitly via
+                    // `TensorMemory::Shm` when cross-process sharing is needed.
+                    // (PBO sits between Dma and Mem but is GL-backed and created
+                    // only via `ImageProcessor::create_image`.)
                     #[cfg(target_os = "linux")]
                     {
-                        // Linux: Try DMA -> SHM -> Mem
+                        // Linux: Try DMA -> Mem
                         match DmaTensor::<T>::new(shape, name) {
                             Ok(tensor) => Ok(TensorStorage::Dma(tensor)),
-                            Err(_) => {
-                                match ShmTensor::<T>::new(shape, name)
-                                    .map(TensorStorage::Shm)
-                                {
-                                    Ok(tensor) => Ok(tensor),
-                                    Err(_) => MemTensor::<T>::new(shape, name)
-                                        .map(TensorStorage::Mem),
-                                }
-                            }
+                            Err(_) => MemTensor::<T>::new(shape, name).map(TensorStorage::Mem),
                         }
                     }
                     #[cfg(target_os = "macos")]
                     {
-                        // macOS: Try IOSurface -> SHM -> Mem. IOSurface
-                        // is the GPU-shareable backend (zero-copy via
-                        // ANGLE), filling the same role as DMA-BUF on
-                        // Linux. Falls back to SHM if IOSurface alloc
-                        // fails (memory pressure or sandboxed contexts).
+                        // macOS: Try IOSurface -> Mem. IOSurface is the
+                        // GPU-shareable backend (zero-copy via ANGLE), filling the
+                        // same role as DMA-BUF on Linux.
                         match IoSurfaceTensor::<T>::new(shape, name) {
                             Ok(tensor) => Ok(TensorStorage::Dma(tensor)),
-                            Err(_) => match ShmTensor::<T>::new(shape, name)
-                                .map(TensorStorage::Shm)
-                            {
-                                Ok(tensor) => Ok(tensor),
-                                Err(_) => MemTensor::<T>::new(shape, name)
-                                    .map(TensorStorage::Mem),
-                            },
+                            Err(_) => MemTensor::<T>::new(shape, name).map(TensorStorage::Mem),
                         }
                     }
                     #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
                     {
-                        // Other Unix (BSD): Try SHM -> Mem (no DMA)
-                        match ShmTensor::<T>::new(shape, name) {
-                            Ok(tensor) => Ok(TensorStorage::Shm(tensor)),
-                            Err(_) => {
-                                MemTensor::<T>::new(shape, name).map(TensorStorage::Mem)
-                            }
-                        }
+                        // Other Unix (BSD): Mem only (no DMA; Shm is explicit-only)
+                        MemTensor::<T>::new(shape, name).map(TensorStorage::Mem)
                     }
                     #[cfg(not(unix))]
                     {
@@ -1731,36 +1717,16 @@ where
                 };
             }
             None => {
-                // Auto-select: DMA → Shm → Mem on Linux; Shm → Mem on macOS.
-                // DMA gets the 64-aligned pitch; host fallbacks keep the tight
-                // (host) pitch, so the recorded stride matches the storage used.
+                // Auto-select priority: DMA → Mem (DMA gets the 64-aligned
+                // pitch; the Mem fallback keeps the tight host pitch, so the
+                // recorded stride matches the storage used). Shm is NOT
+                // auto-selected — it offers no advantage over Mem for an
+                // in-process image and Mem always succeeds, so it sits below Mem
+                // and is reached only via an explicit `TensorMemory::Shm`.
                 #[cfg(target_os = "linux")]
                 {
                     match TensorStorage::<T>::new_dma_with_byte_size(&shape, dma_byte_size, None) {
                         Ok(s) => (s, aligned_stride),
-                        Err(_) => {
-                            match TensorStorage::<T>::new_shm_with_byte_size(
-                                &shape,
-                                host_byte_size,
-                                None,
-                            ) {
-                                Ok(s) => (s, host_stride),
-                                Err(_) => (
-                                    TensorStorage::<T>::new_mem_with_byte_size(
-                                        &shape,
-                                        host_byte_size,
-                                        None,
-                                    )?,
-                                    host_stride,
-                                ),
-                            }
-                        }
-                    }
-                }
-                #[cfg(all(unix, not(target_os = "linux")))]
-                {
-                    match TensorStorage::<T>::new_shm_with_byte_size(&shape, host_byte_size, None) {
-                        Ok(s) => (s, host_stride),
                         Err(_) => (
                             TensorStorage::<T>::new_mem_with_byte_size(
                                 &shape,
@@ -1771,7 +1737,7 @@ where
                         ),
                     }
                 }
-                #[cfg(not(unix))]
+                #[cfg(not(target_os = "linux"))]
                 {
                     (
                         TensorStorage::<T>::new_mem_with_byte_size(&shape, host_byte_size, None)?,
@@ -2452,9 +2418,19 @@ where
                 // DMA-BUF are cached per (identity, offset) in the GL backend.
                 Tensor::wrap(TensorStorage::Dma(parent.view(offset_bytes, shape)?))
             }
+            #[cfg(unix)]
+            TensorStorage::Shm(parent) => {
+                // Shares the parent's segment via a cloned fd (the SHM sharing
+                // model) and its BufferIdentity, distinguished by offset.
+                Tensor::wrap(TensorStorage::Shm(ShmTensor::view(
+                    parent,
+                    offset_bytes,
+                    shape,
+                )?))
+            }
             _ => {
                 return Err(Error::InvalidOperation(
-                    "subview only supported for Mem and Dma tensors".into(),
+                    "subview only supported for Mem, Dma, and Shm tensors".into(),
                 ))
             }
         };
@@ -2832,16 +2808,19 @@ where
             }
         }
         // Offset tensors are supported for storages that apply the offset
-        // inside their own `map()`: DMA (`DmaMap` adjusts the mmap range) and
-        // Mem (`MemMap` adjusts the slice base). Other backings have no
-        // sub-region concept, so a non-zero offset is rejected.
+        // inside their own `map()`: DMA (`DmaMap` adjusts the mmap range), Mem
+        // (`MemMap` adjusts the slice base), and Shm (`ShmMap` adjusts the slice
+        // base). Other backings have no sub-region concept, so a non-zero
+        // offset is rejected.
         if self.plane_offset.is_some_and(|o| o > 0) {
             let supported = matches!(self.storage, TensorStorage::Mem(_));
             #[cfg(target_os = "linux")]
             let supported = supported || matches!(self.storage, TensorStorage::Dma(_));
+            #[cfg(unix)]
+            let supported = supported || matches!(self.storage, TensorStorage::Shm(_));
             if !supported {
                 return Err(Error::InvalidOperation(
-                    "plane offset only supported for DMA and Mem tensors".into(),
+                    "plane offset only supported for DMA, Mem, and Shm tensors".into(),
                 ));
             }
         }
@@ -3538,9 +3517,10 @@ mod tests {
         let dma_enabled = tensor.is_ok();
 
         let tensor = Tensor::<f32>::new(&shape, None, None).expect("Failed to create tensor");
+        // Auto-select priority is Dma > Mem; Shm is never auto-selected.
         match dma_enabled {
             true => assert_eq!(tensor.memory(), TensorMemory::Dma),
-            false => assert_eq!(tensor.memory(), TensorMemory::Shm),
+            false => assert_eq!(tensor.memory(), TensorMemory::Mem),
         }
     }
 
@@ -3549,13 +3529,12 @@ mod tests {
     fn test_tensor() {
         let shape = vec![1];
         let tensor = Tensor::<f32>::new(&shape, None, None).expect("Failed to create tensor");
-        // macOS auto-fallback chain: IOSurface (Dma) → SHM → Mem.
-        // Healthy systems always return Dma; SHM/Mem only appear under
-        // memory pressure or sandboxed contexts where IOSurfaceCreate
-        // fails.
+        // macOS auto-fallback chain: IOSurface (Dma) → Mem. Healthy systems
+        // return Dma; Mem only appears under memory pressure or sandboxed
+        // contexts where IOSurfaceCreate fails. Shm is never auto-selected.
         let m = tensor.memory();
         assert!(
-            matches!(m, TensorMemory::Dma | TensorMemory::Shm | TensorMemory::Mem),
+            matches!(m, TensorMemory::Dma | TensorMemory::Mem),
             "Unexpected auto-fallback result on macOS: {m:?}"
         );
     }
@@ -3565,12 +3544,9 @@ mod tests {
     fn test_tensor() {
         let shape = vec![1];
         let tensor = Tensor::<f32>::new(&shape, None, None).expect("Failed to create tensor");
-        // Other Unix (BSD): auto-detection tries SHM first, falls back to Mem.
-        assert!(
-            tensor.memory() == TensorMemory::Shm || tensor.memory() == TensorMemory::Mem,
-            "Expected SHM or Mem, got {:?}",
-            tensor.memory()
-        );
+        // Other Unix (BSD): no DMA, so auto-selection is Mem (Shm is
+        // explicit-only, never auto-selected).
+        assert_eq!(tensor.memory(), TensorMemory::Mem);
     }
 
     #[test]
@@ -3871,20 +3847,57 @@ mod tests {
     }
 
     #[test]
-    fn subview_rejects_unsupported_storage() {
-        // subview shares either a heap `Arc` (Mem) or a dma-buf fd (Dma); any
-        // other backing (here Shm) must be refused with InvalidOperation rather
-        // than silently mishandled.
+    #[cfg(unix)]
+    fn shm_subview_partitions_parent_buffer() {
+        // Mirrors `mem_subview_partitions_parent_buffer` for Shm: one [2,4] u8
+        // parent shared segment (8 bytes); two [1,4] sub-views at byte offsets 0
+        // and 4 must share the segment (zero-copy, via cloned fd) and be
+        // independently writable — view 0 owns [0,4), view 1 owns [4,8).
         if !crate::is_shm_available() {
             eprintln!("SKIPPED: shm not available");
             return;
         }
-        let shm = Tensor::<u8>::new(&[64], Some(TensorMemory::Shm), None).unwrap();
-        match shm.subview(0, &[4]) {
-            Err(Error::InvalidOperation(_)) => {}
-            Err(other) => panic!("expected InvalidOperation, got {other:?}"),
-            Ok(_) => panic!("subview must reject Shm storage"),
+        let parent = Tensor::<u8>::new(&[2, 4], Some(TensorMemory::Shm), None).unwrap();
+        let view0 = parent.subview(0, &[1, 4]).expect("shm subview at offset 0");
+        let view1 = parent.subview(4, &[1, 4]).expect("shm subview at offset 4");
+
+        view1
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(&[10, 20, 30, 40]);
+        view0
+            .map()
+            .unwrap()
+            .as_mut_slice()
+            .copy_from_slice(&[1, 2, 3, 4]);
+
+        assert_eq!(view0.map().unwrap().as_slice(), &[1, 2, 3, 4]);
+        assert_eq!(view1.map().unwrap().as_slice(), &[10, 20, 30, 40]);
+        // The parent sees the full partitioned segment (shared, zero-copy).
+        assert_eq!(
+            parent.map().unwrap().as_slice(),
+            &[1, 2, 3, 4, 10, 20, 30, 40]
+        );
+        // A sub-view of a sub-view composes the offset.
+        let nested = view1.subview(2, &[1, 2]).expect("nested shm subview");
+        assert_eq!(nested.map().unwrap().as_slice(), &[30, 40]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn shm_subview_rejects_unaligned_and_oob() {
+        if !crate::is_shm_available() {
+            eprintln!("SKIPPED: shm not available");
+            return;
         }
+        // f32 align 4: a 2-byte offset cannot back a valid `*const f32`.
+        let parent = Tensor::<f32>::new(&[8], Some(TensorMemory::Shm), None).unwrap();
+        assert!(parent.subview(2, &[1]).is_err());
+        assert!(parent.subview(4, &[1]).is_ok());
+        // Out of bounds: offset 6 + 4 bytes = 10 > 8-byte (u8) segment.
+        let p2 = Tensor::<u8>::new(&[8], Some(TensorMemory::Shm), None).unwrap();
+        assert!(p2.subview(6, &[4]).is_err());
     }
 
     #[test]

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -330,17 +330,12 @@ impl fmt::Display for DType {
 /// `None` for types that do not have a `DType` representation (e.g.
 /// user-defined wrappers in tests).
 ///
-/// Used by image-tensor constructors that need the runtime dtype to
-/// look up FourCC / pixel-format mappings on the macOS IOSurface path,
-/// where the GPU backend cares about whether the bytes are u8 / f16 /
-/// f32 even though the static `Tensor<T>` carries the same information
-/// at the type level.
-///
-/// macOS-only: the sole caller is the IOSurface DMA branch in
-/// `Tensor::<T>::image()`, which is itself `cfg(target_os = "macos")`.
-/// Leaving this ungated makes it dead code on every other target, which
-/// fails CI under `-D warnings`.
-#[cfg(target_os = "macos")]
+/// Runtime dtype of a static `Tensor<T>` element type — a safe `TypeId`
+/// allowlist of HAL's primitive numeric types (`Some` for `u8`..`i64` /
+/// `f16` / `f32` / `f64`, `None` otherwise). Used by the macOS IOSurface
+/// image constructors (FourCC / pixel-format lookup) and by the `Mem`
+/// backing's `alloc_zeroed` fast path (these types' `T::zero()` is the
+/// all-zeros bit pattern), so it is compiled on every target.
 pub(crate) fn dtype_of<T: 'static>() -> Option<DType> {
     use std::any::TypeId;
     let id = TypeId::of::<T>();
@@ -1189,7 +1184,10 @@ where
         shape: &[usize],
         byte_size: usize,
         name: Option<&str>,
-    ) -> Result<Self> {
+    ) -> Result<Self>
+    where
+        T: 'static,
+    {
         MemTensor::<T>::with_capacity_bytes(shape, byte_size, name).map(TensorStorage::Mem)
     }
 

--- a/crates/tensor/src/mem.rs
+++ b/crates/tensor/src/mem.rs
@@ -62,15 +62,76 @@ impl<T> MemBacking<T> {
     }
 
     /// Build a zeroed backing of `n` elements.
+    ///
+    /// For every numeric type HAL instantiates (`u8`..=`f64`), `T::zero()` is
+    /// the all-zeros bit pattern, so the allocation comes from `alloc_zeroed`
+    /// (calloc): the kernel hands back lazily-zeroed pages instead of eagerly
+    /// writing every element. That matters because this backs every
+    /// `Tensor::image(.., Mem)` and the per-call image intermediates the CPU
+    /// converter allocates — a `(0..n).map(UnsafeCell::new).collect()` forces a
+    /// full eager memset and commits every page up front. The bit pattern is
+    /// checked at runtime, so the fast path is taken only when it is provably
+    /// correct; any exotic `T` whose zero is not all-zeros uses the per-element
+    /// loop.
     fn zeroed(n: usize) -> Self
     where
         T: Num + Clone,
     {
+        if n == 0 {
+            return Self {
+                cells: Vec::new().into_boxed_slice(),
+            };
+        }
+        if zero_is_all_zero_bytes::<T>() {
+            // SAFETY: `T::zero()` is the all-zeros bit pattern (just checked),
+            // so a zero-filled allocation is a valid `[UnsafeCell<T>; n]`, and
+            // `n > 0`.
+            return unsafe { Self::alloc_zeroed_unchecked(n) };
+        }
         let cells: Vec<UnsafeCell<T>> = (0..n).map(|_| UnsafeCell::new(T::zero())).collect();
         Self {
             cells: cells.into_boxed_slice(),
         }
     }
+
+    /// Allocate `n` zeroed `UnsafeCell<T>` via the global allocator's zeroed
+    /// (calloc) path.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `T::zero()` is the all-zeros bit pattern (so a
+    /// zero-filled block is a valid `[UnsafeCell<T>; n]`) and that `n > 0`.
+    unsafe fn alloc_zeroed_unchecked(n: usize) -> Self {
+        use std::alloc::{alloc_zeroed, handle_alloc_error, Layout};
+        // `UnsafeCell<T>` is `#[repr(transparent)]` over `T`, so its layout
+        // equals `T`'s; allocating an array of it round-trips on `Box` drop.
+        let layout = Layout::array::<UnsafeCell<T>>(n).expect("allocation layout overflow");
+        let ptr = alloc_zeroed(layout) as *mut UnsafeCell<T>;
+        if ptr.is_null() {
+            handle_alloc_error(layout);
+        }
+        // SAFETY: `ptr` is a freshly-allocated, suitably-aligned block of `n`
+        // zeroed `UnsafeCell<T>`; the zero pattern is a valid `T::zero()` per
+        // the contract above. `Box::from_raw` over a slice built from the same
+        // `(ptr, n)` and element type deallocates with the matching
+        // `Layout::array::<UnsafeCell<T>>(n)` on drop.
+        let slice = std::slice::from_raw_parts_mut(ptr, n);
+        Self {
+            cells: Box::from_raw(slice),
+        }
+    }
+}
+
+/// True iff `T::zero()` has an all-zeros bit pattern — the case for every
+/// primitive numeric type HAL uses, enabling the `alloc_zeroed` fast path.
+fn zero_is_all_zero_bytes<T: Num>() -> bool {
+    let z = T::zero();
+    // SAFETY: reads the `size_of::<T>()` initialised bytes of a valid `T`
+    // value; the slice does not outlive `z`.
+    let bytes = unsafe {
+        std::slice::from_raw_parts(&z as *const T as *const u8, std::mem::size_of::<T>())
+    };
+    bytes.iter().all(|&b| b == 0)
 }
 
 #[derive(Debug)]
@@ -482,6 +543,39 @@ mod tests {
         assert_eq!(map.as_slice()[1], 99);
         // Remaining elements should still be zero-initialized.
         assert_eq!(map.as_slice()[2], 0);
+    }
+
+    #[test]
+    fn zeroed_backing_reads_all_zero_across_types() {
+        // Every primitive numeric T has an all-zeros bit pattern for T::zero(),
+        // so `zeroed` takes the alloc_zeroed (calloc) fast path. A large
+        // allocation spanning many pages must still read back entirely zero.
+        fn assert_all_zero<T>(n: usize)
+        where
+            T: Num + Clone + fmt::Debug + Send + Sync + Copy + PartialEq,
+        {
+            assert!(
+                zero_is_all_zero_bytes::<T>(),
+                "{} should use the alloc_zeroed fast path",
+                std::any::type_name::<T>()
+            );
+            let t = MemTensor::<T>::new(&[n], Some("z")).unwrap();
+            let map = t.map().unwrap();
+            assert!(
+                map.as_slice().iter().all(|v| *v == T::zero()),
+                "zeroed {} backing not all-zero",
+                std::any::type_name::<T>()
+            );
+        }
+        let n = 200_000; // spans many pages
+        assert_all_zero::<u8>(n);
+        assert_all_zero::<u16>(n);
+        assert_all_zero::<i32>(n);
+        assert_all_zero::<f32>(n);
+        assert_all_zero::<f64>(n);
+        // n == 0 and n == 1 cover the empty-box and single-element edges.
+        assert_all_zero::<u8>(0);
+        assert_all_zero::<f32>(1);
     }
 
     #[test]

--- a/crates/tensor/src/mem.rs
+++ b/crates/tensor/src/mem.rs
@@ -61,37 +61,49 @@ impl<T> MemBacking<T> {
         self.cells.as_ptr() as *mut T
     }
 
-    /// Build a zeroed backing of `n` elements.
-    ///
-    /// For every numeric type HAL instantiates (`u8`..=`f64`), `T::zero()` is
-    /// the all-zeros bit pattern, so the allocation comes from `alloc_zeroed`
-    /// (calloc): the kernel hands back lazily-zeroed pages instead of eagerly
-    /// writing every element. That matters because this backs every
-    /// `Tensor::image(.., Mem)` and the per-call image intermediates the CPU
-    /// converter allocates — a `(0..n).map(UnsafeCell::new).collect()` forces a
-    /// full eager memset and commits every page up front. The bit pattern is
-    /// checked at runtime, so the fast path is taken only when it is provably
-    /// correct; any exotic `T` whose zero is not all-zeros uses the per-element
-    /// loop.
+    /// Build a zeroed backing of `n` elements by writing `T::zero()` into each
+    /// cell. Type-agnostic; used by the `TensorTrait::new` path. The
+    /// image/capacity path uses [`zeroed_fast`](Self::zeroed_fast) for the
+    /// `alloc_zeroed` win.
     fn zeroed(n: usize) -> Self
     where
         T: Num + Clone,
+    {
+        let cells: Vec<UnsafeCell<T>> = (0..n).map(|_| UnsafeCell::new(T::zero())).collect();
+        Self {
+            cells: cells.into_boxed_slice(),
+        }
+    }
+
+    /// Build a zeroed backing of `n` elements, using the allocator's zeroed
+    /// (calloc) path when `T` is one of HAL's primitive numeric element types.
+    ///
+    /// For those types `T::zero()` is the all-zeros bit pattern, so the kernel
+    /// can hand back lazily-zeroed pages instead of eagerly writing every
+    /// element — a `(0..n).map(UnsafeCell::new).collect()` forces a full memset
+    /// and commits every page up front. This backs every `Tensor::image(.., Mem)`
+    /// and the per-call image intermediates the CPU converter allocates. Any
+    /// other `T` falls back to the per-element [`zeroed`](Self::zeroed) loop.
+    ///
+    /// `crate::dtype_of` is the single source for "is `T` a HAL numeric
+    /// primitive" — a safe `TypeId` allowlist, with no inspection of
+    /// (possibly padded/uninitialised) bytes.
+    fn zeroed_fast(n: usize) -> Self
+    where
+        T: Num + Clone + 'static,
     {
         if n == 0 {
             return Self {
                 cells: Vec::new().into_boxed_slice(),
             };
         }
-        if zero_is_all_zero_bytes::<T>() {
-            // SAFETY: `T::zero()` is the all-zeros bit pattern (just checked),
-            // so a zero-filled allocation is a valid `[UnsafeCell<T>; n]`, and
-            // `n > 0`.
+        if crate::dtype_of::<T>().is_some() {
+            // SAFETY: `dtype_of` is `Some` only for HAL's primitive numeric
+            // types, whose `T::zero()` is the all-zeros bit pattern, so a
+            // zero-filled allocation is a valid `[UnsafeCell<T>; n]`; `n > 0`.
             return unsafe { Self::alloc_zeroed_unchecked(n) };
         }
-        let cells: Vec<UnsafeCell<T>> = (0..n).map(|_| UnsafeCell::new(T::zero())).collect();
-        Self {
-            cells: cells.into_boxed_slice(),
-        }
+        Self::zeroed(n)
     }
 
     /// Allocate `n` zeroed `UnsafeCell<T>` via the global allocator's zeroed
@@ -120,18 +132,6 @@ impl<T> MemBacking<T> {
             cells: Box::from_raw(slice),
         }
     }
-}
-
-/// True iff `T::zero()` has an all-zeros bit pattern — the case for every
-/// primitive numeric type HAL uses, enabling the `alloc_zeroed` fast path.
-fn zero_is_all_zero_bytes<T: Num>() -> bool {
-    let z = T::zero();
-    // SAFETY: reads the `size_of::<T>()` initialised bytes of a valid `T`
-    // value; the slice does not outlive `z`.
-    let bytes = unsafe {
-        std::slice::from_raw_parts(&z as *const T as *const u8, std::mem::size_of::<T>())
-    };
-    bytes.iter().all(|&b| b == 0)
 }
 
 #[derive(Debug)]
@@ -173,7 +173,10 @@ where
         shape: &[usize],
         byte_capacity: usize,
         name: Option<&str>,
-    ) -> Result<Self> {
+    ) -> Result<Self>
+    where
+        T: 'static,
+    {
         let elem = std::mem::size_of::<T>();
         let cap_elems = byte_capacity / elem;
         let logical: usize = shape.iter().product();
@@ -186,7 +189,7 @@ where
         Ok(MemTensor {
             name: name.unwrap_or("mem_tensor").to_owned(),
             shape: shape.to_vec(),
-            data: Arc::new(MemBacking::zeroed(cap_elems)),
+            data: Arc::new(MemBacking::zeroed_fast(cap_elems)),
             offset: 0,
             identity: crate::BufferIdentity::new(),
         })
@@ -547,19 +550,21 @@ mod tests {
 
     #[test]
     fn zeroed_backing_reads_all_zero_across_types() {
-        // Every primitive numeric T has an all-zeros bit pattern for T::zero(),
-        // so `zeroed` takes the alloc_zeroed (calloc) fast path. A large
-        // allocation spanning many pages must still read back entirely zero.
+        // Every HAL primitive numeric T is alloc_zeroed-fast-path eligible
+        // (`dtype_of` is `Some`). A large allocation spanning many pages, built
+        // through the capacity path (`with_capacity_bytes` → `zeroed_fast`),
+        // must still read back entirely zero.
         fn assert_all_zero<T>(n: usize)
         where
-            T: Num + Clone + fmt::Debug + Send + Sync + Copy + PartialEq,
+            T: Num + Clone + fmt::Debug + Send + Sync + Copy + PartialEq + 'static,
         {
             assert!(
-                zero_is_all_zero_bytes::<T>(),
-                "{} should use the alloc_zeroed fast path",
+                crate::dtype_of::<T>().is_some(),
+                "{} should be alloc_zeroed fast-path eligible",
                 std::any::type_name::<T>()
             );
-            let t = MemTensor::<T>::new(&[n], Some("z")).unwrap();
+            let bytes = n * std::mem::size_of::<T>();
+            let t = MemTensor::<T>::with_capacity_bytes(&[n], bytes, Some("z")).unwrap();
             let map = t.map().unwrap();
             assert!(
                 map.as_slice().iter().all(|v| *v == T::zero()),

--- a/crates/tensor/src/shm.rs
+++ b/crates/tensor/src/shm.rs
@@ -25,6 +25,11 @@ where
     pub name: String,
     pub fd: OwnedFd,
     pub shape: Vec<usize>,
+    /// Byte offset into the shared segment where this tensor's logical window
+    /// begins. `0` for whole-segment tensors; non-zero for `view()` sub-regions
+    /// (mirrors `DmaTensor::mmap_offset` / `MemTensor::offset`). Applied in
+    /// `ShmMap::as_slice`, which maps the whole segment and indexes from here.
+    offset: usize,
     pub _marker: std::marker::PhantomData<T>,
     identity: crate::BufferIdentity,
 }
@@ -74,21 +79,92 @@ where
             name,
             fd: shm_fd,
             shape: shape.to_vec(),
+            offset: 0,
             _marker: std::marker::PhantomData,
             identity: crate::BufferIdentity::new(),
         })
     }
 
-    /// Map exposing `byte_size` bytes via `as_slice()` (and mmap'ing exactly
-    /// that many) for self-allocated strided tensors whose rows are padded. The
-    /// caller (`Tensor::map`) validates `byte_size <= capacity_bytes()` first.
+    /// Create a zero-copy sub-region view that shares `parent`'s segment via a
+    /// cloned fd (the SHM sharing model is fd-based, like `clone_fd`/`from_fd`).
+    ///
+    /// The view maps the window `[offset_bytes, offset_bytes + logical_size)`
+    /// measured from `parent`'s own window (`logical_size = shape.product() *
+    /// size_of::<T>()`), so a sub-view of a sub-view composes. N such views into
+    /// one parent share the segment (no copy) and write independently.
+    ///
+    /// # Errors
+    /// - [`Error::InvalidOperation`] if `offset_bytes` is not aligned to
+    ///   `align_of::<T>()` (required for the `ShmMap` pointer cast).
+    /// - [`Error::InsufficientCapacity`] if the window exceeds the segment.
+    pub(crate) fn view(
+        parent: &ShmTensor<T>,
+        offset_bytes: usize,
+        shape: &[usize],
+    ) -> Result<Self> {
+        let elem = std::mem::size_of::<T>();
+        if !offset_bytes.is_multiple_of(std::mem::align_of::<T>()) {
+            return Err(Error::InvalidOperation(format!(
+                "ShmTensor::view: offset {offset_bytes} not aligned to align_of::<T>()={}",
+                std::mem::align_of::<T>()
+            )));
+        }
+        let abs_offset = parent
+            .offset
+            .checked_add(offset_bytes)
+            .ok_or(Error::InvalidSize(offset_bytes))?;
+        let logical = shape.iter().product::<usize>() * elem;
+        let capacity = parent.capacity_bytes();
+        let needed = abs_offset
+            .checked_add(logical)
+            .ok_or(Error::InvalidSize(logical))?;
+        if needed > capacity {
+            return Err(Error::InsufficientCapacity { needed, capacity });
+        }
+        Ok(ShmTensor {
+            name: parent.name.clone(),
+            fd: parent.fd.try_clone()?,
+            shape: shape.to_vec(),
+            offset: abs_offset,
+            _marker: std::marker::PhantomData,
+            // A sub-view is the *same* segment: share the parent's identity so
+            // identity-keyed logic treats the windows as one buffer at distinct
+            // offsets, not unrelated allocations.
+            identity: parent.identity.clone(),
+        })
+    }
+
+    /// Map exposing `byte_size` bytes via `as_slice()` for self-allocated
+    /// strided tensors whose rows are padded. The caller (`Tensor::map`)
+    /// validates `byte_size <= capacity_bytes()` first.
     pub(crate) fn map_with_byte_size(&self, byte_size: usize) -> Result<TensorMap<T>> {
         self.map_inner(Some(byte_size))
     }
 
     fn map_inner(&self, byte_size_override: Option<usize>) -> Result<TensorMap<T>> {
-        let map_bytes = byte_size_override.unwrap_or_else(|| self.size());
-        let size = NonZero::new(map_bytes).ok_or(Error::InvalidSize(map_bytes))?;
+        let exposed = byte_size_override.unwrap_or_else(|| self.size());
+        // Map the whole segment from fd offset 0 and apply `self.offset` in
+        // `ShmMap::as_slice` — mmap cannot take a non-page-aligned fd offset,
+        // and the segment is small (mirrors `DmaMap`, which maps `buf_size`).
+        let mmap_size = self.capacity_bytes();
+        let end = self
+            .offset
+            .checked_add(exposed)
+            .ok_or(Error::InvalidSize(exposed))?;
+        if end > mmap_size {
+            return Err(Error::InsufficientCapacity {
+                needed: end,
+                capacity: mmap_size,
+            });
+        }
+        if std::mem::size_of::<T>() > 1 && !self.offset.is_multiple_of(std::mem::align_of::<T>()) {
+            return Err(Error::InvalidOperation(format!(
+                "ShmMap: offset {} not aligned to align_of::<T>()={}",
+                self.offset,
+                std::mem::align_of::<T>()
+            )));
+        }
+        let size = NonZero::new(mmap_size).ok_or(Error::InvalidSize(mmap_size))?;
         let ptr = unsafe {
             nix::sys::mman::mmap(
                 None,
@@ -101,10 +177,12 @@ where
         };
 
         trace!("Mapping shared memory: {ptr:?}");
-        let shm_ptr = ShmPtr(NonNull::new(ptr.as_ptr()).ok_or(Error::InvalidSize(map_bytes))?);
+        let shm_ptr = ShmPtr(NonNull::new(ptr.as_ptr()).ok_or(Error::InvalidSize(mmap_size))?);
         Ok(TensorMap::Shm(ShmMap {
             ptr: Arc::new(Mutex::new(shm_ptr)),
             shape: self.shape.clone(),
+            offset: self.offset,
+            mmap_size,
             byte_size_override,
             _marker: std::marker::PhantomData,
         }))
@@ -149,6 +227,7 @@ where
             name: name.to_owned(),
             fd: shm_fd,
             shape: shape.to_vec(),
+            offset: 0,
             _marker: std::marker::PhantomData,
             identity: crate::BufferIdentity::new(),
         })
@@ -168,6 +247,7 @@ where
             name: name.unwrap_or("").to_owned(),
             fd,
             shape: shape.to_vec(),
+            offset: 0,
             _marker: std::marker::PhantomData,
             identity: crate::BufferIdentity::new(),
         })
@@ -250,10 +330,14 @@ where
 {
     ptr: Arc<Mutex<ShmPtr>>,
     shape: Vec<usize>,
+    /// Byte offset into the mmap'd segment where this map's window begins
+    /// (non-zero for sub-region views). `as_slice()` returns `base + offset`.
+    offset: usize,
+    /// Bytes actually mmap'd (the whole segment). `unmap()` munmaps exactly
+    /// this, independent of the logical `offset`/`len()` window.
+    mmap_size: usize,
     /// When `Some(bytes)`, `as_slice()` exposes `bytes / sizeof(T)` elements
-    /// (the full padded mmap) instead of `shape.product()`. `unmap()` munmaps
-    /// `size()` = `len() * sizeof(T)`, which tracks this override, so the
-    /// munmap length matches the mmap length.
+    /// (the full padded window) instead of `shape.product()`.
     byte_size_override: Option<usize>,
     _marker: std::marker::PhantomData<T>,
 }
@@ -307,7 +391,9 @@ where
 
     fn unmap(&mut self) {
         let ptr = self.ptr.lock().expect("Failed to lock ShmMap pointer");
-        let err = unsafe { nix::sys::mman::munmap(**ptr, self.size()) };
+        // Munmap the whole mmap'd segment (`mmap_size`), not the logical window
+        // — `offset` only shifts where `as_slice()` reads, not the mapping.
+        let err = unsafe { nix::sys::mman::munmap(**ptr, self.mmap_size) };
         if let Err(e) = err {
             warn!("Failed to unmap shared memory: {e}");
         }
@@ -315,12 +401,14 @@ where
 
     fn as_slice(&self) -> &[T] {
         let ptr = self.ptr.lock().expect("Failed to lock ShmMap pointer");
-        unsafe { std::slice::from_raw_parts(ptr.as_ptr() as *const T, self.len()) }
+        let base = unsafe { (ptr.as_ptr() as *const u8).add(self.offset) as *const T };
+        unsafe { std::slice::from_raw_parts(base, self.len()) }
     }
 
     fn as_mut_slice(&mut self) -> &mut [T] {
         let ptr = self.ptr.lock().expect("Failed to lock ShmMap pointer");
-        unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut T, self.len()) }
+        let base = unsafe { (ptr.as_ptr() as *mut u8).add(self.offset) as *mut T };
+        unsafe { std::slice::from_raw_parts_mut(base, self.len()) }
     }
 }
 

--- a/crates/tensor/src/shm.rs
+++ b/crates/tensor/src/shm.rs
@@ -30,6 +30,13 @@ where
     /// (mirrors `DmaTensor::mmap_offset` / `MemTensor::offset`). Applied in
     /// `ShmMap::as_slice`, which maps the whole segment and indexes from here.
     offset: usize,
+    /// Logical byte length of the backing segment (the size requested at
+    /// `ftruncate`), as opposed to the physical `fstat().st_size` exposed by
+    /// [`capacity_bytes`](Self::capacity_bytes). These diverge on macOS, where
+    /// POSIX shm segments are rounded up to a page, so bounds checks must use
+    /// this logical length to stay platform-consistent. Inherited unchanged by
+    /// `view()` sub-regions (they share the same segment).
+    byte_len: usize,
     pub _marker: std::marker::PhantomData<T>,
     identity: crate::BufferIdentity,
 }
@@ -80,6 +87,7 @@ where
             fd: shm_fd,
             shape: shape.to_vec(),
             offset: 0,
+            byte_len: byte_size,
             _marker: std::marker::PhantomData,
             identity: crate::BufferIdentity::new(),
         })
@@ -114,7 +122,10 @@ where
             .checked_add(offset_bytes)
             .ok_or(Error::InvalidSize(offset_bytes))?;
         let logical = shape.iter().product::<usize>() * elem;
-        let capacity = parent.capacity_bytes();
+        // Bound against the segment's *logical* byte length, not the physical
+        // `capacity_bytes()` (`st_size`): the latter is page-rounded on macOS,
+        // which would let an out-of-bounds window slip through (see `byte_len`).
+        let capacity = parent.byte_len;
         let needed = abs_offset
             .checked_add(logical)
             .ok_or(Error::InvalidSize(logical))?;
@@ -126,6 +137,7 @@ where
             fd: parent.fd.try_clone()?,
             shape: shape.to_vec(),
             offset: abs_offset,
+            byte_len: parent.byte_len,
             _marker: std::marker::PhantomData,
             // A sub-view is the *same* segment: share the parent's identity so
             // identity-keyed logic treats the windows as one buffer at distinct
@@ -228,6 +240,7 @@ where
             fd: shm_fd,
             shape: shape.to_vec(),
             offset: 0,
+            byte_len: size,
             _marker: std::marker::PhantomData,
             identity: crate::BufferIdentity::new(),
         })
@@ -243,11 +256,17 @@ where
             return Err(Error::InvalidSize(0));
         }
 
+        // The true logical length of an externally shared segment is unknown
+        // here; `fstat` is the only signal (exact on Linux, page-rounded on
+        // macOS). Fall back to the declared `size` when it is unavailable.
+        let byte_len = fstat(&fd).map(|s| s.st_size as usize).unwrap_or(size);
+
         Ok(ShmTensor {
             name: name.unwrap_or("").to_owned(),
             fd,
             shape: shape.to_vec(),
             offset: 0,
+            byte_len,
             _marker: std::marker::PhantomData,
             identity: crate::BufferIdentity::new(),
         })


### PR DESCRIPTION
Rolls up four post-0.24.2 cleanup changes into a single PR, rebased on the latest `main` (after #96 WS0 and #97 WS1-core merged). Supersedes #98, #99, #100, #101 (consolidated to avoid four separate review/CI passes). Each change is byte-identical / behaviour-preserving except the perf fix; all verified locally on the merged base.

### Commits
1. **`refactor(python)` — collapse colorimetry enum bridges into a macro.** The four PyO3 colorimetry mirror enums each carried hand-written `From`/`TryFrom` boilerplate; a `bridge_enum!` macro emits the `#[pyclass]` enum + both conversions from one variant list. No behaviour change. **−76 LOC.**
2. **`refactor(cpu)` — collapse NV12/16/24 converters onto one semi-planar decode.** The six `convert_nv{12,16,24}_to_{rgb,rgba}` + six `*_kernel` helpers collapse onto one `semi_planar_decode` closure + three `convert_nv{12,16,24}` wrappers + six one-liners, using `src.height()` uniformly. Each format keeps its exact stride logic — byte-identical output. **−163 LOC.**
3. **`perf(tensor)` — restore `alloc_zeroed` fast path for `Mem` backing.** `MemBacking::zeroed` had regressed to per-element `UnsafeCell::new` init (eager memset + page commit); restore the calloc path via a runtime all-zeros-bit-pattern check (`std::alloc::alloc_zeroed`), backing every `Tensor::image(.., Mem)` and CPU-convert intermediate. New zero-readback test across `u8`/`u16`/`i32`/`f32`/`f64`.
4. **`docs` — refresh stale dependency version, env vars, CUDA/PBO references.** README dep `0.22`→`0.24` + six undocumented `EDGEFIRST_*` vars; tensor `TESTING.md` `cuda_abi.rs`→`cuda.rs`; `create_image` `.pyi` PBO docstring now covers `float16`/`float32`.

### Verification (local, on the merged base)
- `make format lint check` clean (clippy `-D warnings`, ruff, workspace check).
- image cpu 127 / odd_dim 36 / tensor mem 12 (incl. zero-readback) pass; Python colorimetry tests pass.

Not a draft so Copilot review + the build matrix run.