### PR TITLE
macOS CI lane hardening: publish results, GL canary, coverage visibility

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,8 +2,14 @@
 # Reference: https://nexte.st/book/configuration.html
 
 [profile.default]
-# JUnit XML output for CI test reporting
-junit.path = "target/nextest/default/test-results.xml"
+# JUnit XML output for CI test reporting. junit.path is relative to the
+# profile's STORE directory (target/nextest/default — or, under
+# cargo-llvm-cov, target/llvm-cov-target/nextest/default), so a bare
+# filename lands the report at <store>/test-results.xml. The previous
+# full-path value nested it at
+# target/nextest/default/target/nextest/default/test-results.xml, which
+# no CI publish step ever found.
+junit.path = "test-results.xml"
 junit.store-success-output = true
 junit.store-failure-output = true
 
@@ -17,6 +23,6 @@ retries = 1
 # CI profile with more retries and no fail-fast
 fail-fast = false
 retries = 2
-junit.path = "target/nextest/ci/test-results.xml"
+junit.path = "test-results.xml"
 junit.store-success-output = true
 junit.store-failure-output = true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -402,6 +402,19 @@ jobs:
           cd crates/capi/tests
           make test 2>&1 | tee ../../../target/test-metrics-capi-macos.txt
 
+      - name: Coverage summary (macOS)
+        # Tool-free per-lane visibility: overall lines plus the GL-engine
+        # slice (the number the GL-tests-on-ANGLE port moves), straight
+        # from the lcov into the job's step summary.
+        if: always()
+        run: |
+          if [[ -f target/coverage_rust.lcov ]]; then
+            awk -F: '/^LF:/{lf+=$2} /^LH:/{lh+=$2} END{ if (lf>0) printf "## Coverage (macOS lane)\nLines: %d / %d (%.1f%%)\n", lh, lf, 100*lh/lf }' \
+              target/coverage_rust.lcov >> "$GITHUB_STEP_SUMMARY"
+            awk -F'[:,]' '/^SF:.*crates\/image\/src\/gl\//{f=1} f&&/^LF:/{lf+=$2} f&&/^LH:/{lh+=$2} /^end_of_record/{f=0} END{ if (lf>0) printf "\nGL engine (crates/image/src/gl): %d / %d (%.1f%%)\n", lh, lf, 100*lh/lf }' \
+              target/coverage_rust.lcov >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -384,6 +384,11 @@ jobs:
         env:
           COVERAGE: "1"
           COV_LCOV: target/coverage_rust.lcov
+          # gl_backend_available_canary: fail this lane (instead of
+          # silently skipping every GL test) if the ANGLE stack above is
+          # broken. Enforced in coverage pass 2 only — pass 1 runs
+          # unsigned binaries with the dlopen gate closed by design.
+          HAL_TEST_REQUIRE_GL: "1"
         run: |
           ./scripts/test-macos.sh -j 1 \
             2>&1 | tee target/test-metrics-rust-macos.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,6 +433,7 @@ jobs:
           name: test-results-macos
           path: |
             target/nextest/default/test-results.xml
+            target/llvm-cov-target/nextest/default/test-results.xml
             target/test-metrics-*-macos.txt
           retention-days: 30
 
@@ -445,8 +446,12 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/macos@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2.23.0
         if: always()
         with:
+          # Under cargo-llvm-cov the nextest target dir is
+          # target/llvm-cov-target, so the junit lands there; the plain
+          # path covers COVERAGE=0 runs of test-macos.sh.
           files: |
             target/nextest/default/test-results.xml
+            target/llvm-cov-target/nextest/default/test-results.xml
           check_name: Test Results (macOS)
           comment_mode: always
           ignore_runs: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -418,6 +418,21 @@ jobs:
             target/test-metrics-*-macos.txt
           retention-days: 30
 
+      - name: Publish test results
+        # The `/macos` sub-action is the composite (Python) variant — the
+        # root action is docker-based and Linux-only. Same pinned hash.
+        # The coverage flow runs nextest twice and pass 2 (GL-enabled,
+        # signed binaries) overwrites pass 1's junit at the same path, so
+        # the published results are the GL-enabled run.
+        uses: EnricoMi/publish-unit-test-result-action/macos@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2.23.0
+        if: always()
+        with:
+          files: |
+            target/nextest/default/test-results.xml
+          check_name: Test Results (macOS)
+          comment_mode: always
+          ignore_runs: true
+
   # ===========================================================================
   # Software-GL coverage (Mesa llvmpipe)
   #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,6 +284,7 @@ jobs:
           path: |
             target/pytest_results.xml
             target/nextest/default/test-results.xml
