### PR TITLE
Parallel ImageProcessors: scope the global GL lock to Vivante (PR-P)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Parallel `ImageProcessor` execution on non-Vivante GPUs**
+  (`edgefirst-image`): the process-global GL lock is now a per-driver
+  serialization policy. On Vivante (i.MX 8M Plus) every operation still
+  serializes globally (the galcore driver is not thread-safe across
+  contexts); on Mali, V3D, Tegra, llvmpipe — and any platform without a
+  known-bad driver — multiple `ImageProcessor` instances now genuinely
+  execute GPU work in parallel, each on its own dedicated thread and GL
+  context. Measured aggregate scaling for a 720p NV12→RGB letterbox:
+  Mali G310 S(4)=2.05, V3D S(4)=1.16, Tegra S(4)=1.17 (Vivante flat by
+  design). `EDGEFIRST_GL_SERIALIZE=full|lifecycle` overrides the policy
+  (`full` also mitigates a measured Tegra context-switch collapse on
+  degenerate tiny-convert multi-processor workloads). New
+  `parallel_processors_benchmark` and a cross-wire-sensitive parallel
+  correctness test demonstrate and pin the behavior; processor
+  creation/teardown and EGLImage create/destroy remain briefly
+  serialized on every platform.
 - **`ColorimetryMode` (`Fast` | `Exact`) + `EDGEFIRST_COLORIMETRY`**
   (`edgefirst-image`): the colorimetry/performance trade-off is now an
   explicit knob. `ImageProcessorConfig::colorimetry` (default

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -974,59 +974,79 @@ wrapper (`ManuallyDrop`), and the shared EGL display
 the OS reclaims them at exit. GPU contexts, DMA buffers, and G2D
 contexts are released eagerly by their `Drop` impls.
 
-## GL Command Serialization (GL_MUTEX)
+## GL Concurrency Model (serialization policy)
 
-Multiple `ImageProcessor` instances can coexist in the same process. EGL
-and OpenGL ES specify that independent contexts on separate threads should
-not interfere, but several embedded GPU drivers violate this:
+Multiple `ImageProcessor` instances coexist in one process, each owning a
+dedicated GL worker thread and its own EGL context (held current for the
+thread's life) on the process-global shared display. Whether those
+workers execute GPU work **in parallel** is a per-driver policy decided
+when the worker starts:
 
-- **Vivante `galcore` (i.MX 8M Plus)** — concurrent `eglInitialize`,
-  `eglCreateContext`, DMA-BUF import ioctls, and `eglTerminate` from
-  multiple threads corrupt driver-internal state. Causes SIGSEGV (null
-  pointer at offset `0x18` in `galcore` ioctl) and futex deadlocks.
-- **Broadcom V3D 7.1.10.2 (Raspberry Pi 5)** — concurrent `eglTerminate`
-  breaks ref-counting, causing `EGL(NotInitialized)` on surviving
-  contexts; subsequent GL operations fail with `GL_INVALID_OPERATION`.
-- **ARM Mali-G310 (i.MX 95)** — Panfrost handles concurrent EGL/GL
-  correctly. No issues observed.
+| Driver | Policy | Effect |
+|---|---|---|
+| Vivante `galcore` (i.MX 8M Plus) | `Full` | Every message acquires the global `GL_MUTEX` — all instances serialize (the pre-2026-06 behavior on every platform). |
+| Mali/Panfrost, V3D, Tegra, llvmpipe | `LifecycleOnly` | Messages run unlocked; instances execute GL concurrently on the same GPU. |
 
-### Solution
+Override with `EDGEFIRST_GL_SERIALIZE=full|lifecycle` — `full` is the
+escape hatch for unknown-bad drivers (or tiny-convert-heavy
+multi-processor workloads on Tegra, below); `lifecycle` forces
+parallelism for experiments.
 
-A global `GL_MUTEX` (`std::sync::Mutex<()>` in
-[`crates/image/src/gl/context.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/gl/context.rs))
-serializes **all** EGL and GL operations across every `GLProcessorST`
-instance. Acquired in three places:
+### Why Vivante serializes
 
-1. **Initialization** — wraps `GLProcessorST::new()` (display creation,
+EGL/GLES specify that independent contexts on separate threads must not
+interfere; Vivante `galcore` violates this — concurrent `eglInitialize`,
+`eglCreateContext`, DMA-BUF import ioctls, and runtime GL from multiple
+threads corrupt driver-internal state (SIGSEGV at offset `0x18` in
+`galcore` ioctl, futex deadlocks). Separately, concurrent multi-processor
+*lifecycles* can abort intermittently (`double free or corruption`) even
+when fully serialized — the 2026-06 lock-scoping spike reproduced it
+under `Full` policy, implicating driver thread-exit TLS destructors that
+no userspace lock can order. That known bug keeps the
+`EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS` test skip.
+
+### What stays globally serialized everywhere
+
+1. **Initialization** — `GLProcessorST::new()` (display probe/creation,
    context setup, shader compilation, DMA-BUF roundtrip verification).
-2. **Message dispatch** — wraps every incoming GL-thread message
-   (convert, draw masks, PBO create/download, etc.) so only one GL thread
-   executes driver calls at a time.
-3. **Teardown** — wraps `GLProcessorST::drop()` → `GlContext::drop()`
-   so `eglDestroyContext` (and `eglMakeCurrent(EGL_NO_CONTEXT)`) are
-   serialized. The shared display is never terminated, so teardown
-   does not race against display state.
+   Also makes the once-per-process GL function-pointer load race-free.
+2. **Teardown** — `GLProcessorST::drop()` → `GlContext::drop()`
+   (`eglDestroyContext` serialization; V3D historically broke display
+   ref-counting on concurrent `eglTerminate`, which the HAL additionally
+   avoids by never terminating the shared display).
+3. **EGLImage create/destroy** — a dedicated short `EGL_IMAGE_MUTEX`
+   (display-level EGL ops; a separate mutex because `Full`-policy
+   workers already hold `GL_MUTEX` at creation time). Zero steady-state
+   cost: imports are cache-miss-only after warmup.
 
-The mutex uses `unwrap_or_else(|e| e.into_inner())` to recover from
-poisoning: if a prior GL operation panicked, subsequent operations on
-other instances can still proceed rather than propagating a poison error.
+All mutexes recover from poisoning via `unwrap_or_else(into_inner)` so a
+panicked instance does not poison the others.
 
-### Performance implications
+### Measured scaling (parallel_processors_benchmark, 2026-06)
 
-All GL operations are serialized — no concurrent GPU execution across
-`ImageProcessor` instances. Acceptable because:
+`S(n)` = aggregate throughput with `n` processors ÷ single-processor
+baseline, NV12 720p → RGB 640×640 letterbox (DMA):
 
-- The primary use case (edge AI inference pipelines) typically uses a
-  single processor per pipeline. Multiple instances exist mainly in test
-  scenarios.
-- GPU operations are I/O-bound on embedded targets; mutex overhead
-  (microseconds) is negligible compared to DMA transfers and shader
-  execution (milliseconds).
-- The alternative (concurrent GPU access) crashes on Vivante.
+| Board | S(2) | S(4) | Notes |
+|---|---|---|---|
+| imx95 (Mali G310) | 2.00 | 2.05 | near-ideal until GPU saturates |
+| rpi5 (V3D) | 1.16 | 1.16 | V3D saturates ≈750 conv/s |
+| orin (Tegra) | 1.08 | 1.17 | |
+| imx8mp (Vivante, `Full`) | 1.03 | 1.04 | flat by design |
 
-Future work could relax to init/teardown-only serialization on drivers
-known to be safe for concurrent runtime ops (e.g. Mali), but the current
-approach prioritizes correctness across all targets.
+Dispatch-dominated 64×64 converts additionally show rpi5 S(4)=2.24 and
+imx95 S(4)=1.52 — but **Tegra collapses on that degenerate cell**
+(S(2)=0.26): per-convert syncs force GPU context switches between active
+contexts and the ~0.45 ms switch cost dwarfs sub-100 µs converts
+(corroborated: `EDGEFIRST_GL_SERIALIZE=full` restores the cell to 0.83).
+Realistic converts scale positively on the same board; use the `full`
+override if a deployment really does hammer tiny converts from many
+processors on Tegra.
+
+Correctness under parallelism is pinned by
+`test_parallel_processors_unique_outputs` (4 processors × distinct
+inputs × barrier × per-processor oracles, run on every lane) and the
+ignored on-demand `stress_parallel_processors_oracle` board tool.
 
 ## Tracing Spans
 
@@ -1257,7 +1277,7 @@ Python surface to supply colorimetry from the producer's signalling into
 |--------------|----------------|
 | Reuse tensors across frames | Each new tensor allocates a fresh `BufferIdentity`. The EGL image cache is keyed by `BufferIdentity.id`/`chroma_id` plus the import geometry (`width`/`height`/`row_stride`/`format`). New ID → cache miss → full `eglCreateImageKHR` import (~100–300 µs). Hold tensors alive. Batch tiles key on the parent's identity+geometry, so the destination EGLImage is imported once and reused across the tile loop. |
 | Allocate via `create_image()` | The processor selects DMA-buf, PBO, or heap based on the runtime GPU probe at `new()` time. Bypassing with `Tensor::new(memory=...)` forces a slow transfer path on every `convert()`. |
-| One `ImageProcessor` per pipeline | Each instance owns its OpenGL context, GL thread, and per-thread caches (the EGL display is process-global and shared). Multiple instances still serialize on `GL_MUTEX`, so concurrent use across instances buys nothing. |
+| One `ImageProcessor` per pipeline; more pipelines = more processors | Each instance owns its OpenGL context, dedicated GL thread, and per-thread caches (the EGL display is process-global and shared). On Mali, V3D, Tegra, and llvmpipe, instances execute GPU work **in parallel** (see "GL Concurrency Model" — measured up to S(4)=2.05 aggregate scaling on Mali); only Vivante serializes across instances. Within one instance, work is serialized on its own thread — share a processor across threads only behind your own queue. |
 | Native CPU feature builds (Rule 6) | A build-time concern. `RUSTFLAGS` controls whether the f16 mask kernel at [`crates/image/src/cpu/masks.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/image/src/cpu/masks.rs) compiles to native widening instructions or to the soft-float `__extendhfsf2` helper. Distributed binaries stay on triple baseline ISA; benchmark hosts opt in via `RUSTFLAGS` overrides. |
 
 See the [Optimization Guide](https://github.com/EdgeFirstAI/hal/blob/main/README.md#optimization-guide)

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -79,6 +79,10 @@ name = "mask_benchmark"
 harness = false
 
 [[bench]]
+name = "parallel_processors_benchmark"
+harness = false
+
+[[bench]]
 name = "mask_decode_benchmark"
 harness = false
 

--- a/crates/image/benches/parallel_processors_benchmark.rs
+++ b/crates/image/benches/parallel_processors_benchmark.rs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Multi-processor GL throughput scaling benchmark.
+//!
+//! Measures aggregate convert throughput with {1, 2, 4} `ImageProcessor`
+//! instances running concurrently, each on its own thread with its own GL
+//! context. On `LifecycleOnly` platforms (Mali, V3D, Tegra, llvmpipe) the
+//! processors execute GL work in parallel and the aggregate rate should
+//! scale above 1×; on Vivante (`Full` serialization policy) the rate stays
+//! ≈1× by design. The scaling factor S(n) is the demonstration evidence
+//! for the per-driver GL serialization policy — evidence, not a hard gate.
+//!
+//! Cells:
+//! - `gpu_bound`: NV12 1280×720 → RGB 640×640 letterbox (DMA where
+//!   available) — a realistic model-input convert dominated by GPU work.
+//! - `overhead`: RGBA 64×64 → RGB 64×64 (heap) — dominated by per-message
+//!   dispatch, exposing channel-hop / lock overhead.
+//!
+//! Each cell runs a fixed wall-clock window; every thread counts completed
+//! converts. The recorded `BenchResult` carries ONE synthetic sample: the
+//! effective aggregate per-convert latency `window / total_converts`
+//! (lower = better; `S(n) = t(1) / t(n)`), which keeps the `--json` output
+//! compatible with `scripts/bench_compare.py`.
+//!
+//! ## Run (on-target)
+//! ```bash
+//! ./parallel_processors_benchmark --json out.json
+//! ```
+
+mod common;
+
+use edgefirst_bench::{BenchResult, BenchSuite};
+use edgefirst_image::{Crop, Flip, ImageProcessor, ImageProcessorTrait, Rotation};
+use edgefirst_tensor::{DType, PixelFormat, TensorMemory, TensorTrait};
+use std::sync::{Arc, Barrier};
+use std::time::{Duration, Instant};
+
+const WINDOW: Duration = Duration::from_secs(3);
+const WARMUP_CONVERTS: usize = 5;
+
+#[derive(Clone, Copy)]
+struct Cell {
+    tag: &'static str,
+    src_fmt: PixelFormat,
+    src_w: usize,
+    src_h: usize,
+    dst_fmt: PixelFormat,
+    dst_w: usize,
+    dst_h: usize,
+    letterbox: bool,
+    use_dma: bool,
+}
+
+const CELLS: [Cell; 2] = [
+    Cell {
+        tag: "gpu_bound",
+        src_fmt: PixelFormat::Nv12,
+        src_w: 1280,
+        src_h: 720,
+        dst_fmt: PixelFormat::Rgb,
+        dst_w: 640,
+        dst_h: 640,
+        letterbox: true,
+        use_dma: true,
+    },
+    Cell {
+        tag: "overhead",
+        src_fmt: PixelFormat::Rgba,
+        src_w: 64,
+        src_h: 64,
+        dst_fmt: PixelFormat::Rgb,
+        dst_w: 64,
+        dst_h: 64,
+        letterbox: false,
+        use_dma: false,
+    },
+];
+
+/// Run one (cell, n_procs) configuration; returns per-thread convert counts.
+fn run_config(cell: Cell, n_procs: usize) -> Result<Vec<usize>, String> {
+    let mem = if cell.use_dma && edgefirst_tensor::is_dma_available() {
+        Some(TensorMemory::Dma)
+    } else {
+        Some(TensorMemory::Mem)
+    };
+    let barrier = Arc::new(Barrier::new(n_procs));
+
+    let handles: Vec<_> = (0..n_procs)
+        .map(|i| {
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || -> Result<usize, String> {
+                let mut proc = ImageProcessor::new()
+                    .map_err(|e| format!("processor {i} creation failed: {e}"))?;
+                let src = proc
+                    .create_image(cell.src_w, cell.src_h, cell.src_fmt, DType::U8, mem)
+                    .map_err(|e| format!("src alloc failed: {e}"))?;
+                {
+                    use edgefirst_tensor::TensorMapTrait;
+                    let t = src.as_u8().unwrap();
+                    let mut m = t.map().map_err(|e| format!("map failed: {e}"))?;
+                    for (j, b) in m.as_mut_slice().iter_mut().enumerate() {
+                        *b = ((i * 41 + j) % 223) as u8;
+                    }
+                }
+                let crop = if cell.letterbox {
+                    Crop::letterbox([114, 114, 114, 255])
+                } else {
+                    Crop::default()
+                };
+                // Pre-allocate and REUSE the destination: real pipelines pool
+                // buffers, and per-iteration allocation would measure the
+                // allocator (PBO/DMA churn) instead of convert dispatch.
+                let mut dst = proc
+                    .create_image(cell.dst_w, cell.dst_h, cell.dst_fmt, DType::U8, mem)
+                    .map_err(|e| format!("dst alloc failed: {e}"))?;
+                let convert_once =
+                    |proc: &mut ImageProcessor, dst: &mut _| -> Result<(), String> {
+                        proc.convert(&src, dst, Rotation::None, Flip::None, crop)
+                            .map_err(|e| format!("convert failed: {e}"))?;
+                        Ok(())
+                    };
+
+                for _ in 0..WARMUP_CONVERTS {
+                    convert_once(&mut proc, &mut dst)?;
+                }
+                barrier.wait();
+                let deadline = Instant::now() + WINDOW;
+                let mut count = 0usize;
+                while Instant::now() < deadline {
+                    convert_once(&mut proc, &mut dst)?;
+                    count += 1;
+                }
+                Ok(count)
+            })
+        })
+        .collect();
+
+    handles
+        .into_iter()
+        .enumerate()
+        .map(|(i, h)| {
+            h.join()
+                .map_err(|e| format!("thread {i} panicked: {e:?}"))?
+        })
+        .collect()
+}
+
+fn main() {
+    let mut suite = BenchSuite::from_args();
+
+    println!("== Parallel ImageProcessor throughput scaling ==");
+    println!(
+        "   window = {WINDOW:?}/cell, warmup = {WARMUP_CONVERTS} converts/proc\n"
+    );
+
+    for cell in CELLS {
+        let mut base_rate: Option<f64> = None;
+        for n in [1usize, 2, 4] {
+            let name = format!("parallel/{}/n{}", cell.tag, n);
+            let counts = match run_config(cell, n) {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("  {name:50} [unsupported: {e}]");
+                    continue;
+                }
+            };
+            let total: usize = counts.iter().sum();
+            if total == 0 {
+                println!("  {name:50} [no converts completed in window]");
+                continue;
+            }
+            let rate = total as f64 / WINDOW.as_secs_f64();
+            let scaling = base_rate.map(|b| rate / b);
+            if n == 1 {
+                base_rate = Some(rate);
+            }
+            let min = counts.iter().min().unwrap();
+            let max = counts.iter().max().unwrap();
+            let effective = Duration::from_secs_f64(WINDOW.as_secs_f64() / total as f64);
+            println!(
+                "  {name:50} agg {rate:8.1} conv/s  per-proc [{min}..{max}]  {}",
+                scaling.map_or(String::from("S=1.00 (base)"), |s| format!("S={s:.2}")),
+            );
+            suite.record(&BenchResult {
+                name,
+                iterations: total,
+                times: vec![effective],
+            });
+        }
+        println!();
+    }
+
+    suite.finish();
+}

--- a/crates/image/benches/parallel_processors_benchmark.rs
+++ b/crates/image/benches/parallel_processors_benchmark.rs
@@ -114,12 +114,11 @@ fn run_config(cell: Cell, n_procs: usize) -> Result<Vec<usize>, String> {
                 let mut dst = proc
                     .create_image(cell.dst_w, cell.dst_h, cell.dst_fmt, DType::U8, mem)
                     .map_err(|e| format!("dst alloc failed: {e}"))?;
-                let convert_once =
-                    |proc: &mut ImageProcessor, dst: &mut _| -> Result<(), String> {
-                        proc.convert(&src, dst, Rotation::None, Flip::None, crop)
-                            .map_err(|e| format!("convert failed: {e}"))?;
-                        Ok(())
-                    };
+                let convert_once = |proc: &mut ImageProcessor, dst: &mut _| -> Result<(), String> {
+                    proc.convert(&src, dst, Rotation::None, Flip::None, crop)
+                        .map_err(|e| format!("convert failed: {e}"))?;
+                    Ok(())
+                };
 
                 for _ in 0..WARMUP_CONVERTS {
                     convert_once(&mut proc, &mut dst)?;
@@ -150,9 +149,7 @@ fn main() {
     let mut suite = BenchSuite::from_args();
 
     println!("== Parallel ImageProcessor throughput scaling ==");
-    println!(
-        "   window = {WINDOW:?}/cell, warmup = {WARMUP_CONVERTS} converts/proc\n"
-    );
+    println!("   window = {WINDOW:?}/cell, warmup = {WARMUP_CONVERTS} converts/proc\n");
 
     for cell in CELLS {
         let mut base_rate: Option<f64> = None;

--- a/crates/image/src/gl/context.rs
+++ b/crates/image/src/gl/context.rs
@@ -21,45 +21,60 @@ use std::{
 /// EGL cleanup, and dlclose can unmap memory still referenced by the driver.
 static EGL_LIB: OnceLock<&'static libloading::Library> = OnceLock::new();
 
-/// Global mutex that serializes **all** OpenGL and EGL operations across
-/// every `GLProcessorST` instance in the process.
+/// Global mutex serializing GL/EGL **lifecycle** operations across every
+/// `GLProcessorST` instance in the process — and, on Vivante only, every
+/// per-message operation as well.
 ///
-/// Some GPU drivers (notably Vivante `galcore` on i.MX8M Plus) are not
-/// thread-safe for concurrent EGL/GL calls, even when each thread targets
-/// an independent EGL display and context. Concurrent access can corrupt
-/// driver-internal state, leading to deadlocks or SIGSEGV inside kernel
-/// ioctls. Broadcom V3D exhibits a milder variant where concurrent
-/// `eglTerminate` breaks display ref-counting.
+/// The Vivante `galcore` driver (i.MX 8M Plus) is not thread-safe for
+/// concurrent EGL/GL calls, even when each thread targets an independent
+/// context: concurrent access corrupts driver-internal state (deadlocks or
+/// SIGSEGV inside kernel ioctls). On Vivante the worker therefore acquires
+/// this mutex for **every** message (`SerializationPolicy::Full`) — the
+/// pre-2026-06 behavior for all platforms.
 ///
-/// This mutex is acquired by `GLProcessorThreaded` for **every** operation
-/// on its dedicated GL thread:
-/// - Initialization (`GLProcessorST::new` — EGL init, shader compilation,
-///   DMA-BUF verification)
-/// - Every message dispatch (convert, draw, PBO create/download, etc.)
+/// Everywhere else (Mali, V3D, Tegra, llvmpipe, ANGLE) the per-message
+/// acquisition is skipped (`SerializationPolicy::LifecycleOnly`): each
+/// `GLProcessorThreaded` owns a dedicated worker thread and its own EGL
+/// context held current for the thread's life, and the EGL spec requires
+/// concurrent contexts on distinct threads to work. The P0 spike (2026-06,
+/// 4 processors × barrier × 200-convert oracle stress, 5 reps per leg)
+/// validated this clean on Mali G310, V3D, and Tegra/Orin. Multiple
+/// `ImageProcessor` instances now genuinely execute GL work in parallel on
+/// those platforms.
+///
+/// What ALWAYS stays under this mutex, on every platform:
+/// - Initialization (`GLProcessorST::new` — EGL display probe/init, context
+///   creation, shader compilation, DMA-BUF verification)
 /// - Teardown (`GLProcessorST::drop` → `GlContext::drop`)
 ///
-/// This ensures that only one GL thread interacts with the GPU driver at
-/// any given time. Multiple `ImageProcessor` instances remain usable from
-/// different application threads — their GL commands are simply serialized
-/// through this mutex rather than executed in parallel.
+/// These are rare, cheap-to-serialize events that cover driver bring-up
+/// races. NOTE: the known Vivante concurrent-multi-processor double-free
+/// (see `EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS`) is NOT prevented by any
+/// locking — it reproduces with full serialization and appears to live in
+/// driver thread-exit TLS destructors; the test skip remains necessary.
+///
+/// Override: `EDGEFIRST_GL_SERIALIZE=full|lifecycle` forces the policy —
+/// `full` is the escape hatch for unknown-bad drivers, `lifecycle` forces
+/// parallelism (e.g. Vivante experiments). Unset = per-driver default.
 pub(super) static GL_MUTEX: Mutex<()> = Mutex::new(());
 
-/// SPIKE (P0, throwaway): dedicated short lock for EGLImage create/destroy,
-/// env-gated by `EDGEFIRST_GL_IMAGE_LOCK=1`. A separate mutex (NOT
-/// `GL_MUTEX`) because in Full-serialization mode the worker already holds
-/// `GL_MUTEX` when creating images — re-locking it would deadlock.
+/// Dedicated short lock serializing EGLImage create/destroy across
+/// processors (a separate mutex from `GL_MUTEX`: in `Full` policy the
+/// worker already holds `GL_MUTEX` when creating images, and `std::sync::
+/// Mutex` is not reentrant).
+///
+/// `eglCreateImageKHR`/`eglDestroyImageKHR` are display-level operations
+/// the EGL spec requires to be thread-safe, but this module's premise is
+/// embedded drivers violating the spec. The P0 spike ran Mali/V3D/Tegra
+/// clean WITHOUT this lock (5 reps each), so it is likely removable; it is
+/// kept because the steady-state cost is zero — image creation is
+/// cache-miss-only (one import per buffer after warmup, pinned by the
+/// `image.convert.gl.egl_import` span gates).
 static EGL_IMAGE_MUTEX: Mutex<()> = Mutex::new(());
 
-/// SPIKE (P0): returns a guard for EGLImage lifecycle ops when the
-/// `EDGEFIRST_GL_IMAGE_LOCK=1` leg is active, else `None`.
-pub(super) fn image_lifecycle_guard() -> Option<std::sync::MutexGuard<'static, ()>> {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let on = *ENABLED.get_or_init(|| {
-        std::env::var("EDGEFIRST_GL_IMAGE_LOCK")
-            .map(|v| v == "1")
-            .unwrap_or(false)
-    });
-    on.then(|| EGL_IMAGE_MUTEX.lock().unwrap_or_else(|e| e.into_inner()))
+/// Acquire the EGLImage lifecycle lock (see [`EGL_IMAGE_MUTEX`]).
+pub(super) fn image_lifecycle_guard() -> std::sync::MutexGuard<'static, ()> {
+    EGL_IMAGE_MUTEX.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 /// Shared EGL display — created once, reused by all `GlContext` instances.

--- a/crates/image/src/gl/context.rs
+++ b/crates/image/src/gl/context.rs
@@ -44,6 +44,24 @@ static EGL_LIB: OnceLock<&'static libloading::Library> = OnceLock::new();
 /// through this mutex rather than executed in parallel.
 pub(super) static GL_MUTEX: Mutex<()> = Mutex::new(());
 
+/// SPIKE (P0, throwaway): dedicated short lock for EGLImage create/destroy,
+/// env-gated by `EDGEFIRST_GL_IMAGE_LOCK=1`. A separate mutex (NOT
+/// `GL_MUTEX`) because in Full-serialization mode the worker already holds
+/// `GL_MUTEX` when creating images — re-locking it would deadlock.
+static EGL_IMAGE_MUTEX: Mutex<()> = Mutex::new(());
+
+/// SPIKE (P0): returns a guard for EGLImage lifecycle ops when the
+/// `EDGEFIRST_GL_IMAGE_LOCK=1` leg is active, else `None`.
+pub(super) fn image_lifecycle_guard() -> Option<std::sync::MutexGuard<'static, ()>> {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let on = *ENABLED.get_or_init(|| {
+        std::env::var("EDGEFIRST_GL_IMAGE_LOCK")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    });
+    on.then(|| EGL_IMAGE_MUTEX.lock().unwrap_or_else(|e| e.into_inner()))
+}
+
 /// Shared EGL display — created once, reused by all `GlContext` instances.
 ///
 /// On Vivante galcore (i.MX8M Plus), opening multiple DRM fds causes

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -4548,6 +4548,8 @@ impl GLProcessorST {
         // Steady-state frame loops must show ZERO of these after warmup — the
         // span count is the observable for cache-behavior equality gates.
         let _span = tracing::trace_span!("image.convert.gl.egl_import", target).entered();
+        // SPIKE (P0): optional dedicated lock for the create leg.
+        let _image_guard = super::context::image_lifecycle_guard();
         let image = GlContext::egl_create_image_with_fallback(
             &self.gl_context.egl,
             self.gl_context.display,

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -674,11 +674,23 @@ impl GLProcessorST {
 
     pub fn new(kind: Option<EglDisplayKind>) -> Result<GLProcessorST, crate::Error> {
         let gl_context = GlContext::new(kind)?;
-        gls::load_with(|s| {
-            gl_context
-                .egl
-                .get_proc_address(s)
-                .map_or(std::ptr::null(), |p| p as *const _)
+        // Load the GL function pointers exactly once per process (the same
+        // pattern as macOS's GL_LOADED). `gls` bindings are gl_generator
+        // `static mut` function-pointer tables, so re-running `load_with` on
+        // every processor construction is a data race the moment another
+        // processor's worker thread is calling GL without holding `GL_MUTEX`
+        // — a prerequisite for scoping the per-message lock to Vivante.
+        // Once-loading is also semantically right: the pointers come from the
+        // process-global shared EGL display, so every context resolves the
+        // same addresses.
+        static GL_LOADED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        GL_LOADED.get_or_init(|| {
+            gls::load_with(|s| {
+                gl_context
+                    .egl
+                    .get_proc_address(s)
+                    .map_or(std::ptr::null(), |p| p as *const _)
+            });
         });
 
         let (

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -4548,7 +4548,9 @@ impl GLProcessorST {
         // Steady-state frame loops must show ZERO of these after warmup — the
         // span count is the observable for cache-behavior equality gates.
         let _span = tracing::trace_span!("image.convert.gl.egl_import", target).entered();
-        // SPIKE (P0): optional dedicated lock for the create leg.
+        // EGLImage creation is a display-level EGL op shared by every
+        // processor — serialized by a dedicated short lock (zero cost in
+        // steady state: creations are cache-miss-only).
         let _image_guard = super::context::image_lifecycle_guard();
         let image = GlContext::egl_create_image_with_fallback(
             &self.gl_context.egl,

--- a/crates/image/src/gl/resources.rs
+++ b/crates/image/src/gl/resources.rs
@@ -23,7 +23,7 @@ impl Drop for EglImage {
         }
 
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            // SPIKE (P0): optional dedicated lock for the destroy leg.
+            // Display-level EGL op — same dedicated lock as creation.
             let _image_guard = super::context::image_lifecycle_guard();
             let e =
                 GlContext::egl_destroy_image_with_fallback(&self.egl, self.display, self.egl_image);

--- a/crates/image/src/gl/resources.rs
+++ b/crates/image/src/gl/resources.rs
@@ -23,6 +23,8 @@ impl Drop for EglImage {
         }
 
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SPIKE (P0): optional dedicated lock for the destroy leg.
+            let _image_guard = super::context::image_lifecycle_guard();
             let e =
                 GlContext::egl_destroy_image_with_fallback(&self.egl, self.display, self.egl_image);
             if let Err(e) = e {

--- a/crates/image/src/gl/threaded.rs
+++ b/crates/image/src/gl/threaded.rs
@@ -315,12 +315,20 @@ impl GLProcessorThreaded {
                 gl_converter.is_vivante(),
             )));
             let mut poisoned = false;
+            // SPIKE (P0, throwaway): `EDGEFIRST_GL_SERIALIZE=lifecycle` skips
+            // the per-message global lock (creation/teardown stay locked) to
+            // measure multi-processor parallelism on non-Vivante boards.
+            let serialize_per_msg = std::env::var("EDGEFIRST_GL_SERIALIZE")
+                .map(|v| v != "lifecycle")
+                .unwrap_or(true);
             while let Some(msg) = recv.blocking_recv() {
                 // Serialize all GL operations across GLProcessorST instances.
                 // See `GL_MUTEX` doc comment in context.rs for rationale.
-                let _guard = super::context::GL_MUTEX
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner());
+                let _guard = serialize_per_msg.then(|| {
+                    super::context::GL_MUTEX
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                });
 
                 // After a panic, the GL context is in an undefined state. Reject
                 // all subsequent messages with an error rather than risking wrong

--- a/crates/image/src/gl/threaded.rs
+++ b/crates/image/src/gl/threaded.rs
@@ -315,15 +315,27 @@ impl GLProcessorThreaded {
                 gl_converter.is_vivante(),
             )));
             let mut poisoned = false;
-            // SPIKE (P0, throwaway): `EDGEFIRST_GL_SERIALIZE=lifecycle` skips
-            // the per-message global lock (creation/teardown stay locked) to
-            // measure multi-processor parallelism on non-Vivante boards.
-            let serialize_per_msg = std::env::var("EDGEFIRST_GL_SERIALIZE")
-                .map(|v| v != "lifecycle")
-                .unwrap_or(true);
+            // Per-message serialization policy: Full on Vivante (galcore is
+            // not thread-safe for concurrent GL across contexts),
+            // LifecycleOnly everywhere else — multiple processors then run
+            // GL work in parallel, each on its own thread + context. See the
+            // GL_MUTEX doc comment in context.rs. EDGEFIRST_GL_SERIALIZE
+            // overrides per-driver defaults (full = escape hatch for
+            // unknown-bad drivers; lifecycle = force-parallel).
+            let serialize_per_msg = match std::env::var("EDGEFIRST_GL_SERIALIZE").as_deref() {
+                Ok("full") => true,
+                Ok("lifecycle") => false,
+                _ => gl_converter.is_vivante(),
+            };
+            log::debug!(
+                "GL serialization policy: {}",
+                if serialize_per_msg {
+                    "Full (per-message global lock)"
+                } else {
+                    "LifecycleOnly (parallel across processors)"
+                }
+            );
             while let Some(msg) = recv.blocking_recv() {
-                // Serialize all GL operations across GLProcessorST instances.
-                // See `GL_MUTEX` doc comment in context.rs for rationale.
                 let _guard = serialize_per_msg.then(|| {
                     super::context::GL_MUTEX
                         .lock()

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -8401,16 +8401,17 @@ mod image_tests {
         });
     }
 
-    /// SPIKE (P0, lock-scoping): heavy multi-processor oracle stress for the
-    /// on-board legs of the GL serialization spike. Run explicitly:
-    ///   EDGEFIRST_GL_SERIALIZE=lifecycle [EDGEFIRST_GL_IMAGE_LOCK=1] \
-    ///     <test binary> spike_parallel_processors_oracle --ignored
-    /// 4 processors × 4 threads × barrier × 200 NV12 720p → RGB 640 letterbox
+    /// Heavy on-demand stressor for the GL serialization policy: 4
+    /// processors × 4 threads × barrier × 200 NV12 720p → RGB 640 letterbox
     /// converts (DMA where available); every output must byte-match the
     /// thread's own pre-barrier sequential oracle from the same processor.
+    /// Ignored by default (heavy; board tool — the CI-weight version is
+    /// `test_parallel_processors_unique_outputs`). Run explicitly, optionally
+    /// pinning the policy via EDGEFIRST_GL_SERIALIZE=full|lifecycle:
+    ///   <test binary> stress_parallel_processors_oracle --ignored
     #[test]
-    #[ignore = "P0 lock-scoping spike — run explicitly on boards with EDGEFIRST_GL_SERIALIZE legs"]
-    fn spike_parallel_processors_oracle() {
+    #[ignore = "heavy on-demand GL-parallelism stressor; run explicitly on boards"]
+    fn stress_parallel_processors_oracle() {
         use std::sync::{mpsc, Arc, Barrier};
         use std::time::Duration;
 
@@ -8487,13 +8488,13 @@ mod image_tests {
 
             for (i, h) in handles.into_iter().enumerate() {
                 h.join()
-                    .unwrap_or_else(|e| panic!("spike thread {i} panicked: {e:?}"));
+                    .unwrap_or_else(|e| panic!("stressor thread {i} panicked: {e:?}"));
             }
             let _ = tx.send(());
         });
 
         rx.recv_timeout(TIMEOUT).unwrap_or_else(|_| {
-            panic!("spike_parallel_processors_oracle timed out after {TIMEOUT:?}")
+            panic!("stress_parallel_processors_oracle timed out after {TIMEOUT:?}")
         });
     }
 

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -8401,6 +8401,118 @@ mod image_tests {
         });
     }
 
+    /// THE parallel-processors demonstration test: 4 ImageProcessors on 4
+    /// threads, each with its own GL context and worker, converting
+    /// per-thread-DISTINCT synthetic inputs concurrently (barrier-released);
+    /// every output must byte-match the thread's own pre-barrier sequential
+    /// oracle from the same processor. On LifecycleOnly platforms (Mali,
+    /// V3D, Tegra, llvmpipe, macOS) the converts genuinely overlap on the
+    /// GPU; on Vivante they serialize via the Full policy and the test still
+    /// must pass. Distinct inputs make any cross-processor state leakage
+    /// (wrong texture, wrong context, clobbered upload) visible as a byte
+    /// diff rather than a coincidental match — proven by a scratch
+    /// cross-wire run (neighbor's input post-oracle) failing on every
+    /// thread with ~53% of bytes diverged.
+    ///
+    /// Skipped under EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS like
+    /// `test_multiple_image_processors_separate_threads`: the galcore driver
+    /// can abort intermittently on concurrent multi-processor lifecycles
+    /// regardless of locking (P0 spike: reproduces fully serialized).
+    #[test]
+    fn test_parallel_processors_unique_outputs() {
+        use std::sync::{mpsc, Arc, Barrier};
+        use std::time::Duration;
+
+        const N: usize = 4;
+        const ROUNDS: usize = 25;
+        const TIMEOUT: Duration = Duration::from_secs(60);
+
+        if std::env::var_os("EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS").is_some() {
+            eprintln!(
+                "SKIPPED: test_parallel_processors_unique_outputs — known Vivante \
+                 GC7000UL concurrent-multi-processor driver abort \
+                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)"
+            );
+            return;
+        }
+
+        let _lock = acquire_env_lock();
+        let (tx, rx) = mpsc::channel::<()>();
+
+        std::thread::spawn(move || {
+            let barrier = Arc::new(Barrier::new(N));
+            let handles: Vec<_> = (0..N)
+                .map(|i| {
+                    let barrier = Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        let mut proc = ImageProcessor::new().unwrap_or_else(|e| {
+                            panic!("ImageProcessor::new() failed on thread {i}: {e}")
+                        });
+                        // CI-weight geometry (llvmpipe renders on the CPU).
+                        let (w, h) = (640usize, 480usize);
+                        let mem = if edgefirst_tensor::is_dma_available() {
+                            Some(TensorMemory::Dma)
+                        } else {
+                            Some(TensorMemory::Mem)
+                        };
+                        let src = proc
+                            .create_image(w, h, PixelFormat::Nv12, DType::U8, mem)
+                            .unwrap();
+                        {
+                            let t = src.as_u8().unwrap();
+                            let mut m = t.map().unwrap();
+                            let s = m.as_mut_slice();
+                            for (j, b) in s[..w * h].iter_mut().enumerate() {
+                                *b = ((i * 53 + j) % 200 + 16) as u8;
+                            }
+                            for b in &mut s[w * h..] {
+                                *b = (80 + i * 24) as u8;
+                            }
+                        }
+                        let lb = Crop::letterbox([114, 114, 114, 255]);
+                        let convert_once = |proc: &mut ImageProcessor| -> Vec<u8> {
+                            let mut dst = proc
+                                .create_image(320, 320, PixelFormat::Rgba, DType::U8, mem)
+                                .unwrap();
+                            proc.convert(&src, &mut dst, Rotation::None, Flip::None, lb)
+                                .unwrap_or_else(|e| {
+                                    panic!("convert failed on thread {i}: {e}")
+                                });
+                            let t = dst.as_u8().unwrap();
+                            let m = t.map().unwrap();
+                            m.as_slice().to_vec()
+                        };
+
+                        let oracle = convert_once(&mut proc);
+                        barrier.wait();
+                        for round in 0..ROUNDS {
+                            let out = convert_once(&mut proc);
+                            let diffs =
+                                oracle.iter().zip(&out).filter(|(a, b)| a != b).count();
+                            assert!(
+                                diffs == 0,
+                                "thread {i} round {round}: {diffs}/{} bytes diverged \
+                                 from this processor's own oracle — cross-processor \
+                                 GL state leakage under parallel execution",
+                                oracle.len()
+                            );
+                        }
+                    })
+                })
+                .collect();
+
+            for (i, h) in handles.into_iter().enumerate() {
+                h.join()
+                    .unwrap_or_else(|e| panic!("parallel thread {i} panicked: {e:?}"));
+            }
+            let _ = tx.send(());
+        });
+
+        rx.recv_timeout(TIMEOUT).unwrap_or_else(|_| {
+            panic!("test_parallel_processors_unique_outputs timed out after {TIMEOUT:?}")
+        });
+    }
+
     /// Heavy on-demand stressor for the GL serialization policy: 4
     /// processors × 4 threads × barrier × 200 NV12 720p → RGB 640 letterbox
     /// converts (DMA where available); every output must byte-match the

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -8475,9 +8475,7 @@ mod image_tests {
                                 .create_image(320, 320, PixelFormat::Rgba, DType::U8, mem)
                                 .unwrap();
                             proc.convert(&src, &mut dst, Rotation::None, Flip::None, lb)
-                                .unwrap_or_else(|e| {
-                                    panic!("convert failed on thread {i}: {e}")
-                                });
+                                .unwrap_or_else(|e| panic!("convert failed on thread {i}: {e}"));
                             let t = dst.as_u8().unwrap();
                             let m = t.map().unwrap();
                             m.as_slice().to_vec()
@@ -8487,8 +8485,7 @@ mod image_tests {
                         barrier.wait();
                         for round in 0..ROUNDS {
                             let out = convert_once(&mut proc);
-                            let diffs =
-                                oracle.iter().zip(&out).filter(|(a, b)| a != b).count();
+                            let diffs = oracle.iter().zip(&out).filter(|(a, b)| a != b).count();
                             assert!(
                                 diffs == 0,
                                 "thread {i} round {round}: {diffs}/{} bytes diverged \
@@ -8573,9 +8570,7 @@ mod image_tests {
                                 .create_image(640, 640, PixelFormat::Rgb, DType::U8, mem)
                                 .unwrap();
                             proc.convert(&src, &mut dst, Rotation::None, Flip::None, lb)
-                                .unwrap_or_else(|e| {
-                                    panic!("convert failed on thread {i}: {e}")
-                                });
+                                .unwrap_or_else(|e| panic!("convert failed on thread {i}: {e}"));
                             let t = dst.as_u8().unwrap();
                             let m = t.map().unwrap();
                             m.as_slice().to_vec()
@@ -8585,8 +8580,7 @@ mod image_tests {
                         barrier.wait();
                         for round in 0..ROUNDS {
                             let out = convert_once(&mut proc);
-                            let diffs =
-                                oracle.iter().zip(&out).filter(|(a, b)| a != b).count();
+                            let diffs = oracle.iter().zip(&out).filter(|(a, b)| a != b).count();
                             assert!(
                                 diffs == 0,
                                 "thread {i} round {round}: {diffs}/{} bytes diverged \

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -8401,6 +8401,102 @@ mod image_tests {
         });
     }
 
+    /// SPIKE (P0, lock-scoping): heavy multi-processor oracle stress for the
+    /// on-board legs of the GL serialization spike. Run explicitly:
+    ///   EDGEFIRST_GL_SERIALIZE=lifecycle [EDGEFIRST_GL_IMAGE_LOCK=1] \
+    ///     <test binary> spike_parallel_processors_oracle --ignored
+    /// 4 processors × 4 threads × barrier × 200 NV12 720p → RGB 640 letterbox
+    /// converts (DMA where available); every output must byte-match the
+    /// thread's own pre-barrier sequential oracle from the same processor.
+    #[test]
+    #[ignore = "P0 lock-scoping spike — run explicitly on boards with EDGEFIRST_GL_SERIALIZE legs"]
+    fn spike_parallel_processors_oracle() {
+        use std::sync::{mpsc, Arc, Barrier};
+        use std::time::Duration;
+
+        const N: usize = 4;
+        const ROUNDS: usize = 200;
+        const TIMEOUT: Duration = Duration::from_secs(600);
+
+        let _lock = acquire_env_lock();
+        let (tx, rx) = mpsc::channel::<()>();
+
+        std::thread::spawn(move || {
+            let barrier = Arc::new(Barrier::new(N));
+            let handles: Vec<_> = (0..N)
+                .map(|i| {
+                    let barrier = Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        let mut proc = ImageProcessor::new().unwrap_or_else(|e| {
+                            panic!("ImageProcessor::new() failed on thread {i}: {e}")
+                        });
+                        let (w, h) = (1280usize, 720usize);
+                        let mem = if edgefirst_tensor::is_dma_available() {
+                            Some(TensorMemory::Dma)
+                        } else {
+                            Some(TensorMemory::Mem)
+                        };
+
+                        // Per-thread-distinct synthetic NV12 so cross-wired
+                        // GL state between processors shows up as a byte diff.
+                        let src = proc
+                            .create_image(w, h, PixelFormat::Nv12, DType::U8, mem)
+                            .unwrap();
+                        {
+                            let t = src.as_u8().unwrap();
+                            let mut m = t.map().unwrap();
+                            let s = m.as_mut_slice();
+                            for (j, b) in s[..w * h].iter_mut().enumerate() {
+                                *b = ((i * 37 + j) % 200 + 16) as u8;
+                            }
+                            for b in &mut s[w * h..] {
+                                *b = (96 + i * 16) as u8;
+                            }
+                        }
+                        let lb = Crop::letterbox([114, 114, 114, 255]);
+
+                        let convert_once = |proc: &mut ImageProcessor| -> Vec<u8> {
+                            let mut dst = proc
+                                .create_image(640, 640, PixelFormat::Rgb, DType::U8, mem)
+                                .unwrap();
+                            proc.convert(&src, &mut dst, Rotation::None, Flip::None, lb)
+                                .unwrap_or_else(|e| {
+                                    panic!("convert failed on thread {i}: {e}")
+                                });
+                            let t = dst.as_u8().unwrap();
+                            let m = t.map().unwrap();
+                            m.as_slice().to_vec()
+                        };
+
+                        let oracle = convert_once(&mut proc);
+                        barrier.wait();
+                        for round in 0..ROUNDS {
+                            let out = convert_once(&mut proc);
+                            let diffs =
+                                oracle.iter().zip(&out).filter(|(a, b)| a != b).count();
+                            assert!(
+                                diffs == 0,
+                                "thread {i} round {round}: {diffs}/{} bytes diverged \
+                                 from the pre-barrier oracle",
+                                oracle.len()
+                            );
+                        }
+                    })
+                })
+                .collect();
+
+            for (i, h) in handles.into_iter().enumerate() {
+                h.join()
+                    .unwrap_or_else(|e| panic!("spike thread {i} panicked: {e:?}"));
+            }
+            let _ = tx.send(());
+        });
+
+        rx.recv_timeout(TIMEOUT).unwrap_or_else(|_| {
+            panic!("spike_parallel_processors_oracle timed out after {TIMEOUT:?}")
+        });
+    }
+
     // =========================================================================
     // F16 / F32 auto-chain fallback integration tests
     // =========================================================================


### PR DESCRIPTION
## Summary

The process-global `GL_MUTEX` existed for the Vivante galcore driver but was acquired per message on **every** platform, fully serializing all `GLProcessorThreaded` instances — ARCHITECTURE.md itself said multiple `ImageProcessor`s "buy nothing". Each instance already owns a dedicated worker thread and its own EGL context on the shared display; the per-message lock was the only cross-processor serializer.

Per-message serialization is now a per-driver policy: **Full on Vivante** (lock-for-lock identical to the previous behavior), **LifecycleOnly everywhere else** — multiple ImageProcessors now genuinely execute GPU work in parallel on Mali, V3D, Tegra, and llvmpipe, each with its own context and dedicated thread. `EDGEFIRST_GL_SERIALIZE=full|lifecycle` overrides the default. Creation, teardown, and EGLImage create/destroy stay briefly serialized on every platform (rare events; a dedicated short `EGL_IMAGE_MUTEX` for images since Full-policy workers hold `GL_MUTEX` at creation).

## The prerequisite bug this surfaced

`gls` GL bindings are `static mut` function-pointer tables, and Linux re-ran `gls::load_with` on **every** processor construction — sound only while construction and all messages shared one lock. The first commit loads the pointers once per process (`OnceLock`, mirroring macOS), eliminating a UB data race the moment the lock is scoped. Behavior no-op alone.

## Evidence

**P0 spike** (4 processors × 4 threads × barrier × 200 NV12 720p→RGB 640 letterbox converts vs per-thread oracles, ×5 reps/leg):
- Mali (imx95), V3D (rpi5), Tegra (orin): **15/15 runs clean** in lifecycle mode — with and without the image lock — outputs byte-equal, no crashes, no deadlocks, clean dmesg.
- imx8mp Full control: the known intermittent concurrent-multi-processor abort reproduced 1/5 — and **2/5 on a control build with the fn-pointer fix reverted**, proving it pre-existing. No locking prevents it (reproduces fully serialized; likely driver thread-exit TLS); `EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS` remains required and this PR does not claim otherwise.

**Correctness**: new `test_parallel_processors_unique_outputs` — 4 processors converting per-thread-distinct inputs concurrently, byte-compared against per-processor sequential oracles. Green on all four boards (genuinely parallel on three of them) and natively on macOS. Sensitivity proven by a scratch cross-wire build (neighbor's input substituted post-oracle): all threads fail round 0 with ~53% of bytes diverged. Plus the ignored `stress_parallel_processors_oracle` board tool (the spike harness, kept).

**Scaling** (`parallel_processors_benchmark`, new; 3 s windows, pre-allocated reused destinations, aggregate conv/s; evidence-not-hard-gate per plan):

| Board | gpu_bound S(2) | gpu_bound S(4) | overhead S(4) |
|---|---|---|---|
| imx95 / Mali G310 | **2.00** | **2.05** | 1.52 |
| rpi5 / V3D | 1.16 | 1.16 | **2.24** |
| orin / Tegra | 1.08 | 1.17 | 0.25 † |
| imx8mp / Vivante (Full) | 1.03 | 1.04 | 0.94 (flat by design) |

† The one S(2)≤1 cell, explained and corroborated: Tegra's GPU context-switch cost (~0.45 ms) dominates degenerate sub-100 µs converts when two contexts are active; forcing `EDGEFIRST_GL_SERIALIZE=full` restores the cell to 0.83 (4914 vs 1483 conv/s), proving it driver scheduling rather than a HAL defect. Realistic converts scale positively on the same board; the override covers tiny-convert-heavy multi-processor deployments. DVFS note: governors clock up under parallel load, which can inflate cold-board S(2); within-run ratios are directionally valid.

**Suites**: post-change full suites **425/0 on all four boards** — imx95/rpi5/orin ran their entire suites under the new parallel default.

## Docs

ARCHITECTURE.md's "GL Command Serialization" section is now "GL Concurrency Model" (policy table, what stays serialized and why, the Vivante lifecycle-abort caveat no locking fixes, the measured scaling table, the Tegra characteristic); the optimization-guide row claiming concurrency "buys nothing" now documents the parallelism contract. CHANGELOG entry included.

Groundwork for PR-A (macOS GlPlatform seam), which extends the same model to macOS via per-processor ANGLE contexts.
