### PR TITLE
DO NOT MERGE: canary negative test (ANGLE re-sign disabled)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -402,6 +402,19 @@ jobs:
           cd crates/capi/tests
           make test 2>&1 | tee ../../../target/test-metrics-capi-macos.txt
 
+      - name: Coverage summary (macOS)
+        # Tool-free per-lane visibility: overall lines plus the GL-engine
+        # slice (the number the GL-tests-on-ANGLE port moves), straight
+        # from the lcov into the job's step summary.
+        if: always()
+        run: |
+          if [[ -f target/coverage_rust.lcov ]]; then
+            awk -F: '/^LF:/{lf+=$2} /^LH:/{lh+=$2} END{ if (lf>0) printf "## Coverage (macOS lane)\nLines: %d / %d (%.1f%%)\n", lh, lf, 100*lh/lf }' \
+              target/coverage_rust.lcov >> "$GITHUB_STEP_SUMMARY"
+            awk -F'[:,]' '/^SF:.*crates\/image\/src\/gl\//{f=1} f&&/^LF:/{lf+=$2} f&&/^LH:/{lh+=$2} /^end_of_record/{f=0} END{ if (lf>0) printf "\nGL engine (crates/image/src/gl): %d / %d (%.1f%%)\n", lh, lf, 100*lh/lf }' \
+              target/coverage_rust.lcov >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -384,6 +384,11 @@ jobs:
         env:
           COVERAGE: "1"
           COV_LCOV: target/coverage_rust.lcov
+          # gl_backend_available_canary: fail this lane (instead of
+          # silently skipping every GL test) if the ANGLE stack above is
+          # broken. Enforced in coverage pass 2 only — pass 1 runs
+          # unsigned binaries with the dlopen gate closed by design.
+          HAL_TEST_REQUIRE_GL: "1"
         run: |
           ./scripts/test-macos.sh -j 1 \
             2>&1 | tee target/test-metrics-rust-macos.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -433,6 +433,7 @@ jobs:
           name: test-results-macos
           path: |
             target/nextest/default/test-results.xml
+            target/llvm-cov-target/nextest/default/test-results.xml
             target/test-metrics-*-macos.txt
           retention-days: 30
 
@@ -445,8 +446,12 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/macos@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2.23.0
         if: always()
         with:
+          # Under cargo-llvm-cov the nextest target dir is
+          # target/llvm-cov-target, so the junit lands there; the plain
+          # path covers COVERAGE=0 runs of test-macos.sh.
           files: |
             target/nextest/default/test-results.xml
+            target/llvm-cov-target/nextest/default/test-results.xml
           check_name: Test Results (macOS)
           comment_mode: always
           ignore_runs: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -353,14 +353,12 @@ jobs:
         # test_yuyv_to_rgba_opengl_macos integration test silently
         # skips and the entire GL backend ships untested in CI.
         run: |
-          set -euxo pipefail
-          brew tap startergo/gn
-          brew tap startergo/angle
-          brew install startergo/angle/angle
-          ANGLE_DIR="$(brew --prefix angle)/lib"
-          codesign --force --sign - "$ANGLE_DIR/libEGL.dylib"
-          codesign --force --sign - "$ANGLE_DIR/libGLESv2.dylib"
-          echo "ANGLE installed at $ANGLE_DIR"
+          # NEGATIVE TEST (draft PR only — DO NOT MERGE): ANGLE install
+          # disabled entirely to prove gl_backend_available_canary turns
+          # this lane red instead of green-with-silent-GL-skips. (The
+          # earlier resign-only variant passed: macOS 15 runners do not
+          # enforce library validation on unsigned-ANGLE dlopen.)
+          echo "ANGLE deliberately NOT installed"
 
       - name: Run Clippy
         # Use default features only (no OpenCV, no Linux-specific hardware features)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -418,6 +418,21 @@ jobs:
             target/test-metrics-*-macos.txt
           retention-days: 30
 
+      - name: Publish test results
+        # The `/macos` sub-action is the composite (Python) variant — the
+        # root action is docker-based and Linux-only. Same pinned hash.
+        # The coverage flow runs nextest twice and pass 2 (GL-enabled,
+        # signed binaries) overwrites pass 1's junit at the same path, so
+        # the published results are the GL-enabled run.
+        uses: EnricoMi/publish-unit-test-result-action/macos@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2.23.0
+        if: always()
+        with:
+          files: |
+            target/nextest/default/test-results.xml
+          check_name: Test Results (macOS)
+          comment_mode: always
+          ignore_runs: true
+
   # ===========================================================================
   # Software-GL coverage (Mesa llvmpipe)
   #

--- a/TESTING.md
+++ b/TESTING.md
@@ -761,7 +761,7 @@ Tests run across multiple runner types:
 |-----|--------|--------------|----------|
 | Build & Test (x86_64) | `ubuntu-22.04-xlarge` | x86_64 | No GPU |
 | Doc Tests | `ubuntu-22.04-xlarge` | x86_64 | No GPU |
