### PR TITLE
GL proto dispatch convergence: plan table, dtype collapse, texture-lifecycle fixes (PR-C)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -336,7 +336,11 @@ JSON files are collected in `benchmarks/<platform>/` and processed by `.github/s
 
 ## Benchmark Results
 
-**Data collected:** March 30, 2026 (v0.15.0, per-texture EGL binding optimization)
+**Data collected:** March 30, 2026 (v0.15.0, per-texture EGL binding
+optimization) unless a section states otherwise — the GL convert,
+letterbox, and mask-rendering tables were re-collected June 2026 after
+the GL convergence engine (PR #109/#110, issue #106); each carries its
+own capture note.
 
 ### Buffer Infrastructure
 
@@ -410,19 +414,23 @@ macOS when you need a backing tensor that the GL backend can also import.**
 
 ### Image Preprocessing: Letterbox Pipeline (Camera → Model Input)
 
+**GL rows re-collected:** June 2026 (GL convergence engine, PR #109/#110;
+median of 3 runs × n=100, `pipeline_benchmark`). G2D/CPU rows are the
+v0.15.0 capture (those backends were not changed).
+
 **1080p → 640×640:**
 
 | Platform | Compute | Buffer | YUYV→RGBA | YUYV→RGB | YUYV→8BPi | NV12→RGBA | VYUY→RGBA |
 |----------|---------|--------|-----------|----------|-----------|-----------|-----------|
 | imx8mp-frdm | G2D | DMA | 2.7 ms | 4.0 ms | — | 4.1 ms | — |
-| imx8mp-frdm | GL | DMA | 1.7 ms | 11.8 ms | — | 3.5 ms | — |
+| imx8mp-frdm | GL | DMA | 1.8 ms | 11.3 ms | — | 3.2 ms | — |
 | imx8mp-frdm | CPU | Heap | 17.4 ms | 17.6 ms | — | 33.9 ms | 17.5 ms |
 | imx95-frdm | G2D | DMA | 3.9 ms | 4.6 ms | — | 3.7 ms | — |
-| imx95-frdm | GL | DMA | 1.2 ms | 3.3 ms | — | 1.5 ms | — |
+| imx95-frdm | GL | DMA | 1.2 ms | 2.6 ms | — | 1.2 ms | — |
 | imx95-frdm | CPU | Heap | 14.5 ms | 14.9 ms | — | 16.6 ms | 14.5 ms |
-| rpi5-hailo | GL | DMA | 3.3 ms | 4.1 ms | — | 1.2 ms | — |
+| rpi5-hailo | GL | DMA | 3.3 ms | 4.0 ms | — | 1.2 ms | — |
 | rpi5-hailo | CPU | Heap | 7.6 ms | 7.2 ms | — | 8.1 ms | 7.6 ms |
-| jetson-orin-nano | GL | DMA | — | — | — | — | — |
+| jetson-orin-nano | GL | PBO | 4.3 ms | 4.6 ms | — | 4.3 ms | — |
 | jetson-orin-nano | CPU | Heap | 6.1 ms | 5.9 ms | — | 5.3 ms | 6.2 ms |
 | x86-desktop | CPU | Heap | 3.0 ms | 1.5 ms | — | 1.8 ms | 5.4 ms |
 | mbp-m2-max | CPU | Heap | 1.5 ms | 1.7 ms | 2.0 ms | 1.3 ms | — |
@@ -446,23 +454,37 @@ macOS when you need a backing tensor that the GL backend can also import.**
 
 ### Format Conversion (Same Size, No Resize)
 
+**imx8mp/imx95 GL rows re-collected:** June 11, 2026
+(`image_benchmark`, PR #110 head, n=100). This closes the issue #106
+drift: the 2026-06-09 capture had imx8mp RGBA→BGRA at 13.8 ms (+79%)
+and RGBA→GREY at 14.9 ms (+91%) versus this table; the GL convergence
+engine (PR #109) reclaimed both to the v0.15.0 numbers, and the
+RGBA→BGRA / RGBA→GREY cells are now permanent `image_benchmark`
+sentinels so same-size drift cannot go unmeasured again. Orin YUYV GL
+cells are the 2026-06-10 PR #109 capture; remaining GL cells and all
+G2D/CPU rows are the v0.15.0 capture.
+
 **1080p → 1080p:**
 
 | Platform | Compute | Buffer | YUYV→RGBA | YUYV→RGB | NV12→RGBA | RGB→RGBA | RGBA→BGRA | RGBA→GREY |
 |----------|---------|--------|-----------|----------|-----------|----------|-----------|-----------|
 | imx8mp-frdm | G2D | DMA | 6.0 ms | 10.5 ms | 6.3 ms | — | — | — |
-| imx8mp-frdm | GL | DMA | 7.2 ms | 49.9 ms | 6.1 ms | — | 7.7 ms | 7.8 ms |
+| imx8mp-frdm | GL | DMA | 7.3 ms | 49.0 ms | 6.1 ms | — | 7.7 ms | 7.9 ms |
 | imx8mp-frdm | CPU | Heap | 13.5 ms | 11.8 ms | 25.7 ms | 13.7 ms | 30.2 ms | 10.0 ms |
 | imx95-frdm | G2D | DMA | 4.6 ms | 4.3 ms | 4.5 ms | — | — | — |
-| imx95-frdm | GL | DMA | 3.1 ms | 11.8 ms | 3.2 ms | — | 3.1 ms | 2.9 ms |
+| imx95-frdm | GL | DMA | 3.0 ms | 5.7 ms | 3.2 ms | — | 3.1 ms | 2.2 ms |
 | imx95-frdm | CPU | Heap | 12.4 ms | 11.0 ms | 16.1 ms | 11.1 ms | 24.8 ms | 9.0 ms |
 | rpi5-hailo | GL | DMA | 7.2 ms | 10.4 ms | 5.4 ms | — | 8.4 ms | 6.2 ms |
 | rpi5-hailo | CPU | Heap | 6.8 ms | 5.4 ms | 8.0 ms | 6.6 ms | 12.2 ms | 2.5 ms |
-| jetson-orin-nano | GL | DMA | — | — | — | 1.5 ms | 4.2 ms | 1.5 ms |
+| jetson-orin-nano | GL | PBO | 2.3 ms | 2.2 ms | — | 1.5 ms | 4.2 ms | 1.5 ms |
 | jetson-orin-nano | CPU | Heap | 3.0 ms | 2.8 ms | 2.1 ms | 789 us | 3.2 ms | 1.4 ms |
 | x86-desktop | CPU | Heap | 516 us | 559 us | 256 us | 261 us | 758 us | 219 us |
 | mbp-m2-max | GL | IOSurface | 409 us | — | — | — | — | — |
 | mbp-m2-max | CPU | Heap | 541 us | 499 us | 329 us | 141 us | 784 us | 314 us |
+
+The imx8mp YUYV→RGB / RGBA→RGB cells (~49 ms) are the Vivante two-pass
+packed-RGB path (GL has no 3-byte render format); imx95 YUYV→RGB halved
+versus v0.15.0 (11.8 → 5.7 ms) from the engine's single-finish two-pass.
 
 The macOS GL row only covers YUYV→RGBA today; other format pairs fall
 through to CPU. Even with that single working pair the speedup is **1.3×**
@@ -693,42 +715,48 @@ done
 
 ### Mask Rendering
 
+**Data re-collected:** June 11, 2026 (GL proto-dispatch convergence;
+median of 3 runs × n=100; imx8mp/imx95/rpi5 at PR #110 head,
+jetson-orin-nano at PR #109 head). CPU / x86 / macOS rows retain the
+v0.15.0 capture — those paths are measured by the batched-GEMM tables
+below.
+
 **640×640 RGBA destination, ~2 detections (YOLOv8n-seg):**
 
 | Platform | Compute | Buffer | draw_decoded_masks (pre-decoded) | draw_proto_masks (fused) | hybrid_materialize_and_draw |
 |----------|---------|--------|-------------------------------|------------------------|---------------------------|
-| imx8mp-frdm | GL | DMA | 2.4 ms | 276 ms | 19.5 ms |
+| imx8mp-frdm | GL | DMA | 2.7 ms | 274 ms | 6.1 ms |
 | imx8mp-frdm | CPU | Heap | 5.3 ms | 77.8 ms | 8.3 ms |
-| imx95-frdm | GL | DMA | 1.9 ms | 26.0 ms | 5.6 ms |
+| imx95-frdm | GL | DMA | 1.2 ms | 24.4 ms | 4.8 ms |
 | imx95-frdm | CPU | Heap | 5.3 ms | 76.2 ms | 8.4 ms |
-| rpi5-hailo | GL | DMA | 1.5 ms | 8.0 ms | 5.6 ms |
+| rpi5-hailo | GL | DMA | 1.3 ms | 7.7 ms | 2.4 ms |
 | rpi5-hailo | CPU | Heap | 885 us | 14.5 ms | 1.7 ms |
-| jetson-orin-nano | GL | DMA | 556 us | 3.0 ms | 1.7 ms |
+| jetson-orin-nano | GL | DMA | 518 us | 3.0 ms | 1.4 ms |
 | jetson-orin-nano | CPU | Heap | 873 us | 22.1 ms | 1.9 ms |
 | x86-desktop | CPU | Heap | 648 us | 5.1 ms | 635 us |
 | mbp-m2-max | CPU | Heap | 215 us | 6.9 ms | 419 us |
 
 **Hybrid Path Comparison (CPU materialize + GL overlay vs fused GPU):**
 
-The hybrid path decodes masks on CPU (`materialize_segmentations`) then overlays via GL (`draw_decoded_masks`). This is faster than fused GPU `draw_proto_masks` on all tested platforms. The auto-selection in `ImageProcessor::draw_proto_masks()` prefers the hybrid path when both CPU and OpenGL backends are available.
+The hybrid path decodes masks on CPU (`materialize_segmentations`) then overlays via GL (`draw_decoded_masks`). This is faster than fused GPU `draw_proto_masks` on all tested platforms — dramatically so on Vivante, whose fragment scheduling falls off a cliff on the per-quad sigmoid work (see the eager-materialize guidance in `crates/image/ARCHITECTURE.md`). The auto-selection in `ImageProcessor::draw_proto_masks()` prefers the hybrid path when both CPU and OpenGL backends are available. The hybrid column is ~3× faster than the v0.15.0 capture across the boards thanks to the v0.22 batched-GEMM materialise.
 
 **New in v0.15.0:** The `materialize_masks()` API exposes the CPU materialization step as a first-class operation, enabling a three-stage pipeline (`decode_proto` → `materialize_masks` → `draw_decoded_masks`) where users can inspect, export, or fork the intermediate masks for analytics before rendering. Mask values are continuous sigmoid confidence (u8 0-255), not binary thresholded.
 
 | Platform | Full GPU (GL draw_proto_masks) | Hybrid (GL) | Speedup | Auto draw_proto_masks |
 |----------|-------------------------------|-------------|---------|----------------------|
-| imx8mp-frdm | 276 ms | 19.5 ms | **14.2×** | 4.2 ms |
-| imx95-frdm | 26.0 ms | 5.6 ms | **4.6×** | 4.2 ms |
-| rpi5-hailo | 8.0 ms | 5.6 ms | **1.4×** | 2.0 ms |
-| jetson-orin-nano | 3.0 ms | 1.7 ms | **1.8×** | 1.1 ms |
+| imx8mp-frdm | 274 ms | 6.1 ms | **44.9×** | 4.0 ms |
+| imx95-frdm | 24.4 ms | 4.8 ms | **5.1×** | 3.7 ms |
+| rpi5-hailo | 7.7 ms | 2.4 ms | **3.2×** | 1.6 ms |
+| jetson-orin-nano | 3.0 ms | 1.4 ms | **2.1×** | 1.2 ms |
 
 **Mask Decode Cost (CPU-only, measured in mask_benchmark):**
 
 | Platform | Proto Decode (NMS+coefficients) | Full Materialize (NMS+coefficients+pixels) |
 |----------|-------------------------------|-------------------------------------------|
-| imx8mp-frdm | 1.5 ms | 4.9 ms |
-| imx95-frdm | 1.2 ms | 4.3 ms |
-| rpi5-hailo | 376 us | 1.4 ms |
-| jetson-orin-nano | 440 us | 1.6 ms |
+| imx8mp-frdm | 916 us | 4.0 ms |
+| imx95-frdm | 712 us | 3.6 ms |
+| rpi5-hailo | 186 us | 1.2 ms |
+| jetson-orin-nano | 194 us | 1.1 ms |
 | x86-desktop | 381 us | 903 us |
 | mbp-m2-max | 222 us | 862 us |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **GL proto-mask texture lifecycle** (`edgefirst-image`): two latent bugs
+  with one root cause. (1) The experimental GLES 3.1 compute-shader proto
+  repack (`EDGEFIRST_PROTO_COMPUTE=1`) rendered garbage masks on every
+  conformant driver — `glBindImageTexture` requires immutable-format
+  textures in ES 3.1, so its `imageStore` writes never landed. (2)
+  Alternating proto dtypes (int8 ↔ float) on one processor raised
+  `GL_INVALID_VALUE`: the float paths re-allocated the shared proto
+  texture without updating the dims gate, so the next int8 upload wrote
+  into an incompatible allocation. Proto textures are now immutable
+  `TexStorage3D` allocations recreated on any dims/format change, which
+  also gives the f32/f16 paths the re-upload fast path they lacked (they
+  re-ran `glTexImage3D` on every call) and fixes an undefined
+  `texelFetch` past the array depth in the int8 two-pass dequant shader
+  when `num_protos % 4 != 0`.
+
+### Changed
+
+- **GL proto-segmentation render internals** (`edgefirst-image`): the
+  per-dtype render variants collapsed into one plan-driven path selected
+  by a pure, host-tested decision table (`proto_dispatch::plan_proto`).
+  The int8 two-pass dequant target and FBO are now persistent and
+  dims-gated instead of re-created per call, and per-detection /
+  per-dispatch uniform locations are cached instead of looked up by
+  string each draw. New `image.draw.gl.proto` tracing span records the
+  chosen upload strategy and program. No public API change; outputs are
+  unchanged (pinned by new cross-dtype, fallback, compute, churn, and
+  interpolation-mode regression tests).
+
 ### Added
 
 - **`ColorimetryMode` (`Fast` | `Exact`) + `EDGEFIRST_COLORIMETRY`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Issue #106 closed — imx8mp GL drift reclaimed and documented**:
+  `image_benchmark` regains the same-size 1080p RGBA→BGRA / RGBA→GREY
+  cells as permanent drift sentinels, verified back at the v0.15.0
+  numbers on imx8mp (7.7 / 7.9 ms, from 13.8 / 14.9 ms at the
+  2026-06-09 drift capture). BENCHMARKS.md's GL convert, letterbox, and
+  mask tables are re-collected on the convergence engine with per-table
+  capture notes (imx95 YUYV→RGB 1080p halved to 5.7 ms; the mask hybrid
+  path is ~3× faster than the stale v0.15.0 figures).
 - **GL proto-segmentation render internals** (`edgefirst-image`): the
   per-dtype render variants collapsed into one plan-driven path selected
   by a pure, host-tested decision table (`proto_dispatch::plan_proto`).

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -805,12 +805,23 @@ every output pixel.
 
 #### Shader variants
 
-| Variant | Proto storage | Interpolation |
-|---------|---------------|---------------|
-| int8-nearest | `R8I` quantized | Nearest neighbor |
-| int8-bilinear | `R8I` quantized | Manual 4-tap bilinear |
-| f32 | `R32F` float | Hardware `GL_LINEAR` |
-| f16 | `R16F` half | Hardware `GL_LINEAR` |
+The variant is chosen by the pure `proto_dispatch::plan_proto` table —
+`(proto dtype, layout, compute availability, GL_OES_texture_float_linear,
+int8 interpolation mode) → ProtoPlan { upload, program, count_uniform }`
+— host-tested exhaustively, the same shape as `render::plan_convert` and
+`float_dispatch::classify_float_render`. All uploads land in one shared
+immutable `TexStorage3D` array recreated on any (dims, internal-format)
+change (`ensure_proto_texture`).
+
+| Plan (upload / program) | Proto storage | Interpolation | Notes |
+|---------|---------------|---------------|-------|
+| `I8CpuRepack` / int8-nearest | `R8I` quantized | Nearest `texelFetch` | |
+| `I8CpuRepack` / int8-bilinear | `R8I` quantized | Manual 4-tap bilinear | Default int8 mode. |
+| `I8Compute` / (any int8 program) | `R8I` data via SSBO → `R32I` | As selected | GLES 3.1 compute HWC→CHW repack; opt-in via `EDGEFIRST_PROTO_COMPUTE=1`. |
+| `I8…` / int8-two-pass | dequant render → `RGBA16F` | Hardware `GL_LINEAR` | Dequant pass into a persistent, dims-gated FBO texture; tail layer zero-guarded for `num_protos % 4 != 0`. |
+| `F32R32f` / f32 | `R32F` float | Hardware `GL_LINEAR` | Requires `GL_OES_texture_float_linear`. |
+| `F32ToRgba16f` / f16 | `RGBA16F` (4 protos/layer) | Hardware `GL_LINEAR` | Capability fallback when float-linear is absent (force for testing: `EDGEFIRST_GL_NO_FLOAT_LINEAR=1`). |
+| `F16Rgba16f` / f16 | `RGBA16F` (4 protos/layer) | Hardware `GL_LINEAR` | Native-f16 protos; never widened to f32. |
 
 Control quantized proto interpolation via
 `processor.set_int8_interpolation_mode(...)`.
@@ -1116,6 +1127,7 @@ image.materialize_masks                                 [user-facing fn]
 | `image.convert.cpu.format_convert`                     | Per-pixel format conversion (e.g. NV12 → RGB, RGBA → BGRA). The `pass` field tells you whether this ran before, after, or instead of resize. | `pre_resize` indicates the source needed conversion to RGB/RGBA/GREY before `fast_image_resize` could run; `direct` indicates no resize was needed; `post_resize` indicates the destination format differed from the intermediate. |
 | `image.convert.cpu.resize_flip_rotate`                 | `fast_image_resize::Resizer` + rayon parallel slice, with composed flip/rotate/letterbox geometry. | The bulk of CPU `convert()` cost. The CPU backend is selected only when neither GL nor G2D accepts the (src, dst) format pair. |
 | `image.draw_decoded_masks`                             | Per-detection alpha-blend of `Segmentation` mask onto the destination image (CPU or GL depending on backend). | When backend == GL, this dispatches to the shader-based mask blit. |
+| `image.draw.gl.proto`                                  | The fused GL proto-segmentation render: proto texture upload + per-detection quad draws. The `upload` / `program` fields record the `ProtoPlan` chosen by the pure `proto_dispatch::plan_proto` table (e.g. `I8CpuRepack`/`Int8Bilinear`, `F32R32f`/`F32`, `F16Rgba16f`/`F16`), alongside `dtype`, `num_protos`, and `detections`. | Filter by `upload` to isolate one upload strategy's latency. Steady-state at fixed proto dims re-uploads via `TexSubImage3D` into the immutable `TexStorage3D` allocation (the `ensure_proto_texture` gate); re-allocation happens only on dims/format churn. |
 | `image.materialize_masks`                              | Wrapper around the four `kernel_*` spans, paired with letterbox inversion and bbox-clipped row iteration. `mode = "proto"` returns proto-resolution masks; `mode = "scaled"` resamples to `(width, height)`. | Use the proto-resolution mode when you only need IoU computation against ground truth at the proto grid (the default Ultralytics evaluation mode). |
 | `image.materialize_masks.kernel_i8`                    | Fused i8 dequant + i8 × i8 → i32 matmul + sigmoid at proto resolution. NEON FP16 on aarch64. | The fastest path; avoids producing an intermediate f32 protos buffer. |
 | `image.materialize_masks.kernel_i16xi8`                | i16 coeff dequant + i16 × i8 → i32 matmul. Used when mask coefficients are stored at i16. | Preserves the i16 dynamic range that an i8 coeff dequant would lose. |

--- a/crates/image/benches/image_benchmark.rs
+++ b/crates/image/benches/image_benchmark.rs
@@ -302,6 +302,23 @@ fn bench_convert(proc: &mut ImageProcessor, suite: &mut BenchSuite) {
             CAMERA_1080P_RGBA.as_slice(),
             4,
         ),
+        // RGBA→BGRA and RGBA→GREY are the issue #106 drift sentinels: the
+        // 2026-06 capture found them +79%/+91% over the v0.15.0 doc numbers
+        // on Vivante while other boards held, and the cells had meanwhile
+        // dropped out of this bench — keep them measurable so same-size
+        // swizzle/extraction drift can never go unnoticed again.
+        (
+            PixelFormat::Rgba,
+            PixelFormat::Bgra,
+            CAMERA_1080P_RGBA.as_slice(),
+            4,
+        ),
+        (
+            PixelFormat::Rgba,
+            PixelFormat::Grey,
+            CAMERA_1080P_RGBA.as_slice(),
+            4,
+        ),
         (
             PixelFormat::Rgba,
             PixelFormat::PlanarRgb,

--- a/crates/image/src/gl/mod.rs
+++ b/crates/image/src/gl/mod.rs
@@ -52,6 +52,10 @@ mod dma_import;
 // backends. No gbm/IOSurface types; compiled on both.
 mod core;
 mod float_dispatch;
+// Pure decision table for the proto-segmentation render path (upload
+// strategy × program × count uniform). No GL types; host-tested
+// exhaustively. See `proto_dispatch.rs`.
+mod proto_dispatch;
 // Portable GL render lowering (y-flip viewport, source UV, batch chunk planner).
 // No platform types; compiled on both platforms, consumed by the converged
 // tile/batch renderer. See `render.rs`.

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -110,6 +110,15 @@ impl DstReadback {
     }
 }
 
+/// Borrowed proto data for the layered-float render plans: the
+/// dispatcher's dtype arm keeps the `TensorMap` alive and hands the typed
+/// view down to `render_proto_layers`, which matches it against
+/// `ProtoPlan::upload`.
+enum ProtoLayersData<'a> {
+    F32(ndarray::ArrayView3<'a, f32>),
+    F16(ndarray::ArrayView3<'a, half::f16>),
+}
+
 /// Uniform locations for one `nv_r8` program variant, resolved once at link
 /// time — `glGetUniformLocation` is a per-call string lookup in the driver
 /// and the NV draw previously issued 12 per frame.
@@ -209,6 +218,12 @@ pub struct GLProcessorST {
     int8_interpolation_mode: Int8InterpolationMode,
     /// Intermediate FBO texture for two-pass int8 dequant path.
     proto_dequant_texture: Texture,
+    /// Allocated dequant texture dims for the recreate-on-change gate:
+    /// (w, h, layers, internal_fmt). Mirrors `proto_tex_dims`.
+    proto_dequant_tex_dims: (usize, usize, usize, u32),
+    /// Persistent FBO for the two-pass int8 dequant render — previously a
+    /// fresh `FrameBuffer::new()` per call.
+    proto_dequant_fbo: FrameBuffer,
     /// Compute shader program for HWC→CHW proto repack (GLES 3.1 only).
     proto_repack_compute_program: Option<u32>,
     /// SSBO for proto data upload (compute shader path).
@@ -933,6 +948,8 @@ impl GLProcessorST {
             supports_f16_color,
             int8_interpolation_mode: Int8InterpolationMode::Bilinear,
             proto_dequant_texture,
+            proto_dequant_tex_dims: (0, 0, 0, 0),
+            proto_dequant_fbo: FrameBuffer::new(),
             vertex_buffer,
             texture_buffer,
             convert_fbo: FrameBuffer::new(),
@@ -5283,6 +5300,7 @@ impl GLProcessorST {
                 .map_err(|e| crate::Error::InvalidShape(format!("{e}")))?;
                 let quantization = edgefirst_decoder::Quantization::new(scale, zp);
                 self.render_proto_segmentation_int8(
+                    plan,
                     detect,
                     coeff_slice,
                     protos_view,
@@ -5302,37 +5320,17 @@ impl GLProcessorST {
                     m.as_slice(),
                 )
                 .map_err(|e| crate::Error::InvalidShape(format!("{e}")))?;
-                match plan.upload {
-                    super::proto_dispatch::ProtoUpload::F32R32f => {
-                        self.render_proto_segmentation_f32(
-                            detect,
-                            coeff_slice,
-                            protos_view,
-                            height,
-                            width,
-                            num_protos,
-                            texture_target,
-                            color_mode,
-                        )?;
-                    }
-                    super::proto_dispatch::ProtoUpload::F32ToRgba16f => {
-                        self.render_proto_segmentation_f16(
-                            detect,
-                            coeff_slice,
-                            protos_view,
-                            height,
-                            width,
-                            num_protos,
-                            texture_target,
-                            color_mode,
-                        )?;
-                    }
-                    other => {
-                        return Err(crate::Error::InvalidShape(format!(
-                            "plan_proto returned {other:?} for F32 protos"
-                        )));
-                    }
-                }
+                self.render_proto_layers(
+                    plan,
+                    detect,
+                    coeff_slice,
+                    ProtoLayersData::F32(protos_view),
+                    height,
+                    width,
+                    num_protos,
+                    texture_target,
+                    color_mode,
+                )?;
             }
             DType::F16 => {
                 let t = proto_data.protos.as_f16().expect("F16");
@@ -5342,10 +5340,11 @@ impl GLProcessorST {
                     m.as_slice(),
                 )
                 .map_err(|e| crate::Error::InvalidShape(format!("{e}")))?;
-                self.render_proto_segmentation_f16_native(
+                self.render_proto_layers(
+                    plan,
                     detect,
                     coeff_slice,
-                    protos_view,
+                    ProtoLayersData::F16(protos_view),
                     height,
                     width,
                     num_protos,
@@ -5472,11 +5471,12 @@ impl GLProcessorST {
         Ok(())
     }
 
-    /// Int8 proto path: upload raw i8 protos as `GL_R8I`, dispatch by
-    /// interpolation mode.
+    /// Int8 proto path: upload raw i8 protos per `plan.upload`, render per
+    /// `plan.program`.
     #[allow(clippy::too_many_arguments)]
     fn render_proto_segmentation_int8(
         &mut self,
+        plan: super::proto_dispatch::ProtoPlan,
         detect: &[DetectBox],
         mask_coefficients: &[f32],
         protos: ndarray::ArrayView3<'_, i8>,
@@ -5489,7 +5489,12 @@ impl GLProcessorST {
     ) -> crate::Result<()> {
         // Protos are (H, W, num_protos) in row-major HWC. The GL texture
         // needs layer-first CHW (one proto per layer).
-        if let Some(compute_program) = self.proto_repack_compute_program {
+        if plan.upload == super::proto_dispatch::ProtoUpload::I8Compute {
+            let compute_program = self.proto_repack_compute_program.ok_or_else(|| {
+                crate::Error::InvalidShape(
+                    "plan selected I8Compute without a compiled compute program".into(),
+                )
+            })?;
             // === GLES 3.1 compute shader path ===
             // Upload HWC data as-is to SSBO, let GPU transpose via compute.
             // Fall through to CPU repack if proto array is non-contiguous.
@@ -5592,9 +5597,15 @@ impl GLProcessorST {
         let proto_scale = quantization.scale;
         let proto_scaled_zp = -(quantization.zero_point as f32) * quantization.scale;
 
-        match self.int8_interpolation_mode {
-            Int8InterpolationMode::Nearest => {
-                let program = &self.proto_segmentation_int8_nearest_program;
+        match plan.program {
+            super::proto_dispatch::ProtoProgram::Int8Nearest
+            | super::proto_dispatch::ProtoProgram::Int8Bilinear => {
+                let program =
+                    if plan.program == super::proto_dispatch::ProtoProgram::Int8Nearest {
+                        &self.proto_segmentation_int8_nearest_program
+                    } else {
+                        &self.proto_segmentation_int8_bilinear_program
+                    };
                 gls::use_program(program.id);
                 program.load_uniform_1i(c"num_protos", num_protos as i32)?;
                 program.load_uniform_1f(c"proto_scale", proto_scale)?;
@@ -5607,21 +5618,7 @@ impl GLProcessorST {
                     color_mode,
                 )?;
             }
-            Int8InterpolationMode::Bilinear => {
-                let program = &self.proto_segmentation_int8_bilinear_program;
-                gls::use_program(program.id);
-                program.load_uniform_1i(c"num_protos", num_protos as i32)?;
-                program.load_uniform_1f(c"proto_scale", proto_scale)?;
-                program.load_uniform_1f(c"proto_scaled_zp", proto_scaled_zp)?;
-                self.render_proto_detection_quads(
-                    program,
-                    detect,
-                    mask_coefficients,
-                    num_protos,
-                    color_mode,
-                )?;
-            }
-            Int8InterpolationMode::TwoPass => {
+            super::proto_dispatch::ProtoProgram::Int8TwoPass => {
                 self.render_proto_int8_two_pass(
                     detect,
                     mask_coefficients,
@@ -5633,6 +5630,11 @@ impl GLProcessorST {
                     color_mode,
                 )?;
             }
+            other => {
+                return Err(crate::Error::InvalidShape(format!(
+                    "proto program {other:?} is not an int8 program"
+                )));
+            }
         }
 
         Ok(())
@@ -5642,7 +5644,7 @@ impl GLProcessorST {
     /// existing f16 shader using GL_LINEAR.
     #[allow(clippy::too_many_arguments)]
     fn render_proto_int8_two_pass(
-        &self,
+        &mut self,
         detect: &[DetectBox],
         mask_coefficients: &[f32],
         quantization: &edgefirst_decoder::Quantization,
@@ -5663,41 +5665,21 @@ impl GLProcessorST {
             (fbo as u32, vp)
         };
 
-        // Pass 1: Dequantize int8 → RGBA16F texture via framebuffer
-        let dequant_fbo = FrameBuffer::new();
-        gls::bind_texture(texture_target, self.proto_dequant_texture.id);
-        gls::tex_image3d::<u8>(
+        // Pass 1: Dequantize int8 → RGBA16F texture via the persistent
+        // dequant FBO. The render target is gated like the proto texture
+        // (recreate-on-change immutable storage) instead of a fresh
+        // TexImage3D per call.
+        if Self::ensure_immutable_tex_array(
+            &mut self.proto_dequant_texture,
+            &mut self.proto_dequant_tex_dims,
             texture_target,
-            0,
-            gls::gl::RGBA16F as i32,
-            width as i32,
-            height as i32,
-            num_layers as i32,
-            0,
-            gls::gl::RGBA,
-            gls::gl::HALF_FLOAT,
-            None,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_MIN_FILTER,
-            gls::gl::LINEAR as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_MAG_FILTER,
-            gls::gl::LINEAR as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_S,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_T,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
+            gls::gl::RGBA16F,
+            width,
+            height,
+            num_layers,
+        ) {
+            Self::set_proto_tex_params(texture_target, gls::gl::LINEAR);
+        }
 
         let proto_scale = quantization.scale;
         let proto_scaled_zp = -(quantization.zero_point as f32) * quantization.scale;
@@ -5713,7 +5695,7 @@ impl GLProcessorST {
 
         // Render each RGBA16F layer (4 protos per layer)
         for layer in 0..num_layers {
-            dequant_fbo.bind();
+            self.proto_dequant_fbo.bind();
             unsafe {
                 gls::gl::FramebufferTextureLayer(
                     gls::gl::FRAMEBUFFER,
@@ -5725,41 +5707,10 @@ impl GLProcessorST {
                 gls::gl::Viewport(0, 0, width as i32, height as i32);
             }
             dequant_program.load_uniform_1i(c"base_layer", (layer * 4) as i32)?;
-
-            // Full-screen quad
-            unsafe {
-                gls::gl::BindBuffer(gls::gl::ARRAY_BUFFER, self.vertex_buffer.id);
-                gls::gl::EnableVertexAttribArray(self.vertex_buffer.buffer_index);
-                let verts: [f32; 12] = [
-                    -1.0, -1.0, 0.0, 1.0, -1.0, 0.0, 1.0, 1.0, 0.0, -1.0, 1.0, 0.0,
-                ];
-                gls::gl::BufferSubData(
-                    gls::gl::ARRAY_BUFFER,
-                    0,
-                    (size_of::<f32>() * 12) as isize,
-                    verts.as_ptr() as *const c_void,
-                );
-                gls::gl::BindBuffer(gls::gl::ARRAY_BUFFER, self.texture_buffer.id);
-                gls::gl::EnableVertexAttribArray(self.texture_buffer.buffer_index);
-                let tc: [f32; 8] = [0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0];
-                gls::gl::BufferSubData(
-                    gls::gl::ARRAY_BUFFER,
-                    0,
-                    (size_of::<f32>() * 8) as isize,
-                    tc.as_ptr() as *const c_void,
-                );
-                let idx: [u32; 4] = [0, 1, 2, 3];
-                gls::gl::DrawElements(
-                    gls::gl::TRIANGLE_FAN,
-                    4,
-                    gls::gl::UNSIGNED_INT,
-                    idx.as_ptr() as *const c_void,
-                );
-            }
+            self.draw_fullscreen_quad()?;
         }
 
-        // Drop the dequant FBO (its Drop unbinds to 0) and restore the caller's.
-        drop(dequant_fbo);
+        // Restore the caller's FBO and viewport.
         unsafe {
             gls::gl::BindFramebuffer(gls::gl::FRAMEBUFFER, saved_fbo);
             gls::gl::Viewport(
@@ -5787,136 +5738,102 @@ impl GLProcessorST {
         Ok(())
     }
 
-    /// F32 proto path: upload as `GL_R32F` with `GL_LINEAR` filtering.
+    /// One render for every layered-float proto plan — F32→R32F native,
+    /// F32→RGBA16F fallback, and native F16→RGBA16F — driven entirely by
+    /// the [`ProtoPlan`](super::proto_dispatch::ProtoPlan): upload strategy
+    /// picks the repack + texture format, `plan.program` the sampler
+    /// program, `plan.count_uniform` the layer-count uniform. Replaces the
+    /// three per-dtype `render_proto_segmentation_{f32,f16,f16_native}`
+    /// bodies that differed only in those three choices.
     #[allow(clippy::too_many_arguments)]
-    fn render_proto_segmentation_f32(
+    fn render_proto_layers(
         &mut self,
+        plan: super::proto_dispatch::ProtoPlan,
         detect: &[DetectBox],
         mask_coefficients: &[f32],
-        protos_f32: ndarray::ArrayView3<'_, f32>,
+        data: ProtoLayersData<'_>,
         height: usize,
         width: usize,
         num_protos: usize,
         texture_target: u32,
         color_mode: crate::ColorMode,
     ) -> crate::Result<()> {
-        // Repack protos to layer-first layout: (num_protos, H, W)
-        let tex_data = super::proto_dispatch::repack_layers(protos_f32);
+        use super::proto_dispatch::{CountUniform, ProtoProgram, ProtoUpload};
 
-        self.upload_proto_texture(
-            texture_target,
-            gls::gl::R32F,
-            width,
-            height,
-            num_protos,
-            gls::gl::RED,
-            gls::gl::FLOAT,
-            gls::gl::LINEAR,
-            &tex_data,
-        );
-
-        let program = &self.proto_segmentation_f32_program;
-        gls::use_program(program.id);
-        program.load_uniform_1i(c"num_protos", num_protos as i32)?;
-        self.render_proto_detection_quads(
-            program,
-            detect,
-            mask_coefficients,
-            num_protos,
-            color_mode,
-        )?;
-
-        Ok(())
-    }
-
-    /// F16 fallback path: repack f32 protos to RGBA16F and use existing
-    /// f16 shader with GL_LINEAR. Used when GL_OES_texture_float_linear
-    /// is not available.
-    #[allow(clippy::too_many_arguments)]
-    fn render_proto_segmentation_f16(
-        &mut self,
-        detect: &[DetectBox],
-        mask_coefficients: &[f32],
-        protos_f32: ndarray::ArrayView3<'_, f32>,
-        height: usize,
-        width: usize,
-        num_protos: usize,
-        texture_target: u32,
-        color_mode: crate::ColorMode,
-    ) -> crate::Result<()> {
         let num_layers = num_protos.div_ceil(4);
-        let (tex_data, _) =
-            super::proto_dispatch::repack_rgba_f16_layers(protos_f32, half::f16::from_f32);
+        match (plan.upload, &data) {
+            (ProtoUpload::F32R32f, ProtoLayersData::F32(v)) => {
+                // Repack protos to layer-first layout: (num_protos, H, W)
+                let tex_data = super::proto_dispatch::repack_layers(*v);
+                self.upload_proto_texture(
+                    texture_target,
+                    gls::gl::R32F,
+                    width,
+                    height,
+                    num_protos,
+                    gls::gl::RED,
+                    gls::gl::FLOAT,
+                    gls::gl::LINEAR,
+                    &tex_data,
+                );
+            }
+            (ProtoUpload::F32ToRgba16f, ProtoLayersData::F32(v)) => {
+                let (tex_data, _) =
+                    super::proto_dispatch::repack_rgba_f16_layers(*v, half::f16::from_f32);
+                self.upload_proto_texture(
+                    texture_target,
+                    gls::gl::RGBA16F,
+                    width,
+                    height,
+                    num_layers,
+                    gls::gl::RGBA,
+                    gls::gl::HALF_FLOAT,
+                    gls::gl::LINEAR,
+                    &tex_data,
+                );
+            }
+            (ProtoUpload::F16Rgba16f, ProtoLayersData::F16(v)) => {
+                let (tex_data, _) = super::proto_dispatch::repack_rgba_f16_layers(*v, |x| x);
+                self.upload_proto_texture(
+                    texture_target,
+                    gls::gl::RGBA16F,
+                    width,
+                    height,
+                    num_layers,
+                    gls::gl::RGBA,
+                    gls::gl::HALF_FLOAT,
+                    gls::gl::LINEAR,
+                    &tex_data,
+                );
+            }
+            (upload, _) => {
+                return Err(crate::Error::InvalidShape(format!(
+                    "proto upload {upload:?} incompatible with the provided proto data"
+                )));
+            }
+        }
 
-        self.upload_proto_texture(
-            texture_target,
-            gls::gl::RGBA16F,
-            width,
-            height,
-            num_layers,
-            gls::gl::RGBA,
-            gls::gl::HALF_FLOAT,
-            gls::gl::LINEAR,
-            &tex_data,
-        );
-
-        let program = &self.proto_segmentation_program;
+        let program = match plan.program {
+            ProtoProgram::F32 => &self.proto_segmentation_f32_program,
+            ProtoProgram::F16 => &self.proto_segmentation_program,
+            other => {
+                return Err(crate::Error::InvalidShape(format!(
+                    "proto program {other:?} is not a layered-float program"
+                )));
+            }
+        };
         gls::use_program(program.id);
-        program.load_uniform_1i(c"num_layers", num_layers as i32)?;
+        match plan.count_uniform {
+            CountUniform::NumProtos => program.load_uniform_1i(c"num_protos", num_protos as i32)?,
+            CountUniform::NumLayers => program.load_uniform_1i(c"num_layers", num_layers as i32)?,
+        }
         self.render_proto_detection_quads(
             program,
             detect,
             mask_coefficients,
             num_protos,
             color_mode,
-        )?;
-
-        Ok(())
-    }
-
-    /// Native-f16 variant of [`Self::render_proto_segmentation_f16`]: uploads
-    /// protos that are already in half-precision directly into `RGBA16F`
-    /// without a f32→f16 conversion pass. Used for `TensorDyn::F16` proto
-    /// tensors produced by fp16 inference engines.
-    #[allow(clippy::too_many_arguments)]
-    fn render_proto_segmentation_f16_native(
-        &mut self,
-        detect: &[DetectBox],
-        mask_coefficients: &[f32],
-        protos_f16: ndarray::ArrayView3<'_, half::f16>,
-        height: usize,
-        width: usize,
-        num_protos: usize,
-        texture_target: u32,
-        color_mode: crate::ColorMode,
-    ) -> crate::Result<()> {
-        let num_layers = num_protos.div_ceil(4);
-        let (tex_data, _) = super::proto_dispatch::repack_rgba_f16_layers(protos_f16, |v| v);
-
-        self.upload_proto_texture(
-            texture_target,
-            gls::gl::RGBA16F,
-            width,
-            height,
-            num_layers,
-            gls::gl::RGBA,
-            gls::gl::HALF_FLOAT,
-            gls::gl::LINEAR,
-            &tex_data,
-        );
-
-        let program = &self.proto_segmentation_program;
-        gls::use_program(program.id);
-        program.load_uniform_1i(c"num_layers", num_layers as i32)?;
-        self.render_proto_detection_quads(
-            program,
-            detect,
-            mask_coefficients,
-            num_protos,
-            color_mode,
-        )?;
-
-        Ok(())
+        )
     }
 
     fn render_segmentation(
@@ -6051,16 +5968,39 @@ impl GLProcessorST {
         h: usize,
         layers: usize,
     ) -> bool {
+        Self::ensure_immutable_tex_array(
+            &mut self.proto_texture,
+            &mut self.proto_tex_dims,
+            target,
+            internal_fmt,
+            w,
+            h,
+            layers,
+        )
+    }
+
+    /// The shared immutable-array allocation gate behind
+    /// [`Self::ensure_proto_texture`] — also used by the two-pass dequant
+    /// target, which keeps its own texture/dims pair.
+    fn ensure_immutable_tex_array(
+        texture: &mut Texture,
+        tex_dims: &mut (usize, usize, usize, u32),
+        target: u32,
+        internal_fmt: u32,
+        w: usize,
+        h: usize,
+        layers: usize,
+    ) -> bool {
         let dims = (w, h, layers, internal_fmt);
         gls::active_texture(gls::gl::TEXTURE0);
-        if dims == self.proto_tex_dims {
-            gls::bind_texture(target, self.proto_texture.id);
+        if dims == *tex_dims {
+            gls::bind_texture(target, texture.id);
             return false;
         }
         // Immutable storage cannot be re-specified: recreate the object
         // (the old one is deleted by Texture's Drop).
-        self.proto_texture = Texture::new();
-        gls::bind_texture(target, self.proto_texture.id);
+        *texture = Texture::new();
+        gls::bind_texture(target, texture.id);
         unsafe {
             gls::gl::TexStorage3D(
                 target,
@@ -6071,7 +6011,7 @@ impl GLProcessorST {
                 layers as i32,
             );
         }
-        self.proto_tex_dims = dims;
+        *tex_dims = dims;
         true
     }
 

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -5983,8 +5983,8 @@ impl GLProcessorST {
         }
     }
 
-    /// Upload data to the proto `GL_TEXTURE_2D_ARRAY`, using `glTexSubImage3D`
-    /// when the texture dimensions haven't changed (avoids driver reallocation).
+    /// Ensure the shared proto `GL_TEXTURE_2D_ARRAY` uses immutable storage and
+    /// is recreated when dimensions or internal format change.
     #[allow(clippy::too_many_arguments)]
     /// Ensure `proto_texture` is an immutable-storage (`TexStorage3D`) array
     /// of exactly `(w, h, layers, internal_fmt)`, recreating the texture

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -224,8 +224,17 @@ pub struct GLProcessorST {
     /// Persistent FBO for the two-pass int8 dequant render — previously a
     /// fresh `FrameBuffer::new()` per call.
     proto_dequant_fbo: FrameBuffer,
+    /// Per-detection quad uniform locations, `(program_id, mask_coeff,
+    /// class_index)`, re-resolved only when the bound proto program
+    /// changes. `Cell` because the resolving call sites hold `&self`
+    /// borrows of the program; id 0 = unresolved.
+    proto_quad_locs: std::cell::Cell<(u32, i32, i32)>,
     /// Compute shader program for HWC→CHW proto repack (GLES 3.1 only).
     proto_repack_compute_program: Option<u32>,
+    /// `(width, height, num_protos)` uniform locations for the compute
+    /// program, resolved once at compile — previously three
+    /// GetUniformLocation string lookups per dispatch.
+    proto_compute_locs: (i32, i32, i32),
     /// SSBO for proto data upload (compute shader path).
     proto_ssbo: u32,
     /// Current allocated size of proto SSBO in bytes (0 = not allocated).
@@ -950,6 +959,7 @@ impl GLProcessorST {
             proto_dequant_texture,
             proto_dequant_tex_dims: (0, 0, 0, 0),
             proto_dequant_fbo: FrameBuffer::new(),
+            proto_quad_locs: std::cell::Cell::new((0, -1, -1)),
             vertex_buffer,
             texture_buffer,
             convert_fbo: FrameBuffer::new(),
@@ -973,6 +983,7 @@ impl GLProcessorST {
             cached_opacity: f32::NAN, // sentinel: forces first set_opacity_uniform to initialize all shaders
             proto_tex_dims: (0, 0, 0, 0),
             proto_repack_compute_program: None,
+            proto_compute_locs: (-1, -1, -1),
             proto_ssbo: 0,
             proto_ssbo_size: 0,
             nv_r8_program,
@@ -1001,6 +1012,13 @@ impl GLProcessorST {
                 Ok(program) => {
                     log::info!("Proto repack compute shader compiled successfully");
                     converter.proto_repack_compute_program = Some(program);
+                    unsafe {
+                        converter.proto_compute_locs = (
+                            gls::gl::GetUniformLocation(program, c"width".as_ptr()),
+                            gls::gl::GetUniformLocation(program, c"height".as_ptr()),
+                            gls::gl::GetUniformLocation(program, c"num_protos".as_ptr()),
+                        );
+                    }
                     let mut ssbo = 0u32;
                     unsafe { gls::gl::GenBuffers(1, &mut ssbo) };
                     converter.proto_ssbo = ssbo;
@@ -5215,6 +5233,19 @@ impl GLProcessorST {
             self.int8_interpolation_mode,
         )?;
 
+        // The proto render's span — the path previously had none (only a
+        // FunctionTimer wall-clock at the draw_proto_masks entry). Plan
+        // fields make the chosen upload/program visible in traces.
+        let _span = tracing::trace_span!(
+            "image.draw.gl.proto",
+            dtype = ?proto_data.protos.dtype(),
+            upload = ?plan.upload,
+            program = ?plan.program,
+            num_protos,
+            detections = detect.len(),
+        )
+        .entered();
+
         // Coefficient slice for the GL uniform upload path. The shaders
         // consume f32 regardless of source dtype, but we hold the F32 case
         // as a borrowed slice (no allocation) and only widen for F16. The
@@ -5375,6 +5406,19 @@ impl GLProcessorST {
     ) -> crate::Result<()> {
         let cvt_screen_coord = |normalized: f32| normalized * 2.0 - 1.0;
 
+        // Resolve the per-detection uniform locations once per program
+        // switch — `load_uniform_*` is a driver string lookup plus a
+        // redundant UseProgram, and this loop previously paid both twice
+        // per detection per frame. The caller has already bound `program`.
+        let (cached_id, mut loc_coeff, mut loc_class) = self.proto_quad_locs.get();
+        if cached_id != program.id {
+            unsafe {
+                loc_coeff = gls::gl::GetUniformLocation(program.id, c"mask_coeff".as_ptr());
+                loc_class = gls::gl::GetUniformLocation(program.id, c"class_index".as_ptr());
+            }
+            self.proto_quad_locs.set((program.id, loc_coeff, loc_class));
+        }
+
         // Stride the flat `mask_coefficients` buffer by `num_protos` so we
         // get one slice per detection. `chunks_exact` requires the total
         // length to be a multiple of `num_protos`; the dispatcher already
@@ -5390,8 +5434,10 @@ impl GLProcessorST {
                 packed_coeff[i / 4][i % 4] = *val;
             }
 
-            program.load_uniform_4fv(c"mask_coeff", &packed_coeff)?;
-            program.load_uniform_1i(c"class_index", color_index as i32)?;
+            unsafe {
+                gls::gl::Uniform4fv(loc_coeff, 8, packed_coeff.as_ptr() as *const f32);
+                gls::gl::Uniform1i(loc_class, color_index as i32);
+            }
 
             let dst_roi = RegionOfInterest {
                 left: cvt_screen_coord(det.bbox.xmin),
@@ -5514,8 +5560,7 @@ impl GLProcessorST {
             // Allocate as R32I (imageStore-compatible; the int8 fragment
             // shaders read integers identically from R8I or R32I via
             // texelFetch). Immutable storage + binding handled by the gate.
-            if self.ensure_proto_texture(texture_target, gls::gl::R32I, width, height, num_protos)
-            {
+            if self.ensure_proto_texture(texture_target, gls::gl::R32I, width, height, num_protos) {
                 Self::set_proto_tex_params(texture_target, gls::gl::NEAREST);
             }
 
@@ -5551,11 +5596,9 @@ impl GLProcessorST {
                     gls::gl::R32I,
                 );
 
-                // Dispatch compute
+                // Dispatch compute (uniform locations resolved at compile)
                 gls::gl::UseProgram(compute_program);
-                let loc_w = gls::gl::GetUniformLocation(compute_program, c"width".as_ptr());
-                let loc_h = gls::gl::GetUniformLocation(compute_program, c"height".as_ptr());
-                let loc_np = gls::gl::GetUniformLocation(compute_program, c"num_protos".as_ptr());
+                let (loc_w, loc_h, loc_np) = self.proto_compute_locs;
                 gls::gl::Uniform1i(loc_w, width as i32);
                 gls::gl::Uniform1i(loc_h, height as i32);
                 gls::gl::Uniform1i(loc_np, num_protos as i32);
@@ -5600,12 +5643,11 @@ impl GLProcessorST {
         match plan.program {
             super::proto_dispatch::ProtoProgram::Int8Nearest
             | super::proto_dispatch::ProtoProgram::Int8Bilinear => {
-                let program =
-                    if plan.program == super::proto_dispatch::ProtoProgram::Int8Nearest {
-                        &self.proto_segmentation_int8_nearest_program
-                    } else {
-                        &self.proto_segmentation_int8_bilinear_program
-                    };
+                let program = if plan.program == super::proto_dispatch::ProtoProgram::Int8Nearest {
+                    &self.proto_segmentation_int8_nearest_program
+                } else {
+                    &self.proto_segmentation_int8_bilinear_program
+                };
                 gls::use_program(program.id);
                 program.load_uniform_1i(c"num_protos", num_protos as i32)?;
                 program.load_uniform_1f(c"proto_scale", proto_scale)?;
@@ -6002,14 +6044,7 @@ impl GLProcessorST {
         *texture = Texture::new();
         gls::bind_texture(target, texture.id);
         unsafe {
-            gls::gl::TexStorage3D(
-                target,
-                1,
-                internal_fmt,
-                w as i32,
-                h as i32,
-                layers as i32,
-            );
+            gls::gl::TexStorage3D(target, 1, internal_fmt, w as i32, h as i32, layers as i32);
         }
         *tex_dims = dims;
         true

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1881,7 +1881,19 @@ impl GLProcessorST {
             }
         }
 
-        let has_float_linear = extensions.contains("GL_OES_texture_float_linear");
+        // EDGEFIRST_GL_NO_FLOAT_LINEAR=1 forces the capability off so the
+        // f32→f16-repack proto fallback (taken only on GPUs lacking the
+        // extension) is reachable on float-linear-capable lanes — no CI lane
+        // has such a GPU, so without the override the fallback arm has zero
+        // coverage anywhere.
+        let force_no_float_linear = std::env::var("EDGEFIRST_GL_NO_FLOAT_LINEAR")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        let has_float_linear =
+            extensions.contains("GL_OES_texture_float_linear") && !force_no_float_linear;
+        if force_no_float_linear {
+            log::info!("GL_OES_texture_float_linear forced OFF via EDGEFIRST_GL_NO_FLOAT_LINEAR");
+        }
         log::debug!("GL_OES_texture_float_linear: {has_float_linear}");
 
         let has_bgra = extensions.contains("GL_EXT_texture_format_BGRA8888");
@@ -5556,61 +5568,31 @@ impl GLProcessorST {
         texture_target: u32,
         color_mode: crate::ColorMode,
     ) -> crate::Result<()> {
-        // Upload raw int8 protos as R8I texture array (1 proto per layer)
-        gls::bind_texture(texture_target, self.proto_texture.id);
-        gls::active_texture(gls::gl::TEXTURE0);
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_MIN_FILTER,
-            gls::gl::NEAREST as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_MAG_FILTER,
-            gls::gl::NEAREST as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_S,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_T,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-
         // Protos are (H, W, num_protos) in row-major HWC. The GL texture
         // needs layer-first CHW (one proto per layer).
         if let Some(compute_program) = self.proto_repack_compute_program {
             // === GLES 3.1 compute shader path ===
             // Upload HWC data as-is to SSBO, let GPU transpose via compute.
             // Fall through to CPU repack if proto array is non-contiguous.
-            let data = match protos.as_slice() {
+            let mut data = match protos.as_slice() {
                 Some(s) => std::borrow::Cow::Borrowed(s),
                 None => std::borrow::Cow::Owned(protos.iter().copied().collect()),
             };
-            // Pad to 4-byte boundary for SSBO int[] alignment
-            let data_bytes = (data.len() + 3) & !3;
+            // Pad to a 4-byte boundary for SSBO int[] alignment — by copying,
+            // not by over-reading past the slice end.
+            if data.len() % 4 != 0 {
+                let mut owned = data.into_owned();
+                owned.resize(owned.len().next_multiple_of(4), 0);
+                data = std::borrow::Cow::Owned(owned);
+            }
+            let data_bytes = data.len();
 
-            // Allocate texture as R32I (required for imageStore in compute).
-            // Fragment shaders using isampler2DArray read integers correctly
-            // from either R8I or R32I via texelFetch.
-            let dims = (width, height, num_protos, gls::gl::R32I);
-            if dims != self.proto_tex_dims {
-                gls::tex_image3d::<i32>(
-                    texture_target,
-                    0,
-                    gls::gl::R32I as i32,
-                    width as i32,
-                    height as i32,
-                    num_protos as i32,
-                    0,
-                    gls::gl::RED_INTEGER,
-                    gls::gl::INT,
-                    None,
-                );
-                self.proto_tex_dims = dims;
+            // Allocate as R32I (imageStore-compatible; the int8 fragment
+            // shaders read integers identically from R8I or R32I via
+            // texelFetch). Immutable storage + binding handled by the gate.
+            if self.ensure_proto_texture(texture_target, gls::gl::R32I, width, height, num_protos)
+            {
+                Self::set_proto_tex_params(texture_target, gls::gl::NEAREST);
             }
 
             unsafe {
@@ -5690,6 +5672,7 @@ impl GLProcessorST {
                 num_protos,
                 gls::gl::RED_INTEGER,
                 gls::gl::BYTE,
+                gls::gl::NEAREST,
                 &tex_data,
             );
         }
@@ -5895,7 +5878,7 @@ impl GLProcessorST {
     /// F32 proto path: upload as `GL_R32F` with `GL_LINEAR` filtering.
     #[allow(clippy::too_many_arguments)]
     fn render_proto_segmentation_f32(
-        &self,
+        &mut self,
         detect: &[DetectBox],
         mask_coefficients: &[f32],
         protos_f32: ndarray::ArrayView3<'_, f32>,
@@ -5905,31 +5888,6 @@ impl GLProcessorST {
         texture_target: u32,
         color_mode: crate::ColorMode,
     ) -> crate::Result<()> {
-        let program = &self.proto_segmentation_f32_program;
-        gls::use_program(program.id);
-        gls::bind_texture(texture_target, self.proto_texture.id);
-        gls::active_texture(gls::gl::TEXTURE0);
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_MIN_FILTER,
-            gls::gl::LINEAR as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_MAG_FILTER,
-            gls::gl::LINEAR as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_S,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_T,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-
         // Repack protos to layer-first layout: (num_protos, H, W)
         let mut tex_data = vec![0.0f32; height * width * num_protos];
         for k in 0..num_protos {
@@ -5940,19 +5898,20 @@ impl GLProcessorST {
             }
         }
 
-        gls::tex_image3d(
+        self.upload_proto_texture(
             texture_target,
-            0,
-            gls::gl::R32F as i32,
-            width as i32,
-            height as i32,
-            num_protos as i32,
-            0,
+            gls::gl::R32F,
+            width,
+            height,
+            num_protos,
             gls::gl::RED,
             gls::gl::FLOAT,
-            Some(&tex_data),
+            gls::gl::LINEAR,
+            &tex_data,
         );
 
+        let program = &self.proto_segmentation_f32_program;
+        gls::use_program(program.id);
         program.load_uniform_1i(c"num_protos", num_protos as i32)?;
         self.render_proto_detection_quads(
             program,
@@ -5970,7 +5929,7 @@ impl GLProcessorST {
     /// is not available.
     #[allow(clippy::too_many_arguments)]
     fn render_proto_segmentation_f16(
-        &self,
+        &mut self,
         detect: &[DetectBox],
         mask_coefficients: &[f32],
         protos_f32: ndarray::ArrayView3<'_, f32>,
@@ -5983,44 +5942,20 @@ impl GLProcessorST {
         let num_layers = num_protos.div_ceil(4);
         let (tex_data, _) = Self::repack_protos_to_rgba_f16(protos_f32);
 
-        let program = &self.proto_segmentation_program;
-        gls::use_program(program.id);
-        gls::bind_texture(texture_target, self.proto_texture.id);
-        gls::active_texture(gls::gl::TEXTURE0);
-        gls::tex_parameteri(
+        self.upload_proto_texture(
             texture_target,
-            gls::gl::TEXTURE_MIN_FILTER,
-            gls::gl::LINEAR as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_MAG_FILTER,
-            gls::gl::LINEAR as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_S,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_T,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-
-        gls::tex_image3d(
-            texture_target,
-            0,
-            gls::gl::RGBA16F as i32,
-            width as i32,
-            height as i32,
-            num_layers as i32,
-            0,
+            gls::gl::RGBA16F,
+            width,
+            height,
+            num_layers,
             gls::gl::RGBA,
             gls::gl::HALF_FLOAT,
-            Some(&tex_data),
+            gls::gl::LINEAR,
+            &tex_data,
         );
 
+        let program = &self.proto_segmentation_program;
+        gls::use_program(program.id);
         program.load_uniform_1i(c"num_layers", num_layers as i32)?;
         self.render_proto_detection_quads(
             program,
@@ -6039,7 +5974,7 @@ impl GLProcessorST {
     /// tensors produced by fp16 inference engines.
     #[allow(clippy::too_many_arguments)]
     fn render_proto_segmentation_f16_native(
-        &self,
+        &mut self,
         detect: &[DetectBox],
         mask_coefficients: &[f32],
         protos_f16: ndarray::ArrayView3<'_, half::f16>,
@@ -6052,44 +5987,20 @@ impl GLProcessorST {
         let num_layers = num_protos.div_ceil(4);
         let (tex_data, _) = Self::repack_protos_f16_to_rgba_f16(protos_f16);
 
-        let program = &self.proto_segmentation_program;
-        gls::use_program(program.id);
-        gls::bind_texture(texture_target, self.proto_texture.id);
-        gls::active_texture(gls::gl::TEXTURE0);
-        gls::tex_parameteri(
+        self.upload_proto_texture(
             texture_target,
-            gls::gl::TEXTURE_MIN_FILTER,
-            gls::gl::LINEAR as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_MAG_FILTER,
-            gls::gl::LINEAR as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_S,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-        gls::tex_parameteri(
-            texture_target,
-            gls::gl::TEXTURE_WRAP_T,
-            gls::gl::CLAMP_TO_EDGE as i32,
-        );
-
-        gls::tex_image3d(
-            texture_target,
-            0,
-            gls::gl::RGBA16F as i32,
-            width as i32,
-            height as i32,
-            num_layers as i32,
-            0,
+            gls::gl::RGBA16F,
+            width,
+            height,
+            num_layers,
             gls::gl::RGBA,
             gls::gl::HALF_FLOAT,
-            Some(&tex_data),
+            gls::gl::LINEAR,
+            &tex_data,
         );
 
+        let program = &self.proto_segmentation_program;
+        gls::use_program(program.id);
         program.load_uniform_1i(c"num_layers", num_layers as i32)?;
         self.render_proto_detection_quads(
             program,
@@ -6210,6 +6121,72 @@ impl GLProcessorST {
     /// Upload data to the proto `GL_TEXTURE_2D_ARRAY`, using `glTexSubImage3D`
     /// when the texture dimensions haven't changed (avoids driver reallocation).
     #[allow(clippy::too_many_arguments)]
+    /// Ensure `proto_texture` is an immutable-storage (`TexStorage3D`) array
+    /// of exactly `(w, h, layers, internal_fmt)`, recreating the texture
+    /// object on any change, and bind it on `TEXTURE0`. Returns `true` when
+    /// recreated (sampler params reset with the object and must be
+    /// re-applied by the caller).
+    ///
+    /// Immutable storage is what makes the compute path's
+    /// `BindImageTexture` legal — ES 3.1 requires it, and `imageStore` into
+    /// a `TexImage3D`-allocated texture silently writes nowhere on
+    /// conformant drivers (Vivante and Mali both rendered garbage masks).
+    /// Recreate-on-change is what keeps the `(dims, internal_fmt)` gate
+    /// honest when renders alternate proto dtypes on one processor: the
+    /// previous `TexImage3D` scheme left `proto_tex_dims` stale after a
+    /// float upload re-allocated the shared texture, so the next int8
+    /// upload `TexSubImage3D`'d into an R32F allocation → GL_INVALID_VALUE
+    /// (0x501). Both found by the proto churn/compute regression tests.
+    fn ensure_proto_texture(
+        &mut self,
+        target: u32,
+        internal_fmt: u32,
+        w: usize,
+        h: usize,
+        layers: usize,
+    ) -> bool {
+        let dims = (w, h, layers, internal_fmt);
+        gls::active_texture(gls::gl::TEXTURE0);
+        if dims == self.proto_tex_dims {
+            gls::bind_texture(target, self.proto_texture.id);
+            return false;
+        }
+        // Immutable storage cannot be re-specified: recreate the object
+        // (the old one is deleted by Texture's Drop).
+        self.proto_texture = Texture::new();
+        gls::bind_texture(target, self.proto_texture.id);
+        unsafe {
+            gls::gl::TexStorage3D(
+                target,
+                1,
+                internal_fmt,
+                w as i32,
+                h as i32,
+                layers as i32,
+            );
+        }
+        self.proto_tex_dims = dims;
+        true
+    }
+
+    /// Apply the proto texture sampler params (`filter` + CLAMP_TO_EDGE).
+    /// Needed (only) after [`Self::ensure_proto_texture`] recreates the
+    /// object; params are per-texture state.
+    fn set_proto_tex_params(target: u32, filter: u32) {
+        unsafe { super::core::set_tex_filter(target, filter) };
+        gls::tex_parameteri(
+            target,
+            gls::gl::TEXTURE_WRAP_S,
+            gls::gl::CLAMP_TO_EDGE as i32,
+        );
+        gls::tex_parameteri(
+            target,
+            gls::gl::TEXTURE_WRAP_T,
+            gls::gl::CLAMP_TO_EDGE as i32,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn upload_proto_texture<T: Copy>(
         &mut self,
         target: u32,
@@ -6219,39 +6196,26 @@ impl GLProcessorST {
         layers: usize,
         format: u32,
         dtype: u32,
+        filter: u32,
         data: &[T],
     ) {
-        let dims = (w, h, layers, internal_fmt);
-        if dims == self.proto_tex_dims {
-            unsafe {
-                gls::gl::TexSubImage3D(
-                    target,
-                    0,
-                    0,
-                    0,
-                    0,
-                    w as i32,
-                    h as i32,
-                    layers as i32,
-                    format,
-                    dtype,
-                    data.as_ptr() as *const std::ffi::c_void,
-                );
-            }
-        } else {
-            gls::tex_image3d(
+        if self.ensure_proto_texture(target, internal_fmt, w, h, layers) {
+            Self::set_proto_tex_params(target, filter);
+        }
+        unsafe {
+            gls::gl::TexSubImage3D(
                 target,
                 0,
-                internal_fmt as i32,
+                0,
+                0,
+                0,
                 w as i32,
                 h as i32,
                 layers as i32,
-                0,
                 format,
                 dtype,
-                Some(data),
+                data.as_ptr() as *const std::ffi::c_void,
             );
-            self.proto_tex_dims = dims;
         }
     }
 

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -5250,6 +5250,17 @@ impl GLProcessorST {
         }
         let texture_target = gls::gl::TEXTURE_2D_ARRAY;
 
+        // Pure path decision: upload strategy × program × count uniform.
+        // Rejects NCHW layouts and unsupported proto dtypes up front (the
+        // caller falls back to the CPU path on NotSupported).
+        let plan = super::proto_dispatch::plan_proto(
+            proto_data.protos.dtype(),
+            proto_data.layout,
+            self.proto_repack_compute_program.is_some(),
+            self.has_float_linear,
+            self.int8_interpolation_mode,
+        )?;
+
         // Coefficient slice for the GL uniform upload path. The shaders
         // consume f32 regardless of source dtype, but we hold the F32 case
         // as a borrowed slice (no allocation) and only widen for F16. The
@@ -5278,49 +5289,23 @@ impl GLProcessorST {
             DType::I8 => {
                 let t = proto_data.mask_coefficients.as_i8().expect("I8");
                 mc_map_i8 = t.map()?;
-                coeff_dequant = if let Some(q) = t.quantization() {
-                    use edgefirst_tensor::QuantMode;
-                    let (scale, zp) = match q.mode() {
-                        QuantMode::PerTensor { scale, zero_point } => (scale, zero_point as f32),
-                        QuantMode::PerTensorSymmetric { scale } => (scale, 0.0),
-                        other => {
-                            return Err(crate::Error::NotSupported(format!(
-                                "I8 mask_coefficients quantization mode {other:?} not supported on GL seg path"
-                            )));
-                        }
-                    };
-                    mc_map_i8
-                        .as_slice()
-                        .iter()
-                        .map(|&v| (v as f32 - zp) * scale)
-                        .collect()
-                } else {
-                    mc_map_i8.as_slice().iter().map(|&v| v as f32).collect()
-                };
+                let quant = t.quantization();
+                coeff_dequant = super::proto_dispatch::dequant_coeffs(
+                    mc_map_i8.as_slice(),
+                    quant.as_ref().map(|q| q.mode()),
+                    "I8",
+                )?;
                 &coeff_dequant[..]
             }
             DType::I16 => {
                 let t = proto_data.mask_coefficients.as_i16().expect("I16");
                 let mc_map_i16 = t.map()?;
-                coeff_dequant = if let Some(q) = t.quantization() {
-                    use edgefirst_tensor::QuantMode;
-                    let (scale, zp) = match q.mode() {
-                        QuantMode::PerTensor { scale, zero_point } => (scale, zero_point as f32),
-                        QuantMode::PerTensorSymmetric { scale } => (scale, 0.0),
-                        other => {
-                            return Err(crate::Error::NotSupported(format!(
-                                "I16 mask_coefficients quantization mode {other:?} not supported on GL seg path"
-                            )));
-                        }
-                    };
-                    mc_map_i16
-                        .as_slice()
-                        .iter()
-                        .map(|&v| (v as f32 - zp) * scale)
-                        .collect()
-                } else {
-                    mc_map_i16.as_slice().iter().map(|&v| v as f32).collect()
-                };
+                let quant = t.quantization();
+                coeff_dequant = super::proto_dispatch::dequant_coeffs(
+                    mc_map_i16.as_slice(),
+                    quant.as_ref().map(|q| q.mode()),
+                    "I16",
+                )?;
                 &coeff_dequant[..]
             }
             other => {
@@ -5329,17 +5314,6 @@ impl GLProcessorST {
                 )));
             }
         };
-
-        // The GL shader upload path assumes NHWC layout for ArrayView3 creation.
-        // NCHW protos would require a transpose to NHWC before texture upload —
-        // return NotSupported so the caller falls back to the CPU path.
-        if proto_data.layout == ProtoLayout::Nchw {
-            return Err(crate::Error::NotSupported(
-                "GL segmentation path does not yet support NCHW proto layout; \
-                 caller should use CPU fallback"
-                    .into(),
-            ));
-        }
 
         // Each proto-dtype arm holds its `TensorMap` for the duration of the
         // GL upload and passes an `ArrayView3` borrowed from the mapped slice
@@ -5391,28 +5365,36 @@ impl GLProcessorST {
                     m.as_slice(),
                 )
                 .map_err(|e| crate::Error::InvalidShape(format!("{e}")))?;
-                if self.has_float_linear {
-                    self.render_proto_segmentation_f32(
-                        detect,
-                        coeff_slice,
-                        protos_view,
-                        height,
-                        width,
-                        num_protos,
-                        texture_target,
-                        color_mode,
-                    )?;
-                } else {
-                    self.render_proto_segmentation_f16(
-                        detect,
-                        coeff_slice,
-                        protos_view,
-                        height,
-                        width,
-                        num_protos,
-                        texture_target,
-                        color_mode,
-                    )?;
+                match plan.upload {
+                    super::proto_dispatch::ProtoUpload::F32R32f => {
+                        self.render_proto_segmentation_f32(
+                            detect,
+                            coeff_slice,
+                            protos_view,
+                            height,
+                            width,
+                            num_protos,
+                            texture_target,
+                            color_mode,
+                        )?;
+                    }
+                    super::proto_dispatch::ProtoUpload::F32ToRgba16f => {
+                        self.render_proto_segmentation_f16(
+                            detect,
+                            coeff_slice,
+                            protos_view,
+                            height,
+                            width,
+                            num_protos,
+                            texture_target,
+                            color_mode,
+                        )?;
+                    }
+                    other => {
+                        return Err(crate::Error::InvalidShape(format!(
+                            "plan_proto returned {other:?} for F32 protos"
+                        )));
+                    }
                 }
             }
             DType::F16 => {

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -5143,69 +5143,6 @@ impl GLProcessorST {
     /// suitable for upload to a GL_TEXTURE_2D_ARRAY with GL_RGBA16F.
     ///
     /// Returns `(repacked_bytes, num_layers)` where each layer is H*W*4 half-floats.
-    fn repack_protos_to_rgba_f16(protos: ndarray::ArrayView3<'_, f32>) -> (Vec<u8>, usize) {
-        let (height, width, num_protos) = protos.dim();
-        let num_layers = num_protos.div_ceil(4);
-        // Each layer is H*W*4 half-floats, each half-float is 2 bytes
-        let layer_stride = height * width * 4;
-        let mut buf = vec![0u16; layer_stride * num_layers];
-
-        for y in 0..height {
-            for x in 0..width {
-                for k in 0..num_layers * 4 {
-                    let val = if k < num_protos {
-                        half::f16::from_f32(protos[[y, x, k]])
-                    } else {
-                        half::f16::ZERO
-                    };
-                    let layer = k / 4;
-                    let channel = k % 4;
-                    buf[layer * layer_stride + y * width * 4 + x * 4 + channel] = val.to_bits();
-                }
-            }
-        }
-
-        // Reinterpret u16 buffer as bytes
-        let byte_buf = unsafe {
-            std::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 2).to_vec()
-        };
-        (byte_buf, num_layers)
-    }
-
-    /// Native-f16 variant of [`Self::repack_protos_to_rgba_f16`]: shuffles
-    /// already-f16 protos into RGBA-layer order without the f32→f16
-    /// conversion step. Used when the decoder produced an fp16 proto
-    /// tensor — `TensorDyn::F16` in the current [`ProtoData`] representation
-    /// — from an fp16 inference engine.
-    fn repack_protos_f16_to_rgba_f16(
-        protos: ndarray::ArrayView3<'_, half::f16>,
-    ) -> (Vec<u8>, usize) {
-        let (height, width, num_protos) = protos.dim();
-        let num_layers = num_protos.div_ceil(4);
-        let layer_stride = height * width * 4;
-        let mut buf = vec![0u16; layer_stride * num_layers];
-
-        for y in 0..height {
-            for x in 0..width {
-                for k in 0..num_layers * 4 {
-                    let val = if k < num_protos {
-                        protos[[y, x, k]]
-                    } else {
-                        half::f16::ZERO
-                    };
-                    let layer = k / 4;
-                    let channel = k % 4;
-                    buf[layer * layer_stride + y * width * 4 + x * 4 + channel] = val.to_bits();
-                }
-            }
-        }
-
-        let byte_buf = unsafe {
-            std::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 2).to_vec()
-        };
-        (byte_buf, num_layers)
-    }
-
     /// Render YOLO proto segmentation masks using the fused GPU pipeline.
     ///
     /// Dispatches on the proto tensor's runtime dtype via
@@ -5637,14 +5574,7 @@ impl GLProcessorST {
             }
         } else {
             // === GLES 3.0 fallback: CPU repack ===
-            let mut tex_data = vec![0i8; height * width * num_protos];
-            for k in 0..num_protos {
-                for y in 0..height {
-                    for x in 0..width {
-                        tex_data[k * height * width + y * width + x] = protos[[y, x, k]];
-                    }
-                }
-            }
+            let tex_data = super::proto_dispatch::repack_layers(protos);
 
             self.upload_proto_texture(
                 texture_target,
@@ -5871,14 +5801,7 @@ impl GLProcessorST {
         color_mode: crate::ColorMode,
     ) -> crate::Result<()> {
         // Repack protos to layer-first layout: (num_protos, H, W)
-        let mut tex_data = vec![0.0f32; height * width * num_protos];
-        for k in 0..num_protos {
-            for y in 0..height {
-                for x in 0..width {
-                    tex_data[k * height * width + y * width + x] = protos_f32[[y, x, k]];
-                }
-            }
-        }
+        let tex_data = super::proto_dispatch::repack_layers(protos_f32);
 
         self.upload_proto_texture(
             texture_target,
@@ -5922,7 +5845,8 @@ impl GLProcessorST {
         color_mode: crate::ColorMode,
     ) -> crate::Result<()> {
         let num_layers = num_protos.div_ceil(4);
-        let (tex_data, _) = Self::repack_protos_to_rgba_f16(protos_f32);
+        let (tex_data, _) =
+            super::proto_dispatch::repack_rgba_f16_layers(protos_f32, half::f16::from_f32);
 
         self.upload_proto_texture(
             texture_target,
@@ -5967,7 +5891,7 @@ impl GLProcessorST {
         color_mode: crate::ColorMode,
     ) -> crate::Result<()> {
         let num_layers = num_protos.div_ceil(4);
-        let (tex_data, _) = Self::repack_protos_f16_to_rgba_f16(protos_f16);
+        let (tex_data, _) = super::proto_dispatch::repack_rgba_f16_layers(protos_f16, |v| v);
 
         self.upload_proto_texture(
             texture_target,

--- a/crates/image/src/gl/proto_dispatch.rs
+++ b/crates/image/src/gl/proto_dispatch.rs
@@ -1,0 +1,321 @@
+//! Pure decision table for the GL proto-segmentation render path.
+//!
+//! `plan_proto` maps `(proto dtype, layout, capabilities, interpolation
+//! mode)` to a [`ProtoPlan`] — which upload strategy feeds the proto
+//! texture, which shader program samples it, and which count uniform that
+//! program consumes. The table is GL-free and host-tested exhaustively,
+//! mirroring `float_dispatch::classify_float_render` and
+//! `render::plan_convert`: capability differences arrive as inputs, never
+//! as platform branches inside the renderer.
+//!
+//! `dequant_coeffs` is the shared coefficient-widening helper for the
+//! integer mask-coefficient dtypes (the GL shaders consume f32 uniforms
+//! regardless of source dtype).
+
+use edgefirst_decoder::ProtoLayout;
+use edgefirst_tensor::{DType, QuantMode};
+
+use super::Int8InterpolationMode;
+
+/// How proto layers reach the GPU texture (all paths land in the shared
+/// immutable `TexStorage3D` allocation via `ensure_proto_texture`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProtoUpload {
+    /// HWC int8 bytes to an SSBO; a GLES 3.1 compute shader transposes
+    /// into the R32I texture via `imageStore`.
+    I8Compute,
+    /// CPU HWC→CHW repack, uploaded as R8I.
+    I8CpuRepack,
+    /// CPU HWC→CHW repack, uploaded as R32F (one proto per layer).
+    F32R32f,
+    /// f32→f16 repack packing 4 protos per RGBA16F layer — the capability
+    /// fallback for GPUs without `GL_OES_texture_float_linear`.
+    F32ToRgba16f,
+    /// Native-f16 shuffle packing 4 protos per RGBA16F layer (no widening
+    /// — uploading f16 protos as F32 would double the upload bytes).
+    F16Rgba16f,
+}
+
+/// Which shader program samples the proto texture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ProtoProgram {
+    Int8Nearest,
+    Int8Bilinear,
+    /// Two-pass: dequant int8→RGBA16F render, then the f16 program with
+    /// hardware GL_LINEAR.
+    Int8TwoPass,
+    F32,
+    /// The RGBA16F-packed program — shared by the f32 fallback and the
+    /// native f16 path.
+    F16,
+}
+
+/// Which layer-count uniform the selected program consumes: `num_protos`
+/// (one proto per layer) or `num_layers` (4 protos packed per RGBA layer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CountUniform {
+    NumProtos,
+    NumLayers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ProtoPlan {
+    pub(super) upload: ProtoUpload,
+    pub(super) program: ProtoProgram,
+    pub(super) count_uniform: CountUniform,
+}
+
+/// Decide the proto render plan. Pure: capabilities are inputs.
+///
+/// * `compute_active` — the processor compiled the proto-repack compute
+///   program (GLES 3.1 compute present AND `EDGEFIRST_PROTO_COMPUTE=1`).
+/// * `has_float_linear` — `GL_OES_texture_float_linear` (possibly forced
+///   off via `EDGEFIRST_GL_NO_FLOAT_LINEAR`).
+///
+/// Errors preserve the dispatcher's user-facing messages: NCHW layouts and
+/// unsupported proto dtypes are `NotSupported`/`InvalidShape` exactly as
+/// before the table existed.
+pub(super) fn plan_proto(
+    proto_dtype: DType,
+    layout: ProtoLayout,
+    compute_active: bool,
+    has_float_linear: bool,
+    int8_mode: Int8InterpolationMode,
+) -> crate::Result<ProtoPlan> {
+    // The GL upload path assumes NHWC for ArrayView3 creation; NCHW would
+    // need a transpose first — the caller falls back to CPU.
+    if layout == ProtoLayout::Nchw {
+        return Err(crate::Error::NotSupported(
+            "GL segmentation path does not yet support NCHW proto layout; \
+             caller should use CPU fallback"
+                .into(),
+        ));
+    }
+
+    let plan = match proto_dtype {
+        DType::I8 => {
+            let upload = if compute_active {
+                ProtoUpload::I8Compute
+            } else {
+                ProtoUpload::I8CpuRepack
+            };
+            let program = match int8_mode {
+                Int8InterpolationMode::Nearest => ProtoProgram::Int8Nearest,
+                Int8InterpolationMode::Bilinear => ProtoProgram::Int8Bilinear,
+                Int8InterpolationMode::TwoPass => ProtoProgram::Int8TwoPass,
+            };
+            // The two-pass dequant target packs 4 protos per RGBA16F layer
+            // and samples through the f16 program, but its layer math is
+            // internal to the pass — the int8 entry points consume
+            // `num_protos`.
+            ProtoPlan {
+                upload,
+                program,
+                count_uniform: CountUniform::NumProtos,
+            }
+        }
+        DType::F32 => {
+            if has_float_linear {
+                ProtoPlan {
+                    upload: ProtoUpload::F32R32f,
+                    program: ProtoProgram::F32,
+                    count_uniform: CountUniform::NumProtos,
+                }
+            } else {
+                ProtoPlan {
+                    upload: ProtoUpload::F32ToRgba16f,
+                    program: ProtoProgram::F16,
+                    count_uniform: CountUniform::NumLayers,
+                }
+            }
+        }
+        DType::F16 => ProtoPlan {
+            upload: ProtoUpload::F16Rgba16f,
+            program: ProtoProgram::F16,
+            count_uniform: CountUniform::NumLayers,
+        },
+        other => {
+            return Err(crate::Error::InvalidShape(format!(
+                "GL seg path: proto dtype {other:?} not supported"
+            )));
+        }
+    };
+    Ok(plan)
+}
+
+/// Widen integer mask coefficients to the f32 the GL shaders consume,
+/// applying per-tensor dequantization. `None` quantization is a plain
+/// cast. Per-channel modes are rejected with the dispatcher's original
+/// message (a single scale/zp uniform cannot express them).
+pub(super) fn dequant_coeffs<T: Copy + Into<f32>>(
+    vals: &[T],
+    mode: Option<QuantMode<'_>>,
+    dtype_label: &str,
+) -> crate::Result<Vec<f32>> {
+    let (scale, zp) = match mode {
+        None => (1.0_f32, 0.0_f32),
+        Some(QuantMode::PerTensor { scale, zero_point }) => (scale, zero_point as f32),
+        Some(QuantMode::PerTensorSymmetric { scale }) => (scale, 0.0),
+        Some(other) => {
+            return Err(crate::Error::NotSupported(format!(
+                "{dtype_label} mask_coefficients quantization mode {other:?} \
+                 not supported on GL seg path"
+            )));
+        }
+    };
+    Ok(vals.iter().map(|&v| (v.into() - zp) * scale).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MODES: [Int8InterpolationMode; 3] = [
+        Int8InterpolationMode::Nearest,
+        Int8InterpolationMode::Bilinear,
+        Int8InterpolationMode::TwoPass,
+    ];
+
+    /// Every (dtype, capability, mode) row of the table, exhaustively.
+    #[test]
+    fn plan_proto_full_table() {
+        for compute in [false, true] {
+            for linear in [false, true] {
+                // I8: upload follows compute_active, program follows mode,
+                // float-linear is irrelevant.
+                for mode in MODES {
+                    let plan =
+                        plan_proto(DType::I8, ProtoLayout::Nhwc, compute, linear, mode).unwrap();
+                    assert_eq!(
+                        plan.upload,
+                        if compute {
+                            ProtoUpload::I8Compute
+                        } else {
+                            ProtoUpload::I8CpuRepack
+                        }
+                    );
+                    assert_eq!(
+                        plan.program,
+                        match mode {
+                            Int8InterpolationMode::Nearest => ProtoProgram::Int8Nearest,
+                            Int8InterpolationMode::Bilinear => ProtoProgram::Int8Bilinear,
+                            Int8InterpolationMode::TwoPass => ProtoProgram::Int8TwoPass,
+                        }
+                    );
+                    assert_eq!(plan.count_uniform, CountUniform::NumProtos);
+                }
+
+                // F32: float-linear picks native R32F vs the RGBA16F
+                // fallback; compute and int8 mode are irrelevant.
+                for mode in MODES {
+                    let plan =
+                        plan_proto(DType::F32, ProtoLayout::Nhwc, compute, linear, mode).unwrap();
+                    if linear {
+                        assert_eq!(plan.upload, ProtoUpload::F32R32f);
+                        assert_eq!(plan.program, ProtoProgram::F32);
+                        assert_eq!(plan.count_uniform, CountUniform::NumProtos);
+                    } else {
+                        assert_eq!(plan.upload, ProtoUpload::F32ToRgba16f);
+                        assert_eq!(plan.program, ProtoProgram::F16);
+                        assert_eq!(plan.count_uniform, CountUniform::NumLayers);
+                    }
+                }
+
+                // F16 native: one row regardless of capabilities.
+                for mode in MODES {
+                    let plan =
+                        plan_proto(DType::F16, ProtoLayout::Nhwc, compute, linear, mode).unwrap();
+                    assert_eq!(plan.upload, ProtoUpload::F16Rgba16f);
+                    assert_eq!(plan.program, ProtoProgram::F16);
+                    assert_eq!(plan.count_uniform, CountUniform::NumLayers);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn plan_proto_rejects_nchw_for_every_dtype() {
+        for dtype in [DType::I8, DType::F32, DType::F16] {
+            let err = plan_proto(
+                dtype,
+                ProtoLayout::Nchw,
+                false,
+                true,
+                Int8InterpolationMode::Bilinear,
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, crate::Error::NotSupported(ref m) if m.contains("NCHW")),
+                "{dtype:?}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn plan_proto_rejects_unsupported_dtypes() {
+        for dtype in [DType::U8, DType::I16, DType::I32, DType::F64] {
+            let err = plan_proto(
+                dtype,
+                ProtoLayout::Nhwc,
+                false,
+                true,
+                Int8InterpolationMode::Bilinear,
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, crate::Error::InvalidShape(ref m) if m.contains("not supported")),
+                "{dtype:?}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dequant_coeffs_per_tensor() {
+        let vals: [i8; 4] = [-115, 0, 20, 127];
+        let out = dequant_coeffs(
+            &vals,
+            Some(QuantMode::PerTensor {
+                scale: 0.5,
+                zero_point: 20,
+            }),
+            "I8",
+        )
+        .unwrap();
+        assert_eq!(out, vec![-67.5, -10.0, 0.0, 53.5]);
+    }
+
+    #[test]
+    fn dequant_coeffs_symmetric_and_passthrough() {
+        let vals: [i16; 3] = [-2, 0, 2];
+        let sym = dequant_coeffs(
+            &vals,
+            Some(QuantMode::PerTensorSymmetric { scale: 0.25 }),
+            "I16",
+        )
+        .unwrap();
+        assert_eq!(sym, vec![-0.5, 0.0, 0.5]);
+
+        // No quantization metadata → plain cast.
+        let plain = dequant_coeffs(&vals, None, "I16").unwrap();
+        assert_eq!(plain, vec![-2.0, 0.0, 2.0]);
+    }
+
+    #[test]
+    fn dequant_coeffs_rejects_per_channel() {
+        let vals: [i8; 2] = [1, 2];
+        let scales = [0.5_f32];
+        let err = dequant_coeffs(
+            &vals,
+            Some(QuantMode::PerChannelSymmetric {
+                scales: &scales,
+                axis: 0,
+            }),
+            "I8",
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, crate::Error::NotSupported(ref m) if m.contains("quantization mode")),
+            "{err:?}"
+        );
+    }
+}

--- a/crates/image/src/gl/proto_dispatch.rs
+++ b/crates/image/src/gl/proto_dispatch.rs
@@ -143,6 +143,58 @@ pub(super) fn plan_proto(
     Ok(plan)
 }
 
+/// HWC → layer-first repack: one proto per texture layer
+/// (`out[k][y][x] = in[y][x][k]`). Monomorphized per element type — the
+/// int8 (R8I) and f32 (R32F) upload paths share this exact transpose.
+pub(super) fn repack_layers<T: Copy + Default>(protos: ndarray::ArrayView3<'_, T>) -> Vec<T> {
+    let (height, width, num_protos) = protos.dim();
+    let mut out = vec![T::default(); height * width * num_protos];
+    for k in 0..num_protos {
+        for y in 0..height {
+            for x in 0..width {
+                out[k * height * width + y * width + x] = protos[[y, x, k]];
+            }
+        }
+    }
+    out
+}
+
+/// HWC → RGBA16F-packed layers: 4 protos per layer, zero-padded tail
+/// channels when `num_protos % 4 != 0`. Returns the raw f16 bits as bytes
+/// plus the layer count. `conv` is monomorphized per source dtype — the
+/// f32 fallback narrows (`f16::from_f32`), the native-f16 path passes
+/// through; protos are never widened to f32 (doubles upload bytes).
+pub(super) fn repack_rgba_f16_layers<S: Copy>(
+    protos: ndarray::ArrayView3<'_, S>,
+    conv: impl Fn(S) -> half::f16,
+) -> (Vec<u8>, usize) {
+    let (height, width, num_protos) = protos.dim();
+    let num_layers = num_protos.div_ceil(4);
+    // Each layer is H*W*4 half-floats, each half-float is 2 bytes.
+    let layer_stride = height * width * 4;
+    let mut buf = vec![0u16; layer_stride * num_layers];
+
+    for y in 0..height {
+        for x in 0..width {
+            for k in 0..num_layers * 4 {
+                let val = if k < num_protos {
+                    conv(protos[[y, x, k]])
+                } else {
+                    half::f16::ZERO
+                };
+                let layer = k / 4;
+                let channel = k % 4;
+                buf[layer * layer_stride + y * width * 4 + x * 4 + channel] = val.to_bits();
+            }
+        }
+    }
+
+    // Reinterpret the u16 buffer as bytes for the GL upload.
+    let byte_buf =
+        unsafe { std::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len() * 2).to_vec() };
+    (byte_buf, num_layers)
+}
+
 /// Widen integer mask coefficients to the f32 the GL shaders consume,
 /// applying per-tensor dequantization. `None` quantization is a plain
 /// cast. Per-channel modes are rejected with the dispatcher's original
@@ -267,6 +319,57 @@ mod tests {
                 "{dtype:?}: {err:?}"
             );
         }
+    }
+
+    #[test]
+    fn repack_layers_transposes_hwc_to_layer_first() {
+        // 2x2x3 HWC: value encodes (y, x, k) as y*100 + x*10 + k.
+        let data: Vec<i32> = (0..2 * 2 * 3)
+            .map(|i| {
+                let (y, x, k) = (i / 6, (i / 3) % 2, i % 3);
+                y * 100 + x * 10 + k
+            })
+            .collect();
+        let view = ndarray::ArrayView3::from_shape((2, 2, 3), &data).unwrap();
+        let out = repack_layers(view);
+        // out[k][y][x]
+        assert_eq!(out.len(), 12);
+        for k in 0..3 {
+            for y in 0..2 {
+                for x in 0..2 {
+                    assert_eq!(out[k * 4 + y * 2 + x] as usize, y * 100 + x * 10 + k);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn repack_rgba_f16_layers_packs_quads_and_zero_pads_tail() {
+        // 1x2x6 HWC → 2 RGBA layers; 6 protos fill layer 0 fully and half
+        // of layer 1 (channels 2,3 of every pixel zero-padded).
+        let data: Vec<f32> = (0..2 * 6).map(|i| i as f32).collect();
+        let view = ndarray::ArrayView3::from_shape((1, 2, 6), &data).unwrap();
+        let (bytes, num_layers) = repack_rgba_f16_layers(view, half::f16::from_f32);
+        assert_eq!(num_layers, 2);
+        let halves: Vec<half::f16> = bytes
+            .chunks_exact(2)
+            .map(|b| half::f16::from_bits(u16::from_le_bytes([b[0], b[1]])))
+            .collect();
+        let layer_stride = 2 * 4; // H*W*4 per layer
+        for x in 0..2 {
+            for k in 0..8 {
+                let expected = if k < 6 { (x * 6 + k) as f32 } else { 0.0 };
+                let got = halves[(k / 4) * layer_stride + x * 4 + (k % 4)].to_f32();
+                assert_eq!(got, expected, "x={x} k={k}");
+            }
+        }
+
+        // Native-f16 identity conversion produces the identical packing.
+        let data_f16: Vec<half::f16> = data.iter().map(|v| half::f16::from_f32(*v)).collect();
+        let view_f16 = ndarray::ArrayView3::from_shape((1, 2, 6), &data_f16).unwrap();
+        let (bytes_native, layers_native) = repack_rgba_f16_layers(view_f16, |v| v);
+        assert_eq!(layers_native, 2);
+        assert_eq!(bytes_native, bytes);
     }
 
     #[test]

--- a/crates/image/src/gl/shaders.rs
+++ b/crates/image/src/gl/shaders.rs
@@ -489,8 +489,17 @@ void main() {
     vec4 result;
     for (int c = 0; c < 4; c++) {
         int layer = base_layer + c;
-        float raw = float(texelFetch(proto_tex, ivec3(ix, iy, layer), 0).r);
-        result[c] = raw * proto_scale + proto_scaled_zp;
+        // Tail guard: when num_protos % 4 != 0 the last output layer's
+        // trailing channels have no source proto. texelFetch beyond the
+        // array depth is undefined in GLSL ES (a NaN there would survive
+        // the zero coefficients downstream: NaN * 0 = NaN), so emit an
+        // explicit zero proto instead.
+        if (layer < tex_size.z) {
+            float raw = float(texelFetch(proto_tex, ivec3(ix, iy, layer), 0).r);
+            result[c] = raw * proto_scale + proto_scaled_zp;
+        } else {
+            result[c] = 0.0;
+        }
     }
     color = result;
 }

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -3164,6 +3164,52 @@ mod gl_tests {
         compare_images(&dst_cpu_repack, &dst_compute, 0.99, function!());
     }
 
+    /// All three int8 proto interpolation modes must agree on the rendered
+    /// masks: Bilinear (shader-computed weights) and TwoPass (dequant to
+    /// RGBA16F + hardware GL_LINEAR) sample the same data with equivalent
+    /// filtering, and Nearest only loses the sub-texel blend. TwoPass had
+    /// no test on any lane before this — it is the path with the cached
+    /// dequant FBO, the gated immutable dequant texture, and the shared
+    /// fullscreen quad. Switching modes on ONE processor also exercises
+    /// per-draw plan changes against the persistent proto/dequant textures.
+    #[test]
+    fn proto_int8_interpolation_modes_agree() {
+        use crate::Int8InterpolationMode;
+
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let (boxes, proto_i8) = decode_yolov8_proto_fixture();
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+
+        let mut render_mode = |mode: Int8InterpolationMode| {
+            gl.set_int8_interpolation_mode(mode).unwrap();
+            render_proto_to_rgba(&mut gl, &boxes, &proto_i8)
+        };
+        let bilinear = render_mode(Int8InterpolationMode::Bilinear);
+        let two_pass = render_mode(Int8InterpolationMode::TwoPass);
+        let nearest = render_mode(Int8InterpolationMode::Nearest);
+        // And back to bilinear on the same processor: must reproduce the
+        // first render despite the dequant texture/FBO created in between.
+        let bilinear_again = render_mode(Int8InterpolationMode::Bilinear);
+
+        // Measured actuals: Vivante GC7000UL >= 0.95; Mali G310 = 0.8153 —
+        // a PRE-EXISTING driver filtering delta (bit-identical score on the
+        // pre-refactor build), believed to be Mali's coarser fixed-point
+        // f16 texture interpolation. 0.80 still catches structural
+        // breakage: the broken compute-repack upload scored ~0.77.
+        compare_images(&bilinear, &two_pass, 0.80, function!());
+        compare_images(&bilinear, &nearest, 0.90, function!());
+        let a = bilinear.as_u8().unwrap().map().unwrap();
+        let b = bilinear_again.as_u8().unwrap().map().unwrap();
+        assert_eq!(
+            a.as_slice(),
+            b.as_slice(),
+            "bilinear render diverged after mode churn"
+        );
+    }
+
     /// Proto texture uploads must stay correct across dims/format churn on
     /// ONE processor: int8 (R8I) → f32 (R32F, same dims — internal-format
     /// churn) → f32 with 30 layers (layer-count churn, deliberately not a

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -11,7 +11,7 @@ mod gl_tests {
         probe_egl_displays, Crop, EglDisplayKind, Flip, GLProcessorThreaded, ImageProcessorTrait,
         Rotation,
     };
-    use edgefirst_decoder::DetectBox;
+    use edgefirst_decoder::{DetectBox, ProtoData, ProtoLayout};
     #[cfg(feature = "dma_test_formats")]
     use edgefirst_tensor::is_dma_available;
     use edgefirst_tensor::{
@@ -2839,14 +2839,57 @@ mod gl_tests {
     /// bilinear interpolation (GPU vs CPU) and mask threshold rounding.
     #[test]
     fn test_proto_fused_vs_hybrid_ssim() {
-        use edgefirst_decoder::{configs, ConfigOutput, DecoderBuilder, Nms};
-
         if !is_opengl_available() {
             eprintln!("SKIPPED: {} - OpenGL not available", function!());
             return;
         }
 
-        // Load cached YOLOv8 seg model outputs as TensorDyn::I8 inputs.
+        let (output_boxes, proto_data) = decode_yolov8_proto_fixture();
+
+        // Materialize masks on CPU for the hybrid path
+        let cpu_proc = crate::CPUProcessor::new();
+        let segmentation = cpu_proc
+            .materialize_segmentations(&output_boxes, &proto_data, None)
+            .unwrap();
+
+        // Create two identical RGBA canvases
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        let mut dst_hybrid = TensorDyn::from(
+            edgefirst_tensor::Tensor::<u8>::image(640, 640, PixelFormat::Rgba, None).unwrap(),
+        );
+        let mut dst_fused = TensorDyn::from(
+            edgefirst_tensor::Tensor::<u8>::image(640, 640, PixelFormat::Rgba, None).unwrap(),
+        );
+
+        // Render via hybrid path (pre-decoded masks)
+        gl.draw_decoded_masks(
+            &mut dst_hybrid,
+            &output_boxes,
+            &segmentation,
+            Default::default(),
+        )
+        .unwrap();
+
+        // Render via fused GL proto path
+        gl.draw_proto_masks(
+            &mut dst_fused,
+            &output_boxes,
+            &proto_data,
+            Default::default(),
+        )
+        .unwrap();
+
+        // Compare — threshold 0.90 to allow bilinear interpolation differences
+        // between GPU proto rendering and CPU materialization
+        compare_images(&dst_hybrid, &dst_fused, 0.90, function!());
+    }
+
+    /// Decode the cached YOLOv8-seg fixture outputs (int8 boxes + protos)
+    /// into post-NMS detections and the int8 `ProtoData`. Shared scaffolding
+    /// for every proto-rendering test.
+    fn decode_yolov8_proto_fixture() -> (Vec<DetectBox>, ProtoData) {
+        use edgefirst_decoder::{configs, ConfigOutput, DecoderBuilder, Nms};
+
         let boxes_raw: &[u8] = &edgefirst_bench::testdata::read("yolov8_boxes_116x8400.bin");
         let boxes_i8 =
             unsafe { std::slice::from_raw_parts(boxes_raw.as_ptr() as *const i8, boxes_raw.len()) };
@@ -2894,43 +2937,286 @@ mod gl_tests {
             .expect("decode_proto must succeed")
             .expect("yolov8-seg config produces ProtoData");
         assert!(!output_boxes.is_empty(), "No detections from model");
+        (output_boxes, proto_data)
+    }
 
-        // Materialize masks on CPU for the hybrid path
-        let cpu_proc = crate::CPUProcessor::new();
-        let segmentation = cpu_proc
-            .materialize_segmentations(&output_boxes, &proto_data, None)
+    /// Build F32 and F16 `ProtoData` by dequantizing the int8 fixture — the
+    /// same synthesis the mask bench uses for its float dtype cells.
+    fn proto_fixture_as_float(proto_i8: &ProtoData, n_det: usize) -> (ProtoData, ProtoData) {
+        use half::f16;
+
+        let (protos_f32, proto_shape) = match &proto_i8.protos {
+            TensorDyn::I8(t) => {
+                let shape = t.shape().to_vec();
+                let q = t.quantization().expect("i8 protos must carry quant");
+                let scale = q.scale()[0];
+                let zp = q.zero_point().map(|z| z[0]).unwrap_or(0) as f32;
+                let m = t.map().unwrap();
+                let v: Vec<f32> = m
+                    .as_slice()
+                    .iter()
+                    .map(|v| (*v as f32 - zp) * scale)
+                    .collect();
+                (v, shape)
+            }
+            other => panic!("expected i8 protos in fixture, got {other:?}"),
+        };
+        let num_protos = *proto_shape.last().unwrap();
+
+        let coeffs_f32: Vec<f32> = match &proto_i8.mask_coefficients {
+            TensorDyn::F32(t) => t.map().unwrap().as_slice().to_vec(),
+            TensorDyn::F16(t) => t
+                .map()
+                .unwrap()
+                .as_slice()
+                .iter()
+                .map(|v: &f16| v.to_f32())
+                .collect(),
+            TensorDyn::I8(t) => {
+                let q = t
+                    .quantization()
+                    .expect("i8 mask coefficients must carry quant");
+                let scale = q.scale()[0];
+                let zp = q.zero_point().map(|z| z[0]).unwrap_or(0) as f32;
+                let m = t.map().unwrap();
+                m.as_slice()
+                    .iter()
+                    .map(|v| (*v as f32 - zp) * scale)
+                    .collect()
+            }
+            other => panic!("unexpected coefficient dtype {other:?}"),
+        };
+        let coeff_shape = [n_det, num_protos];
+
+        let proto_f32 = ProtoData {
+            mask_coefficients: TensorDyn::F32(
+                Tensor::<f32>::from_slice(&coeffs_f32, &coeff_shape).unwrap(),
+            ),
+            protos: TensorDyn::F32(Tensor::<f32>::from_slice(&protos_f32, &proto_shape).unwrap()),
+            layout: ProtoLayout::Nhwc,
+        };
+
+        let protos_f16: Vec<f16> = protos_f32.iter().map(|v| f16::from_f32(*v)).collect();
+        let coeffs_f16: Vec<f16> = coeffs_f32.iter().map(|v| f16::from_f32(*v)).collect();
+        let proto_f16 = ProtoData {
+            mask_coefficients: TensorDyn::F16(
+                Tensor::<f16>::from_slice(&coeffs_f16, &coeff_shape).unwrap(),
+            ),
+            protos: TensorDyn::F16(Tensor::<f16>::from_slice(&protos_f16, &proto_shape).unwrap()),
+            layout: ProtoLayout::Nhwc,
+        };
+
+        (proto_f32, proto_f16)
+    }
+
+    /// Keep only the first `keep` proto layers (and matching coefficients)
+    /// of an F32 `ProtoData` — HWC layout, so channels are sliced per pixel.
+    fn slice_proto_layers_f32(pd: &ProtoData, keep: usize, n_det: usize) -> ProtoData {
+        let (protos, shape) = match &pd.protos {
+            TensorDyn::F32(t) => (t.map().unwrap().as_slice().to_vec(), t.shape().to_vec()),
+            other => panic!("expected f32 protos, got {other:?}"),
+        };
+        let (h, w, c) = (shape[0], shape[1], shape[2]);
+        assert!(keep <= c);
+        let mut sliced = Vec::with_capacity(h * w * keep);
+        for px in protos.chunks_exact(c) {
+            sliced.extend_from_slice(&px[..keep]);
+        }
+        let coeffs = match &pd.mask_coefficients {
+            TensorDyn::F32(t) => t.map().unwrap().as_slice().to_vec(),
+            other => panic!("expected f32 coefficients, got {other:?}"),
+        };
+        let mut sliced_coeffs = Vec::with_capacity(n_det * keep);
+        for det in coeffs.chunks_exact(c) {
+            sliced_coeffs.extend_from_slice(&det[..keep]);
+        }
+        ProtoData {
+            mask_coefficients: TensorDyn::F32(
+                Tensor::<f32>::from_slice(&sliced_coeffs, &[n_det, keep]).unwrap(),
+            ),
+            protos: TensorDyn::F32(Tensor::<f32>::from_slice(&sliced, &[h, w, keep]).unwrap()),
+            layout: ProtoLayout::Nhwc,
+        }
+    }
+
+    /// Render the fused GL proto path into a fresh 640x640 RGBA canvas.
+    fn render_proto_to_rgba(
+        gl: &mut GLProcessorThreaded,
+        boxes: &[DetectBox],
+        pd: &ProtoData,
+    ) -> TensorDyn {
+        let mut dst = TensorDyn::from(
+            edgefirst_tensor::Tensor::<u8>::image(640, 640, PixelFormat::Rgba, None).unwrap(),
+        );
+        gl.draw_proto_masks(&mut dst, boxes, pd, Default::default())
             .unwrap();
+        dst
+    }
 
-        // Create two identical RGBA canvases
+    /// Forces `has_float_linear` off for processors created in scope —
+    /// makes the f32→f16-repack proto fallback reachable on float-linear
+    /// GPUs (no CI lane has a GPU without the extension).
+    struct FloatLinearEnvGuard;
+    impl FloatLinearEnvGuard {
+        fn set() -> Self {
+            std::env::set_var("EDGEFIRST_GL_NO_FLOAT_LINEAR", "1");
+            FloatLinearEnvGuard
+        }
+    }
+    impl Drop for FloatLinearEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("EDGEFIRST_GL_NO_FLOAT_LINEAR");
+        }
+    }
+
+    /// Opts processors created in scope into the GLES 3.1 compute-shader
+    /// proto repack (otherwise env-gated off — it has zero coverage without
+    /// this).
+    struct ProtoComputeEnvGuard;
+    impl ProtoComputeEnvGuard {
+        fn set() -> Self {
+            std::env::set_var("EDGEFIRST_PROTO_COMPUTE", "1");
+            ProtoComputeEnvGuard
+        }
+    }
+    impl Drop for ProtoComputeEnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("EDGEFIRST_PROTO_COMPUTE");
+        }
+    }
+
+    /// The float proto-render paths must agree with the int8 fused reference:
+    /// F32 (R32F, hardware bilinear where float-linear exists) and F16-native
+    /// (RGBA16F packed) render the SAME dequantized data, so int8-vs-f32 may
+    /// differ only by quantization + interpolation (default int8 mode is
+    /// shader bilinear ≈ hardware bilinear), and f32-vs-f16 only by f16
+    /// rounding. Before this test the three float variants had no direct
+    /// coverage at all.
+    #[test]
+    fn proto_float_dtypes_match_int8_reference() {
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let (boxes, proto_i8) = decode_yolov8_proto_fixture();
+        let (proto_f32, proto_f16) = proto_fixture_as_float(&proto_i8, boxes.len());
+
         let mut gl = GLProcessorThreaded::new(None).unwrap();
-        let mut dst_hybrid = TensorDyn::from(
-            edgefirst_tensor::Tensor::<u8>::image(640, 640, PixelFormat::Rgba, None).unwrap(),
-        );
-        let mut dst_fused = TensorDyn::from(
-            edgefirst_tensor::Tensor::<u8>::image(640, 640, PixelFormat::Rgba, None).unwrap(),
-        );
+        let dst_i8 = render_proto_to_rgba(&mut gl, &boxes, &proto_i8);
+        let dst_f32 = render_proto_to_rgba(&mut gl, &boxes, &proto_f32);
+        let dst_f16 = render_proto_to_rgba(&mut gl, &boxes, &proto_f16);
 
-        // Render via hybrid path (pre-decoded masks)
-        gl.draw_decoded_masks(
-            &mut dst_hybrid,
-            &output_boxes,
-            &segmentation,
-            Default::default(),
-        )
-        .unwrap();
+        compare_images(&dst_i8, &dst_f32, 0.90, function!());
+        compare_images(&dst_f32, &dst_f16, 0.98, function!());
+    }
 
-        // Render via fused GL proto path
-        gl.draw_proto_masks(
-            &mut dst_fused,
-            &output_boxes,
-            &proto_data,
-            Default::default(),
-        )
-        .unwrap();
+    /// The `!has_float_linear` f32 arm repacks F32 protos into RGBA16F and
+    /// renders through the f16 shader — a capability fallback no CI lane's
+    /// GPU exercises naturally. Force the capability off and pin the
+    /// fallback's output against the native R32F render: same data, only
+    /// RGBA16F precision and packing differ.
+    #[test]
+    fn proto_f32_no_float_linear_fallback_matches() {
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let (boxes, proto_i8) = decode_yolov8_proto_fixture();
+        let (proto_f32, _) = proto_fixture_as_float(&proto_i8, boxes.len());
 
-        // Compare — threshold 0.90 to allow bilinear interpolation differences
-        // between GPU proto rendering and CPU materialization
-        compare_images(&dst_hybrid, &dst_fused, 0.90, function!());
+        let dst_native = {
+            let mut gl = GLProcessorThreaded::new(None).unwrap();
+            render_proto_to_rgba(&mut gl, &boxes, &proto_f32)
+        };
+        let dst_fallback = {
+            let _guard = FloatLinearEnvGuard::set();
+            let mut gl = GLProcessorThreaded::new(None).unwrap();
+            render_proto_to_rgba(&mut gl, &boxes, &proto_f32)
+        };
+
+        compare_images(&dst_native, &dst_fallback, 0.98, function!());
+    }
+
+    /// The GLES 3.1 compute-shader HWC→CHW proto repack must produce the
+    /// same masks as the CPU repack — only the transposition strategy
+    /// differs, not the data or sampling. The compute path is env-gated
+    /// (EDGEFIRST_PROTO_COMPUTE=1); where the GPU lacks GLES 3.1 compute the
+    /// guard is a no-op and both renders take the CPU repack (still a valid,
+    /// if vacuous, comparison).
+    #[test]
+    fn proto_compute_repack_matches_cpu_repack() {
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let (boxes, proto_i8) = decode_yolov8_proto_fixture();
+
+        let dst_cpu_repack = {
+            let mut gl = GLProcessorThreaded::new(None).unwrap();
+            render_proto_to_rgba(&mut gl, &boxes, &proto_i8)
+        };
+        let dst_compute = {
+            let _guard = ProtoComputeEnvGuard::set();
+            let mut gl = GLProcessorThreaded::new(None).unwrap();
+            render_proto_to_rgba(&mut gl, &boxes, &proto_i8)
+        };
+
+        compare_images(&dst_cpu_repack, &dst_compute, 0.99, function!());
+    }
+
+    /// Proto texture uploads must stay correct across dims/format churn on
+    /// ONE processor: int8 (R8I) → f32 (R32F, same dims — internal-format
+    /// churn) → f32 with 30 layers (layer-count churn, deliberately not a
+    /// multiple of 4) → int8 again. Each render must byte-match a fresh
+    /// processor rendering the same input once. This is the regression test
+    /// for the proto dims gate: a gate keyed on dims-without-ifmt, or a
+    /// SubImage3D into a stale allocation, breaks one of these legs.
+    #[test]
+    fn proto_dims_and_format_churn_uploads_correctly() {
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let (boxes, proto_i8) = decode_yolov8_proto_fixture();
+        let (proto_f32, _) = proto_fixture_as_float(&proto_i8, boxes.len());
+        let proto_f32_30 = slice_proto_layers_f32(&proto_f32, 30, boxes.len());
+
+        let oracle = |pd: &ProtoData| {
+            let mut gl = GLProcessorThreaded::new(None).unwrap();
+            render_proto_to_rgba(&mut gl, &boxes, pd)
+        };
+        let oracle_i8 = oracle(&proto_i8);
+        let oracle_f32 = oracle(&proto_f32);
+        let oracle_f32_30 = oracle(&proto_f32_30);
+
+        let mut gl = GLProcessorThreaded::new(None).unwrap();
+        for (step, (pd, expected)) in [
+            (&proto_i8, &oracle_i8),
+            (&proto_f32, &oracle_f32),
+            (&proto_f32_30, &oracle_f32_30),
+            (&proto_i8, &oracle_i8),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let out = render_proto_to_rgba(&mut gl, &boxes, pd);
+            let a = expected.as_u8().unwrap().map().unwrap();
+            let b = out.as_u8().unwrap().map().unwrap();
+            let (a, b) = (a.as_slice(), b.as_slice());
+            let diffs = a.iter().zip(b).filter(|(x, y)| x != y).count();
+            let max_diff = a
+                .iter()
+                .zip(b)
+                .map(|(x, y)| x.abs_diff(*y))
+                .max()
+                .unwrap_or(0);
+            assert!(
+                diffs == 0,
+                "churn step {step}: {diffs}/{} bytes diverged from the \
+                 fresh-processor oracle (max |diff| {max_diff})",
+                a.len()
+            );
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

PR-C of the GL convergence plan (originally stacked on #109, now rebased onto main after its merge). Collapses the per-dtype proto-segmentation fan-out into a pure, host-tested decision table (`proto_dispatch::plan_proto`, the same shape as `render::plan_convert` and `float_dispatch::classify_float_render`) driving one plan-consuming render path.

## The bugs the new tests caught (both latent on main, both proven fails-before)

Coverage came first: before this PR only the int8 fused path had a test; the f32 / f16-fallback / f16-native variants, the compute repack, and any dtype-alternation sequence had **zero coverage on any lane**. The new tests found two production bugs on their first run, on both Vivante (GC7000UL) and Mali (G310):

1. **The GLES 3.1 compute proto repack (`EDGEFIRST_PROTO_COMPUTE=1`) never worked on conformant drivers.** `glBindImageTexture` requires an immutable-format texture in ES 3.1; the texture was `TexImage3D`-allocated, so every `imageStore` silently wrote nowhere and the masks sampled an undefined allocation (SSIM ~0.76 vs CPU repack on both GPUs).
2. **Alternating proto dtypes (int8 ↔ float) on one processor corrupted the next upload.** The float paths re-allocated the shared proto texture without updating the dims gate, so the following int8 upload took the `TexSubImage3D` fast path into an R32F/RGBA16F allocation — `GL_INVALID_VALUE` on Vivante, a sticky `GL_INVALID_OPERATION` surfacing at the next error check on V3D/Mali.

One fix for both: `ensure_proto_texture` / `ensure_immutable_tex_array` — immutable `TexStorage3D` allocations keyed on `(w, h, layers, internal_fmt)`, recreating the texture object on any change. This also handed the f32/f16/f16-native paths the re-upload fast path they lacked (they re-ran `glTexImage3D` every call) and fixed the proto path's bind-before-ActiveTexture ordering.

**Bug 2 was silently eating benchmark cells on main:** the mask bench runs f32 → f16 → int8 per detection count on one processor, so all three `draw_proto_masks/gl/i8_*/n32` cells have been reporting `[unsupported]`. This PR restores them on every board.

## Refactor steps (one commit each, every commit green on all three cfg lanes)

- **C1** (`609fdeb`): float/compute/churn coverage + the texture-lifecycle fixes above + `EDGEFIRST_GL_NO_FLOAT_LINEAR` seam (the f32→f16 fallback is reachable on no CI lane's GPU otherwise).
- **C2** (`d363f28`): `proto_dispatch.rs` pure `plan_proto` table with exhaustive host tests; `dequant_coeffs<T>` replacing the copy-paste I8/I16 coefficient arms.
- **C3** (`0f18714`): `repack_layers<T>` + `repack_rgba_f16_layers<S>(view, conv)` replacing four repack implementations (monomorphized — native f16 is never widened to f32).
- **C4** (`e8bef51`): delete `render_proto_segmentation_{f32,f16,f16_native}` → one plan-driven `render_proto_layers`; two-pass gains a persistent dequant FBO + dims-gated immutable dequant texture + the shared `draw_fullscreen_quad`; the dequant shader zero-guards the `num_protos % 4 != 0` tail layer (out-of-range `texelFetch` is UB in GLSL ES, and a NaN there survives zero coefficients).
- **C5** (`b11351c`): per-detection `mask_coeff`/`class_index` uniform locations cached per program (was 2 driver string lookups + a redundant `UseProgram` per detection per frame); compute uniforms resolved at compile; new `image.draw.gl.proto` span with plan fields; ARCHITECTURE.md span catalog + rewritten shader-variants table; CHANGELOG.

## Test evidence

- Full suites **438/0** on imx8mp, imx95, **and rpi5** (9 new tests over #109's 429).
- Both texture-lifecycle fixes proven fails-before on-board (the failing runs predate the fix commit); the churn test additionally validates int8↔float↔30-layer sequences byte-identical to fresh-processor oracles.
- New `proto_int8_interpolation_modes_agree` covers TwoPass for the first time on any lane. It surfaced a **pre-existing** Mali characteristic: bilinear-vs-TwoPass agreement is 0.8153 on G310 vs ≥0.95 on Vivante — bit-identical score on a pre-refactor scratch build, believed to be Mali's coarser f16 texture filtering; documented in the test with a 0.80 threshold that still catches structural breakage (the broken compute path scored ~0.77).
- 14 host tests for the pure table/repack/dequant functions, runnable on macOS and Linux.

## Benchmark gates (mask bench, base = #109 head, alternating reps ×3, same toolchain, in-session)

| Board | GL cells (the gate) | Notes |
|---|---|---|
| imx95 (Mali) | All flat or improved — `i8_two_pass/n8` **−6%** (dequant FBO + dims-gate win), `forced_opengl` −5% | +3 restored `i8_*/n32` cells |
| rpi5 (V3D) | All flat or improved — `forced_opengl` −1.5% | +3 restored cells |
| imx8mp (Vivante) | Flat except `i8_two_pass/n8` **+3.3%** (tight reps, real) | +3 restored cells |

**The one accepted regression:** Vivante `i8_two_pass/n8` +3.3% (~+6.6 ms on a ~200 ms cell). This cell sits on the documented Vivante fragment-shader cliff where ARCHITECTURE.md already directs deployments to the CPU-materialize hybrid path; TwoPass is not the default mode; and the same change improves Mali −6% and is required for correctness (immutable storage). Suspected mechanism: immutable-storage tiling vs the old realloc-per-call orphaning.

CPU-side cells (`materialize_masks/*`, `decode_masks/proto`, `proto_extraction`) show bimodal per-rep scatter in both directions on untouched code (e.g. rpi5 `decode_masks/proto` **−33%**, imx8mp `proto_extraction` +6.6%) — the same codegen-layout sensitivity diagnosed for PR-B's rpi5 flags; informational, not gated.

Net production LOC in the proto block: ~−250.

## Issue #106 closure (added after #109 merged)

This PR also completes and **closes #106**. The policy half (ColorimetryMode) and the engine work that reclaimed the drift shipped in #109; the closing commit here delivers what the issue defers to the post-PR-B doc refresh:

- `image_benchmark` regains the same-size 1080p **RGBA→BGRA / RGBA→GREY** cells — the named drift cells (+79%/+91% at the 2026-06-09 capture) which had silently dropped out of the bench — as permanent drift sentinels. Verified on imx8mp at this PR's head: **RGBA→BGRA 7.7 ms (v0.15.0: 7.7), RGBA→GREY 7.9 ms (7.8), YUYV→RGBA 7.3 ms (7.2)** — fully reclaimed. The imx95 control reproduces its doc numbers.
- BENCHMARKS.md refreshed with per-table capture notes: same-size convert (imx95 YUYV→RGB halved to 5.7 ms), letterbox pipeline (including the previously-empty orin GL row), and the mask-rendering tables (hybrid ~3× faster than the stale figures; Vivante fused-vs-hybrid now 44.9×). The NV-path section's per-colorimetry `auto` policy documentation landed with #109.

Closes #106.