### PR TITLE
GL convert-engine convergence: destination fan-out collapse, 0x501 fix, ColorimetryMode (PR-B)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -125,12 +125,18 @@ nearest-like and also matches CPU.
 | imx8mp-frdm | Vivante GC7000UL | **2.5 ms** | **29.2 ms** | **Sampler** (shader ~12× slower; sampler also correct here) |
 | jetson-orin-nano | Tegra (NVIDIA) | 2.4 ms | 2.1 ms | **Shader** (R8 upload; no DMA-buf import) |
 
-**`auto` policy:** prefer `ShaderR8` (portable, colorimetry-exact) everywhere
-**except** single-plane, BT.601-limited, even-and-4-aligned NV12 on **Vivante**,
-where `ExternalSampler` is both ~12× faster and colorimetry-correct. Full-range /
-BT.709 sources on Vivante still take `ShaderR8` (slower but correct — the fixed
-driver matrix would be wrong). `EDGEFIRST_NV_CONVERT_PATH` overrides this for
-benchmarking and platform bring-up.
+**`auto` policy (HIGH-PERFORMANCE default, issue #106):** prefer `ShaderR8`
+(portable, colorimetry-exact) wherever it is also the fast path — every GPU
+above except Vivante. On **Vivante**, single-plane 4-aligned NV12 takes
+`ExternalSampler` for **every** colorimetry in the default
+`ColorimetryMode::Fast`: the driver applies its fixed BT.601-limited matrix,
+which is exact for BT.601-limited sources and approximate for the rest — the
+12× speed gap (2.5 ms vs 29 ms) is the trade. Opt in to exactness with
+`ImageProcessorConfig::colorimetry = ColorimetryMode::Exact` or
+`EDGEFIRST_COLORIMETRY=exact`: the sampler is then used only when the driver
+matrix matches the source's resolved (encoding, range) exactly.
+`EDGEFIRST_NV_CONVERT_PATH` still force-overrides the path for benchmarking
+and platform bring-up.
 
 Source-width constraint for the `Sampler` (NV12 EGLImage) path: **even width**
 (4:2:0 chroma is W/2). The import uses the 64-byte-aligned row pitch, so widths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`ColorimetryMode` (`Fast` | `Exact`) + `EDGEFIRST_COLORIMETRY`**
+  (`edgefirst-image`): the colorimetry/performance trade-off is now an
+  explicit knob. `ImageProcessorConfig::colorimetry` (default
+  `ColorimetryMode::Fast`, issue #106 policy) or the
+  `EDGEFIRST_COLORIMETRY=fast|exact` environment variable (which takes
+  precedence and pins the mode for the processor's lifetime). **Behavior
+  change on Vivante (i.MX 8M Plus):** under `auto`, single-plane 4-aligned
+  NV12 sources now take the hardware external sampler for *every*
+  colorimetry by default (~12× faster: 2.5 ms vs 29 ms at 720p; the
+  driver applies its fixed BT.601-limited matrix, approximate for
+  non-BT.601-limited sources). `ColorimetryMode::Exact` restores the
+  previous behavior (sampler only when the driver matrix matches the
+  source exactly, colorimetry-exact in-shader matrix otherwise). All other
+  GPUs are unaffected — the exact in-shader path is already the fast path
+  there.
 - **Batched preprocessing — `convert_deferred()` + `flush()`** (`edgefirst-image`,
   C API, Python): render `N` model inputs into row-band views of one batched
   destination as **one GPU import + one sync**. Loop

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -436,12 +436,18 @@ that tells the engine what completes the convert.
 | `TexturePbo` | PBO | offscreen texture seeded from the PBO via UNPACK | `glReadnPixels` into the PBO PACK binding |
 | `TextureMem` | Mem/Shm (or DMA without import) | offscreen texture seeded from the mapped tensor | `glReadnPixels` into the mapped tensor |
 
-A single `convert_dest_texture` drives both texture lowerings (the former
-`convert_pbo_to_pbo` / `convert_any_to_pbo` / `convert_pbo_to_mem` /
-`convert_dest_non_dma` quartet); the source side independently picks the PBO
-UNPACK upload or the CPU texture upload. The DMA two-pass paths (packed RGB,
-NV→planar) still branch inside `convert_dest_dma` ahead of the full engine
-collapse.
+One `convert_via_engine` executes every u8/i8 convert: the pure plan table
+`render::plan_convert(src_fmt, dst_fmt, lowering)` picks `SinglePass`,
+`TwoPassPackedRgb` (zero-copy packed RGB needs an RGBA-reinterpret second
+pass), or `TwoPassNvPlanar` (NV→planar through the full `select_nv_path`
+machinery; also the Vivante single-pass GPU-hang workaround). Single-pass
+converts share the same `bind_dst → render → readback` body for every
+src/dst memory combination — the source side independently picks the PBO
+UNPACK upload or the CPU texture upload. The two-pass functions survive as
+render strategies, not duplicated dispatch. Both decision tables
+(`lower_dst`, `plan_convert`) are host-tested in `render.rs` with no GL
+dependency, so a new platform changes capability *inputs*, never the
+tables.
 
 **Why the PBO lowering never maps:** the GL thread must not call
 `tensor.map()` on a PBO image — that sends a `PboMap` message back to the
@@ -1056,6 +1062,7 @@ image.convert                                           [user-facing fn, orchest
 │
 ├── image.convert.gl                                    [OpenGL backend, picked first]
 │   │ fields: src_fmt, dst_fmt, is_int8, src_memory, dst_memory, dst_tile?, last_import_reason?
+│   ├── image.convert.gl.engine                         ← plan + destination lowering for the convert ({plan, lowering, src_pbo})
 │   ├── image.convert.gl.egl_import                     ← one actual eglCreateImageKHR (cache MISS only; zero in steady state)
 │   ├── image.convert.gl.pack_rgb.pass1_rgba            ← NV* → intermediate RGBA (resize + crop + flip)
 │   ├── image.convert.gl.pack_rgb.pass2_pack            ← intermediate RGBA → packed RGB (3:4 width ratio)
@@ -1098,6 +1105,7 @@ image.materialize_masks                                 [user-facing fn]
 |--------------------------------------------------------|--------------------------|------------------|
 | `image.convert`                                        | Orchestration: probe backends, pick OpenGL → G2D → CPU, dispatch. | The `src_memory` and `dst_memory` fields reveal whether you're on a zero-copy DMA-buf path, the PBO path, or the heap fallback. Cache-miss EGLImage imports show up as outliers here when callers reuse fds without reusing tensors. `dst_tile` (the batch-tile rect / index) is present when the call renders into a destination region rather than the whole tensor. |
 | `image.convert.gl`                                     | The chosen GL backend's full shader pipeline: bind/import source, set up FBO/renderbuffer, run conversion shader, `glFinish`. | First call at a new (src_fmt, dst_fmt, dims) tuple includes shader compile/link cost. Steady-state cost is dominated by the GPU draw and the `glFinish` at the end. `dst_tile` and `last_import_reason` reveal the tile rect/index and whether the source re-imported. |
+| `image.convert.gl.engine`                              | The convert engine's decision record: which `ConvertPlan` (`SinglePass` / `TwoPassPackedRgb` / `TwoPassNvPlanar`) and which destination lowering (`ZeroCopy` / `TextureMem` / `TexturePbo`) this convert took, plus whether the source is PBO-backed. | The plan/lowering pair maps 1:1 onto the GL work performed — filter traces by these fields to isolate one lowering's latency. Both decisions are pure host-tested tables in `render.rs` (`plan_convert`, `lower_dst`). |
 | `image.convert.gl.egl_import`                          | One actual `eglCreateImageKHR` — every EGLImage creation (DMA-BUF, NV R8, RGB renderbuffer paths) funnels through this single choke point. | The cache-behavior observable: a steady-state frame loop over a fixed buffer pool must emit ZERO of these after warmup. Any per-frame occurrence means the EGLImage cache stopped hitting (key drift, geometry churn, or pool misuse). The `GLProcessorThreaded::egl_cache_stats()` counters (`src`/`dst`/`nv_r8` hits/misses) are the assertable form, pinned by the `dma_pool_steady_state_zero_imports` test. |
 | `image.convert.gl.pack_rgb.pass1_rgba`                 | NV12 → intermediate RGBA texture (full geometry: resize, crop, rotation, flip, letterbox). | Reused for the "packed RGB" output path (DMA destination with 3-byte-per-pixel width × 3 / 4 render geometry). |
 | `image.convert.gl.pack_rgb.pass2_pack`                 | Intermediate RGBA → RGB DMA destination via the packed shader. | Only the second pass touches the DMA buffer; the first pass renders into the cached intermediate texture. |

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -417,33 +417,37 @@ HWC→CHW proto-tensor repack on the GPU. Enable it with
 implementation logs a warning and falls back to CPU repack transparently —
 no API changes.
 
-### PBO convert dispatch
+### Destination lowering (`bind_dst`)
 
-When `convert()` is called with PBO-backed images, the GL thread must not
-call `tensor.map()` on those images — that would send a message back to
-itself and deadlock. The convert path dispatches to specialized methods:
+Every u8/i8 `convert()` lowers its destination through one seam: the pure
+classifier `render::lower_dst(zero_copy_import, dst_memory)` picks the
+lowering and `bind_dst()` performs the GL work, returning a `DstTarget`
+that tells the engine what completes the convert.
 
-| Source → Destination | Method |
-|---------------------|--------|
-| DMA → DMA | `convert_dest_dma` (EGLImage on both sides) |
-| PBO → PBO | `convert_pbo_to_pbo` (UNPACK + PACK) |
-| Mem/DMA → PBO | `convert_any_to_pbo` (texture + PACK) |
-| PBO → Mem | `convert_pbo_to_mem` (UNPACK + ReadnPixels) |
-| Mem/DMA → Mem/DMA | `convert_dest_non_dma` (texture + memcpy) |
+| Lowering | Destination | Render target | Completion |
+|----------|-------------|---------------|------------|
+| `ZeroCopy` | DMA (with EGL dma_buf import) | dst's own EGLImage (renderbuffer on Mali, texture-FBO elsewhere) | none — render writes the buffer |
+| `TexturePbo` | PBO | offscreen texture seeded from the PBO via UNPACK | `glReadnPixels` into the PBO PACK binding |
+| `TextureMem` | Mem/Shm (or DMA without import) | offscreen texture seeded from the mapped tensor | `glReadnPixels` into the mapped tensor |
 
-**PBO destination renderbuffer setup:** When the destination is a PBO tensor
-and the shader needs a pre-initialized renderbuffer (e.g., for letterbox
-padding), the code must use `setup_renderbuffer_from_pbo()` — **never**
-`setup_renderbuffer_non_dma()`. The latter calls `dst.map()`, which sends a
-`PboMap` message to the GL thread via the channel. Since we are already
-executing on the GL thread (processing an `ImageConvert` message), this
-deadlocks. `setup_renderbuffer_from_pbo()` avoids this by binding the PBO as
-`GL_PIXEL_UNPACK_BUFFER` and loading data with `glTexImage2D(NULL)`, which
-reads directly from the PBO without any channel round-trip.
+A single `convert_dest_texture` drives both texture lowerings (the former
+`convert_pbo_to_pbo` / `convert_any_to_pbo` / `convert_pbo_to_mem` /
+`convert_dest_non_dma` quartet); the source side independently picks the PBO
+UNPACK upload or the CPU texture upload. The DMA two-pass paths (packed RGB,
+NV→planar) still branch inside `convert_dest_dma` ahead of the full engine
+collapse.
 
-`convert_pbo_to_mem()` is not affected because its destination is a Mem
-tensor, so `dst.map()` is a direct memory operation with no GL thread
-message.
+**Why the PBO lowering never maps:** the GL thread must not call
+`tensor.map()` on a PBO image — that sends a `PboMap` message back to the
+GL thread itself and deadlocks. `bind_dst` therefore seeds the render
+texture by binding the PBO as `GL_PIXEL_UNPACK_BUFFER` and calling
+`glTexImage2D(NULL)` (GL reads directly from the PBO), and the readback
+targets the PACK binding. Mem tensors map directly — no channel round-trip
+— so the `TextureMem` lowering may map freely.
+
+**Int8 letterbox bias is lowering-independent:** the int8 fragment shader
+XORs rendered pixels with 0x80 and no readback un-biases, so the letterbox
+clear colour is pre-biased (`int8_bias_clear`) on every lowering alike.
 
 ### CUDA registration of the float PBO
 

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -357,10 +357,16 @@ YUV→RGB on every backend is driven by the source tensor's per-tensor
   EGL-hint support (verified on Vivante GC7000UL, Mali-G310, V3D).
 - **Path A** (`samplerExternalOES`, driver YUV) sets the matching EGL
   `YUV_COLOR_SPACE_HINT` / `SAMPLE_RANGE_HINT` from the resolved colorimetry.
-  Because hint-ignoring drivers (Vivante) would otherwise apply a fixed
-  BT.601-limited matrix, **single-plane NV12 with non-default colorimetry
-  (full-range, or non-BT.601) is forced to Path B** so the exact matrix always
-  applies; only multiplane NV12 (which Path B cannot import) stays on Path A.
+  Hint-ignoring drivers (Vivante) apply a fixed BT.601-limited matrix
+  regardless. How `auto` weighs that against Vivante's ~12× Path-B cost is
+  the **`ColorimetryMode`** knob (`ImageProcessorConfig::colorimetry`, env
+  `EDGEFIRST_COLORIMETRY`; issue #106 policy): the default **`Fast`** keeps
+  single-plane 4-aligned NV12 on Path A for every colorimetry (approximate
+  matrix for non-BT.601-limited sources), while the **`Exact`** opt-in
+  forces non-matching colorimetries to Path B so the exact matrix always
+  applies. Multiplane NV12 (which Path B cannot import) stays on Path A in
+  both modes, as does every non-Vivante GPU's Path-B preference (exact is
+  already the fast path there).
 - Packed **YUYV/VYUY**: the **macOS** YUYV shader threads the same six
   colorimetry uniforms as the NV path (`yuv_to_rgb_coeffs`), so an untagged
   720p source resolves to BT.709 limited and matches the camera fixture (~0.997

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -990,8 +990,9 @@ impl GLProcessorST {
             }
         };
 
-        // Run the full DMA-buf EGLImage render pipeline
-        if let Err(e) = self.convert_dest_dma(
+        // Run the full DMA-buf EGLImage render pipeline (RGBA→RGBA DMA is a
+        // single-pass zero-copy plan through the engine).
+        if let Err(e) = self.convert_via_engine(
             &mut dst,
             PixelFormat::Rgba,
             &src,
@@ -1001,7 +1002,7 @@ impl GLProcessorST {
             Flip::None,
             ResolvedCrop::no_crop(),
         ) {
-            log::info!("verify_dma_buf_roundtrip: convert_dest_dma failed: {e}");
+            log::info!("verify_dma_buf_roundtrip: convert failed: {e}");
             return false;
         }
 
@@ -1122,28 +1123,114 @@ impl GLProcessorST {
             self.gl_context.transfer_backend,
         );
 
-        match super::render::lower_dst(self.gl_context.transfer_backend.is_dma(), dst.memory()) {
-            super::render::DstLowering::ZeroCopy => {
-                log::trace!("GL path: DMA (zero-copy EGLImage)");
-                let res = self
-                    .convert_dest_dma(dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop);
-                log::trace!("GL DMA result: {}", if res.is_ok() { "ok" } else { "err" });
-                res
+        self.convert_via_engine(dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop)
+    }
+
+    /// The single u8/i8 convert engine: classify the destination
+    /// ([`super::render::lower_dst`]), pick the render plan
+    /// ([`super::render::plan_convert`]), then `bind_dst` → render →
+    /// readback. The two-pass plans delegate to their render strategies;
+    /// every single-pass convert — DMA, Mem, or PBO on either side — runs
+    /// the same code.
+    #[allow(clippy::too_many_arguments)]
+    fn convert_via_engine(
+        &mut self,
+        dst: &mut Tensor<u8>,
+        dst_fmt: PixelFormat,
+        src: &Tensor<u8>,
+        src_fmt: PixelFormat,
+        is_int8: bool,
+        rotation: crate::Rotation,
+        flip: Flip,
+        crop: ResolvedCrop,
+    ) -> crate::Result<()> {
+        let lowering =
+            super::render::lower_dst(self.gl_context.transfer_backend.is_dma(), dst.memory());
+        let plan = super::render::plan_convert(src_fmt, dst_fmt, lowering);
+        let _span = tracing::trace_span!(
+            "image.convert.gl.engine",
+            ?plan,
+            ?lowering,
+            src_pbo = src.memory() == TensorMemory::Pbo,
+        )
+        .entered();
+
+        // v1 view()/batch() destination support covers only the single-pass
+        // PACKED zero-copy path (the glViewport/scissor band set in
+        // bind_dst). Packed RGB and every planar layout reinterpret the
+        // destination geometry (`W*3/4 × H`, `H*3` bands), which the band
+        // lowering does not yet handle, so a view destination declines them
+        // → CPU fallback. (Band tiling for those is a follow-up.)
+        if dst.view_origin().is_some()
+            && lowering == super::render::DstLowering::ZeroCopy
+            && (dst_fmt == PixelFormat::Rgb || dst_fmt.layout() == PixelLayout::Planar)
+        {
+            return Err(crate::Error::NotSupported(
+                "GL view()/batch() destination not yet supported for two-pass packed-RGB / \
+                 planar formats (CPU fallback handles it)"
+                    .into(),
+            ));
+        }
+
+        match plan {
+            super::render::ConvertPlan::TwoPassPackedRgb => {
+                return self.convert_to_packed_rgb(
+                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
+                )
             }
-            lowering => {
-                log::trace!(
-                    "GL path: texture target ({lowering:?}, src={:?} dst={:?})",
-                    src.memory(),
-                    dst.memory()
-                );
-                let start = Instant::now();
-                let res = self.convert_dest_texture(
-                    dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop,
-                );
-                log::debug!("convert_dest_texture takes {:?}", start.elapsed());
-                res
+            super::render::ConvertPlan::TwoPassNvPlanar => {
+                return self.convert_nv_to_planar_two_pass(
+                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
+                )
+            }
+            super::render::ConvertPlan::SinglePass => {}
+        }
+
+        let target = self.bind_dst(dst, dst_fmt, crop)?;
+
+        // Bias the letterbox clear colour for int8 on every lowering: the
+        // fragment shader XORs rendered pixels and no readback un-biases,
+        // so the glClear'd letterbox region must be pre-biased.
+        let crop = Self::int8_bias_clear(is_int8, crop);
+
+        let start = Instant::now();
+        match src.as_pbo() {
+            Some(src_pbo) => {
+                // A PBO source uploads via its UNPACK binding — mapping it on
+                // the GL thread would deadlock on the Pbo message round-trip.
+                if src_pbo.is_mapped() {
+                    return Err(crate::Error::OpenGl(
+                        "Cannot convert from a mapped PBO tensor".to_string(),
+                    ));
+                }
+                let src_buffer_id = src_pbo.buffer_id();
+                self.draw_src_texture_from_pbo(
+                    src,
+                    src_fmt,
+                    src_buffer_id,
+                    dst,
+                    dst_fmt,
+                    is_int8,
+                    rotation,
+                    flip,
+                    crop,
+                )?;
+            }
+            None => {
+                self.render_packed_or_planar(
+                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
+                )?;
             }
         }
+        log::debug!("engine render ({plan:?}) takes {:?}", start.elapsed());
+
+        if let DstTarget::Texture { readback } = target {
+            // Data is already int8-biased by the shader — readback copies bytes.
+            let start = Instant::now();
+            self.readback_rendered(dst, dst_fmt, readback.pbo_id())?;
+            log::debug!("engine readback takes {:?}", start.elapsed());
+        }
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1905,90 +1992,6 @@ impl GLProcessorST {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn convert_dest_dma(
-        &mut self,
-        dst: &mut Tensor<u8>,
-        dst_fmt: PixelFormat,
-        src: &Tensor<u8>,
-        src_fmt: PixelFormat,
-        is_int8: bool,
-        rotation: crate::Rotation,
-        flip: Flip,
-        crop: ResolvedCrop,
-    ) -> crate::Result<()> {
-        assert!(self.gl_context.transfer_backend.is_dma());
-        // v1 view()/batch() destination support covers only the SINGLE-PASS path
-        // (Rgba/Bgra/Grey, rendered by `convert_to` with the glViewport/scissor
-        // band set in `setup_renderbuffer_dma`). The two-pass packed-RGB and
-        // planar paths reinterpret the destination geometry (`W*3/4 × H`,
-        // `H*3` bands), which the band lowering does not yet handle, so decline a
-        // view dst for those → CPU fallback. (Two-pass band tiling is a follow-up.)
-        if dst.view_origin().is_some()
-            && (dst_fmt == PixelFormat::Rgb || dst_fmt.layout() == PixelLayout::Planar)
-        {
-            return Err(crate::Error::NotSupported(
-                "GL view()/batch() destination not yet supported for two-pass packed-RGB / \
-                 planar formats (CPU fallback handles it)"
-                    .into(),
-            ));
-        }
-        if dst_fmt == PixelFormat::Rgb {
-            log::trace!(
-                "GL DMA dispatch: {src_fmt}→{dst_fmt} int8={is_int8} → two-pass packed RGB \
-                 (RGBA intermediate + packed_rgba8{}shader)",
-                if is_int8 { "_int8_" } else { "_" }
-            );
-            self.convert_to_packed_rgb(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
-        } else if dst_fmt.layout() == PixelLayout::Planar {
-            // All NV12/NV16/NV24 → Planar go through the two-pass pipeline
-            // (NV*→RGBA8 intermediate → RGBA→PlanarRgb), because the intermediate
-            // pass delegates to `convert_to`, which routes NV* through
-            // `select_nv_path` — giving planar output the SAME colorimetry-exact
-            // `ShaderR8` path (and Vivante carve-out, and multiplane→ExternalSampler)
-            // as the packed path. The old single-pass `convert_to_planar` binds
-            // `samplerExternalOES` directly (driver YUV→RGB): colorimetry-wrong on
-            // hint-ignoring/bilinear-chroma drivers for NV12, and has NO sampler
-            // path at all for NV16/NV24. Two-pass also subsumes the Vivante NV12
-            // single-pass GPU hang (EDGEAI-1180).
-            if matches!(
-                src_fmt,
-                PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
-            ) {
-                log::trace!(
-                    "GL DMA dispatch: {src_fmt}→{dst_fmt} int8={is_int8} → two-pass planar \
-                     (RGBA intermediate + planar_2d{}shader; select_nv_path-driven)",
-                    if is_int8 { "_int8_" } else { "_" }
-                );
-                self.convert_nv_to_planar_two_pass(
-                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
-                )
-            } else {
-                log::trace!(
-                    "GL DMA dispatch: {src_fmt}→{dst_fmt} int8={is_int8} → planar output \
-                     (renderbuffer + planar{}shader)",
-                    if is_int8 { "_int8_" } else { "_" }
-                );
-                self.bind_dst(dst, dst_fmt, crop)?;
-                // Bias letterbox clear color for int8 — glClear bypasses the shader.
-                let crop = Self::int8_bias_clear(is_int8, crop);
-                self.convert_to_planar(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
-            }
-        } else {
-            log::trace!(
-                "GL DMA dispatch: {src_fmt}→{dst_fmt} int8={is_int8} → single-pass EGLImage \
-                 (renderbuffer, {}shader)",
-                if is_int8 { "int8 " } else { "standard " }
-            );
-            self.bind_dst(dst, dst_fmt, crop)?;
-            // The draws select their int8 (XOR 0x80) program variants from
-            // `is_int8`; the letterbox clear bypasses the shader so its fill
-            // colour is pre-biased here.
-            let crop = Self::int8_bias_clear(is_int8, crop);
-            self.convert_to(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
-        }
-    }
-
     /// Bias a letterbox clear colour by XOR 0x80 for int8 destinations, since
     /// `glClear` bypasses the shader that otherwise applies the bias. No-op when
     /// not int8 or when there is no fill colour. Shared by every destination path.
@@ -2118,80 +2121,6 @@ impl GLProcessorST {
             }
         }
         check_gl_error(function!(), line!())?;
-        Ok(())
-    }
-
-    /// Convert into any non-zero-copy destination — the single texture-target
-    /// flow shared by every (src memory) × (dst memory ∈ {Mem, Shm, Pbo})
-    /// combination: `bind_dst` → render → `readback_rendered`. Replaces the
-    /// former `convert_dest_non_dma` / `convert_pbo_to_pbo` /
-    /// `convert_any_to_pbo` / `convert_pbo_to_mem` quartet, which differed
-    /// only in FBO setup (now owned by `bind_dst`) and readback target (now
-    /// carried by [`DstTarget`]).
-    ///
-    /// Source binding is the one src-dependent piece: a PBO source uploads
-    /// via its UNPACK binding (mapping it on the GL thread would deadlock on
-    /// the Pbo message round-trip); everything else takes the CPU texture
-    /// upload inside `render_packed_or_planar`.
-    #[allow(clippy::too_many_arguments)]
-    fn convert_dest_texture(
-        &mut self,
-        dst: &mut Tensor<u8>,
-        dst_fmt: PixelFormat,
-        src: &Tensor<u8>,
-        src_fmt: PixelFormat,
-        is_int8: bool,
-        rotation: crate::Rotation,
-        flip: Flip,
-        crop: ResolvedCrop,
-    ) -> crate::Result<()> {
-        let DstTarget::Texture { readback } = self.bind_dst(dst, dst_fmt, crop)? else {
-            return Err(crate::Error::OpenGl(
-                "convert_dest_texture: bind_dst lowered to a zero-copy target".to_string(),
-            ));
-        };
-
-        // Bias the letterbox clear colour for int8 on EVERY texture-target
-        // path: the fragment shader XORs rendered pixels and the readback
-        // never un-biases, so the glClear'd letterbox region must be
-        // pre-biased regardless of which memory the source or destination
-        // lives in. (The former any→PBO and PBO→Mem paths skipped this,
-        // leaving their int8 letterbox fill 0x80 off.)
-        let crop = Self::int8_bias_clear(is_int8, crop);
-
-        let start = Instant::now();
-        match src.as_pbo() {
-            Some(src_pbo) => {
-                if src_pbo.is_mapped() {
-                    return Err(crate::Error::OpenGl(
-                        "Cannot convert from a mapped PBO tensor".to_string(),
-                    ));
-                }
-                let src_buffer_id = src_pbo.buffer_id();
-                self.draw_src_texture_from_pbo(
-                    src,
-                    src_fmt,
-                    src_buffer_id,
-                    dst,
-                    dst_fmt,
-                    is_int8,
-                    rotation,
-                    flip,
-                    crop,
-                )?;
-            }
-            None => {
-                self.render_packed_or_planar(
-                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
-                )?;
-            }
-        }
-        log::debug!("texture-target render takes {:?}", start.elapsed());
-
-        // Data is already int8-biased by the shader — readback copies bytes.
-        let start = Instant::now();
-        self.readback_rendered(dst, dst_fmt, readback.pbo_id())?;
-        log::debug!("texture-target readback takes {:?}", start.elapsed());
         Ok(())
     }
 

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1902,19 +1902,22 @@ impl GLProcessorST {
         // + `DmaImportAttrs` both pivot on `view_origin`); render this tile into
         // its band via `glViewport`. A whole tensor fills its full surface. The
         // matching `glScissor` (so the letterbox clear cannot wipe sibling tiles)
-        // is set in `convert_to`, which owns the clear.
-        //
-        // The destination DMA EGLImage is TOP-DOWN: GL framebuffer row 0 maps to
-        // memory row 0 (verified on-target — a tile at GL `y` lands in memory
-        // band `y`). The renderer's existing texcoord flip keeps the image
-        // upright, so the band's GL viewport `y` is simply `region.y` — NOT the
-        // bottom-left `parent_h - (y+h)` flip (that is for bottom-up surfaces).
-        let (vx, vy, vw, vh) = match dst.view_origin() {
-            Some(vo) => (vo.x as i32, vo.y as i32, dst_w as i32, dst_h as i32),
-            None => (0, 0, width, height),
+        // is set in `convert_to`, which owns the clear — both lower the band
+        // through `region_to_viewport_top_down`, the single home for the
+        // verified top-down orientation of the dst DMA EGLImage.
+        let vp = match dst.view_origin() {
+            Some(vo) => super::render::region_to_viewport_top_down(crate::Region::new(
+                vo.x, vo.y, dst_w, dst_h,
+            )),
+            None => super::render::Viewport {
+                x: 0,
+                y: 0,
+                w: width,
+                h: height,
+            },
         };
         unsafe {
-            gls::gl::Viewport(vx, vy, vw, vh);
+            gls::gl::Viewport(vp.x, vp.y, vp.w, vp.h);
         }
         Ok(())
     }
@@ -2778,12 +2781,16 @@ impl GLProcessorST {
                 }
             }
         }
-        // Top-down band rect, matching `setup_renderbuffer_dma`'s viewport (the
-        // dst EGLImage is top-down: GL row 0 == memory row 0).
+        // Band rect via `region_to_viewport_top_down` — the SAME lowering as
+        // the band viewport in `bind_dst`'s setup, so scissor and viewport can
+        // never disagree on the orientation convention.
         let _scissor = match dst.view_origin() {
             Some(vo) => {
+                let vp = super::render::region_to_viewport_top_down(crate::Region::new(
+                    vo.x, vo.y, dst_w, dst_h,
+                ));
                 unsafe {
-                    gls::gl::Scissor(vo.x as i32, vo.y as i32, dst_w as i32, dst_h as i32);
+                    gls::gl::Scissor(vp.x, vp.y, vp.w, vp.h);
                     gls::gl::Enable(gls::gl::SCISSOR_TEST);
                 }
                 ScissorGuard(true)

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1264,6 +1264,7 @@ impl GLProcessorST {
                     },
                     0,
                     crate::Flip::None,
+                    false,
                 )?;
             } else {
                 // Non-DMA background: upload bg pixels into the
@@ -1458,6 +1459,7 @@ impl GLProcessorST {
                     },
                     0,
                     crate::Flip::None,
+                    false,
                 )?;
             } else {
                 self.upload_pixels_to_render_texture(bg, bg_fmt, dst_w, dst_h)?;
@@ -1979,30 +1981,11 @@ impl GLProcessorST {
                 if is_int8 { "int8 " } else { "standard " }
             );
             self.bind_dst(dst, dst_fmt, crop)?;
-            // For int8 output, swap to int8 shader programs that apply XOR 0x80
-            // in the fragment shader — zero CPU readback.
-            if is_int8 {
-                std::mem::swap(&mut self.texture_program, &mut self.texture_int8_program);
-                std::mem::swap(
-                    &mut self.texture_program_yuv,
-                    &mut self.texture_int8_program_yuv,
-                );
-                // Path B int8: swap nv_r8_program ↔ nv_r8_int8_program so that
-                // draw_nv_texture_2d picks up the bias shader automatically.
-                std::mem::swap(&mut self.nv_r8_program, &mut self.nv_r8_int8_program);
-                // Bias the letterbox clear color since glClear bypasses the shader.
-                let crop = Self::int8_bias_clear(true, crop);
-                let result = self.convert_to(src, src_fmt, dst, dst_fmt, rotation, flip, crop);
-                std::mem::swap(&mut self.texture_program, &mut self.texture_int8_program);
-                std::mem::swap(
-                    &mut self.texture_program_yuv,
-                    &mut self.texture_int8_program_yuv,
-                );
-                std::mem::swap(&mut self.nv_r8_program, &mut self.nv_r8_int8_program);
-                result
-            } else {
-                self.convert_to(src, src_fmt, dst, dst_fmt, rotation, flip, crop)
-            }
+            // The draws select their int8 (XOR 0x80) program variants from
+            // `is_int8`; the letterbox clear bypasses the shader so its fill
+            // colour is pre-biased here.
+            let crop = Self::int8_bias_clear(is_int8, crop);
+            self.convert_to(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
         }
     }
 
@@ -2021,10 +2004,10 @@ impl GLProcessorST {
     }
 
     /// Render `src` into the already-bound destination FBO as `dst_fmt`,
-    /// dispatching packed vs planar and applying the int8 shader-program swap
-    /// (packed only; the planar shader handles int8 internally). This is the
-    /// converged per-tile draw shared by the non-DMA / PBO / DMA destination
-    /// paths — they differ only in FBO setup and readback, never in this draw.
+    /// dispatching packed vs planar; the draws select their int8 program
+    /// variants from `is_int8` at draw time. This is the converged per-tile
+    /// draw shared by the texture and DMA destination paths — they differ
+    /// only in FBO setup and readback, never in this draw.
     #[allow(clippy::too_many_arguments)]
     fn render_packed_or_planar(
         &mut self,
@@ -2037,76 +2020,11 @@ impl GLProcessorST {
         flip: Flip,
         crop: ResolvedCrop,
     ) -> crate::Result<()> {
-        let swap_int8 = is_int8 && dst_fmt.layout() != PixelLayout::Planar;
-        if swap_int8 {
-            std::mem::swap(&mut self.texture_program, &mut self.texture_int8_program);
-            std::mem::swap(
-                &mut self.texture_program_yuv,
-                &mut self.texture_int8_program_yuv,
-            );
-        }
-        let render_result = if dst_fmt.layout() == PixelLayout::Planar {
+        if dst_fmt.layout() == PixelLayout::Planar {
             self.convert_to_planar(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
         } else {
-            self.convert_to(src, src_fmt, dst, dst_fmt, rotation, flip, crop)
-        };
-        if swap_int8 {
-            std::mem::swap(&mut self.texture_program, &mut self.texture_int8_program);
-            std::mem::swap(
-                &mut self.texture_program_yuv,
-                &mut self.texture_int8_program_yuv,
-            );
+            self.convert_to(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
         }
-        render_result
-    }
-
-    /// Render a PBO source into the already-bound destination FBO via
-    /// [`draw_src_texture_from_pbo`](Self::draw_src_texture_from_pbo), applying
-    /// the int8 texture-program swap around the draw so the GPU writes
-    /// XOR-0x80'd values. The PBO draw never reaches the NV (`nv_r8`) or planar
-    /// branch, so this swaps **only** the two packed texture programs — narrower
-    /// than [`render_packed_or_planar`](Self::render_packed_or_planar). The
-    /// PBO-source arm of `convert_dest_texture`, which owns the
-    /// [`int8_bias_clear`](Self::int8_bias_clear) on `crop` (glClear bypasses
-    /// the shader); this helper never biases.
-    #[allow(clippy::too_many_arguments)]
-    fn render_from_pbo(
-        &mut self,
-        src: &Tensor<u8>,
-        src_fmt: PixelFormat,
-        src_buffer_id: u32,
-        dst: &mut Tensor<u8>,
-        dst_fmt: PixelFormat,
-        is_int8: bool,
-        rotation: crate::Rotation,
-        flip: Flip,
-        crop: ResolvedCrop,
-    ) -> crate::Result<()> {
-        if is_int8 {
-            std::mem::swap(&mut self.texture_program, &mut self.texture_int8_program);
-            std::mem::swap(
-                &mut self.texture_program_yuv,
-                &mut self.texture_int8_program_yuv,
-            );
-        }
-        let render_result = self.draw_src_texture_from_pbo(
-            src,
-            src_fmt,
-            src_buffer_id,
-            dst,
-            dst_fmt,
-            rotation,
-            flip,
-            crop,
-        );
-        if is_int8 {
-            std::mem::swap(&mut self.texture_program, &mut self.texture_int8_program);
-            std::mem::swap(
-                &mut self.texture_program_yuv,
-                &mut self.texture_int8_program_yuv,
-            );
-        }
-        render_result
     }
 
     /// Read the rendered FBO colour attachment (`COLOR_ATTACHMENT0`) into the
@@ -2250,7 +2168,7 @@ impl GLProcessorST {
                     ));
                 }
                 let src_buffer_id = src_pbo.buffer_id();
-                self.render_from_pbo(
+                self.draw_src_texture_from_pbo(
                     src,
                     src_fmt,
                     src_buffer_id,
@@ -2584,6 +2502,7 @@ impl GLProcessorST {
         src_buffer_id: u32,
         dst: &Tensor<u8>,
         _dst_fmt: PixelFormat,
+        is_int8: bool,
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
@@ -2656,7 +2575,12 @@ impl GLProcessorST {
                 }
             }
 
-            gls::gl::UseProgram(self.texture_program.id);
+            // Draw-time program selection (see draw_src_texture).
+            gls::gl::UseProgram(if is_int8 {
+                self.texture_int8_program.id
+            } else {
+                self.texture_program.id
+            });
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
             gls::gl::BindTexture(texture_target, self.camera_normal_texture.id);
             super::core::set_tex_filter_clamp(texture_target, gls::gl::LINEAR);
@@ -2900,6 +2824,7 @@ impl GLProcessorST {
         src_fmt: PixelFormat,
         dst: &Tensor<u8>,
         _dst_fmt: PixelFormat,
+        is_int8: bool,
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
@@ -3012,6 +2937,7 @@ impl GLProcessorST {
                             dst_roi,
                             rotation_offset,
                             flip,
+                            is_int8,
                         )?;
                     }
                     Err(e) => {
@@ -3036,6 +2962,7 @@ impl GLProcessorST {
                             dst_roi,
                             rotation_offset,
                             flip,
+                            is_int8,
                         )?;
                         log::debug!("draw_src_texture takes {:?}", start.elapsed());
                     }
@@ -3058,6 +2985,7 @@ impl GLProcessorST {
                             dst_roi,
                             rotation_offset,
                             flip,
+                            is_int8,
                         )?;
                     }
                     Err(e) => {
@@ -3078,6 +3006,7 @@ impl GLProcessorST {
                             dst_roi,
                             rotation_offset,
                             flip,
+                            is_int8,
                         )?;
                         log::debug!("draw_src_texture takes {:?}", start.elapsed());
                     }
@@ -3096,7 +3025,16 @@ impl GLProcessorST {
             // buffers) cannot be uploaded as one R8 texture → CPU below.
             tracing::trace!(path = "ShaderR8-upload", src_fmt = ?src_fmt, "image.convert.gl.nv_path");
             self.last_nv_convert_path = NvConvertPath::ShaderR8;
-            self.draw_nv_texture_2d(src, src_fmt, None, src_roi, dst_roi, rotation_offset, flip)?;
+            self.draw_nv_texture_2d(
+                src,
+                src_fmt,
+                None,
+                src_roi,
+                dst_roi,
+                rotation_offset,
+                flip,
+                is_int8,
+            )?;
         } else {
             // Non-DMA source, non-NV (or multiplane NV): CPU texture-upload path.
             if matches!(
@@ -3106,7 +3044,15 @@ impl GLProcessorST {
                 self.last_nv_convert_path = NvConvertPath::Cpu;
             }
             let start = Instant::now();
-            self.draw_src_texture(src, src_fmt, src_roi, dst_roi, rotation_offset, flip)?;
+            self.draw_src_texture(
+                src,
+                src_fmt,
+                src_roi,
+                dst_roi,
+                rotation_offset,
+                flip,
+                is_int8,
+            )?;
             log::debug!("draw_src_texture takes {:?}", start.elapsed());
         }
 
@@ -3304,7 +3250,9 @@ impl GLProcessorST {
         // convert_to() renders to the currently-bound FBO (packed_rgb_fbo → intermediate).
         // It uses dst only for width/height in ROI coordinate math.
         // Handles: source binding (DMA EGLImage or upload), crop, letterbox, rotation, flip.
-        self.convert_to(src, src_fmt, dst, dst_fmt, rotation, flip, crop)?;
+        // Pass 1 renders UN-biased (is_int8 = false): the int8 XOR-0x80 bias is
+        // applied once, by pass 2's packing shader.
+        self.convert_to(src, src_fmt, dst, dst_fmt, false, rotation, flip, crop)?;
         drop(_pass1);
 
         // --- Pass 2: Pack intermediate RGBA → RGB DMA destination ---
@@ -3449,7 +3397,9 @@ impl GLProcessorST {
         // Note: dst_fmt is passed but ignored (_dst_fmt in convert_to's signature) — the actual
         // output format is RGBA because we bound packed_rgb_fbo above. dst is used only for
         // width/height in ROI coordinate math.
-        self.convert_to(src, src_fmt, dst, dst_fmt, rotation, flip, crop)?;
+        // Pass 1 renders UN-biased (is_int8 = false): the int8 XOR-0x80 bias is
+        // applied once, by pass 2's planar deinterleave shader.
+        self.convert_to(src, src_fmt, dst, dst_fmt, false, rotation, flip, crop)?;
         drop(_pass1);
 
         // --- Pass 2: RGBA→PlanarRgb to DMA destination ---
@@ -3870,6 +3820,7 @@ impl GLProcessorST {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw_src_texture(
         &mut self,
         src: &Tensor<u8>,
@@ -3878,6 +3829,7 @@ impl GLProcessorST {
         mut dst_roi: RegionOfInterest,
         rotation_offset: usize,
         flip: Flip,
+        is_int8: bool,
     ) -> Result<(), Error> {
         let src_w = src.width().ok_or(Error::NotAnImage)?;
         let src_h = src.height().ok_or(Error::NotAnImage)?;
@@ -3892,8 +3844,16 @@ impl GLProcessorST {
                 )));
             }
         };
+        // Draw-time program selection: the int8 program is the same shader
+        // plus the XOR-0x80 bias, selected here instead of swap-and-restore
+        // around the render.
+        let program_id = if is_int8 {
+            self.texture_int8_program.id
+        } else {
+            self.texture_program.id
+        };
         unsafe {
-            gls::gl::UseProgram(self.texture_program.id);
+            gls::gl::UseProgram(program_id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
             gls::gl::BindTexture(texture_target, self.camera_normal_texture.id);
             super::core::set_tex_filter_clamp(texture_target, gls::gl::LINEAR);
@@ -4020,13 +3980,20 @@ impl GLProcessorST {
         mut dst_roi: RegionOfInterest,
         rotation_offset: usize,
         flip: Flip,
+        is_int8: bool,
     ) -> Result<(), Error> {
         let src_key = EglCacheKey::from_tensor(src, src_fmt, false);
         let luma_id = src_key.luma_id;
 
+        // Draw-time program selection (see draw_src_texture).
+        let program_id = if is_int8 {
+            self.texture_int8_program_yuv.id
+        } else {
+            self.texture_program_yuv.id
+        };
         let texture_target = gls::gl::TEXTURE_EXTERNAL_OES;
         unsafe {
-            gls::gl::UseProgram(self.texture_program_yuv.id);
+            gls::gl::UseProgram(program_id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
             gls::gl::BindTexture(texture_target, self.camera_eglimage_texture.id);
             super::core::set_tex_filter_clamp(texture_target, gls::gl::LINEAR);
@@ -4145,6 +4112,7 @@ impl GLProcessorST {
         mut dst_roi: RegionOfInterest,
         rotation_offset: usize,
         flip: Flip,
+        is_int8: bool,
     ) -> Result<(), Error> {
         let src_w = src.width().ok_or(Error::NotAnImage)?;
         let src_h = src.height().ok_or(Error::NotAnImage)?;
@@ -4169,10 +4137,15 @@ impl GLProcessorST {
         let src_key = EglCacheKey::from_tensor(src, src_fmt, false);
         let luma_id = src_key.luma_id;
 
-        // `nv_r8_program` may have been swapped to the int8 variant by
-        // `convert_dest_dma` for int8 destinations — always use the current
-        // `nv_r8_program` slot (consistent with the texture_program_yuv swap).
-        let prog_id = self.nv_r8_program.id;
+        // Draw-time program selection: the int8 NV program is the same shader
+        // plus the XOR-0x80 bias. Selected here for EVERY destination lowering
+        // (the old swap scheme only covered DMA destinations, leaving the
+        // heap-source int8 NV output un-biased on texture destinations).
+        let prog_id = if is_int8 {
+            self.nv_r8_int8_program.id
+        } else {
+            self.nv_r8_program.id
+        };
 
         unsafe {
             gls::gl::UseProgram(prog_id);

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -79,6 +79,37 @@ pub(super) enum NvPathPref {
     ForceShader,
 }
 
+/// Bound destination render target for one convert, produced by
+/// [`GLProcessorST::bind_dst`]. The GL counterpart of
+/// [`super::render::DstLowering`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DstTarget {
+    /// The destination buffer itself is the FBO colour attachment (EGLImage
+    /// renderbuffer or texture): the render writes it directly, no readback.
+    ZeroCopyImage,
+    /// Offscreen texture render target; `readback` copies the result out.
+    Texture { readback: DstReadback },
+}
+
+/// How a [`DstTarget::Texture`] render reaches the destination tensor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DstReadback {
+    /// `glReadnPixels` straight into the mapped Mem tensor.
+    Mem,
+    /// `glReadnPixels` into this destination PBO's PACK binding.
+    Pbo(u32),
+}
+
+impl DstReadback {
+    /// The PBO id in the `Option` shape `readback_rendered` consumes.
+    fn pbo_id(self) -> Option<u32> {
+        match self {
+            DstReadback::Mem => None,
+            DstReadback::Pbo(id) => Some(id),
+        }
+    }
+}
+
 /// OpenGL single-threaded image converter.
 pub struct GLProcessorST {
     camera_eglimage_texture: Texture,
@@ -1091,34 +1122,28 @@ impl GLProcessorST {
             self.gl_context.transfer_backend,
         );
 
-        if self.gl_context.transfer_backend.is_dma() && dst.memory() == TensorMemory::Dma {
-            log::trace!("GL path: DMA (zero-copy EGLImage)");
-            let res =
-                self.convert_dest_dma(dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop);
-            log::trace!("GL DMA result: {}", if res.is_ok() { "ok" } else { "err" });
-            return res;
+        match super::render::lower_dst(self.gl_context.transfer_backend.is_dma(), dst.memory()) {
+            super::render::DstLowering::ZeroCopy => {
+                log::trace!("GL path: DMA (zero-copy EGLImage)");
+                let res = self
+                    .convert_dest_dma(dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop);
+                log::trace!("GL DMA result: {}", if res.is_ok() { "ok" } else { "err" });
+                res
+            }
+            lowering => {
+                log::trace!(
+                    "GL path: texture target ({lowering:?}, src={:?} dst={:?})",
+                    src.memory(),
+                    dst.memory()
+                );
+                let start = Instant::now();
+                let res = self.convert_dest_texture(
+                    dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop,
+                );
+                log::debug!("convert_dest_texture takes {:?}", start.elapsed());
+                res
+            }
         }
-        if src.memory() == TensorMemory::Pbo && dst.memory() == TensorMemory::Pbo {
-            log::trace!("GL path: PBO-to-PBO");
-            return self
-                .convert_pbo_to_pbo(dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop);
-        }
-        if dst.memory() == TensorMemory::Pbo {
-            log::trace!("GL path: any-to-PBO (src={:?})", src.memory());
-            return self
-                .convert_any_to_pbo(dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop);
-        }
-        if src.memory() == TensorMemory::Pbo {
-            log::trace!("GL path: PBO-to-mem");
-            return self
-                .convert_pbo_to_mem(dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop);
-        }
-        log::trace!("GL path: non-DMA (CPU upload/readback)");
-        let start = Instant::now();
-        let res =
-            self.convert_dest_non_dma(dst, dst_fmt, src, src_fmt, is_int8, rotation, flip, crop);
-        log::debug!("convert_dest_non_dma takes {:?}", start.elapsed());
-        res
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1687,6 +1712,47 @@ impl GLProcessorST {
         self.nv_r8_texture.invalidate_egl_binding();
     }
 
+    /// Classify and bind the destination render target — the single entry
+    /// point absorbing the per-memory `setup_renderbuffer_*` fan-out. The
+    /// pure classification lives in [`super::render::lower_dst`]; this
+    /// performs the GL work and tells the caller what completes the convert.
+    fn bind_dst(
+        &mut self,
+        dst: &Tensor<u8>,
+        dst_fmt: PixelFormat,
+        crop: ResolvedCrop,
+    ) -> crate::Result<DstTarget> {
+        match super::render::lower_dst(self.gl_context.transfer_backend.is_dma(), dst.memory()) {
+            super::render::DstLowering::ZeroCopy => {
+                self.setup_renderbuffer_dma(dst, dst_fmt)?;
+                Ok(DstTarget::ZeroCopyImage)
+            }
+            super::render::DstLowering::TexturePbo => {
+                let dst_pbo = dst.as_pbo().ok_or_else(|| {
+                    crate::Error::OpenGl(
+                        "bind_dst: PBO-lowered destination is not a PBO tensor".to_string(),
+                    )
+                })?;
+                if dst_pbo.is_mapped() {
+                    return Err(crate::Error::OpenGl(
+                        "Cannot convert to a mapped PBO tensor".to_string(),
+                    ));
+                }
+                let id = dst_pbo.buffer_id();
+                self.setup_renderbuffer_from_pbo(dst, dst_fmt, id)?;
+                Ok(DstTarget::Texture {
+                    readback: DstReadback::Pbo(id),
+                })
+            }
+            super::render::DstLowering::TextureMem => {
+                self.setup_renderbuffer_non_dma(dst, dst_fmt, crop)?;
+                Ok(DstTarget::Texture {
+                    readback: DstReadback::Mem,
+                })
+            }
+        }
+    }
+
     fn setup_renderbuffer_dma(
         &mut self,
         dst: &Tensor<u8>,
@@ -1901,19 +1967,9 @@ impl GLProcessorST {
                      (renderbuffer + planar{}shader)",
                     if is_int8 { "_int8_" } else { "_" }
                 );
-                self.setup_renderbuffer_dma(dst, dst_fmt)?;
+                self.bind_dst(dst, dst_fmt, crop)?;
                 // Bias letterbox clear color for int8 — glClear bypasses the shader.
-                let crop = if is_int8 {
-                    let mut crop = crop;
-                    if let Some(ref mut color) = crop.dst_color {
-                        color[0] ^= 0x80;
-                        color[1] ^= 0x80;
-                        color[2] ^= 0x80;
-                    }
-                    crop
-                } else {
-                    crop
-                };
+                let crop = Self::int8_bias_clear(is_int8, crop);
                 self.convert_to_planar(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
             }
         } else {
@@ -1922,7 +1978,7 @@ impl GLProcessorST {
                  (renderbuffer, {}shader)",
                 if is_int8 { "int8 " } else { "standard " }
             );
-            self.setup_renderbuffer_dma(dst, dst_fmt)?;
+            self.bind_dst(dst, dst_fmt, crop)?;
             // For int8 output, swap to int8 shader programs that apply XOR 0x80
             // in the fragment shader — zero CPU readback.
             if is_int8 {
@@ -1935,12 +1991,7 @@ impl GLProcessorST {
                 // draw_nv_texture_2d picks up the bias shader automatically.
                 std::mem::swap(&mut self.nv_r8_program, &mut self.nv_r8_int8_program);
                 // Bias the letterbox clear color since glClear bypasses the shader.
-                let mut crop = crop;
-                if let Some(ref mut color) = crop.dst_color {
-                    color[0] ^= 0x80;
-                    color[1] ^= 0x80;
-                    color[2] ^= 0x80;
-                }
+                let crop = Self::int8_bias_clear(true, crop);
                 let result = self.convert_to(src, src_fmt, dst, dst_fmt, rotation, flip, crop);
                 std::mem::swap(&mut self.texture_program, &mut self.texture_int8_program);
                 std::mem::swap(
@@ -2014,12 +2065,10 @@ impl GLProcessorST {
     /// the int8 texture-program swap around the draw so the GPU writes
     /// XOR-0x80'd values. The PBO draw never reaches the NV (`nv_r8`) or planar
     /// branch, so this swaps **only** the two packed texture programs — narrower
-    /// than [`render_packed_or_planar`](Self::render_packed_or_planar). Shared by
-    /// `convert_pbo_to_pbo` / `convert_pbo_to_mem`, which differ only in FBO
-    /// setup and readback target, never in this draw. Callers that need the
-    /// letterbox clear biased (glClear bypasses the shader) apply
-    /// [`int8_bias_clear`](Self::int8_bias_clear) to `crop` first; this helper
-    /// does not, since the mem path fills via CPU upload instead.
+    /// than [`render_packed_or_planar`](Self::render_packed_or_planar). The
+    /// PBO-source arm of `convert_dest_texture`, which owns the
+    /// [`int8_bias_clear`](Self::int8_bias_clear) on `crop` (glClear bypasses
+    /// the shader); this helper never biases.
     #[allow(clippy::too_many_arguments)]
     fn render_from_pbo(
         &mut self,
@@ -2154,8 +2203,20 @@ impl GLProcessorST {
         Ok(())
     }
 
+    /// Convert into any non-zero-copy destination — the single texture-target
+    /// flow shared by every (src memory) × (dst memory ∈ {Mem, Shm, Pbo})
+    /// combination: `bind_dst` → render → `readback_rendered`. Replaces the
+    /// former `convert_dest_non_dma` / `convert_pbo_to_pbo` /
+    /// `convert_any_to_pbo` / `convert_pbo_to_mem` quartet, which differed
+    /// only in FBO setup (now owned by `bind_dst`) and readback target (now
+    /// carried by [`DstTarget`]).
+    ///
+    /// Source binding is the one src-dependent piece: a PBO source uploads
+    /// via its UNPACK binding (mapping it on the GL thread would deadlock on
+    /// the Pbo message round-trip); everything else takes the CPU texture
+    /// upload inside `render_packed_or_planar`.
     #[allow(clippy::too_many_arguments)]
-    fn convert_dest_non_dma(
+    fn convert_dest_texture(
         &mut self,
         dst: &mut Tensor<u8>,
         dst_fmt: PixelFormat,
@@ -2166,19 +2227,53 @@ impl GLProcessorST {
         flip: Flip,
         crop: ResolvedCrop,
     ) -> crate::Result<()> {
-        self.setup_renderbuffer_non_dma(dst, dst_fmt, crop)?;
+        let DstTarget::Texture { readback } = self.bind_dst(dst, dst_fmt, crop)? else {
+            return Err(crate::Error::OpenGl(
+                "convert_dest_texture: bind_dst lowered to a zero-copy target".to_string(),
+            ));
+        };
 
-        // Bias letterbox clear color for int8 — glClear bypasses the shader.
+        // Bias the letterbox clear colour for int8 on EVERY texture-target
+        // path: the fragment shader XORs rendered pixels and the readback
+        // never un-biases, so the glClear'd letterbox region must be
+        // pre-biased regardless of which memory the source or destination
+        // lives in. (The former any→PBO and PBO→Mem paths skipped this,
+        // leaving their int8 letterbox fill 0x80 off.)
         let crop = Self::int8_bias_clear(is_int8, crop);
 
         let start = Instant::now();
-        self.render_packed_or_planar(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)?;
-        log::debug!("Draw to framebuffer takes {:?}", start.elapsed());
+        match src.as_pbo() {
+            Some(src_pbo) => {
+                if src_pbo.is_mapped() {
+                    return Err(crate::Error::OpenGl(
+                        "Cannot convert from a mapped PBO tensor".to_string(),
+                    ));
+                }
+                let src_buffer_id = src_pbo.buffer_id();
+                self.render_from_pbo(
+                    src,
+                    src_fmt,
+                    src_buffer_id,
+                    dst,
+                    dst_fmt,
+                    is_int8,
+                    rotation,
+                    flip,
+                    crop,
+                )?;
+            }
+            None => {
+                self.render_packed_or_planar(
+                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
+                )?;
+            }
+        }
+        log::debug!("texture-target render takes {:?}", start.elapsed());
 
-        // ReadnPixels into Mem dst — data is already int8-biased by the shader.
+        // Data is already int8-biased by the shader — readback copies bytes.
         let start = Instant::now();
-        self.readback_rendered(dst, dst_fmt, None)?;
-        log::debug!("Read from framebuffer takes {:?}", start.elapsed());
+        self.readback_rendered(dst, dst_fmt, readback.pbo_id())?;
+        log::debug!("texture-target readback takes {:?}", start.elapsed());
         Ok(())
     }
 
@@ -2476,75 +2571,6 @@ impl GLProcessorST {
         )
     }
 
-    /// Convert between two PBO-backed images.
-    ///
-    /// Source PBO is bound as `GL_PIXEL_UNPACK_BUFFER` for zero-copy texture upload
-    /// (avoids `tensor.map()` to prevent GL-thread deadlocks). Destination uses
-    /// `GL_PIXEL_PACK_BUFFER` for zero-copy readback into the PBO.
-    #[allow(clippy::too_many_arguments)]
-    fn convert_pbo_to_pbo(
-        &mut self,
-        dst: &mut Tensor<u8>,
-        dst_fmt: PixelFormat,
-        src: &Tensor<u8>,
-        src_fmt: PixelFormat,
-        is_int8: bool,
-        rotation: crate::Rotation,
-        flip: Flip,
-        crop: ResolvedCrop,
-    ) -> crate::Result<()> {
-        let (src_buffer_id, dst_buffer_id) = {
-            let src_pbo = src.as_pbo().ok_or_else(|| {
-                crate::Error::OpenGl("convert_pbo_to_pbo: src is not a PBO tensor".to_string())
-            })?;
-            let dst_pbo = dst.as_pbo().ok_or_else(|| {
-                crate::Error::OpenGl("convert_pbo_to_pbo: dst is not a PBO tensor".to_string())
-            })?;
-
-            if src_pbo.is_mapped() || dst_pbo.is_mapped() {
-                return Err(crate::Error::OpenGl(
-                    "Cannot convert PBO tensors while they are mapped".to_string(),
-                ));
-            }
-
-            (src_pbo.buffer_id(), dst_pbo.buffer_id())
-        };
-
-        // Use PBO-as-UNPACK to set up the framebuffer render texture.
-        // `setup_renderbuffer_non_dma` would call `dst.map()` which sends a
-        // PboMap message back to this GL thread — causing a deadlock.
-        self.setup_renderbuffer_from_pbo(dst, dst_fmt, dst_buffer_id)?;
-
-        // Bias letterbox clear color for int8 — glClear bypasses the shader.
-        let crop = Self::int8_bias_clear(is_int8, crop);
-
-        // Upload source from PBO and render (int8 program swap owned by the
-        // shared `render_from_pbo` wrapper). We cannot call
-        // convert_to/draw_src_texture directly because they call
-        // src.tensor().map() which sends a message back to THIS thread, causing
-        // a deadlock. Instead, bind the source PBO as UNPACK buffer and upload
-        // to the texture with a NULL pointer — GL reads directly from the PBO,
-        // zero CPU copy.
-        let start = Instant::now();
-        self.render_from_pbo(
-            src,
-            src_fmt,
-            src_buffer_id,
-            dst,
-            dst_fmt,
-            is_int8,
-            rotation,
-            flip,
-            crop,
-        )?;
-        log::debug!("PBO render takes {:?}", start.elapsed());
-
-        let start_read = Instant::now();
-        self.readback_rendered(dst, dst_fmt, Some(dst_buffer_id))?;
-        log::debug!("PBO readback takes {:?}", start_read.elapsed());
-        Ok(())
-    }
-
     /// Upload source image from a PBO and render to the current framebuffer.
     /// This is the PBO equivalent of draw_src_texture — instead of mapping
     /// the tensor to CPU and calling glTexImage2D with a data pointer, we
@@ -2793,99 +2819,6 @@ impl GLProcessorST {
         }
 
         check_gl_error(function!(), line!())?;
-        Ok(())
-    }
-
-    /// Convert any source (Mem/DMA) to a PBO destination.
-    /// Source is uploaded via normal texture path (maps tensor for CPU upload).
-    /// Destination readback uses PBO PACK binding (no map on GL thread).
-    #[allow(clippy::too_many_arguments)]
-    fn convert_any_to_pbo(
-        &mut self,
-        dst: &mut Tensor<u8>,
-        dst_fmt: PixelFormat,
-        src: &Tensor<u8>,
-        src_fmt: PixelFormat,
-        is_int8: bool,
-        rotation: crate::Rotation,
-        flip: Flip,
-        crop: ResolvedCrop,
-    ) -> crate::Result<()> {
-        let dst_pbo = dst.as_pbo().ok_or_else(|| {
-            crate::Error::OpenGl("convert_any_to_pbo: dst is not a PBO tensor".to_string())
-        })?;
-        if dst_pbo.is_mapped() {
-            return Err(crate::Error::OpenGl(
-                "Cannot convert to a mapped PBO tensor".to_string(),
-            ));
-        }
-        let dst_buffer_id = dst_pbo.buffer_id();
-
-        // Use PBO-as-UNPACK to set up the framebuffer render texture.
-        // `setup_renderbuffer_non_dma` would call `dst.map()` which sends a
-        // PboMap message back to this GL thread — causing a deadlock.
-        self.setup_renderbuffer_from_pbo(dst, dst_fmt, dst_buffer_id)?;
-
-        let start = Instant::now();
-        self.render_packed_or_planar(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)?;
-        log::debug!("any-to-PBO render takes {:?}", start.elapsed());
-
-        let start_read = Instant::now();
-        self.readback_rendered(dst, dst_fmt, Some(dst_buffer_id))?;
-        log::debug!("any-to-PBO readback takes {:?}", start_read.elapsed());
-        Ok(())
-    }
-
-    /// Convert a PBO source to a non-PBO (Mem) destination.
-    /// Source is uploaded via PBO UNPACK binding (no map on GL thread).
-    /// Destination readback uses normal ReadnPixels into mapped Mem tensor.
-    #[allow(clippy::too_many_arguments)]
-    fn convert_pbo_to_mem(
-        &mut self,
-        dst: &mut Tensor<u8>,
-        dst_fmt: PixelFormat,
-        src: &Tensor<u8>,
-        src_fmt: PixelFormat,
-        is_int8: bool,
-        rotation: crate::Rotation,
-        flip: Flip,
-        crop: ResolvedCrop,
-    ) -> crate::Result<()> {
-        let src_pbo = src.as_pbo().ok_or_else(|| {
-            crate::Error::OpenGl("convert_pbo_to_mem: src is not a PBO tensor".to_string())
-        })?;
-        if src_pbo.is_mapped() {
-            return Err(crate::Error::OpenGl(
-                "Cannot convert from a mapped PBO tensor".to_string(),
-            ));
-        }
-        let src_buffer_id = src_pbo.buffer_id();
-
-        self.setup_renderbuffer_non_dma(dst, dst_fmt, crop)?;
-
-        // Render from the PBO source; the int8 program swap (GPU writes XOR'd
-        // values so ReadnPixels reads already-biased data) is owned by the
-        // shared `render_from_pbo` wrapper. The letterbox fill is handled by the
-        // CPU upload in `setup_renderbuffer_non_dma` above, so no
-        // `int8_bias_clear` is applied here.
-        let start = Instant::now();
-        self.render_from_pbo(
-            src,
-            src_fmt,
-            src_buffer_id,
-            dst,
-            dst_fmt,
-            is_int8,
-            rotation,
-            flip,
-            crop,
-        )?;
-        log::debug!("PBO-to-mem render takes {:?}", start.elapsed());
-
-        // ReadnPixels into Mem dst — data is already int8-biased by the shader.
-        let start = Instant::now();
-        self.readback_rendered(dst, dst_fmt, None)?;
-        log::debug!("PBO-to-mem readback takes {:?}", start.elapsed());
         Ok(())
     }
 
@@ -3520,7 +3453,7 @@ impl GLProcessorST {
         drop(_pass1);
 
         // --- Pass 2: RGBA→PlanarRgb to DMA destination ---
-        // setup_renderbuffer_dma rebinds convert_fbo with the DMA destination EGLImage,
+        // bind_dst rebinds convert_fbo with the DMA destination EGLImage,
         // replacing packed_rgb_fbo that was active during pass 1. It also sets the viewport
         // to (dst_w, dst_h * 3) for the tall R8 planar renderbuffer.
         let _pass2 = tracing::trace_span!(
@@ -3529,7 +3462,7 @@ impl GLProcessorST {
             dst_h
         )
         .entered();
-        self.setup_renderbuffer_dma(dst, dst_fmt)?;
+        self.bind_dst(dst, dst_fmt, crop)?;
 
         // Pass 2 is a fullscreen blit from the intermediate to the planar
         // destination. Pass 1 (convert_to above) already placed the image
@@ -3541,9 +3474,9 @@ impl GLProcessorST {
         // a second time. Observed downstream as bounding boxes compressed by
         // exactly (content/canvas) in the padded dimension on i.MX 8M Plus.
         //
-        // The int8 clear-color bias that lived here is gone with the clear:
-        // pass 1 performed all letterbox fills, and pass 2's shader applies
-        // the int8 bias itself (is_int8 flag on the draw below).
+        // No int8 bias-clear here either: pass 2 performs no clear, and the
+        // planar deinterleave shader applies the int8 bias itself (is_int8
+        // flag on the draw below).
         let dst_roi = RegionOfInterest {
             left: -1.,
             top: 1.,

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -2253,8 +2253,8 @@ impl GLProcessorST {
         };
         unsafe {
             gls::gl::UseProgram(self.texture_program.id);
-            gls::gl::BindTexture(gls::gl::TEXTURE_2D, self.render_texture.id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
+            gls::gl::BindTexture(gls::gl::TEXTURE_2D, self.render_texture.id);
             super::core::set_tex_filter(gls::gl::TEXTURE_2D, gls::gl::LINEAR);
 
             gls::gl::TexImage2D(
@@ -2385,8 +2385,8 @@ impl GLProcessorST {
         self.convert_fbo.bind();
         unsafe {
             gls::gl::UseProgram(self.texture_program.id);
-            gls::gl::BindTexture(gls::gl::TEXTURE_2D, self.render_texture.id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
+            gls::gl::BindTexture(gls::gl::TEXTURE_2D, self.render_texture.id);
             super::core::set_tex_filter(gls::gl::TEXTURE_2D, gls::gl::LINEAR);
 
             // Upload existing PBO content to the render texture.
@@ -2631,8 +2631,8 @@ impl GLProcessorST {
             }
 
             gls::gl::UseProgram(self.texture_program.id);
-            gls::gl::BindTexture(texture_target, self.camera_normal_texture.id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
+            gls::gl::BindTexture(texture_target, self.camera_normal_texture.id);
             super::core::set_tex_filter_clamp(texture_target, gls::gl::LINEAR);
             if src_fmt == PixelFormat::Grey {
                 for swizzle in [
@@ -3403,6 +3403,11 @@ impl GLProcessorST {
                     gls::gl::BindTexture(gls::gl::TEXTURE_2D, self.render_texture.id);
                     super::core::set_tex_filter(gls::gl::TEXTURE_2D, gls::gl::NEAREST);
                     gls::gl::EGLImageTargetTexture2DOES(gls::gl::TEXTURE_2D, dest_egl.as_ptr());
+                    // Raw re-target bypasses bind_egl_image's key tracking:
+                    // drop the cached key so a later bind_egl_image on this
+                    // texture cannot "reuse" a binding this call replaced
+                    // (silent write into the wrong destination buffer).
+                    self.render_texture.invalidate_egl_binding();
                     gls::gl::FramebufferTexture2D(
                         gls::gl::FRAMEBUFFER,
                         gls::gl::COLOR_ATTACHMENT0,
@@ -3437,6 +3442,13 @@ impl GLProcessorST {
 
         // Draw full-viewport quad to pack RGBA→RGB
         self.draw_fullscreen_quad()?;
+
+        // Pass 2 bound the intermediate on TEXTURE1; restore unit 0 as the
+        // active unit. Draw/setup sites select their unit before binding, but
+        // the processor-wide invariant between operations is "unit 0 active" —
+        // leaking unit 1 here is what broke the second heap-source convert
+        // (GL_INVALID_VALUE upload into the wrong texture).
+        unsafe { gls::gl::ActiveTexture(gls::gl::TEXTURE0) };
 
         unsafe { gls::gl::Finish() };
         check_gl_error(function!(), line!())?;
@@ -3679,8 +3691,8 @@ impl GLProcessorST {
                 &self.texture_program_planar
             };
             gls::gl::UseProgram(program.id);
-            gls::gl::BindTexture(texture_target, self.camera_eglimage_texture.id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
+            gls::gl::BindTexture(texture_target, self.camera_eglimage_texture.id);
             super::core::set_tex_filter(texture_target, gls::gl::LINEAR);
             gls::gl::TexParameteri(
                 texture_target,
@@ -3949,8 +3961,8 @@ impl GLProcessorST {
         };
         unsafe {
             gls::gl::UseProgram(self.texture_program.id);
-            gls::gl::BindTexture(texture_target, self.camera_normal_texture.id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
+            gls::gl::BindTexture(texture_target, self.camera_normal_texture.id);
             super::core::set_tex_filter_clamp(texture_target, gls::gl::LINEAR);
             if src_fmt == PixelFormat::Grey {
                 for swizzle in [
@@ -4082,8 +4094,8 @@ impl GLProcessorST {
         let texture_target = gls::gl::TEXTURE_EXTERNAL_OES;
         unsafe {
             gls::gl::UseProgram(self.texture_program_yuv.id);
-            gls::gl::BindTexture(texture_target, self.camera_eglimage_texture.id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
+            gls::gl::BindTexture(texture_target, self.camera_eglimage_texture.id);
             super::core::set_tex_filter_clamp(texture_target, gls::gl::LINEAR);
 
             // Note: GL_TEXTURE_SWIZZLE_* is not supported for

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -2809,7 +2809,17 @@ impl GLProcessorST {
     ///   covers single-plane NV12/NV16/NV24 but NOT true-multiplane NV12.
     /// - [`NvConvertPath::ExternalSampler`] (samplerExternalOES) is wired for
     ///   NV12 only (incl. multiplane); NV16/NV24 have no sampler path.
-    fn select_nv_path(&self, src: &Tensor<u8>, src_fmt: PixelFormat) -> NvConvertPath {
+    ///
+    /// `render_fmt` is the format of the render target this draw writes
+    /// (Rgb/PlanarRgb arrive here only as the LOGICAL format of a two-pass
+    /// convert whose pass 1 renders an RGBA intermediate; the only R8 render
+    /// target reachable with an NV source is a single-pass Grey destination).
+    fn select_nv_path(
+        &self,
+        src: &Tensor<u8>,
+        src_fmt: PixelFormat,
+        render_fmt: PixelFormat,
+    ) -> NvConvertPath {
         // `ShaderR8` (R8 texelFetch) only applies to SINGLE-PLANE semi-planar
         // NV12/NV16/NV24. Everything else routed through this picker —
         // RGBA/Grey/YUYV/RGB and true-multiplane NV12 — uses the
@@ -2827,7 +2837,18 @@ impl GLProcessorST {
         match self.nv_path_pref {
             NvPathPref::ForceShader => NvConvertPath::ShaderR8,
             NvPathPref::ForceSampler => {
-                if src_fmt == PixelFormat::Nv12 {
+                if src_fmt == PixelFormat::Nv12
+                    && self.is_vivante
+                    && render_fmt == PixelFormat::Grey
+                {
+                    // See the Auto-arm comment: sampler → R8 target wedges the
+                    // GC7000UL. Refuse the force rather than hang the GPU.
+                    log::warn!(
+                        "EDGEFIRST_NV_CONVERT_PATH=sampler refused for NV12→Grey on Vivante \
+                         (samplerExternalOES → R8 render target hangs the GPU); using shader"
+                    );
+                    NvConvertPath::ShaderR8
+                } else if src_fmt == PixelFormat::Nv12 {
                     NvConvertPath::ExternalSampler
                 } else {
                     log::warn!(
@@ -2856,8 +2877,16 @@ impl GLProcessorST {
             //   (encoding, range); everything else renders through the exact
             //   in-shader matrix, at Vivante's 12× cost.
             NvPathPref::Auto => {
+                // NEVER pair the external sampler with an R8 (Grey) render
+                // target on Vivante: samplerExternalOES → R8 attachment wedges
+                // the GC7000UL (the EDGEAI-1180 hang class — found when the
+                // Fast policy first routed nv12@dma→grey@dma to the sampler;
+                // the GPU hangs unrecoverably mid-draw). This gate applies in
+                // BOTH colorimetry modes: the old BT.601-limited carve-out had
+                // the same latent hang, just unreachable with HD sources.
                 let vivante_sampler_usable = src_fmt == PixelFormat::Nv12
                     && self.is_vivante
+                    && render_fmt != PixelFormat::Grey
                     && src.width().is_some_and(|w| w.is_multiple_of(4));
                 let take_sampler = vivante_sampler_usable
                     && match self.colorimetry_mode {
@@ -2985,7 +3014,7 @@ impl GLProcessorST {
             // prefers the portable, colorimetry-exact in-shader ShaderR8 for
             // single-plane NV12/NV16/NV24, using the driver ExternalSampler only
             // for true-multiplane NV12 (which ShaderR8 cannot import).
-            let chosen = self.select_nv_path(src, src_fmt);
+            let chosen = self.select_nv_path(src, src_fmt, _dst_fmt);
 
             if chosen == NvConvertPath::ShaderR8 {
                 match self.get_or_create_nv_r8_egl_image(src, src_fmt) {

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -238,7 +238,7 @@ pub struct GLProcessorST {
     bgra_warned: bool,
     /// Whether the GPU is a Verisilicon/Vivante core (detected via GL_RENDERER).
     /// Used to block operations known to cause unrecoverable GPU hangs.
-    is_vivante: bool,
+    pub(super) is_vivante: bool,
     /// Whether to use renderbuffer-backed EGLImages for DMA destinations.
     ///
     /// Set `EDGEFIRST_OPENGL_RENDERSURFACE=1` to enable (required on i.MX 95 / Mali-G310
@@ -298,6 +298,11 @@ pub struct GLProcessorST {
     pub(super) last_nv_convert_path: NvConvertPath,
     /// Client preference for NV* path selection (`EDGEFIRST_NV_CONVERT_PATH`).
     nv_path_pref: NvPathPref,
+    /// Colorimetry/performance trade-off (see [`crate::ColorimetryMode`]).
+    colorimetry_mode: crate::ColorimetryMode,
+    /// `true` when `EDGEFIRST_COLORIMETRY` pinned the mode for this
+    /// processor's lifetime — `set_colorimetry_mode` then logs and keeps it.
+    colorimetry_env_pinned: bool,
     /// When `true`, a convert's terminal `glFinish` is skipped so a batch of
     /// tiles rendered into one shared destination import syncs only once, via a
     /// single `finish_via_fence` at [`flush`](Self::flush). Set for the duration
@@ -875,6 +880,29 @@ impl GLProcessorST {
             log::info!("EDGEFIRST_NV_CONVERT_PATH override: {nv_path_pref:?}");
         }
 
+        // Colorimetry/performance trade-off. The env var pins the mode for the
+        // processor's lifetime (set_colorimetry_mode logs and keeps it);
+        // otherwise the config default is Fast (issue #106 policy) and
+        // `set_colorimetry_mode` may change it.
+        let colorimetry_env = match std::env::var("EDGEFIRST_COLORIMETRY") {
+            Ok(v) => match v.to_ascii_lowercase().as_str() {
+                "exact" => Some(crate::ColorimetryMode::Exact),
+                "fast" => Some(crate::ColorimetryMode::Fast),
+                "" => None,
+                other => {
+                    log::warn!(
+                        "EDGEFIRST_COLORIMETRY={other:?} not recognised \
+                         (expected fast|exact), ignoring"
+                    );
+                    None
+                }
+            },
+            Err(_) => None,
+        };
+        if let Some(mode) = colorimetry_env {
+            log::info!("EDGEFIRST_COLORIMETRY override: {mode:?}");
+        }
+
         let mut converter = GLProcessorST {
             gl_context,
             texture_program,
@@ -938,6 +966,8 @@ impl GLProcessorST {
             nv_r8_egl_cache: EglImageCache::new(egl_cache_capacity),
             last_nv_convert_path: NvConvertPath::None,
             nv_path_pref,
+            colorimetry_mode: colorimetry_env.unwrap_or_default(),
+            colorimetry_env_pinned: colorimetry_env.is_some(),
             defer_finish: false,
             pending_flush: false,
         };
@@ -1116,6 +1146,24 @@ impl GLProcessorST {
     pub fn set_int8_interpolation_mode(&mut self, mode: Int8InterpolationMode) {
         self.int8_interpolation_mode = mode;
         log::debug!("Int8 interpolation mode set to {:?}", mode);
+    }
+
+    /// Sets the colorimetry/performance trade-off (see
+    /// [`crate::ColorimetryMode`]). When `EDGEFIRST_COLORIMETRY` pinned the
+    /// mode at construction, the env value wins: this logs and keeps it.
+    pub fn set_colorimetry_mode(&mut self, mode: crate::ColorimetryMode) {
+        if self.colorimetry_env_pinned {
+            if mode != self.colorimetry_mode {
+                log::info!(
+                    "ColorimetryMode::{mode:?} requested but EDGEFIRST_COLORIMETRY pins \
+                     {:?} — keeping the env override",
+                    self.colorimetry_mode
+                );
+            }
+            return;
+        }
+        self.colorimetry_mode = mode;
+        log::debug!("Colorimetry mode set to {:?}", mode);
     }
 
     /// Snapshot the EGLImage cache counters (src, dst, NV R8).
@@ -2789,30 +2837,41 @@ impl GLProcessorST {
                     NvConvertPath::ShaderR8
                 }
             }
-            // Auto: prefer the portable, colorimetry-exact in-shader ShaderR8.
+            // Auto: prefer the portable, colorimetry-exact in-shader ShaderR8
+            // wherever it is also the fast path (Mali, V3D, Tegra — shader and
+            // sampler are comparable there, so exactness is free).
             //
             // EXCEPTION — Vivante (i.MX 8MP): the texelFetch shader is ~12×
             // slower than the hardware samplerExternalOES (on-target benchmark:
-            // NV12 720p convert 29ms shader vs 2.5ms sampler), and Vivante's
-            // fixed BT.601-limited sampler matrix MATCHES the reference for
-            // BT.601-limited sources (Phase 2 probe: ≤1 vs CPU). So for
-            // single-plane NV12 that is BT.601-limited and 4-aligned (the
-            // sampler import constraint), prefer ExternalSampler on Vivante.
-            // Full-range / BT.709 on Vivante still take ShaderR8 (slow but
-            // colorimetry-correct — the driver would apply the wrong matrix).
+            // NV12 720p convert 29ms shader vs 2.5ms sampler). For single-plane
+            // 4-aligned NV12 (the sampler import constraint) the pick follows
+            // the HIGH-PERFORMANCE-default policy (issue #106):
+            //
+            // * `ColorimetryMode::Fast` (default): take the sampler for EVERY
+            //   colorimetry — the driver applies its fixed BT.601-limited
+            //   matrix, which is exact for BT.601-limited sources (Phase 2
+            //   probe: ≤1 vs CPU) and approximate for the rest.
+            // * `ColorimetryMode::Exact` (config/env opt-in): take the sampler
+            //   only when the driver matrix MATCHES the source's resolved
+            //   (encoding, range); everything else renders through the exact
+            //   in-shader matrix, at Vivante's 12× cost.
             NvPathPref::Auto => {
-                let vivante_sampler_fast_path = src_fmt == PixelFormat::Nv12
+                let vivante_sampler_usable = src_fmt == PixelFormat::Nv12
                     && self.is_vivante
-                    && src.width().is_some_and(|w| w.is_multiple_of(4))
-                    && {
-                        let cm = crate::colorimetry::resolve_colorimetry(
-                            src.colorimetry(),
-                            src.height(),
-                        );
-                        cm.encoding == Some(edgefirst_tensor::ColorEncoding::Bt601)
-                            && cm.range == Some(edgefirst_tensor::ColorRange::Limited)
+                    && src.width().is_some_and(|w| w.is_multiple_of(4));
+                let take_sampler = vivante_sampler_usable
+                    && match self.colorimetry_mode {
+                        crate::ColorimetryMode::Fast => true,
+                        crate::ColorimetryMode::Exact => {
+                            let cm = crate::colorimetry::resolve_colorimetry(
+                                src.colorimetry(),
+                                src.height(),
+                            );
+                            cm.encoding == Some(edgefirst_tensor::ColorEncoding::Bt601)
+                                && cm.range == Some(edgefirst_tensor::ColorRange::Limited)
+                        }
                     };
-                if vivante_sampler_fast_path {
+                if take_sampler {
                     NvConvertPath::ExternalSampler
                 } else {
                     NvConvertPath::ShaderR8

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -110,6 +110,63 @@ impl DstReadback {
     }
 }
 
+/// Uniform locations for one `nv_r8` program variant, resolved once at link
+/// time — `glGetUniformLocation` is a per-call string lookup in the driver
+/// and the NV draw previously issued 12 per frame.
+#[derive(Clone, Copy)]
+struct NvUniformLocs {
+    img_size: i32,
+    tex_width: i32,
+    chroma_shift: i32,
+    chroma_lines: i32,
+    y_offset: i32,
+    y_scale: i32,
+    c_vr: i32,
+    c_ug: i32,
+    c_vg: i32,
+    c_ub: i32,
+}
+
+/// Per-program uniform state for one `nv_r8` variant. Uniform values are
+/// per-program GL state and persist across draws, so the constant sampler
+/// binding (`src` = unit 0) is uploaded once at resolve time and
+/// `last_colorimetry` lets the draw skip re-uploading the six YUV-matrix
+/// floats while the source's (encoding, range) is unchanged.
+struct NvUniformState {
+    locs: NvUniformLocs,
+    last_colorimetry: Option<(
+        edgefirst_tensor::ColorEncoding,
+        edgefirst_tensor::ColorRange,
+    )>,
+}
+
+impl NvUniformState {
+    fn resolve(program: &GlProgram) -> Self {
+        unsafe {
+            gls::gl::UseProgram(program.id);
+            let loc =
+                |name: &std::ffi::CStr| gls::gl::GetUniformLocation(program.id, name.as_ptr());
+            // Constant: the NV shaders always sample `src` from unit 0.
+            gls::gl::Uniform1i(loc(c"src"), 0);
+            NvUniformState {
+                locs: NvUniformLocs {
+                    img_size: loc(c"img_size"),
+                    tex_width: loc(c"tex_width"),
+                    chroma_shift: loc(c"chroma_shift"),
+                    chroma_lines: loc(c"chroma_lines"),
+                    y_offset: loc(c"y_offset"),
+                    y_scale: loc(c"y_scale"),
+                    c_vr: loc(c"c_vr"),
+                    c_ug: loc(c"c_ug"),
+                    c_vg: loc(c"c_vg"),
+                    c_ub: loc(c"c_ub"),
+                },
+                last_colorimetry: None,
+            }
+        }
+    }
+}
+
 /// OpenGL single-threaded image converter.
 pub struct GLProcessorST {
     camera_eglimage_texture: Texture,
@@ -229,6 +286,10 @@ pub struct GLProcessorST {
     nv_r8_program: GlProgram,
     /// Path B shader: NV12/NV16/NV24 R8 → RGBA8 with int8 XOR 0x80 bias.
     nv_r8_int8_program: GlProgram,
+    /// Link-time uniform locations + colorimetry-upload skip for `nv_r8_program`.
+    nv_r8_uniforms: NvUniformState,
+    /// Same for `nv_r8_int8_program`.
+    nv_r8_int8_uniforms: NvUniformState,
     /// Texture for the Path-B R8 EGLImage source (TEXTURE_2D, not EXTERNAL_OES).
     nv_r8_texture: Texture,
     /// EGLImage cache for Path-B R8 source imports (keyed like src_egl_cache).
@@ -755,6 +816,15 @@ impl GLProcessorST {
             generate_vertex_shader(),
             generate_nv_to_rgba_int8_shader_2d(),
         )?;
+        // Resolve uniform locations once at link time (the NV draw is per-frame)
+        // and upload the constant sampler bindings while the programs are fresh:
+        // pass-2 packing samples the intermediate on unit 1, planar-2d on unit 0.
+        let nv_r8_uniforms = NvUniformState::resolve(&nv_r8_program);
+        let nv_r8_int8_uniforms = NvUniformState::resolve(&nv_r8_int8_program);
+        packed_rgba8_program_2d.load_uniform_1i(c"tex", 1)?;
+        packed_rgba8_int8_program_2d.load_uniform_1i(c"tex", 1)?;
+        texture_program_planar_2d.load_uniform_1i(c"tex", 0)?;
+        texture_program_planar_int8_2d.load_uniform_1i(c"tex", 0)?;
 
         let camera_eglimage_texture = Texture::new();
         let camera_normal_texture = Texture::new();
@@ -862,6 +932,8 @@ impl GLProcessorST {
             proto_ssbo_size: 0,
             nv_r8_program,
             nv_r8_int8_program,
+            nv_r8_uniforms,
+            nv_r8_int8_uniforms,
             nv_r8_texture: Texture::new(),
             nv_r8_egl_cache: EglImageCache::new(egl_cache_capacity),
             last_nv_convert_path: NvConvertPath::None,
@@ -3260,11 +3332,7 @@ impl GLProcessorST {
             super::core::set_tex_filter(gls::gl::TEXTURE_2D, gls::gl::NEAREST);
         }
 
-        // Set uniform: tex = TEXTURE1 (intermediate RGBA texture)
-        unsafe {
-            let loc_tex = gls::gl::GetUniformLocation(program.id, c"tex".as_ptr());
-            gls::gl::Uniform1i(loc_tex, 1);
-        }
+        // (`tex` = unit 1 is constant per program, uploaded at link time.)
 
         // Draw full-viewport quad to pack RGBA→RGB
         self.draw_fullscreen_quad()?;
@@ -3676,10 +3744,7 @@ impl GLProcessorST {
             gls::gl::BindTexture(texture_target, self.packed_rgb_intermediate_tex.id);
             super::core::set_tex_filter_clamp(texture_target, gls::gl::LINEAR);
 
-            // Set tex uniform to unit 0
-            let loc_tex = gls::gl::GetUniformLocation(program.id, c"tex".as_ptr());
-            gls::gl::Uniform1i(loc_tex, 0);
-
+            // (`tex` = unit 0 is constant per program, uploaded at link time.)
             check_gl_error(function!(), line!())?;
 
             let y_centers = if alpha {
@@ -4100,6 +4165,29 @@ impl GLProcessorST {
             self.nv_r8_program.id
         };
 
+        // YUV→RGB matrix + range, resolved from the source tensor's
+        // colorimetry (missing axes filled by the SD/HD height heuristic).
+        // Path B applies the matrix in-shader, so it is colorimetry-correct
+        // on every GPU regardless of EGL color-hint support.
+        let cm = crate::colorimetry::resolve_colorimetry(src.colorimetry(), src.height());
+        let colorimetry = (
+            cm.encoding
+                .unwrap_or(edgefirst_tensor::ColorEncoding::Bt709),
+            cm.range.unwrap_or(edgefirst_tensor::ColorRange::Limited),
+        );
+        let state = if is_int8 {
+            &mut self.nv_r8_int8_uniforms
+        } else {
+            &mut self.nv_r8_uniforms
+        };
+        let locs = state.locs;
+        // Uniform values persist per program: re-upload the six matrix floats
+        // only when this program's (encoding, range) actually changed. The
+        // marker is recorded AFTER the draw succeeds — an error between here
+        // and the upload must not leave a "already uploaded" claim for values
+        // that never reached the program.
+        let upload_colorimetry = state.last_colorimetry != Some(colorimetry);
+
         unsafe {
             gls::gl::UseProgram(prog_id);
             gls::gl::ActiveTexture(gls::gl::TEXTURE0);
@@ -4176,57 +4264,22 @@ impl GLProcessorST {
                 }
             }
 
-            // Set uniforms (img_size, tex_width, chroma_shift, chroma_lines).
-            let loc_img_size = gls::gl::GetUniformLocation(prog_id, c"img_size".as_ptr());
-            gls::gl::Uniform2i(loc_img_size, src_w as i32, src_h as i32);
+            // Per-source uniforms through link-time-cached locations (the
+            // `src` sampler binding is constant and uploaded at resolve time).
+            gls::gl::Uniform2i(locs.img_size, src_w as i32, src_h as i32);
+            gls::gl::Uniform1i(locs.tex_width, tex_width);
+            gls::gl::Uniform2i(locs.chroma_shift, chroma_shift_x, chroma_shift_y);
+            gls::gl::Uniform1i(locs.chroma_lines, chroma_lines);
 
-            let loc_tex_width = gls::gl::GetUniformLocation(prog_id, c"tex_width".as_ptr());
-            gls::gl::Uniform1i(loc_tex_width, tex_width);
-
-            let loc_chroma_shift = gls::gl::GetUniformLocation(prog_id, c"chroma_shift".as_ptr());
-            gls::gl::Uniform2i(loc_chroma_shift, chroma_shift_x, chroma_shift_y);
-
-            let loc_chroma_lines = gls::gl::GetUniformLocation(prog_id, c"chroma_lines".as_ptr());
-            gls::gl::Uniform1i(loc_chroma_lines, chroma_lines);
-
-            // YUV→RGB matrix + range, resolved from the source tensor's
-            // colorimetry (missing axes filled by the SD/HD height heuristic).
-            // Path B applies the matrix in-shader, so it is colorimetry-correct
-            // on every GPU regardless of EGL color-hint support.
-            let cm = crate::colorimetry::resolve_colorimetry(src.colorimetry(), src.height());
-            let coeffs = crate::colorimetry::yuv_to_rgb_coeffs(
-                cm.encoding
-                    .unwrap_or(edgefirst_tensor::ColorEncoding::Bt709),
-                cm.range.unwrap_or(edgefirst_tensor::ColorRange::Limited),
-            );
-            gls::gl::Uniform1f(
-                gls::gl::GetUniformLocation(prog_id, c"y_offset".as_ptr()),
-                coeffs.y_offset,
-            );
-            gls::gl::Uniform1f(
-                gls::gl::GetUniformLocation(prog_id, c"y_scale".as_ptr()),
-                coeffs.y_scale,
-            );
-            gls::gl::Uniform1f(
-                gls::gl::GetUniformLocation(prog_id, c"c_vr".as_ptr()),
-                coeffs.c_vr,
-            );
-            gls::gl::Uniform1f(
-                gls::gl::GetUniformLocation(prog_id, c"c_ug".as_ptr()),
-                coeffs.c_ug,
-            );
-            gls::gl::Uniform1f(
-                gls::gl::GetUniformLocation(prog_id, c"c_vg".as_ptr()),
-                coeffs.c_vg,
-            );
-            gls::gl::Uniform1f(
-                gls::gl::GetUniformLocation(prog_id, c"c_ub".as_ptr()),
-                coeffs.c_ub,
-            );
-
-            // Bind sampler to unit 0.
-            let loc_src = gls::gl::GetUniformLocation(prog_id, c"src".as_ptr());
-            gls::gl::Uniform1i(loc_src, 0);
+            if upload_colorimetry {
+                let coeffs = crate::colorimetry::yuv_to_rgb_coeffs(colorimetry.0, colorimetry.1);
+                gls::gl::Uniform1f(locs.y_offset, coeffs.y_offset);
+                gls::gl::Uniform1f(locs.y_scale, coeffs.y_scale);
+                gls::gl::Uniform1f(locs.c_vr, coeffs.c_vr);
+                gls::gl::Uniform1f(locs.c_ug, coeffs.c_ug);
+                gls::gl::Uniform1f(locs.c_vg, coeffs.c_vg);
+                gls::gl::Uniform1f(locs.c_ub, coeffs.c_ub);
+            }
 
             gls::gl::BindBuffer(gls::gl::ARRAY_BUFFER, self.vertex_buffer.id);
             gls::gl::EnableVertexAttribArray(self.vertex_buffer.buffer_index);
@@ -4299,6 +4352,16 @@ impl GLProcessorST {
             );
         }
         check_gl_error(function!(), line!())?;
+        // The draw (and its colorimetry upload, when taken) succeeded — only
+        // now record the program's uploaded (encoding, range).
+        if upload_colorimetry {
+            let state = if is_int8 {
+                &mut self.nv_r8_int8_uniforms
+            } else {
+                &mut self.nv_r8_uniforms
+            };
+            state.last_colorimetry = Some(colorimetry);
+        }
         Ok(())
     }
 

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -3181,7 +3181,16 @@ impl GLProcessorST {
         // Handles: source binding (DMA EGLImage or upload), crop, letterbox, rotation, flip.
         // Pass 1 renders UN-biased (is_int8 = false): the int8 XOR-0x80 bias is
         // applied once, by pass 2's packing shader.
-        self.convert_to(src, src_fmt, dst, dst_fmt, false, rotation, flip, crop)?;
+        //
+        // Pass 1 must NOT glFinish (convert_to's standalone-boundary sync):
+        // same-context command ordering already guarantees pass 2 samples the
+        // finished intermediate, and the convert syncs once at pass 2's end.
+        // The flag restores before `?` so an error cannot leak defer state.
+        let saved_defer = self.defer_finish;
+        self.defer_finish = true;
+        let pass1 = self.convert_to(src, src_fmt, dst, dst_fmt, false, rotation, flip, crop);
+        self.defer_finish = saved_defer;
+        pass1?;
         drop(_pass1);
 
         // --- Pass 2: Pack intermediate RGBA → RGB DMA destination ---
@@ -3328,7 +3337,15 @@ impl GLProcessorST {
         // width/height in ROI coordinate math.
         // Pass 1 renders UN-biased (is_int8 = false): the int8 XOR-0x80 bias is
         // applied once, by pass 2's planar deinterleave shader.
-        self.convert_to(src, src_fmt, dst, dst_fmt, false, rotation, flip, crop)?;
+        //
+        // Pass 1 must NOT glFinish (convert_to's standalone-boundary sync):
+        // same-context command ordering already guarantees pass 2 samples the
+        // finished intermediate, and the convert syncs once at pass 2's end.
+        let saved_defer = self.defer_finish;
+        self.defer_finish = true;
+        let pass1 = self.convert_to(src, src_fmt, dst, dst_fmt, false, rotation, flip, crop);
+        self.defer_finish = saved_defer;
+        pass1?;
         drop(_pass1);
 
         // --- Pass 2: RGBA→PlanarRgb to DMA destination ---

--- a/crates/image/src/gl/render.rs
+++ b/crates/image/src/gl/render.rs
@@ -37,6 +37,36 @@
 #![allow(dead_code)]
 
 use crate::Region;
+use edgefirst_tensor::TensorMemory;
+
+/// How a convert's destination is realized on the GPU — the pure half of the
+/// destination lowering (`bind_dst` in `processor/mod.rs` performs the GL
+/// work). One lowering per *destination memory class*, never per platform:
+/// platform differences surface as the `zero_copy_import` capability bit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DstLowering {
+    /// The destination buffer itself becomes the FBO colour attachment
+    /// (EGLImage renderbuffer/texture today, IOSurface pbuffer after the
+    /// platform seam). The render writes the buffer directly — no readback.
+    ZeroCopy,
+    /// Offscreen texture render target, read back into the mapped tensor.
+    TextureMem,
+    /// Offscreen texture render target, read back into the destination PBO's
+    /// PACK binding (the tensor must never be mapped on the GL thread).
+    TexturePbo,
+}
+
+/// Classify the destination lowering from the platform's zero-copy import
+/// capability and the destination's memory class. A DMA destination without
+/// import support (e.g. dma-heap present but `EGL_EXT_image_dma_buf_import`
+/// missing) degrades to the mapped texture path rather than failing.
+pub(super) fn lower_dst(zero_copy_import: bool, dst_mem: TensorMemory) -> DstLowering {
+    match dst_mem {
+        TensorMemory::Dma if zero_copy_import => DstLowering::ZeroCopy,
+        TensorMemory::Pbo => DstLowering::TexturePbo,
+        _ => DstLowering::TextureMem,
+    }
+}
 
 /// A GL viewport / scissor rectangle in **pixels**, bottom-left origin.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,5 +286,22 @@ mod tests {
     fn plan_batch_degenerate_inputs() {
         assert_eq!(plan_batch(0, 64, 2048), BatchPath::OneImport);
         assert_eq!(plan_batch(4, 0, 2048), BatchPath::OneImport);
+    }
+
+    #[test]
+    fn lower_dst_full_table() {
+        use TensorMemory::*;
+        // With zero-copy import: only a DMA destination is zero-copy; PBO
+        // keeps its PACK readback; Mem/Shm read back through the map.
+        assert_eq!(lower_dst(true, Dma), DstLowering::ZeroCopy);
+        assert_eq!(lower_dst(true, Pbo), DstLowering::TexturePbo);
+        assert_eq!(lower_dst(true, Mem), DstLowering::TextureMem);
+        assert_eq!(lower_dst(true, Shm), DstLowering::TextureMem);
+        // Without import support a DMA destination degrades to the mapped
+        // texture path (dma-heap without EGL dma_buf_import) — never an error.
+        assert_eq!(lower_dst(false, Dma), DstLowering::TextureMem);
+        assert_eq!(lower_dst(false, Pbo), DstLowering::TexturePbo);
+        assert_eq!(lower_dst(false, Mem), DstLowering::TextureMem);
+        assert_eq!(lower_dst(false, Shm), DstLowering::TextureMem);
     }
 }

--- a/crates/image/src/gl/render.rs
+++ b/crates/image/src/gl/render.rs
@@ -37,7 +37,7 @@
 #![allow(dead_code)]
 
 use crate::Region;
-use edgefirst_tensor::TensorMemory;
+use edgefirst_tensor::{PixelFormat, PixelLayout, TensorMemory};
 
 /// How a convert's destination is realized on the GPU — the pure half of the
 /// destination lowering (`bind_dst` in `processor/mod.rs` performs the GL
@@ -66,6 +66,57 @@ pub(super) fn lower_dst(zero_copy_import: bool, dst_mem: TensorMemory) -> DstLow
         TensorMemory::Pbo => DstLowering::TexturePbo,
         _ => DstLowering::TextureMem,
     }
+}
+
+/// How a convert renders — the pure plan half of the engine
+/// (`convert_via_engine` in `processor/mod.rs` executes it). Exactly one
+/// plan per (source format, destination format, destination lowering)
+/// triple; the two-pass plans exist only for zero-copy destinations, whose
+/// buffers GL cannot write in the requested layout in one pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ConvertPlan {
+    /// One render pass into the bound destination target (packed via the
+    /// texture shaders, planar via the planar shader), then the lowering's
+    /// readback (none for zero-copy).
+    SinglePass,
+    /// Zero-copy packed-RGB: pass 1 renders RGBA into an intermediate
+    /// texture, pass 2 packs it into the destination reinterpreted as
+    /// RGBA8 at `W*3/4 × H` (GL has no 3-byte render format).
+    TwoPassPackedRgb,
+    /// Zero-copy NV*→planar: pass 1 converts NV*→RGBA through the full
+    /// `select_nv_path` machinery (colorimetry-exact ShaderR8 + Vivante
+    /// carve-out), pass 2 deinterleaves RGBA into the planar destination.
+    /// Also the Vivante GC7000UL single-pass GPU-hang workaround
+    /// (EDGEAI-1180).
+    TwoPassNvPlanar,
+}
+
+/// Decide the render plan. Pure (src format, dst format, dst lowering) →
+/// plan; capability differences arrive via the lowering, never as platform
+/// branches here.
+pub(super) fn plan_convert(
+    src_fmt: PixelFormat,
+    dst_fmt: PixelFormat,
+    lowering: DstLowering,
+) -> ConvertPlan {
+    if lowering != DstLowering::ZeroCopy {
+        // Texture destinations always render once and read back; packed RGB
+        // and planar layouts are handled by the readback format / planar
+        // shader, not by reinterpreting the destination buffer.
+        return ConvertPlan::SinglePass;
+    }
+    if dst_fmt == PixelFormat::Rgb {
+        return ConvertPlan::TwoPassPackedRgb;
+    }
+    if dst_fmt.layout() == PixelLayout::Planar
+        && matches!(
+            src_fmt,
+            PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
+        )
+    {
+        return ConvertPlan::TwoPassNvPlanar;
+    }
+    ConvertPlan::SinglePass
 }
 
 /// A GL viewport / scissor rectangle in **pixels**, bottom-left origin.
@@ -286,6 +337,55 @@ mod tests {
     fn plan_batch_degenerate_inputs() {
         assert_eq!(plan_batch(0, 64, 2048), BatchPath::OneImport);
         assert_eq!(plan_batch(4, 0, 2048), BatchPath::OneImport);
+    }
+
+    #[test]
+    fn plan_convert_full_table() {
+        use DstLowering::*;
+        use PixelFormat::*;
+        let nv = [Nv12, Nv16, Nv24];
+        let non_nv = [Rgba, Bgra, Grey, Yuyv];
+        // Zero-copy: packed RGB always two-pass; NV→planar two-pass; the rest
+        // single-pass (incl. non-NV → planar, which the planar shader handles
+        // in one pass).
+        for src in nv.iter().chain(&non_nv) {
+            assert_eq!(
+                plan_convert(*src, Rgb, ZeroCopy),
+                ConvertPlan::TwoPassPackedRgb,
+                "{src:?}->Rgb zero-copy"
+            );
+        }
+        for src in nv {
+            assert_eq!(
+                plan_convert(src, PlanarRgb, ZeroCopy),
+                ConvertPlan::TwoPassNvPlanar
+            );
+            assert_eq!(
+                plan_convert(src, PlanarRgba, ZeroCopy),
+                ConvertPlan::TwoPassNvPlanar
+            );
+            assert_eq!(plan_convert(src, Rgba, ZeroCopy), ConvertPlan::SinglePass);
+        }
+        for src in non_nv {
+            assert_eq!(
+                plan_convert(src, PlanarRgb, ZeroCopy),
+                ConvertPlan::SinglePass
+            );
+            assert_eq!(plan_convert(src, Rgba, ZeroCopy), ConvertPlan::SinglePass);
+        }
+        // Texture lowerings: ALWAYS single-pass, for every format pair — the
+        // two-pass plans only exist to write zero-copy buffers in-place.
+        for lowering in [TextureMem, TexturePbo] {
+            for src in nv.iter().chain(&non_nv) {
+                for dst in [Rgba, Bgra, Rgb, PlanarRgb, Grey] {
+                    assert_eq!(
+                        plan_convert(*src, dst, lowering),
+                        ConvertPlan::SinglePass,
+                        "{src:?}->{dst:?} via {lowering:?}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/image/src/gl/render.rs
+++ b/crates/image/src/gl/render.rs
@@ -29,13 +29,6 @@
 //!    (`glViewport`), never part of the EGL cache key — that is what makes
 //!    "N tiles → 1 import" hold.
 
-// `Viewport`/`source_uv`/`plan_batch`/`BatchPath` stage the chunking follow-up
-// (split a batch that exceeds `GL_MAX_*` into per-chunk imports) and the
-// source-UV/bottom-up-surface paths; the live top-down DMA batch path computes
-// its band viewport inline (see the orientation note above). Until those land,
-// only the unit tests exercise these — drop the allow when they are wired in.
-#![allow(dead_code)]
-
 use crate::Region;
 use edgefirst_tensor::{PixelFormat, PixelLayout, TensorMemory};
 
@@ -128,13 +121,33 @@ pub(super) struct Viewport {
     pub(super) h: i32,
 }
 
+/// Lower a destination tile to its GL band rectangle on the live Linux
+/// DMA-BUF path, which is **top-down** (GL framebuffer row 0 == memory row 0,
+/// verified on-target): the band's GL `y` is simply `region.y`, with no
+/// bottom-left flip — the renderer's texcoord flip keeps the image upright.
+/// The single home for the orientation convention: BOTH the band `glViewport`
+/// (`bind_dst` setup) and the matching `glScissor` (letterbox-clear
+/// confinement in `convert_to`) lower through here so they can never
+/// disagree. [`region_to_viewport`] is the bottom-up twin for a future
+/// bottom-left-origin surface (e.g. the macOS pbuffer batch path).
+#[inline]
+pub(super) fn region_to_viewport_top_down(region: Region) -> Viewport {
+    Viewport {
+        x: region.x as i32,
+        y: region.y as i32,
+        w: region.width as i32,
+        h: region.height as i32,
+    }
+}
+
 /// Lower a top-left `region` of an image `parent_h` rows tall to a bottom-left
 /// GL viewport. The horizontal axis is unchanged; the vertical axis is flipped
 /// so the region's *top* edge maps to the correct GL row.
 ///
-/// This is the single source of the y-origin convention for the converged
-/// renderer — a destination tile, a letterbox inner box, and a whole-image
-/// render all lower through here.
+/// Staged for the first bottom-left-origin render target (macOS pbuffer batch
+/// path, PR-A); the live Linux DMA-BUF path is top-down and uses
+/// [`region_to_viewport_top_down`]. Until then only the unit tests call this.
+#[allow(dead_code)]
 pub(super) fn region_to_viewport(region: Region, parent_h: usize) -> Viewport {
     // Bottom-left origin: the GL y of the region's top-left corner is the number
     // of rows *below* the region — `parent_h - (y + h)`. Saturating so a region
@@ -154,6 +167,11 @@ pub(super) fn region_to_viewport(region: Region, parent_h: usize) -> Viewport {
 /// `[0, 0, 1, 1]`. Matches the `src_rect_uv` produced by
 /// [`crate::gl::core::float_crop_uniforms`] so the converged renderer and the
 /// float path agree on source addressing.
+///
+/// Staged for the source-view sampling path (the u8 renderer still computes
+/// its `RegionOfInterest` corners inline); until wired, only the unit tests
+/// call this.
+#[allow(dead_code)]
 pub(super) fn source_uv(region: Option<Region>, src_w: usize, src_h: usize) -> [f32; 4] {
     match region {
         Some(r) if src_w > 0 && src_h > 0 => [
@@ -174,6 +192,10 @@ pub(super) fn source_uv(region: Option<Region>, src_w: usize, src_h: usize) -> [
 /// batch is split into chunks of `tiles_per_chunk`, one import per chunk.
 /// `PerTileImport` is the degenerate floor (a single tile already too large to
 /// batch) — equivalent to the legacy per-call path.
+/// Staged for the `GL_MAX_*` chunking follow-up (split an over-limit batch
+/// into per-chunk imports); until wired into `convert_batch`, only the unit
+/// tests exercise this and [`plan_batch`].
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum BatchPath {
     OneImport,
@@ -191,6 +213,7 @@ pub(super) enum BatchPath {
 /// * `n_tiles · rows_per_tile ≤ max_rows`  → `OneImport`
 /// * `rows_per_tile ≤ max_rows < n·rows`   → `Chunked(max_rows / rows_per_tile)`
 /// * `rows_per_tile > max_rows`            → `PerTileImport`
+#[allow(dead_code)]
 pub(super) fn plan_batch(n_tiles: usize, rows_per_tile: usize, max_rows: usize) -> BatchPath {
     if rows_per_tile == 0 || n_tiles == 0 {
         return BatchPath::OneImport;
@@ -213,6 +236,25 @@ mod tests {
 
     fn region(x: usize, y: usize, w: usize, h: usize) -> Region {
         Region::new(x, y, w, h)
+    }
+
+    #[test]
+    fn viewport_top_down_is_identity() {
+        // The live DMA path is top-down: GL y == memory row y, no flip. Three
+        // stacked 16-row tiles keep their memory order in GL coordinates.
+        let ys: Vec<i32> = (0..3)
+            .map(|n| region_to_viewport_top_down(region(0, n * 16, 64, 16)).y)
+            .collect();
+        assert_eq!(ys, vec![0, 16, 32]);
+        assert_eq!(
+            region_to_viewport_top_down(region(10, 4, 20, 8)),
+            Viewport {
+                x: 10,
+                y: 4,
+                w: 20,
+                h: 8
+            }
+        );
     }
 
     #[test]

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -4261,6 +4261,107 @@ mod gl_tests {
         assert_eq!(dma_f16_packed_layout(320, 240), Some((80, 720, 640)));
     }
 
+    /// The int8 letterbox clear colour must be pre-biased (XOR 0x80) on EVERY
+    /// destination lowering: the int8 fragment shader biases rendered pixels
+    /// and the readback never adjusts the glClear'd letterbox region. The
+    /// former any→PBO and PBO→Mem paths skipped the bias, leaving their int8
+    /// letterbox fill 0x80 off versus the Mem→Mem result. Pin every PBO
+    /// src/dst combination's output byte-identical to the Mem→Mem oracle.
+    /// Runs only where image allocation resolves to PBO (Orin / PBO-transfer
+    /// targets); skipped elsewhere.
+    #[test]
+    fn pbo_int8_letterbox_matches_mem_oracle() {
+        use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
+
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let mut proc = match ImageProcessor::with_config(ImageProcessorConfig {
+            backend: ComputeBackend::OpenGl,
+            ..Default::default()
+        }) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                return;
+            }
+        };
+
+        let (sw, sh) = (64usize, 48usize);
+        let probe = proc
+            .create_image(sw, sh, PixelFormat::Rgba, DType::U8, None)
+            .unwrap();
+        if probe.memory() != TensorMemory::Pbo {
+            eprintln!(
+                "SKIPPED: {} - target does not allocate PBO images",
+                function!()
+            );
+            return;
+        }
+
+        let fill = |t: &TensorDyn| {
+            let mut map = t.as_u8().unwrap().map().unwrap();
+            for (i, px) in map.as_mut_slice().chunks_exact_mut(4).enumerate() {
+                px[0] = (i % 251) as u8;
+                px[1] = (i % 199) as u8;
+                px[2] = (i % 127) as u8;
+                px[3] = 255;
+            }
+        };
+        let src_pbo = probe;
+        fill(&src_pbo);
+        let src_mem = proc
+            .create_image(
+                sw,
+                sh,
+                PixelFormat::Rgba,
+                DType::U8,
+                Some(TensorMemory::Mem),
+            )
+            .unwrap();
+        fill(&src_mem);
+
+        // 64×48 → 96×96 letterbox: 96×72 inner box, glClear'd bands above and
+        // below — the region whose int8 bias the PBO paths used to drop.
+        let lb = Crop::letterbox([114, 114, 114, 255]);
+        // Explicit `Some(Pbo)` requests are rejected (PBO backing exists only
+        // through auto-resolution), so the PBO destination is requested as
+        // `None` and the resolved memory asserted instead.
+        let mut convert_to_bytes = |src: &TensorDyn, dst_mem: TensorMemory, label: &str| {
+            let dst_req = match dst_mem {
+                TensorMemory::Pbo => None,
+                other => Some(other),
+            };
+            let mut dst = proc
+                .create_image(96, 96, PixelFormat::Rgb, DType::I8, dst_req)
+                .unwrap();
+            assert_eq!(dst.memory(), dst_mem, "{label}: dst backing not honoured");
+            proc.convert(src, &mut dst, Rotation::None, Flip::None, lb)
+                .unwrap_or_else(|e| panic!("{label} convert failed: {e}"));
+            dst.as_i8()
+                .unwrap()
+                .map()
+                .unwrap()
+                .as_slice()
+                .iter()
+                .map(|&v| v as u8)
+                .collect::<Vec<u8>>()
+        };
+
+        let oracle = convert_to_bytes(&src_mem, TensorMemory::Mem, "mem->mem");
+        for (src, src_name) in [(&src_mem, "mem"), (&src_pbo, "pbo")] {
+            for dst_mem in [TensorMemory::Mem, TensorMemory::Pbo] {
+                let label = format!("{src_name}->{dst_mem:?}");
+                let out = convert_to_bytes(src, dst_mem, &label);
+                assert_eq!(
+                    oracle, out,
+                    "{label}: int8 letterbox output diverged from mem->mem oracle"
+                );
+            }
+        }
+    }
+
     /// On-GPU round-trip: RGBA8 → F32 NHWC `[H,W,3]` PBO via the GL float
     /// render path. Forces the OpenGL backend (no CPU fallback) so the test
     /// genuinely exercises `convert_float_to_pbo`. Uses an identity crop so

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -5572,6 +5572,39 @@ mod gl_tests {
             "Exact mode, BT.601-limited NV12"
         );
 
+        // A Grey destination must NEVER take the sampler, in either mode and
+        // for any colorimetry: samplerExternalOES → R8 render target wedges
+        // the Vivante GC7000UL (EDGEAI-1180 hang class; found when the Fast
+        // policy first routed nv12@dma→grey@dma to the sampler). ShaderR8 on
+        // every GPU. NOTE: this leg HANGS the board rather than failing if
+        // the gate regresses — keep it last-resort observable via the suite
+        // timeout.
+        let mut grey_dst =
+            TensorDyn::image(w, h, PixelFormat::Grey, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        let mut grey_path = |gl: &mut GLProcessorST, src: &TensorDyn| {
+            gl.convert(
+                src,
+                &mut grey_dst,
+                Rotation::None,
+                Flip::None,
+                Crop::no_crop(),
+            )
+            .unwrap();
+            gl.last_nv_convert_path
+        };
+        gl.set_colorimetry_mode(ColorimetryMode::Fast);
+        assert_eq!(
+            grey_path(&mut gl, &src_709),
+            NvConvertPath::ShaderR8,
+            "Fast mode, BT.709 NV12 → Grey must avoid the sampler (R8 target)"
+        );
+        gl.set_colorimetry_mode(ColorimetryMode::Exact);
+        assert_eq!(
+            grey_path(&mut gl, &src_601),
+            NvConvertPath::ShaderR8,
+            "Exact mode, BT.601-limited NV12 → Grey must avoid the sampler (R8 target)"
+        );
+
         // EDGEFIRST_COLORIMETRY pins the mode for the processor's lifetime:
         // a Fast request on an exact-pinned processor is kept at Exact.
         drop(gl);

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -5478,10 +5478,120 @@ mod gl_tests {
         }
     }
 
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    struct ColorimetryEnvGuard;
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    impl ColorimetryEnvGuard {
+        fn set(v: &str) -> Self {
+            std::env::set_var("EDGEFIRST_COLORIMETRY", v);
+            ColorimetryEnvGuard
+        }
+    }
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    impl Drop for ColorimetryEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("EDGEFIRST_COLORIMETRY");
+        }
+    }
+
+    /// HIGH-PERFORMANCE-default colorimetry policy (issue #106): under `auto`
+    /// a non-BT.601-limited single-plane NV12 DMA source takes the hardware
+    /// sampler on Vivante in the default [`ColorimetryMode::Fast`] (~12×
+    /// faster, driver's approximate fixed matrix) and the exact in-shader
+    /// path under the [`ColorimetryMode::Exact`] opt-in. On every other GPU
+    /// the in-shader path IS the fast path, so both modes pick it. Also pins:
+    /// BT.601-limited sources keep the sampler under Exact on Vivante (the
+    /// driver matrix matches exactly), and `EDGEFIRST_COLORIMETRY` wins over
+    /// the setter.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn colorimetry_mode_policy_nv12_auto() {
+        use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
+        use crate::ColorimetryMode;
+        use edgefirst_tensor::{ColorEncoding, ColorRange, Colorimetry};
+
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        let mut gl = match GLProcessorST::new(None) {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                return;
+            }
+        };
+
+        let (w, h) = (64usize, 64usize);
+        let mut nv12 = vec![128u8; w * h * 3 / 2];
+        nv12[..w * h].fill(100);
+        let make_src = |enc: ColorEncoding, range: ColorRange| {
+            let mut src =
+                load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Dma), &nv12).unwrap();
+            src.set_colorimetry(Some(
+                Colorimetry::default().with_encoding(enc).with_range(range),
+            ));
+            src
+        };
+        let src_709 = make_src(ColorEncoding::Bt709, ColorRange::Full);
+        let src_601 = make_src(ColorEncoding::Bt601, ColorRange::Limited);
+        let mut dst =
+            TensorDyn::image(w, h, PixelFormat::Rgba, DType::U8, Some(TensorMemory::Dma)).unwrap();
+        let mut path_for = |gl: &mut GLProcessorST, src: &TensorDyn| {
+            gl.convert(src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+                .unwrap();
+            gl.last_nv_convert_path
+        };
+
+        // Fast (default): sampler on Vivante regardless of colorimetry,
+        // in-shader matrix everywhere else.
+        let expect_fast = if gl.is_vivante {
+            NvConvertPath::ExternalSampler
+        } else {
+            NvConvertPath::ShaderR8
+        };
+        assert_eq!(
+            path_for(&mut gl, &src_709),
+            expect_fast,
+            "Fast mode, BT.709-full NV12"
+        );
+
+        // Exact opt-in: the approximate sampler is off the table for a
+        // non-matching colorimetry — in-shader matrix everywhere…
+        gl.set_colorimetry_mode(ColorimetryMode::Exact);
+        assert_eq!(
+            path_for(&mut gl, &src_709),
+            NvConvertPath::ShaderR8,
+            "Exact mode, BT.709-full NV12"
+        );
+        // …but a BT.601-limited source matches the Vivante driver matrix
+        // exactly, so the sampler carve-out survives Exact mode.
+        assert_eq!(
+            path_for(&mut gl, &src_601),
+            expect_fast,
+            "Exact mode, BT.601-limited NV12"
+        );
+
+        // EDGEFIRST_COLORIMETRY pins the mode for the processor's lifetime:
+        // a Fast request on an exact-pinned processor is kept at Exact.
+        drop(gl);
+        let _env = ColorimetryEnvGuard::set("exact");
+        let mut gl = GLProcessorST::new(None).unwrap();
+        gl.set_colorimetry_mode(ColorimetryMode::Fast);
+        assert_eq!(
+            path_for(&mut gl, &src_709),
+            NvConvertPath::ShaderR8,
+            "env-pinned Exact must override set_colorimetry_mode(Fast)"
+        );
+    }
+
     /// `EDGEFIRST_NV_CONVERT_PATH` selects the NV12 GPU conversion path.
     ///
-    /// - `auto` (default) and `shader` → `ShaderR8` (single-plane NV12 prefers
-    ///   the portable in-shader path).
+    /// - `auto` (default) follows the `ColorimetryMode::Fast` policy:
+    ///   `ExternalSampler` on Vivante (12× faster), `ShaderR8` everywhere
+    ///   else (the exact path is already the fast path). The full policy
+    ///   matrix is covered by `colorimetry_mode_policy_nv12_auto`.
+    /// - `shader` → `ShaderR8` always.
     /// - `sampler` → the driver `ExternalSampler` path is selected; the actual
     ///   recorded path is `ExternalSampler` on success or `Cpu` if the driver
     ///   rejects the NV12 EGLImage import — never `ShaderR8`.
@@ -5500,7 +5610,7 @@ mod gl_tests {
             bytes.push(80); // Cr
         }
 
-        let run = |env: Option<&str>| -> Option<NvConvertPath> {
+        let run = |env: Option<&str>| -> Option<(NvConvertPath, bool)> {
             // The env var is read once in `GLProcessorST::new`; the guard sets it
             // for exactly that construction and removes it on drop (panic-safe).
             let gl = {
@@ -5517,10 +5627,9 @@ mod gl_tests {
             };
             let mut src =
                 load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Dma), &bytes).unwrap();
-            // Tag full-range so the Vivante Auto carve-out (BT.601-LIMITED only)
-            // does NOT engage — keeps `auto → ShaderR8` deterministic on every
-            // platform, including Vivante (where BT.601-limited NV12 would
-            // otherwise correctly prefer ExternalSampler; see select_nv_path).
+            // Tag full-range (not BT.601-limited) so the `auto` leg exercises
+            // the colorimetry-mode policy: the default Fast mode still takes
+            // the sampler on Vivante, ShaderR8 everywhere else.
             src.set_colorimetry(Some(
                 edgefirst_tensor::Colorimetry::default()
                     .with_encoding(edgefirst_tensor::ColorEncoding::Bt709)
@@ -5531,24 +5640,29 @@ mod gl_tests {
                     .unwrap();
             gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
                 .unwrap();
-            Some(gl.last_nv_convert_path)
+            Some((gl.last_nv_convert_path, gl.is_vivante))
         };
 
-        if let Some(p) = run(None) {
+        if let Some((p, is_vivante)) = run(None) {
+            let expect = if is_vivante {
+                // ColorimetryMode::Fast default: the 12×-faster sampler.
+                NvConvertPath::ExternalSampler
+            } else {
+                NvConvertPath::ShaderR8
+            };
             assert_eq!(
-                p,
-                NvConvertPath::ShaderR8,
-                "auto default: single-plane full-range NV12 must prefer ShaderR8"
+                p, expect,
+                "auto default: single-plane full-range NV12 policy pick"
             );
         }
-        if let Some(p) = run(Some("shader")) {
+        if let Some((p, _)) = run(Some("shader")) {
             assert_eq!(
                 p,
                 NvConvertPath::ShaderR8,
                 "forced shader must use ShaderR8"
             );
         }
-        if let Some(p) = run(Some("sampler")) {
+        if let Some((p, _)) = run(Some("sampler")) {
             assert_ne!(
                 p,
                 NvConvertPath::ShaderR8,
@@ -5672,6 +5786,12 @@ mod gl_tests {
                 return;
             }
         };
+        // This test pins the EXACT pipeline (in-shader matrix matching the
+        // CPU reference at chroma edges), so it opts into
+        // ColorimetryMode::Exact — under the default Fast policy a Vivante
+        // board would legitimately take the approximate driver sampler
+        // (covered by colorimetry_mode_policy_nv12_auto).
+        gl.set_colorimetry_mode(crate::ColorimetryMode::Exact);
         let mut src =
             load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Dma), &bytes).unwrap();
         tag(&mut src);
@@ -5688,7 +5808,7 @@ mod gl_tests {
         assert_eq!(
             gl.last_nv_convert_path,
             NvConvertPath::ShaderR8,
-            "NV12→PlanarRgb must use the ShaderR8 two-pass (select_nv_path), not the driver sampler"
+            "NV12→PlanarRgb in Exact mode must use the ShaderR8 two-pass, not the driver sampler"
         );
 
         // Correctness: matches the CPU planar reference (the sampler did not).

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -529,6 +529,106 @@ mod gl_tests {
         }
     }
 
+    /// The int8 variant of every draw must differ from the u8 variant by
+    /// exactly XOR 0x80 on the colour channels — the int8 fragment shaders
+    /// are the u8 shaders plus the bias, nothing else (alpha passes through).
+    ///
+    /// Catches the texture-destination program-selection gap: the heap-source
+    /// NV12 (ShaderR8 upload) int8 convert rendered through the UN-biased NV
+    /// program (only the DMA destination path swapped `nv_r8_program`),
+    /// producing u8-semantics bytes in an i8 tensor — 0x80 off on every
+    /// channel. DMA-independent: runs on any Linux GL including llvmpipe.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn int8_mem_convert_is_xor_biased_u8() {
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let mut renderer = match GLProcessorThreaded::new(None) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                return;
+            }
+        };
+
+        // Gradient luma + off-neutral chroma so the bias is exercised across
+        // values straddling 0x80 (where a missing bias is a ~128 byte diff).
+        let (w, h) = (64usize, 48usize);
+        let mut nv12 = vec![0u8; w * h * 3 / 2];
+        for row in 0..h {
+            for col in 0..w {
+                nv12[row * w + col] = ((row * 255) / h) as u8;
+            }
+        }
+        for i in 0..w * h / 4 {
+            nv12[w * h + 2 * i] = 110; // Cb
+            nv12[w * h + 2 * i + 1] = 150; // Cr
+        }
+        let src = load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Mem), &nv12).unwrap();
+
+        // RGBA must convert everywhere the NV upload path exists; RGB-format
+        // readback is implementation-defined in GLES (V3D rejects it with
+        // GL_INVALID_OPERATION — the cell was absent from rpi5's PR-0 matrix
+        // baseline too), so a failing RGB cell skips rather than fails.
+        let mut validated = 0usize;
+        'fmt: for fmt in [PixelFormat::Rgb, PixelFormat::Rgba] {
+            let mut out = [Vec::new(), Vec::new()];
+            for (slot, dtype) in [(0, DType::U8), (1, DType::I8)] {
+                let mut dst = TensorDyn::image(w, h, fmt, dtype, Some(TensorMemory::Mem)).unwrap();
+                if let Err(e) =
+                    renderer.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+                {
+                    if fmt == PixelFormat::Rgba {
+                        panic!("nv12@mem -> rgba.{dtype:?}@mem must be supported: {e}");
+                    }
+                    eprintln!("SKIPPED cell nv12@mem -> {fmt}.{dtype:?}@mem: {e}");
+                    continue 'fmt;
+                }
+                out[slot] = match dtype {
+                    DType::I8 => dst
+                        .as_i8()
+                        .unwrap()
+                        .map()
+                        .unwrap()
+                        .as_slice()
+                        .iter()
+                        .map(|&v| v as u8)
+                        .collect(),
+                    _ => dst.as_u8().unwrap().map().unwrap().as_slice().to_vec(),
+                };
+            }
+            let channels = fmt.channels();
+            let mut diffs = 0usize;
+            for (i, (&u, &b)) in out[0].iter().zip(out[1].iter()).enumerate() {
+                let expect = if channels == 4 && i % 4 == 3 {
+                    u
+                } else {
+                    u ^ 0x80
+                };
+                // ±1 LSB: the int8 shader's explicit floor(v*255+0.5)+128
+                // quantization double-rounds against the driver's own
+                // float→unorm8 store, shifting ~2% of bytes by one on some
+                // GPUs (seen on Vivante). A missing bias is a ~128 diff, so
+                // the tolerance keeps full sensitivity to the real bug.
+                if (b as i16 - expect as i16).abs() > 1 {
+                    diffs += 1;
+                    if diffs <= 5 {
+                        eprintln!("byte {i}: u8={u:#04x} i8={b:#04x} expected {expect:#04x}");
+                    }
+                }
+            }
+            assert_eq!(
+                diffs, 0,
+                "nv12@mem -> {fmt}: i8 output is not the XOR-0x80 bias of the u8 output \
+                 ({diffs} bytes differ beyond ±1 — un-biased int8 NV program?)"
+            );
+            validated += 1;
+        }
+        assert!(validated >= 1, "no format validated the int8 NV bias");
+    }
+
     /// Test OpenGL PixelFormat::Nv12→PixelFormat::Rgba conversion against ffmpeg reference
     #[test]
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -537,9 +537,11 @@ mod gl_tests {
     /// NV12 (ShaderR8 upload) int8 convert rendered through the UN-biased NV
     /// program (only the DMA destination path swapped `nv_r8_program`),
     /// producing u8-semantics bytes in an i8 tensor — 0x80 off on every
-    /// channel. DMA-independent: runs on any Linux GL including llvmpipe.
+    /// channel. Needs no DMA at runtime (Mem src/dst — runs on llvmpipe,
+    /// whose coverage lane enables the feature); the `dma_test_formats`
+    /// gate only matches the `load_raw_image` helper's.
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn int8_mem_convert_is_xor_biased_u8() {
         if !is_opengl_available() {
             eprintln!("SKIPPED: {} - OpenGL not available", function!());
@@ -2659,8 +2661,10 @@ mod gl_tests {
     /// destinations — GL has no planar texture destination, so the Mem legs
     /// pin the backend `ImageProcessor` resolves instead (CPU fallback),
     /// guarding the whole dispatch surface against the bug class.
+    /// (`dma_test_formats` gate matches the helpers it uses; the Mem legs
+    /// still run on the llvmpipe coverage lane, which enables the feature.)
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn letterbox_nv_to_planar_content_band_geometry() {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -388,7 +388,7 @@ mod gl_tests {
 
         // NV12 pool (the camera-pipeline shape): Y plane + neutral chroma.
         let mut bytes = vec![100u8; w * h];
-        bytes.extend(std::iter::repeat(128u8).take(w * h / 2));
+        bytes.extend(std::iter::repeat_n(128u8, w * h / 2));
         let pool: Vec<TensorDyn> = (0..POOL)
             .map(|_| {
                 load_raw_image(w, h, PixelFormat::Nv12, Some(TensorMemory::Dma), &bytes).unwrap()
@@ -426,6 +426,107 @@ mod gl_tests {
             "expected at least {FRAMES} cache hits over the loop, got {gained} \
              (warm={warm:?} steady={steady:?})"
         );
+    }
+
+    /// Regression test for the repeat-convert GL_INVALID_VALUE (0x501) state
+    /// leak: heap-RGBA source → two-pass packed RGB → DMA destination succeeded
+    /// on the FIRST convert and failed on the SECOND on Vivante/Mali/V3D alike.
+    ///
+    /// Root cause: `convert_to_packed_rgb` pass 2 exits with `ActiveTexture`
+    /// left at TEXTURE1 and the destination EGLImage texture bound on unit 0,
+    /// while `draw_src_texture` issued `BindTexture` BEFORE `ActiveTexture` —
+    /// binding the camera texture to the leaked unit and then uploading the
+    /// 1280×720 source into the 640×640 destination texture via the
+    /// `TexSubImage2D` fast path → GL_INVALID_VALUE. Driver-independent GLES
+    /// semantics, hence identical on all dmabuf GPUs.
+    ///
+    /// The loop runs each dtype cell several times (not just twice) and pins
+    /// byte-identical output across iterations, so any texture-unit state leak
+    /// between converts surfaces either as an error or as a pixel diff.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn repeat_convert_rgba_mem_to_rgb_dma() {
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+        let mut renderer = match GLProcessorThreaded::new(None) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                return;
+            }
+        };
+
+        // Deterministic RGBA gradient source in plain heap memory (the cell's
+        // defining property: NOT DMA, so the source goes through the
+        // draw_src_texture CPU-upload path).
+        let (src_w, src_h) = (1280usize, 720usize);
+        let mut bytes = vec![0u8; src_w * src_h * 4];
+        for (i, px) in bytes.chunks_exact_mut(4).enumerate() {
+            px[0] = (i % 256) as u8;
+            px[1] = ((i / 256) % 256) as u8;
+            px[2] = ((i / 65536) % 256) as u8;
+            px[3] = 255;
+        }
+        let src = load_raw_image(
+            src_w,
+            src_h,
+            PixelFormat::Rgba,
+            Some(TensorMemory::Mem),
+            &bytes,
+        )
+        .unwrap();
+
+        let lb = Crop::letterbox([114, 114, 114, 255]);
+        for dtype in [DType::U8, DType::I8] {
+            let mut dst = match TensorDyn::image(
+                640,
+                640,
+                PixelFormat::Rgb,
+                dtype,
+                Some(TensorMemory::Dma),
+            ) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("SKIPPED cell {dtype:?}: DMA RGB dst unavailable: {e}");
+                    continue;
+                }
+            };
+            let mut first: Option<Vec<u8>> = None;
+            for round in 0..4 {
+                renderer
+                    .convert(&src, &mut dst, Rotation::None, Flip::None, lb)
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "rgba@mem->rgb.{dtype:?}@dma convert #{} failed: {e} \
+                             (repeat-convert state leak — see 0x501 regression)",
+                            round + 1
+                        )
+                    });
+                let out: Vec<u8> = match dtype {
+                    DType::I8 => dst
+                        .as_i8()
+                        .unwrap()
+                        .map()
+                        .unwrap()
+                        .as_slice()
+                        .iter()
+                        .map(|&v| v as u8)
+                        .collect(),
+                    _ => dst.as_u8().unwrap().map().unwrap().as_slice().to_vec(),
+                };
+                match &first {
+                    None => first = Some(out),
+                    Some(reference) => assert_eq!(
+                        reference,
+                        &out,
+                        "rgba@mem->rgb.{dtype:?}@dma convert #{} output diverged from #1",
+                        round + 1
+                    ),
+                }
+            }
+        }
     }
 
     /// Test OpenGL PixelFormat::Nv12→PixelFormat::Rgba conversion against ffmpeg reference

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -2644,6 +2644,191 @@ mod gl_tests {
         assert_pixels_match(contig_bytes, multi_bytes, 0);
     }
 
+    /// Regression for the two-pass double letterbox (PR #107): pass 2 of the
+    /// zero-copy NV→planar plan re-applied `dst_rect`, mapping the
+    /// already-letterboxed intermediate into the content sub-region a second
+    /// time and shrinking the image by the letterbox content fraction twice.
+    ///
+    /// A synthetic grey NV12 frame letterboxed 1280x720 → 640x640 must place
+    /// content rows at exactly [140, 500); the double-applied bug squeezed
+    /// them to ~[218, 422). Probing rows just inside the correct band (150 /
+    /// 490) is therefore a deterministic kill-shot with no oracle tolerance
+    /// to hide behind — and it equally catches the inverse bug (letterbox
+    /// dropped entirely: pad rows would hold content). Covers PlanarRgb /
+    /// PlanarRgba × u8 / i8 × Dma (the GL TwoPassNvPlanar plan) and Mem
+    /// destinations — GL has no planar texture destination, so the Mem legs
+    /// pin the backend `ImageProcessor` resolves instead (CPU fallback),
+    /// guarding the whole dispatch surface against the bug class.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn letterbox_nv_to_planar_content_band_geometry() {
+        use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
+
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let mut proc = match ImageProcessor::with_config(ImageProcessorConfig {
+            backend: ComputeBackend::OpenGl,
+            ..Default::default()
+        }) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                return;
+            }
+        };
+
+        // Synthetic NV12: Y=200, U=V=128 is neutral grey, so BT.601 vs BT.709
+        // coefficients cancel and the converted RGB is ~200 (full range) to
+        // ~214 (limited): comfortably above the 114 pad in every colorimetry
+        // mode. Threshold at >=170 content / <=140 pad.
+        let (sw, sh) = (1280usize, 720usize);
+        let mut nv12 = vec![0u8; sw * sh * 3 / 2];
+        nv12[..sw * sh].fill(200);
+        nv12[sw * sh..].fill(128);
+        let src_mem = if is_dma_available() {
+            Some(TensorMemory::Dma)
+        } else {
+            Some(TensorMemory::Mem)
+        };
+        let src = load_raw_image(sw, sh, PixelFormat::Nv12, src_mem, &nv12).unwrap();
+
+        // 1280x720 → 640x640: scale 0.5, content 640x360 centred → rows
+        // [140, 500). Probe ≥10 px from the boundary to stay clear of
+        // bilinear edge blending.
+        const CONTENT_ROWS: [usize; 3] = [150, 320, 490];
+        const PAD_ROWS: [usize; 4] = [0, 130, 510, 639];
+        let (dw, dh) = (640usize, 640usize);
+        let lb = Crop::letterbox([114, 114, 114, 255]);
+
+        let mut dst_memories = vec![TensorMemory::Mem];
+        if is_dma_available() {
+            dst_memories.push(TensorMemory::Dma);
+        }
+        for dst_mem in dst_memories {
+            for dst_fmt in [PixelFormat::PlanarRgb, PixelFormat::PlanarRgba] {
+                for dtype in [DType::U8, DType::I8] {
+                    let label = format!("nv12->{dst_fmt}.{dtype:?}@{dst_mem:?}");
+                    let mut dst = proc
+                        .create_image(dw, dh, dst_fmt, dtype, Some(dst_mem))
+                        .unwrap();
+                    proc.convert(&src, &mut dst, Rotation::None, Flip::None, lb)
+                        .unwrap_or_else(|e| panic!("{label}: convert failed: {e}"));
+
+                    // Raw bytes; undo the int8 XOR-0x80 bias so both dtypes
+                    // share one set of thresholds.
+                    let unbias = if dtype == DType::I8 { 0x80u8 } else { 0 };
+                    let bytes: Vec<u8> = match dtype {
+                        DType::U8 => dst.as_u8().unwrap().map().unwrap().as_slice().to_vec(),
+                        _ => dst
+                            .as_i8()
+                            .unwrap()
+                            .map()
+                            .unwrap()
+                            .as_slice()
+                            .iter()
+                            .map(|&v| v as u8 ^ unbias)
+                            .collect(),
+                    };
+
+                    // Only the three colour planes — the alpha plane is 255
+                    // everywhere (content and pad) and is bias-exempt.
+                    for plane in 0..3 {
+                        let plane_base = plane * dh * dw;
+                        for row in CONTENT_ROWS {
+                            for col in (5..dw - 5).step_by(13) {
+                                let v = bytes[plane_base + row * dw + col];
+                                assert!(
+                                    v >= 170,
+                                    "{label}: plane {plane} row {row} col {col} = {v}, \
+                                     expected content (>=170) — letterbox content band \
+                                     misplaced (double-letterbox regression?)"
+                                );
+                            }
+                        }
+                        for row in PAD_ROWS {
+                            for col in (5..dw - 5).step_by(13) {
+                                let v = bytes[plane_base + row * dw + col];
+                                assert!(
+                                    v <= 140,
+                                    "{label}: plane {plane} row {row} col {col} = {v}, \
+                                     expected pad (<=140) — content leaked into the \
+                                     letterbox band"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Letterboxed PixelFormat::Nv12 → planar against the verified RGBA
+    /// reference: the same processor letterboxes camera NV12 720p → RGBA
+    /// 640x640, the reference is channel-split on the CPU, and the GL planar
+    /// output (PlanarRgb@Dma — the TwoPassNvPlanar plan) must match it.
+    /// PlanarRgb@Dma is the only planar destination the GL engine accepts:
+    /// `check_dst_format_supported` rejects PlanarRgba outright and Mem has
+    /// no planar texture destination. Catches placement, scale, and content
+    /// drift in the two-pass plan at full resolution — the per-pixel
+    /// complement to the content-band geometry probe above.
+    #[test]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    fn letterbox_nv12_to_planar_matches_rgba_reference() {
+        if !is_dma_available() {
+            eprintln!("SKIPPED: {} - DMA not available", function!());
+            return;
+        }
+
+        let src = load_raw_image(
+            1280,
+            720,
+            PixelFormat::Nv12,
+            Some(TensorMemory::Dma),
+            &edgefirst_bench::testdata::read("camera720p.nv12"),
+        )
+        .unwrap();
+
+        let crop = letterbox_crop(1280, 720, 640, 640);
+        let (dw, dh) = (640usize, 640usize);
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+
+        // Reference: the verified packed-RGBA letterbox path.
+        let mut dst_rgba = TensorDyn::image(
+            dw,
+            dh,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Dma),
+        )
+        .unwrap();
+        gl.convert(&src, &mut dst_rgba, Rotation::None, Flip::None, crop)
+            .unwrap();
+        let rgba = dst_rgba.as_u8().unwrap().map().unwrap();
+        let rgba = rgba.as_slice();
+
+        // Channel-split the RGBA reference into the planar layout.
+        let mut expected = vec![0u8; 3 * dh * dw];
+        for (i, px) in rgba.chunks_exact(4).enumerate() {
+            for (plane, &channel) in px.iter().take(3).enumerate() {
+                expected[plane * dh * dw + i] = channel;
+            }
+        }
+        let mut dst = TensorDyn::image(
+            dw,
+            dh,
+            PixelFormat::PlanarRgb,
+            DType::U8,
+            Some(TensorMemory::Dma),
+        )
+        .unwrap();
+        gl.convert(&src, &mut dst, Rotation::None, Flip::None, crop)
+            .unwrap_or_else(|e| panic!("nv12->PlanarRgb@Dma: convert failed: {e}"));
+        let map = dst.as_u8().unwrap().map().unwrap();
+        assert_pixels_match(&expected, map.as_slice(), 1);
+    }
+
     /// Compare fused GL proto rendering against hybrid (CPU materialize + GL overlay).
     ///
     /// Both paths should produce visually similar output. Differences arise from

--- a/crates/image/src/gl/threaded.rs
+++ b/crates/image/src/gl/threaded.rs
@@ -54,6 +54,11 @@ enum GLProcessorMessage {
         Int8InterpolationMode,
         tokio::sync::oneshot::Sender<Result<(), Error>>,
     ),
+    /// Set the colorimetry/performance trade-off (`ColorimetryMode`).
+    SetColorimetryMode(
+        crate::ColorimetryMode,
+        tokio::sync::oneshot::Sender<Result<(), Error>>,
+    ),
     /// Snapshot the EGLImage cache counters (steady-state import assertions).
     EglCacheStats(tokio::sync::oneshot::Sender<Result<super::cache::GlCacheStats, Error>>),
     PboCreate(
@@ -344,6 +349,9 @@ impl GLProcessorThreaded {
                         GLProcessorMessage::SetInt8Interpolation(_, resp) => {
                             let _ = resp.send(Err(poison_err));
                         }
+                        GLProcessorMessage::SetColorimetryMode(_, resp) => {
+                            let _ = resp.send(Err(poison_err));
+                        }
                         GLProcessorMessage::EglCacheStats(resp) => {
                             let _ = resp.send(Err(poison_err));
                         }
@@ -515,6 +523,22 @@ impl GLProcessorThreaded {
                                 poisoned = true;
                                 Err(crate::Error::Internal(format!(
                                     "GL thread panicked during SetColors: {}",
+                                    panic_message(e.as_ref()),
+                                )))
+                            }
+                        });
+                    }
+                    GLProcessorMessage::SetColorimetryMode(mode, resp) => {
+                        let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                            gl_converter.set_colorimetry_mode(mode);
+                            Ok(())
+                        }));
+                        let _ = resp.send(match result {
+                            Ok(res) => res,
+                            Err(e) => {
+                                poisoned = true;
+                                Err(crate::Error::Internal(format!(
+                                    "GL thread panicked during SetColorimetryMode: {}",
                                     panic_message(e.as_ref()),
                                 )))
                             }
@@ -873,6 +897,22 @@ impl ImageProcessorTrait for GLProcessorThreaded {
 }
 
 impl GLProcessorThreaded {
+    /// Sets the colorimetry/performance trade-off (see
+    /// [`crate::ColorimetryMode`]). The `EDGEFIRST_COLORIMETRY` environment
+    /// variable takes precedence — when set, this call logs and keeps the
+    /// env-selected mode.
+    pub fn set_colorimetry_mode(&mut self, mode: crate::ColorimetryMode) -> Result<(), Error> {
+        let (err_send, err_recv) = tokio::sync::oneshot::channel();
+        self.sender
+            .as_ref()
+            .ok_or_else(|| Error::Internal("GL processor is shutting down".to_string()))?
+            .blocking_send(GLProcessorMessage::SetColorimetryMode(mode, err_send))
+            .map_err(|_| Error::Internal("GL converter thread exited".to_string()))?;
+        err_recv.blocking_recv().map_err(|_| {
+            Error::Internal("GL converter error messaging closed without update".to_string())
+        })?
+    }
+
     /// Sets the interpolation mode for int8 proto textures.
     pub fn set_int8_interpolation_mode(
         &mut self,

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -981,6 +981,38 @@ pub struct ImageProcessorConfig {
     /// - [`ComputeBackend::Cpu`]: init CPU only
     /// - [`ComputeBackend::Auto`]: existing env-var-driven selection
     pub backend: ComputeBackend,
+
+    /// Colorimetry/performance trade-off for `convert()` (see
+    /// [`ColorimetryMode`]). Defaults to [`ColorimetryMode::Fast`]. The
+    /// `EDGEFIRST_COLORIMETRY` environment variable (`fast` | `exact`)
+    /// overrides this setting when present.
+    pub colorimetry: ColorimetryMode,
+}
+
+/// How `convert()` trades colorimetric exactness against speed on platforms
+/// where the exact path is expensive.
+///
+/// Today this affects one decision: NV12 sources on Vivante GC7000UL
+/// (i.MX 8M Plus), where the hardware external sampler converts ~12× faster
+/// than the colorimetry-exact in-shader matrix (2.5 ms vs 29 ms at 720p)
+/// but applies the driver's fixed BT.601-limited matrix regardless of the
+/// source's tagged colorimetry. Platforms where the exact path is already
+/// the fastest correct path (Mali, V3D, Tegra, ANGLE) behave identically in
+/// both modes.
+///
+/// Override at runtime with `EDGEFIRST_COLORIMETRY=fast|exact` (takes
+/// precedence over the config field), or per-source by forcing a path with
+/// `EDGEFIRST_NV_CONVERT_PATH`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ColorimetryMode {
+    /// Prefer the fastest path whose output is correct-enough video RGB
+    /// (default; issue #106 policy). On Vivante, NV12 takes the hardware
+    /// sampler even when the source is not BT.601-limited.
+    #[default]
+    Fast,
+    /// Prefer bit-exact colorimetry everywhere: the fast path is used only
+    /// when it matches the source's resolved (encoding, range) exactly.
+    Exact,
 }
 
 /// Compute backend selection for [`ImageProcessor`].
@@ -1239,7 +1271,8 @@ impl ImageProcessor {
                         #[cfg(feature = "opengl")]
                         opengl,
                         forced_backend: None,
-                    });
+                    }
+                    .apply_colorimetry_mode(config.colorimetry));
                 }
                 #[cfg(target_os = "macos")]
                 {
@@ -1344,7 +1377,8 @@ impl ImageProcessor {
                             g2d: None,
                             opengl: Some(opengl),
                             forced_backend: Some(ForcedBackend::OpenGl),
-                        })
+                        }
+                        .apply_colorimetry_mode(config.colorimetry))
                     }
                     #[cfg(target_os = "macos")]
                     #[cfg(feature = "opengl")]
@@ -1452,7 +1486,37 @@ impl ImageProcessor {
             #[cfg(feature = "opengl")]
             opengl,
             forced_backend: None,
-        })
+        }
+        .apply_colorimetry_mode(config.colorimetry))
+    }
+
+    /// Apply the configured [`ColorimetryMode`] to whichever backend honours
+    /// it (currently the Linux GL backend); no-op elsewhere. Constructor
+    /// plumbing for [`ImageProcessorConfig::colorimetry`].
+    fn apply_colorimetry_mode(self, _mode: ColorimetryMode) -> Self {
+        #[cfg(all(target_os = "linux", feature = "opengl"))]
+        {
+            let mut me = self;
+            if let Err(e) = me.set_colorimetry_mode(_mode) {
+                log::warn!("Failed to apply ColorimetryMode::{_mode:?}: {e:?}");
+            }
+            me
+        }
+        #[cfg(not(all(target_os = "linux", feature = "opengl")))]
+        self
+    }
+
+    /// Sets the colorimetry/performance trade-off (see [`ColorimetryMode`])
+    /// on the OpenGL backend. No-op if OpenGL is not available. The
+    /// `EDGEFIRST_COLORIMETRY` environment variable takes precedence — when
+    /// it is set, this call logs and keeps the env-selected mode.
+    #[cfg(target_os = "linux")]
+    #[cfg(feature = "opengl")]
+    pub fn set_colorimetry_mode(&mut self, mode: ColorimetryMode) -> Result<()> {
+        if let Some(ref mut gl) = self.opengl {
+            gl.set_colorimetry_mode(mode)?;
+        }
+        Ok(())
     }
 
     /// Sets the interpolation mode for int8 proto textures on the OpenGL

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -56,7 +56,13 @@ def _image_size(path):
         return im.size  # (width, height)
 
 
-def test_flip():
+def test_flip(monkeypatch):
+    # This test's oracle is PIL's exact JPEG decode, so it opts into
+    # colorimetry-exact conversion. The default ColorimetryMode is Fast
+    # (issue #106): on Vivante it routes every NV12 colorimetry through the
+    # external sampler's fixed conversion (~12x faster), which lands ~0.965
+    # against this oracle.
+    monkeypatch.setenv("EDGEFIRST_COLORIMETRY", "exact")
     w, h = _image_size("testdata/zidane.jpg")
     # JPEG decodes to its native NV12; convert downstream produces RGBA.
     src = Tensor.image(w, h, format=PixelFormat.Nv12)
@@ -156,7 +162,9 @@ def test_render():
         )
 
 
-def test_rgb_resize():
+def test_rgb_resize(monkeypatch):
+    # PIL-exact oracle → opt into colorimetry-exact (see test_flip).
+    monkeypatch.setenv("EDGEFIRST_COLORIMETRY", "exact")
     w, h = _image_size("testdata/zidane.jpg")
     src = Tensor.image(w, h, format=PixelFormat.Nv12)
     src.decode_image_file("testdata/zidane.jpg")
@@ -170,7 +178,9 @@ def test_rgb_resize():
         assert calculate_similarity_rms_u8(n, expected) > 0.98
 
 
-def test_rgba_to_rgb():
+def test_rgba_to_rgb(monkeypatch):
+    # PIL-exact oracle → opt into colorimetry-exact (see test_flip).
+    monkeypatch.setenv("EDGEFIRST_COLORIMETRY", "exact")
     w, h = _image_size("testdata/zidane.jpg")
     # Decode the JPEG to native NV12, then convert to RGB (3-channel) output.
     src = Tensor.image(w, h, format=PixelFormat.Nv12)
@@ -980,14 +990,21 @@ def test_from_numpy_grey_unaligned_width_stride_bug(width, height):
         )
 
 
-def test_convert_honors_tagged_colorimetry():
+def test_convert_honors_tagged_colorimetry(monkeypatch):
     """convert() must honor the source tensor's tagged colorimetry (QA F11).
 
     The same NV12 bytes decoded as BT.601 full-range vs BT.709 limited-range
     must produce visibly different RGB pixels — proving the HAL threads the
     per-source colorimetry tag through the conversion instead of applying one
     hardcoded YUV matrix/range.
+
+    Exact tag honoring is the ColorimetryMode::Exact contract, opted into
+    here via EDGEFIRST_COLORIMETRY. The Fast default (issue #106)
+    deliberately collapses colorimetries into the external sampler's fixed
+    conversion on Vivante (~12x faster); non-Vivante GPUs honor tags in both
+    modes.
     """
+    monkeypatch.setenv("EDGEFIRST_COLORIMETRY", "exact")
     w, h = 1280, 720
     nv12 = np.fromfile("testdata/zidane.nv12", dtype=np.uint8).reshape(h * 3 // 2, w)
     converter = ImageProcessor()


### PR DESCRIPTION
## Summary

PR-B of the GL convergence plan (#104 built the seams; this is the deletion half for the convert path). Collapses the 5-way destination fan-out (`convert_dest_dma`, `convert_dest_non_dma`, `convert_pbo_to_pbo`, `convert_any_to_pbo`, `convert_pbo_to_mem` + the 3-way `setup_renderbuffer_*` trio) into one engine: pure `lower_dst`/`plan_convert` decision tables (host-tested, exhaustive) driving `bind_dst` → render → `readback_rendered`.

Also lands, in order of user impact:

- **Fix: repeat-convert `GL_INVALID_VALUE` (0x501)** — `rgba@mem → rgb@dma` failed on every convert after the first on all dmabuf GPUs (Vivante, Mali, V3D). Root cause: `BindTexture` before `ActiveTexture` at six sites, plus packed-RGB pass 2 leaking `TEXTURE1` as the active unit and a raw `EGLImageTargetTexture2DOES` bypassing the bind cache's key tracking. Regression test proven fails-before on imx8mp.
- **Fix: int8 letterbox bias dropped on texture/PBO destinations** — the XOR-0x80 clear-color bias only happened on the DMA path; PBO/Mem destinations letterboxed with an un-biased fill (wrong output). Now applied on every lowering; oracle test proven on orin.
- **Fix: Vivante external sampler × R8 (Grey) render target GPU hang** — the new Fast colorimetry policy initially routed `nv12@dma → grey@dma` to the sampler, which wedges GC7000UL unrecoverably (EDGEAI-1180 class). `select_nv_path` is now render-target-aware and excludes Grey in both modes.
- **`ColorimetryMode { Fast (default), Exact }`** (issue #106 policy): high-performance is the default; colorimetry-exact NV conversion is opt-in via `ImageProcessorConfig.colorimetry` or the `EDGEFIRST_COLORIMETRY` env override (env pins for processor lifetime). On Vivante this takes the 2.5 ms sampler instead of the 28.8 ms exact shader at 720p; non-Vivante GPUs are identical in both modes.
- **Perf: defer pass-1 `glFinish` in two-pass converts** (−33% median / −85% p95 on `nv12@dma→rgb.i8@dma`), **link-time NV uniform-location caching + colorimetry-upload skip**, constant sampler uniforms at link.
- **Letterbox regression tests for the #107 bug class** (this branch is rebased onto #107): a deterministic content-band geometry probe (synthetic grey NV12, probes rows double-letterboxing turns into pad and rows a dropped letterbox turns into content) plus a PlanarRgb@Dma per-pixel oracle vs the channel-split RGBA reference. Both proven fails-before on imx8mp by temporarily re-injecting the pre-#107 pass-2 ROI. Audited all other multi-stage conversions (packed-RGB pass 2, macOS NV→PlanarF16, float paths, G2D, CPU): no other double-application exists.

## Benchmark gates (4 boards, like-for-like toolchain, alternating-rep protocol)

Baselines re-captured at `3947d9f` with the same rustc 1.95 toolchain as HEAD after discovering the archived PR-0 baselines predate a toolchain update worth +4-6% on short GPU-bound cells (proven by a control rebuild of PR-0 source). Per-rep base/head alternation eliminates thermal order bias.

| Board | Result |
|---|---|
| imx8mp (Vivante) | All cells improved. Auto NV12 720p **29.0 → 2.47 ms (−91.5%)**, 1080p NV12→RGBA **63.2 → 6.4 ms**, 4K NV12→RGBA −90%, batch −60..−79%. |
| imx95 (Mali) | Pipeline NV12→RGB −51%, YUYV→RGB −45%, letterbox −14..−25%; zero regressions. |
| orin (Tegra/PBO) | Pipeline −10..−21%; matrix/nv_path flat. One flagged cell (`draw_proto_masks/forced_opengl`) bisect-exonerated: values scatter ±8-15% across builds including pure-baseline builds. |
| rpi5 (V3D) | batch/nv_path/pipeline clean (89 pipeline cells, 0 regressed). Matrix `i8@mem` cells +3.5-6.3%: these are exactly (and only) the cells whose output was **wrong before** — they now run the correct int8 bias shader; `@dma` int8 cells (always biased) are flat. Mask materialize f32/f16 +4-8% (17-27 µs) is rpi5-only (flat/improved on the other three boards) — noted for PR-C, which reworks the proto path. |

**Issue #106 drift-reclaim criterion: MET.** NV12→RGBA 1080p = 6.4 ms vs the 6.1 ms v0.15.0 doc target; RGBA→RGBA at doc level. The original drifted BGRA/GREY 1080p cells no longer exist in `image_benchmark`; their nearest proxies all improved, and part of the original drift was a toolchain/thermal measurement artifact.

**Known limit-pusher (flagged, not fixed):** `image_benchmark`'s 4K section wedges the V3D GPU on rpi5 — on the **baseline** binary and HEAD alike, so it is not a regression from this PR. Benchmarks are on-demand, not CI/CD; 4K cells exist to characterize headroom.

## Test evidence

- imx8mp **425/0** (full suite post-rebase, `EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS=1` per the documented driver double-free), imx95 423/0 + new letterbox tests 2/0, rpi5 422/0, orin 422/0, macOS native 251/0 + 36/0 + 5/0 (single-threaded; a 4-test parallel-run flake in `image_tests` pre-exists on main, verified via worktree — candidate follow-up issue).
- Every fix ships a regression test proven to fail before it; `lower_dst`/`plan_convert`/colorimetry-policy decision tables have exhaustive host unit tests.
- Both clippy lanes (native macOS + aarch64 zigbuild with `opengl,g2d_test_formats,dma_test_formats`) clean at every commit; one logical step per commit for bisectability; docs (ARCHITECTURE.md lowering table + engine span catalog, BENCHMARKS.md auto-policy, CHANGELOG) land with their code.