-| Build & Test (macOS) | `macos-latest` | arm64 (Apple Silicon) | No GPU |
+| Build & Test (macOS) | `macos-latest` | arm64 (Apple Silicon) | Paravirtual Metal GPU (ANGLE; Full GL serialization policy) |
 | Build (aarch64) | `ubuntu-22.04-arm-xlarge` | aarch64 | No GPU (compile only) |
 | Test (aarch64) | `ubuntu-22.04-arm` | aarch64 | No GPU |
 | Hardware Test (imx8mp) | `nxp-imx8mp-latest` | aarch64 | G2D, DMA-heap |
@@ -771,6 +771,12 @@ The hardware runner (`nxp-imx8mp-latest`) is the only environment where
 G2D and DMA-BUF tests are fully exercised. Hardware-gated tests that
 return early on x86 and arm runners are counted as passed (not skipped)
 because the gate is an explicit probe, not a `#[ignore]` attribute.
+
+The x86_64, aarch64, and macOS lanes each publish a "Test Results (…)"
+check on the PR via `EnricoMi/publish-unit-test-result-action` (the
+macOS lane uses the `/macos` composite sub-action — the root action is
+docker-based and Linux-only). The macOS junit comes from coverage
+pass 2, i.e. the GL-enabled run on signed binaries.
 
 The x86_64 build steps moved to `ubuntu-22.04-xlarge` (16 vCPU) in the
 v0.22 → v0.23 cycle, cutting build time roughly 30 min → ~12 min.

--- a/TESTING.md
+++ b/TESTING.md
@@ -112,6 +112,18 @@ The helper builds with `--tests`, signs every binary in
 forwards remaining arguments to `cargo nextest run`. Re-running it is
 idempotent (signing the same binary twice is a no-op).
 
+### 3. CI guard against silent GL skips
+
+Every GL test self-skips when the backend is unavailable — correct for
+developer machines, but it means a broken CI GL stack (e.g. the ANGLE
+re-sign step regressing) would ship an untested GL backend behind a
+green lane. `gl_backend_available_canary` (crates/image lib tests)
+fails the run if `HAL_TEST_REQUIRE_GL=1` is set and
+`GLProcessorThreaded::new` errors. The macOS CI job sets it; local runs
+without the variable skip the canary trivially. On macOS the canary
+additionally requires `HAL_TEST_ALLOW_DLOPEN_ANGLE` so that coverage
+pass 1 (unsigned binaries) skips and pass 2 (signed) enforces.
+
 #### The manual way
 
 For one-off binaries (e.g. a release build of an example):

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -3599,6 +3599,39 @@ mod image_tests {
         }
     }
 
+    /// CI canary: fails the lane when the GL backend cannot initialize.
+    ///
+    /// Every GL test in this suite self-skips when the backend is
+    /// unavailable — correct for developer machines, but it means a broken
+    /// CI GL stack (e.g. the macOS ANGLE re-sign step regressing, the exact
+    /// failure mode documented in the workflow) ships an untested GL
+    /// backend behind a green lane. Gated on `HAL_TEST_REQUIRE_GL=1`, set
+    /// only by CI jobs that install a working GL stack; local runs without
+    /// one pass trivially. On macOS it additionally requires
+    /// `HAL_TEST_ALLOW_DLOPEN_ANGLE`, so coverage pass 1 (unsigned
+    /// binaries, dlopen gate closed) skips it and pass 2 (signed) enforces.
+    #[test]
+    #[cfg(feature = "opengl")]
+    fn gl_backend_available_canary() {
+        if std::env::var_os("HAL_TEST_REQUIRE_GL").is_none_or(|v| v != "1") {
+            eprintln!("SKIPPED: {} — HAL_TEST_REQUIRE_GL unset", function!());
+            return;
+        }
+        #[cfg(target_os = "macos")]
+        if std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+            eprintln!(
+                "SKIPPED: {} — ANGLE dlopen gate closed (coverage pass 1)",
+                function!()
+            );
+            return;
+        }
+        GLProcessorThreaded::new(None).expect(
+            "HAL_TEST_REQUIRE_GL=1 but the GL backend failed to initialize — \
+             check the ANGLE install/re-sign step and binary entitlements \
+             (macOS) or the EGL stack (Linux)",
+        );
+    }
+
     #[test]
     fn test_load_jpeg_with_exif() {
         use edgefirst_codec::peek_info;

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -114,3 +114,7 @@ echo "-> Generating LCOV report -> ${COV_LCOV}"
 cargo llvm-cov report --lcov --output-path "${COV_LCOV}" \
     --ignore-filename-regex '(\.cargo|/rustc/|/target/)'
 echo "-> Coverage report written to ${COV_LCOV}"
+
+echo "-> Coverage summary (per-file table follows)"
+cargo llvm-cov report --summary-only \
+    --ignore-filename-regex '(\.cargo|/rustc/|/target/)'


### PR DESCRIPTION
Verifies PR #113's canary: with the ANGLE re-sign step disabled, the macOS lane must go **red at `gl_backend_available_canary`** (coverage pass 2) instead of green-with-silent-GL-skips. Will be closed once the lane result is recorded on #113.