+            target/llvm-cov-target/nextest/default/test-results.xml
             target/test-metrics-rust-x86_64.txt
             target/test-metrics-capi-x86_64.txt
             target/test-metrics-python-x86_64.txt
@@ -293,9 +294,15 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2.23.0
         if: always()
         with:
+          # Both nextest junit locations: plain runs use target/nextest,
+          # cargo-llvm-cov (make test-rust) relocates the store dir under
+          # target/llvm-cov-target. Until the nextest.toml junit.path fix
+          # the Rust junit landed at a nested path no step ever found —
+          # this check was silently pytest-only.
           files: |
             target/pytest_results.xml
             target/nextest/default/test-results.xml
+            target/llvm-cov-target/nextest/default/test-results.xml
           check_name: Test Results (x86_64)
           comment_mode: always
           ignore_runs: true

--- a/TESTING.md
+++ b/TESTING.md
@@ -761,7 +761,7 @@ Tests run across multiple runner types:
 |-----|--------|--------------|----------|
 | Build & Test (x86_64) | `ubuntu-22.04-xlarge` | x86_64 | No GPU |
 | Doc Tests | `ubuntu-22.04-xlarge` | x86_64 | No GPU |
-| Build & Test (macOS) | `macos-latest` | arm64 (Apple Silicon) | No GPU |
+| Build & Test (macOS) | `macos-latest` | arm64 (Apple Silicon) | Paravirtual Metal GPU (ANGLE; Full GL serialization policy) |
 | Build (aarch64) | `ubuntu-22.04-arm-xlarge` | aarch64 | No GPU (compile only) |
 | Test (aarch64) | `ubuntu-22.04-arm` | aarch64 | No GPU |
 | Hardware Test (imx8mp) | `nxp-imx8mp-latest` | aarch64 | G2D, DMA-heap |
@@ -771,6 +771,12 @@ The hardware runner (`nxp-imx8mp-latest`) is the only environment where
 G2D and DMA-BUF tests are fully exercised. Hardware-gated tests that
 return early on x86 and arm runners are counted as passed (not skipped)
 because the gate is an explicit probe, not a `#[ignore]` attribute.
+
+The x86_64, aarch64, and macOS lanes each publish a "Test Results (…)"
+check on the PR via `EnricoMi/publish-unit-test-result-action` (the
+macOS lane uses the `/macos` composite sub-action — the root action is
+docker-based and Linux-only). The macOS junit comes from coverage
+pass 2, i.e. the GL-enabled run on signed binaries.
 
 The x86_64 build steps moved to `ubuntu-22.04-xlarge` (16 vCPU) in the
 v0.22 → v0.23 cycle, cutting build time roughly 30 min → ~12 min.

--- a/TESTING.md
+++ b/TESTING.md
@@ -112,6 +112,18 @@ The helper builds with `--tests`, signs every binary in
 forwards remaining arguments to `cargo nextest run`. Re-running it is
 idempotent (signing the same binary twice is a no-op).
 
+### 3. CI guard against silent GL skips
+
+Every GL test self-skips when the backend is unavailable — correct for
+developer machines, but it means a broken CI GL stack (e.g. the ANGLE
+re-sign step regressing) would ship an untested GL backend behind a
+green lane. `gl_backend_available_canary` (crates/image lib tests)
+fails the run if `HAL_TEST_REQUIRE_GL=1` is set and
+`GLProcessorThreaded::new` errors. The macOS CI job sets it; local runs
+without the variable skip the canary trivially. On macOS the canary
+additionally requires `HAL_TEST_ALLOW_DLOPEN_ANGLE` so that coverage
+pass 1 (unsigned binaries) skips and pass 2 (signed) enforces.
+
 #### The manual way
 
 For one-off binaries (e.g. a release build of an example):

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -3599,6 +3599,39 @@ mod image_tests {
         }
     }
 
+    /// CI canary: fails the lane when the GL backend cannot initialize.
+    ///
+    /// Every GL test in this suite self-skips when the backend is
+    /// unavailable — correct for developer machines, but it means a broken
+    /// CI GL stack (e.g. the macOS ANGLE re-sign step regressing, the exact
+    /// failure mode documented in the workflow) ships an untested GL
+    /// backend behind a green lane. Gated on `HAL_TEST_REQUIRE_GL=1`, set
+    /// only by CI jobs that install a working GL stack; local runs without
+    /// one pass trivially. On macOS it additionally requires
+    /// `HAL_TEST_ALLOW_DLOPEN_ANGLE`, so coverage pass 1 (unsigned
+    /// binaries, dlopen gate closed) skips it and pass 2 (signed) enforces.
+    #[test]
+    #[cfg(feature = "opengl")]
+    fn gl_backend_available_canary() {
+        if std::env::var_os("HAL_TEST_REQUIRE_GL").is_none_or(|v| v != "1") {
+            eprintln!("SKIPPED: {} — HAL_TEST_REQUIRE_GL unset", function!());
+            return;
+        }
+        #[cfg(target_os = "macos")]
+        if std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+            eprintln!(
+                "SKIPPED: {} — ANGLE dlopen gate closed (coverage pass 1)",
+                function!()
+            );
+            return;
+        }
+        GLProcessorThreaded::new(None).expect(
+            "HAL_TEST_REQUIRE_GL=1 but the GL backend failed to initialize — \
+             check the ANGLE install/re-sign step and binary entitlements \
+             (macOS) or the EGL stack (Linux)",
+        );
+    }
+
     #[test]
     fn test_load_jpeg_with_exif() {
         use edgefirst_codec::peek_info;

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -3613,8 +3613,12 @@ mod image_tests {
     #[test]
     #[cfg(feature = "opengl")]
     fn gl_backend_available_canary() {
-        if std::env::var_os("HAL_TEST_REQUIRE_GL").is_none_or(|v| v != "1") {
-            eprintln!("SKIPPED: {} — HAL_TEST_REQUIRE_GL unset", function!());
+        let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+        if !require_gl {
+            eprintln!(
+                "SKIPPED: {} — HAL_TEST_REQUIRE_GL is not set to 1",
+                function!()
+            );
             return;
         }
         #[cfg(target_os = "macos")]

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -114,3 +114,7 @@ echo "-> Generating LCOV report -> ${COV_LCOV}"
 cargo llvm-cov report --lcov --output-path "${COV_LCOV}" \
     --ignore-filename-regex '(\.cargo|/rustc/|/target/)'
 echo "-> Coverage report written to ${COV_LCOV}"
+
+echo "-> Coverage summary (per-file table follows)"
+cargo llvm-cov report --summary-only \
+    --ignore-filename-regex '(\.cargo|/rustc/|/target/)'

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -115,6 +115,6 @@ cargo llvm-cov report --lcov --output-path "${COV_LCOV}" \
     --ignore-filename-regex '(\.cargo|/rustc/|/target/)'
 echo "-> Coverage report written to ${COV_LCOV}"
 
-echo "-> Coverage summary (per-file table follows)"
+echo "-> Overall coverage summary (per-file detail is in ${COV_LCOV})"
 cargo llvm-cov report --summary-only \
     --ignore-filename-regex '(\.cargo|/rustc/|/target/)'


### PR DESCRIPTION
First PR of the post-convergence hardening effort (macOS full coverage → SonarCloud quality → engine follow-ups). Three small, independent improvements to the macOS lane:

## 1. Publish macOS test results as a PR check (9b7eda5)

The lane uploaded its nextest junit but never published it — PRs showed Test Results checks for x86_64/aarch64 only. Mirrors the x86_64 publish step using the **`/macos` composite sub-action** (same pinned hash; the root action is docker-based and Linux-only). The published junit is coverage pass 2 — the GL-enabled run on signed binaries — so this check doubles as the visible test counter for the upcoming GL-tests-on-ANGLE port.

## 2. GL-availability canary (b856aa6)

Every GL test self-skips when the backend is unavailable. Correct locally, but it means a broken CI GL stack (the documented ANGLE re-sign failure mode: SIGKILL at dlopen, silent skips) ships an untested GL backend behind a green lane. `gl_backend_available_canary` fails the run when `HAL_TEST_REQUIRE_GL=1` (now set by the macOS job) and `GLProcessorThreaded::new` errors. On macOS it additionally requires `HAL_TEST_ALLOW_DLOPEN_ANGLE`, so coverage pass 1 (unsigned binaries by design) skips and pass 2 enforces. Not set on the software-gl lane (explicitly best-effort).

Verified locally: skips without the env, passes against live ANGLE with it. The negative leg (re-sign step removed ⇒ lane red at the canary, not green-with-skips) will be exercised with a follow-up draft PR on the actual runner.

## 3. Per-lane coverage visibility (2560b09)

`test-macos.sh` prints the cargo-llvm-cov summary table, and the job writes overall + `crates/image/src/gl/`-slice covered-line counts from the lcov into the step summary (tool-free awk, validated against a synthetic lcov). The GL slice is the exact number the test port moves — each phase gets a visible before/after.

## Gates

3 cfg lanes 0 warnings; native macOS suite 276/0 (275 + canary); `bash -n` on the script; no Linux behavior touched.