### PR TITLE
Run gl/tests.rs on macOS/ANGLE: 58 engine tests ported in three phases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1260,6 +1260,18 @@ jobs:
             python3 .github/scripts/fix_coverage_paths.py "$xml" tests
           done
 
+          echo "=== Normalizing LCOV source paths to repo-relative ==="
+          # cargo-llvm-cov writes absolute SF: paths. The Linux lanes'
+          # /home/runner/work/hal/hal/... happen to match this scanner
+          # host's checkout, so they resolved by accident; the macOS
+          # lane's /Users/runner/work/hal/hal/... never did — its
+          # coverage (the only ANGLE/IOSurface GL coverage) was silently
+          # dropped by SonarCloud. Strip everything up to the repo root
+          # so every lane resolves identically, on any runner layout.
+          for lcov in $(find coverage/ -name "*.lcov" -type f); do
+            sed -i -E 's|^SF:.*/work/hal/hal/|SF:|' "$lcov"
+          done
+
           RUST_REPORTS=$(find coverage/ -name "*.lcov" | tr '\n' ',' | sed 's/,$//')
           PYTHON_REPORTS=$(find coverage/ -name "coverage_python.xml" | tr '\n' ',' | sed 's/,$//')
 

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -76,6 +76,24 @@ returns early if it returns `false`. This keeps the suite green on developer
 machines without GPU hardware while still exercising the full hardware path
 on target boards and CI runners.
 
+The module runs on **both Linux and macOS/ANGLE** in three tiers, selected
+by per-item `cfg` gates:
+
+| Tier | Gate | Contents |
+|------|------|----------|
+| Portable | none | mask/segmentation/box render, proto suite, src_rect crops, decision tables, F16 zero-copy roundtrip |
+| Zero-copy | `feature = "dma_test_formats"` | `@Dma` fixtures that allocate on both platforms (RGBA/BGRA/GREY/NV*/YUYV — DMA-BUF on Linux, IOSurface on macOS): pool/recycle/steady-state, NV12/YUYV references, subview no-aliasing |
+| Linux-only | `cfg(target_os = "linux")` (± the feature) | display probing, PBO/CUDA destinations, packed-RGB `@Dma` (no IOSurface FourCC), multi-plane fd imports, Neutron scenarios, NV path-selection asserts |
+
+The zero-copy tier probes `is_gpu_image_buffer_available()`
+(`edgefirst_tensor::is_gpu_buffer_available`) instead of the Linux-flavored
+`is_dma_available()`. **Acceptance bar for newly ported tests:** green under
+`EDGEFIRST_GL_SERIALIZE=full` — GitHub's macOS runners expose a
+paravirtualized Metal GPU that takes the Full serialization policy.
+`scripts/test-macos.sh` enables `dma_test_formats` so the macOS lane runs
+the first two tiers; the feature set must stay identical across its
+coverage passes (see the script comment).
+
 The Neutron-scenario tests gate on `/dev/neutron0` as a platform
 discriminator for i.MX 95 with Mali GPU. This device node indicates that
 large-offset DMA-BUF EGLImage imports are supported — these fail with

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -82,8 +82,8 @@ by per-item `cfg` gates:
 | Tier | Gate | Contents |
 |------|------|----------|
 | Portable | none | mask/segmentation/box render, proto suite, src_rect crops, decision tables, F16 zero-copy roundtrip |
-| Zero-copy | `feature = "dma_test_formats"` | `@Dma` fixtures that allocate on both platforms (RGBA/BGRA/GREY/NV*/YUYV — DMA-BUF on Linux, IOSurface on macOS): pool/recycle/steady-state, NV12/YUYV references, subview no-aliasing |
-| Linux-only | `cfg(target_os = "linux")` (± the feature) | display probing, PBO/CUDA destinations, packed-RGB `@Dma` (no IOSurface FourCC), multi-plane fd imports, Neutron scenarios, NV path-selection asserts |
+| Zero-copy | `feature = "dma_test_formats"` | `@Dma` fixtures that allocate on both platforms (RGBA/BGRA/GREY/NV*/YUYV — DMA-BUF on Linux, IOSurface on macOS): pool/recycle/steady-state, NV12/YUYV references, subview no-aliasing, NV16/NV24 Path-B oracles, odd-geometry `g01–g06`/grey/64×64 GPU-vs-CPU oracles |
+| Linux-only | `cfg(target_os = "linux")` (± the feature) | display probing, PBO/CUDA destinations, packed-RGB `@Dma` incl. the int8 odd-geometry oracles (no IOSurface FourCC for 3-byte RGB), DMA stride guards, multi-plane fd imports, Neutron scenarios, NV path-selection asserts and divergence probes |
 
 The zero-copy tier probes `is_gpu_image_buffer_available()`
 (`edgefirst_tensor::is_gpu_buffer_available`) instead of the Linux-flavored

--- a/crates/image/src/gl/mod.rs
+++ b/crates/image/src/gl/mod.rs
@@ -71,12 +71,12 @@ mod processor;
 mod resources;
 mod shaders;
 mod shaders_common;
-// Engine GL tests: written against the Linux display probe + dma_test
-// helpers (112 platform-specific references). macOS engine coverage
-// lives in lib.rs (oracles, parallel correctness, fused F16, cache
-// gates); porting this file's mask/proto/batch sections to run on
-// ANGLE is a tracked follow-up.
-#[cfg(target_os = "linux")]
+// Engine GL tests, in three tiers (see crates/image/TESTING.md):
+//   portable                       — run on Linux AND macOS/ANGLE
+//   cfg(target_os = "linux")       — display probing, PBO/CUDA paths
+//   cfg(all(linux, dma_test_formats)) — DMA-BUF import/pool specifics
+// Per-item cfg gates inside the module select the tier; the mount
+// itself is unconditional so the macOS lane runs the portable tier.
 mod tests;
 mod threaded;
 

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -740,6 +740,63 @@ struct GlSupport {
     supports_f16_color: bool,
 }
 
+/// `glReadPixels` the bound read-framebuffer into `out`, honoring the ES 3
+/// guarantee: only `RGBA`/`UNSIGNED_BYTE` plus ONE implementation-defined
+/// pair are accepted. Mesa and the embedded drivers take `RGB`/`RED`
+/// directly; ANGLE/Metal (and V3D) reject them with `GL_INVALID_OPERATION`.
+/// When the direct read is unsupported, read an RGBA scratch and repack the
+/// leading channels (the FBO attachment has the destination's channel
+/// layout, so RGB keeps rgb, RED keeps r).
+///
+/// Plain `glReadPixels`, NOT `glReadnPixels`: the robust variant is an
+/// ES 3.2 entry point and ANGLE/Metal (ES 3.0 max) rejects it at
+/// validation. `out` is at least `w*h*channels` bytes and reads are tightly
+/// packed (`PACK_ALIGNMENT=1` at init), so the bounds the robust variant
+/// checked hold by construction.
+///
+/// # Safety
+/// Must run on the GL thread with a complete read framebuffer bound and
+/// `ReadBuffer` selected.
+unsafe fn read_pixels_into(w: usize, h: usize, format: u32, out: &mut [u8]) {
+    let direct = format == gls::gl::RGBA || {
+        let mut impl_fmt = 0i32;
+        let mut impl_type = 0i32;
+        gls::gl::GetIntegerv(gls::gl::IMPLEMENTATION_COLOR_READ_FORMAT, &mut impl_fmt);
+        gls::gl::GetIntegerv(gls::gl::IMPLEMENTATION_COLOR_READ_TYPE, &mut impl_type);
+        impl_fmt as u32 == format && impl_type as u32 == gls::gl::UNSIGNED_BYTE
+    };
+    if direct {
+        gls::gl::ReadPixels(
+            0,
+            0,
+            w as i32,
+            h as i32,
+            format,
+            gls::gl::UNSIGNED_BYTE,
+            out.as_mut_ptr() as *mut c_void,
+        );
+        return;
+    }
+    let channels = match format {
+        gls::gl::RGB => 3,
+        gls::gl::RED => 1,
+        _ => 4,
+    };
+    let mut scratch = vec![0u8; w * h * 4];
+    gls::gl::ReadPixels(
+        0,
+        0,
+        w as i32,
+        h as i32,
+        gls::gl::RGBA,
+        gls::gl::UNSIGNED_BYTE,
+        scratch.as_mut_ptr() as *mut c_void,
+    );
+    for (px, dst_px) in scratch.chunks_exact(4).zip(out.chunks_exact_mut(channels)) {
+        dst_px.copy_from_slice(&px[..channels]);
+    }
+}
+
 /// Classify a GL_RENDERER string into driver-policy traits. Pure —
 /// unit-testable without a GL context.
 fn classify_renderer(renderer: &str) -> RendererTraits {
@@ -1703,15 +1760,7 @@ impl GLProcessorST {
                 let mut dst_map = dst.map()?;
                 unsafe {
                     gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
-                    gls::gl::ReadPixels(
-                        0,
-                        0,
-                        dst_w as i32,
-                        dst_h as i32,
-                        format,
-                        gls::gl::UNSIGNED_BYTE,
-                        dst_map.as_mut_ptr() as *mut c_void,
-                    );
+                    read_pixels_into(dst_w, dst_h, format, dst_map.as_mut_slice());
                 }
                 check_gl_error(function!(), line!())?;
                 if dst_fmt == PixelFormat::Bgra {
@@ -1889,15 +1938,7 @@ impl GLProcessorST {
                 let mut dst_map = dst.map()?;
                 unsafe {
                     gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
-                    gls::gl::ReadPixels(
-                        0,
-                        0,
-                        dst_w as i32,
-                        dst_h as i32,
-                        format,
-                        gls::gl::UNSIGNED_BYTE,
-                        dst_map.as_mut_ptr() as *mut c_void,
-                    );
+                    read_pixels_into(dst_w, dst_h, format, dst_map.as_mut_slice());
                 }
                 check_gl_error(function!(), line!())?;
                 if dst_fmt == PixelFormat::Bgra {
@@ -2367,26 +2408,12 @@ impl GLProcessorST {
                 )))
             }
         };
-        // Plain `glReadPixels`, NOT `glReadnPixels`: the robust variant is an
-        // ES 3.2 entry point and ANGLE/Metal (ES 3.0 max) rejects it with
-        // GL_INVALID_OPERATION at validation, before any parameter is looked
-        // at. The destination is always at least `dst.len()` bytes and the
-        // read is tightly packed (PACK_ALIGNMENT=1 at init), so the bounds
-        // the robust variant checked hold by construction.
         let len = dst.len();
         match pbo_id {
             None => unsafe {
                 let mut dst_map = dst.map()?;
                 gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
-                gls::gl::ReadPixels(
-                    0,
-                    0,
-                    dst_w as i32,
-                    dst_h as i32,
-                    dest_format,
-                    gls::gl::UNSIGNED_BYTE,
-                    dst_map.as_mut_ptr() as *mut c_void,
-                );
+                read_pixels_into(dst_w, dst_h, dest_format, dst_map.as_mut_slice());
                 if dst_fmt == PixelFormat::Bgra {
                     for chunk in dst_map.as_mut_slice().chunks_exact_mut(4) {
                         chunk.swap(0, 2);

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -275,6 +275,10 @@ pub struct GLProcessorST {
     dst_egl_cache: ImportCache<PlatformImport>,
     /// Whether the BGRA byte-swap workaround warning has been logged.
     bgra_warned: bool,
+    /// Reusable RGBA staging buffer for `read_pixels_into`'s fallback path
+    /// (drivers whose implementation read-pair rejects direct RGB/RED
+    /// reads — ANGLE/Metal, V3D). Grown on demand, kept at high-water mark.
+    readback_scratch: Vec<u8>,
     /// Whether the GPU is a Verisilicon/Vivante core (detected via GL_RENDERER).
     /// Used to block operations known to cause unrecoverable GPU hangs.
     pub(super) is_vivante: bool,
@@ -769,7 +773,12 @@ struct GlSupport {
 /// # Safety
 /// Must run on the GL thread with a complete read framebuffer bound and
 /// `ReadBuffer` selected.
-unsafe fn read_pixels_into(w: usize, h: usize, format: u32, out: &mut [u8]) {
+///
+/// `scratch` is the caller's reusable RGBA staging buffer
+/// (`GLProcessorST::readback_scratch`) — grown on demand and kept at its
+/// high-water mark, so the fallback path costs no per-call allocation
+/// after the first read of a given size.
+unsafe fn read_pixels_into(w: usize, h: usize, format: u32, scratch: &mut Vec<u8>, out: &mut [u8]) {
     let direct = format == gls::gl::RGBA || {
         let mut impl_fmt = 0i32;
         let mut impl_type = 0i32;
@@ -794,7 +803,9 @@ unsafe fn read_pixels_into(w: usize, h: usize, format: u32, out: &mut [u8]) {
         gls::gl::RED => 1,
         _ => 4,
     };
-    let mut scratch = vec![0u8; w * h * 4];
+    if scratch.len() < w * h * 4 {
+        scratch.resize(w * h * 4, 0);
+    }
     gls::gl::ReadPixels(
         0,
         0,
@@ -1166,6 +1177,7 @@ impl GLProcessorST {
             src_egl_cache: ImportCache::new(egl_cache_capacity),
             dst_egl_cache: ImportCache::new(egl_cache_capacity),
             bgra_warned: false,
+            readback_scratch: Vec::new(),
             is_vivante,
             is_virtual_gpu,
             use_renderbuffer: std::env::var("EDGEFIRST_OPENGL_RENDERSURFACE")
@@ -1772,7 +1784,13 @@ impl GLProcessorST {
                 let mut dst_map = dst.map()?;
                 unsafe {
                     gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
-                    read_pixels_into(dst_w, dst_h, format, dst_map.as_mut_slice());
+                    read_pixels_into(
+                        dst_w,
+                        dst_h,
+                        format,
+                        &mut self.readback_scratch,
+                        dst_map.as_mut_slice(),
+                    );
                 }
                 check_gl_error(function!(), line!())?;
                 if dst_fmt == PixelFormat::Bgra {
@@ -1950,7 +1968,13 @@ impl GLProcessorST {
                 let mut dst_map = dst.map()?;
                 unsafe {
                     gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
-                    read_pixels_into(dst_w, dst_h, format, dst_map.as_mut_slice());
+                    read_pixels_into(
+                        dst_w,
+                        dst_h,
+                        format,
+                        &mut self.readback_scratch,
+                        dst_map.as_mut_slice(),
+                    );
                 }
                 check_gl_error(function!(), line!())?;
                 if dst_fmt == PixelFormat::Bgra {
@@ -2403,7 +2427,7 @@ impl GLProcessorST {
     /// completes. The converged readback shared by the non-DMA and any-to-PBO
     /// paths — they differ only in this target selector.
     fn readback_rendered(
-        &self,
+        &mut self,
         dst: &mut Tensor<u8>,
         dst_fmt: PixelFormat,
         pbo_id: Option<u32>,
@@ -2425,7 +2449,13 @@ impl GLProcessorST {
             None => unsafe {
                 let mut dst_map = dst.map()?;
                 gls::gl::ReadBuffer(gls::gl::COLOR_ATTACHMENT0);
-                read_pixels_into(dst_w, dst_h, dest_format, dst_map.as_mut_slice());
+                read_pixels_into(
+                    dst_w,
+                    dst_h,
+                    dest_format,
+                    &mut self.readback_scratch,
+                    dst_map.as_mut_slice(),
+                );
                 if dst_fmt == PixelFormat::Bgra {
                     for chunk in dst_map.as_mut_slice().chunks_exact_mut(4) {
                         chunk.swap(0, 2);

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -23,7 +23,19 @@ type PlatformImport = <Platform as GlPlatform>::Import;
 /// The `Copy` import handle (`egl::Image` / `egl::Surface`).
 type PlatformHandle = <Platform as GlPlatform>::ImportHandle;
 use super::resources::{Buffer, FrameBuffer, GlProgram, Texture};
-use super::shaders::*;
+use super::shaders::{
+    check_gl_error, generate_color_shader, generate_instanced_segmentation_shader,
+    generate_nv_to_rgba_int8_shader_2d, generate_nv_to_rgba_shader_2d,
+    generate_packed_f32_nhwc_shader, generate_packed_rgba8_int8_shader_2d,
+    generate_packed_rgba8_shader_2d, generate_planar_rgb_f16_packed_shader,
+    generate_planar_rgb_int8_shader, generate_planar_rgb_int8_shader_2d,
+    generate_planar_rgb_shader, generate_planar_rgb_shader_2d, generate_proto_dequant_shader_int8,
+    generate_proto_repack_compute_shader, generate_proto_segmentation_shader,
+    generate_proto_segmentation_shader_f32, generate_proto_segmentation_shader_int8_bilinear,
+    generate_proto_segmentation_shader_int8_nearest, generate_segmentation_shader,
+    generate_texture_fragment_shader, generate_texture_fragment_shader_yuv,
+    generate_texture_int8_shader, generate_texture_int8_shader_yuv, generate_vertex_shader,
+};
 use super::{Int8InterpolationMode, RegionOfInterest, TransferBackend};
 use crate::{Crop, Error, Flip, ImageProcessorTrait, ResolvedCrop, Rotation, DEFAULT_COLORS};
 use edgefirst_tensor::TensorDyn;

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -5,13 +5,13 @@
 #[cfg(feature = "opengl")]
 #[allow(deprecated)]
 mod gl_tests {
-    #[cfg(feature = "dma_test_formats")]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     use crate::opengl_headless::processor::GLProcessorST;
     #[cfg(target_os = "linux")]
     use crate::{probe_egl_displays, EglDisplayKind};
     use crate::{Crop, Flip, GLProcessorThreaded, ImageProcessorTrait, Rotation};
     use edgefirst_decoder::{DetectBox, ProtoData, ProtoLayout};
-    #[cfg(feature = "dma_test_formats")]
+    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     use edgefirst_tensor::is_dma_available;
     use edgefirst_tensor::{
         DType, PixelFormat, Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait,
@@ -223,6 +223,16 @@ mod gl_tests {
         *GL_AVAILABLE.get_or_init(|| GLProcessorThreaded::new(None).is_ok())
     }
 
+    /// Zero-copy GPU image buffers available? DMA-BUF heaps on Linux,
+    /// IOSurface on macOS. The portable seam for tests whose `@Dma`
+    /// fixtures allocate on both platforms (RGBA/BGRA/GREY/NV*/YUYV);
+    /// packed-RGB `@Dma` has no IOSurface FourCC, so tests with RGB DMA
+    /// destinations stay Linux-gated.
+    #[cfg(feature = "dma_test_formats")]
+    fn is_gpu_image_buffer_available() -> bool {
+        edgefirst_tensor::is_gpu_buffer_available()
+    }
+
     /// Returns true when running on an i.MX 95 board with Mali GPU.
     ///
     /// `/dev/neutron0` is used as a platform discriminator for i.MX 95 + Mali GPU,
@@ -364,10 +374,10 @@ mod gl_tests {
     /// behavior across GL refactors: a refactor that re-imports per frame
     /// passes every pixel-equality test but fails this one.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_pool_steady_state_zero_imports() {
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
@@ -439,6 +449,8 @@ mod gl_tests {
     /// byte-identical output across iterations, so any texture-unit state leak
     /// between converts surfaces either as an error or as a pixel diff.
     #[test]
+    // Stays Linux-gated: packed-RGB @Dma destinations have no IOSurface
+    // FourCC, so the fixture cannot allocate on macOS.
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn repeat_convert_rgba_mem_to_rgb_dma() {
         if !is_dma_available() {
@@ -536,7 +548,7 @@ mod gl_tests {
     /// whose coverage lane enables the feature); the `dma_test_formats`
     /// gate only matches the `load_raw_image` helper's.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn int8_mem_convert_is_xor_biased_u8() {
         if !is_opengl_available() {
             eprintln!("SKIPPED: {} - OpenGL not available", function!());
@@ -628,10 +640,10 @@ mod gl_tests {
 
     /// Test OpenGL PixelFormat::Nv12→PixelFormat::Rgba conversion against ffmpeg reference
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn test_opengl_nv12_to_rgba_reference() {
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         // Load PixelFormat::Nv12 source with DMA
@@ -693,10 +705,10 @@ mod gl_tests {
 
     /// Test OpenGL PixelFormat::Yuyv→PixelFormat::Rgba conversion against ffmpeg reference
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn test_opengl_yuyv_to_rgba_reference() {
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         // Load PixelFormat::Yuyv source with DMA
@@ -768,10 +780,13 @@ mod gl_tests {
     /// exact failure that capped batched render-to-DMA-BUF. With the fix each
     /// offset gets its own EGLImage and the buffer is correctly partitioned.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn opengl_render_into_dma_subviews_no_aliasing() {
-        if !is_dma_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+        if !is_gpu_image_buffer_available() || !is_opengl_available() {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            );
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -876,7 +891,7 @@ mod gl_tests {
 
     /// Overwrite an existing tensor's bytes in place (re-map → copy → drop →
     /// DMA_BUF_IOCTL_SYNC(END)), simulating a pool recycle of one buffer.
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn overwrite_in_place(t: &TensorDyn, bytes: &[u8]) {
         let mut map = t.as_u8().unwrap().map().unwrap();
         map.as_mut_slice()[..bytes.len()].copy_from_slice(bytes);
@@ -885,7 +900,7 @@ mod gl_tests {
     /// Write image A into a DMA source, convert, then overwrite the SAME source
     /// with distinct image B and convert again on the SAME processor. Assert the
     /// second output matches a fresh-DMA-source convert of B (no stale read).
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_stale_read_check(
         w: usize,
         h: usize,
@@ -937,10 +952,13 @@ mod gl_tests {
     /// Grey source (profiler's decode-pool format; EXTERNAL_OES Path A).
     /// Grey→Rgba is a scalar luma replicate (no YUV matrix) → byte-exact.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_grey_stale_read() {
-        if !is_dma_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+        if !is_gpu_image_buffer_available() || !is_opengl_available() {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            );
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -957,10 +975,13 @@ mod gl_tests {
     /// NV12 source (EXTERNAL_OES Path A on Vivante / R8 texelFetch Path B on
     /// V3D/Mali). YUV→Rgba carries a small color-matrix rounding → tolerance 4.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_nv12_stale_read() {
-        if !is_dma_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+        if !is_gpu_image_buffer_available() || !is_opengl_available() {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            );
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -974,10 +995,13 @@ mod gl_tests {
 
     /// NV16 source (full-res chroma; R8 texelFetch Path B). tolerance 4.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_nv16_stale_read() {
-        if !is_dma_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+        if !is_gpu_image_buffer_available() || !is_opengl_available() {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            );
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -994,10 +1018,13 @@ mod gl_tests {
     /// the same frame. Exercises the cache/LRU interaction across more than one
     /// recycled identity.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_pool_recycle_all_frames_match_oracle() {
-        if !is_dma_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+        if !is_gpu_image_buffer_available() || !is_opengl_available() {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            );
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1046,7 +1073,7 @@ mod gl_tests {
     /// tensor's effective row stride. Non-uniform content is essential: a solid
     /// fill survives any stride/geometry misread, so it could not detect the
     /// cache-key bug.
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn fill_grey_pattern(t: &TensorDyn, w: usize, h: usize, salt: u8) {
         let stride = t.effective_row_stride().unwrap_or(w);
         let mut map = t.as_u8().unwrap().map().unwrap();
@@ -1067,10 +1094,13 @@ mod gl_tests {
     /// stride and samples the buffer at the wrong pitch → mismatch. This test
     /// FAILS on buggy main and passes once the cache key carries geometry.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_geometry_change_stale_read() {
-        if !is_dma_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+        if !is_gpu_image_buffer_available() || !is_opengl_available() {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            );
             return;
         }
         // Oversized pool (like the profiler's pool_w x 3*max_h R8 surface),
@@ -1133,10 +1163,13 @@ mod gl_tests {
     /// (buffer, geometry) has its own entry, so interleaving is order-
     /// independent and every output must match its fresh-source oracle.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_pool_geometry_interleaved_stale_read() {
-        if !is_dma_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+        if !is_gpu_image_buffer_available() || !is_opengl_available() {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            );
             return;
         }
         let mut pool = [
@@ -1200,10 +1233,13 @@ mod gl_tests {
     /// Regression guard: a single-shot (non-recycled) DMA source must equal a
     /// fresh-source convert — the fix must not break the first-frame path.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn dma_single_shot_grey_matches_fresh() {
-        if !is_dma_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - DMA or OpenGL not available", function!());
+        if !is_gpu_image_buffer_available() || !is_opengl_available() {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            );
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1551,6 +1587,8 @@ mod gl_tests {
     /// PixelFormat::Yuyv 1080p → PixelFormat::Rgb 640x640 with letterbox (two-pass packed PixelFormat::Rgb pipeline).
     /// Compares GL PixelFormat::Rgba (alpha-stripped) against GL packed PixelFormat::Rgb to validate packing.
     #[test]
+    // Stays Linux-gated: packed-RGB @Dma destinations have no IOSurface
+    // FourCC, so the fixture cannot allocate on macOS.
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_opengl_rgb_correctness() {
         if !is_dma_available() {
@@ -1681,6 +1719,8 @@ mod gl_tests {
     /// PixelFormat::Yuyv 1080p → PixelFormat::Rgb 1920x1080 (no letterbox, same size).
     /// Compares GL PixelFormat::Rgba (alpha-stripped) against GL packed PixelFormat::Rgb without scaling.
     #[test]
+    // Stays Linux-gated: packed-RGB @Dma destinations have no IOSurface
+    // FourCC, so the fixture cannot allocate on macOS.
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_opengl_rgb_no_letterbox_correctness() {
         if !is_dma_available() {
@@ -1747,10 +1787,10 @@ mod gl_tests {
     /// Test OpenGL PixelFormat::Nv12→PixelFormat::Bgra conversion with DMA buffers.
     /// Compares against PixelFormat::Nv12→PixelFormat::Rgba by verifying R↔B swap.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn test_opengl_nv12_to_bgra() {
-        if !is_dma_available() {
-            eprintln!("SKIPPED: test_opengl_nv12_to_bgra - DMA not available");
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: test_opengl_nv12_to_bgra - no zero-copy GPU buffers");
             return;
         }
 
@@ -1827,10 +1867,10 @@ mod gl_tests {
 
     /// Test OpenGL PixelFormat::Yuyv→PixelFormat::Bgra conversion with DMA buffers.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn test_opengl_yuyv_to_bgra() {
-        if !is_dma_available() {
-            eprintln!("SKIPPED: test_opengl_yuyv_to_bgra - DMA not available");
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: test_opengl_yuyv_to_bgra - no zero-copy GPU buffers");
             return;
         }
 

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -7,10 +7,9 @@
 mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     use crate::opengl_headless::processor::GLProcessorST;
-    use crate::{
-        probe_egl_displays, Crop, EglDisplayKind, Flip, GLProcessorThreaded, ImageProcessorTrait,
-        Rotation,
-    };
+    #[cfg(target_os = "linux")]
+    use crate::{probe_egl_displays, EglDisplayKind};
+    use crate::{Crop, Flip, GLProcessorThreaded, ImageProcessorTrait, Rotation};
     use edgefirst_decoder::{DetectBox, ProtoData, ProtoLayout};
     #[cfg(feature = "dma_test_formats")]
     use edgefirst_tensor::is_dma_available;
@@ -217,15 +216,11 @@ mod gl_tests {
     static NEUTRON_AVAILABLE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 
     fn is_opengl_available() -> bool {
-        #[cfg(all(target_os = "linux", feature = "opengl"))]
-        {
-            *GL_AVAILABLE.get_or_init(|| GLProcessorThreaded::new(None).is_ok())
-        }
-
-        #[cfg(not(all(target_os = "linux", feature = "opengl")))]
-        {
-            false
-        }
+        // Portable: the unified engine runs on Linux (EGL/DMA-BUF) and
+        // macOS (ANGLE/IOSurface). On the macOS coverage flow this returns
+        // false in pass 1 (unsigned binaries, ANGLE dlopen gate closed) so
+        // the GL tests self-skip there and execute in pass 2.
+        *GL_AVAILABLE.get_or_init(|| GLProcessorThreaded::new(None).is_ok())
     }
 
     /// Returns true when running on an i.MX 95 board with Mali GPU.
@@ -1246,6 +1241,7 @@ mod gl_tests {
     /// available. Default requires a running compositor (Wayland/X11) and
     /// may not be present on headless targets.
     #[test]
+    #[cfg(target_os = "linux")] // Linux display probing
     fn test_probe_egl_displays() {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
@@ -1288,6 +1284,7 @@ mod gl_tests {
     /// that a subsequent GLProcessorThreaded::new() reuses it without
     /// deadlocking.
     #[test]
+    #[cfg(target_os = "linux")] // Linux display probing
     fn test_probe_then_create_gl_context() {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
@@ -1354,6 +1351,7 @@ mod gl_tests {
     /// GLProcessorThreaded::new(Some(kind)) succeeds and produces a working
     /// converter.
     #[test]
+    #[cfg(target_os = "linux")] // Linux display probing
     fn test_override_each_display_kind() {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
@@ -1406,6 +1404,7 @@ mod gl_tests {
     /// Validate that requesting a display kind that doesn't exist on the
     /// system returns an error rather than falling back silently.
     #[test]
+    #[cfg(target_os = "linux")] // Linux display probing
     fn test_override_unavailable_display_errors() {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
@@ -1445,6 +1444,7 @@ mod gl_tests {
     /// Validate that auto-detection (None) still works — this is the existing
     /// default behaviour and must not regress.
     #[test]
+    #[cfg(target_os = "linux")] // Linux display probing
     fn test_auto_detect_display() {
         if !is_opengl_available() {
             eprintln!("SKIPPED: {} - OpenGL not available", function!());
@@ -2101,6 +2101,7 @@ mod gl_tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")] // PBO destinations are Linux-only
     fn test_gl_pbo_destination_smoke() {
         if !is_opengl_available() {
             eprintln!("SKIPPED: {} - OpenGL not available", function!());
@@ -2134,6 +2135,7 @@ mod gl_tests {
     /// deadlock returned. A successful return proves the round-trip
     /// completed.
     #[test]
+    #[cfg(target_os = "linux")] // PBO destinations are Linux-only
     fn test_gl_convert_any_to_pbo_no_deadlock() {
         if !is_opengl_available() {
             eprintln!("SKIPPED: {} - OpenGL not available", function!());
@@ -2197,6 +2199,7 @@ mod gl_tests {
     /// underlying defect as `convert_any_to_pbo`; both sites were patched
     /// in commit c494fae and both need explicit coverage.
     #[test]
+    #[cfg(target_os = "linux")] // PBO destinations are Linux-only
     fn test_gl_convert_pbo_to_pbo_no_deadlock() {
         if !is_opengl_available() {
             eprintln!("SKIPPED: {} - OpenGL not available", function!());
@@ -4891,6 +4894,7 @@ mod gl_tests {
     /// Runs only where image allocation resolves to PBO (Orin / PBO-transfer
     /// targets); skipped elsewhere.
     #[test]
+    #[cfg(target_os = "linux")] // PBO destinations are Linux-only
     fn pbo_int8_letterbox_matches_mem_oracle() {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
@@ -4988,6 +4992,7 @@ mod gl_tests {
     /// genuinely exercises `convert_float_to_pbo`. Uses an identity crop so
     /// the expected values are exact: `dst[y,x,c] == src[y,x,c] / 255`.
     #[test]
+    #[cfg(target_os = "linux")] // PBO destinations are Linux-only
     fn convert_f32_nhwc_pbo_roundtrip() {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
@@ -5089,6 +5094,7 @@ mod gl_tests {
     /// distinct from NEAREST (which would land on a single integer texel,
     /// `2*dx * 16`), so the test discriminates bilinear vs NEAREST sampling.
     #[test]
+    #[cfg(target_os = "linux")] // PBO destinations are Linux-only
     fn convert_f32_nhwc_pbo_resize_bilinear() {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
@@ -5184,6 +5190,7 @@ mod gl_tests {
     /// crop so `dst[c,y,x] == src[y,x,c] / 255` within one f16 ULP at 1.0
     /// (`2^-8`).
     #[test]
+    #[cfg(target_os = "linux")] // PBO destinations are Linux-only
     fn convert_f16_nchw_pbo_roundtrip() {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
         use half::f16;
@@ -5419,6 +5426,7 @@ mod gl_tests {
     ///   content (exact normalization is GPU-dependent; we just need non-zero
     ///   and in-range)
     #[test]
+    #[cfg(target_os = "linux")] // PBO destinations are Linux-only
     fn convert_f32_pbo_letterbox_pad_color() {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
@@ -5524,6 +5532,7 @@ mod gl_tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")] // CUDA interop is Tegra/Linux-only
     fn convert_f32_pbo_cuda_map_roundtrip() {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
@@ -5602,6 +5611,7 @@ mod gl_tests {
     /// `src[y,x,c] / 255.0` within 1e-3. Uses a 16×16 identity crop so the
     /// expected values are exact (no bilinear rounding).
     #[test]
+    #[cfg(target_os = "linux")] // CUDA interop is Tegra/Linux-only
     fn convert_f32_pbo_cuda_map_numeric() {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
         use std::ffi::c_void;

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -5917,7 +5917,7 @@ mod gl_tests {
     ///
     /// Matches the coefficient set used in both the CPU kernels and the
     /// `generate_nv_to_rgba_shader_2d` shader (and the macOS `NV_TO_RGBA_FRAGMENT`).
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn yuv601_to_rgb(y: u8, cb: u8, cr: u8) -> [u8; 3] {
         let yf = y as f32 / 255.0;
         let up = cb as f32 / 255.0 - 128.0 / 255.0;
@@ -5935,7 +5935,7 @@ mod gl_tests {
     /// Build a solid-colour NV16 (4:2:2) buffer of dimensions `(w, h)`.
     ///
     /// Layout: `[H rows of Y][H rows of interleaved CbCr]` (contiguous, width-aligned).
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn make_nv16_solid(w: usize, h: usize, y: u8, cb: u8, cr: u8) -> Vec<u8> {
         let y_plane = vec![y; w * h];
         // NV16: H rows of UV, each row has w/2 pairs → w bytes/row.
@@ -5946,7 +5946,7 @@ mod gl_tests {
     /// Build a solid-colour NV24 (4:4:4) buffer of dimensions `(w, h)`.
     ///
     /// Layout: `[H rows of Y][H rows of interleaved CbCr full-res]`.
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn make_nv24_solid(w: usize, h: usize, y: u8, cb: u8, cr: u8) -> Vec<u8> {
         let y_plane = vec![y; w * h];
         // NV24: H rows of UV, each row has w pairs → 2w bytes/row.
@@ -5961,11 +5961,11 @@ mod gl_tests {
     ///   (b) Every output pixel matches the expected BT.601 full-range RGB
     ///       within ±2 (rounding from f32 shader arithmetic).
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn test_gpu_nv16_to_rgba_path_b() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
 
@@ -6776,11 +6776,11 @@ mod gl_tests {
     ///   (b) Every output pixel matches the expected BT.601 full-range RGB
     ///       within ±2.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn test_gpu_nv24_to_rgba_path_b() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
 
@@ -6849,11 +6849,11 @@ mod gl_tests {
     /// Builds a patterned NV16 source, runs it through the CPU and GPU
     /// converters, and asserts the GPU output matches the CPU output within ±2.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn test_gpu_nv16_matches_cpu_reference() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
 
@@ -6932,11 +6932,11 @@ mod gl_tests {
 
     /// Verify NV24→RGBA Path B output matches the CPU reference converter.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn test_gpu_nv24_matches_cpu_reference() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
 
@@ -7180,7 +7180,7 @@ mod gl_tests {
     ///
     /// This is intentionally the same pattern as `make_odd_both_source` in
     /// `odd_dim_cpu.rs` so the two test suites share an analytic ground truth.
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn fill_patterned_nv(t: &TensorDyn) {
         let fmt = t.format().unwrap();
         let w = t.width().unwrap();
@@ -7228,7 +7228,7 @@ mod gl_tests {
 
     /// Build a pair of identically-filled NV tensors: one `Dma` (for the GPU),
     /// one `Mem` (for the CPU reference).  Returns `(dma_src, mem_src)`.
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn make_patterned_nv_pair(w: usize, h: usize, fmt: PixelFormat) -> (TensorDyn, TensorDyn) {
         let mut dma = TensorDyn::image(w, h, fmt, DType::U8, Some(TensorMemory::Dma)).unwrap();
         let mut mem = TensorDyn::image(w, h, fmt, DType::U8, Some(TensorMemory::Mem)).unwrap();
@@ -7251,7 +7251,7 @@ mod gl_tests {
     /// reading both maps at their real `effective_row_stride`.
     ///
     /// Returns `(max_diff, first_failing_location)`.
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn compare_gpu_vs_cpu_u8(
         gpu_dst: &TensorDyn,
         cpu_dst: &TensorDyn,
@@ -7328,11 +7328,11 @@ mod gl_tests {
     ///       Tolerance 4 absorbs f32 shader rounding; identical fill on both sides
     ///       rules out test-infrastructure bias.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g03_nv16_odd_w_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -7388,11 +7388,11 @@ mod gl_tests {
 
     /// G-04: NV24 odd-width (65×64) end-to-end GPU vs CPU reference.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g04_nv24_odd_w_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -7452,11 +7452,11 @@ mod gl_tests {
     /// constraint that causes incorrect reads on strict tiled GPUs (e.g. V3D)
     /// when the last chroma row straddles the 64-byte alignment boundary.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g05_nv16_odd_both_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let (w, h) = (321usize, 241usize); // QVGA-scale odd both (Mali rejects sub-minimum textures)
@@ -7516,11 +7516,11 @@ mod gl_tests {
     /// UV row at offset `3H − 2` (0-indexed), making it a different boundary
     /// from NV16.  This is the regression cell for the NV24 3H height bug.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g06_nv24_odd_both_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let (w, h) = (321usize, 241usize); // QVGA-scale odd both (Mali rejects sub-minimum textures)
@@ -7653,11 +7653,11 @@ mod gl_tests {
     /// Path A — see `test_nv12_still_uses_path_a` (64×64). Asserts the GPU output
     /// agrees with the CPU reference ±4.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g01_nv12_odd_w_path_b_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -7724,11 +7724,11 @@ mod gl_tests {
     ///   (a) `last_nv_convert_path == ShaderR8` — no CPU fallback for DMA source.
     ///   (b) GPU output matches CPU reference within ±4.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g02_nv12_odd_h_path_b_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         // Even width, odd height — exercises odd-H chroma row boundary.
@@ -7808,11 +7808,12 @@ mod gl_tests {
     /// This guards the odd-W Grey IOSurface / EGLImage path that the macOS NV24
     /// fix relies on (64-aligned pitch + physical-stride shader addressing).
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g_grey_odd_w_vs_cpu() {
+        use crate::opengl_headless::processor::GLProcessorST;
         use edgefirst_codec::{ImageDecoder, ImageLoad};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let jpeg: &[u8] = &edgefirst_bench::testdata::read("coco_grey_odd.jpg");
@@ -8040,11 +8041,11 @@ mod gl_tests {
     /// behaviour on Path B.  Uses the same patterned fill and stride-aware
     /// comparison as the odd-dim cells.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g_even_nv16_64x64_regression() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -8094,11 +8095,11 @@ mod gl_tests {
 
     /// Even-dim regression: NV24 64×64 → RGBA GPU vs CPU ±4.
     #[test]
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
+    #[cfg(feature = "dma_test_formats")]
     fn g_even_nv24_64x64_regression() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
-        if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+        if !is_gpu_image_buffer_available() {
+            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
             return;
         }
         let (w, h) = (64usize, 64usize);

--- a/scripts/test-macos.sh
+++ b/scripts/test-macos.sh
@@ -49,6 +49,13 @@ COV_LCOV="${COV_LCOV:-target/coverage_rust.lcov}"
 
 WS_EXCLUDES=(--workspace --exclude gpu-probe --exclude edgefirst-bench)
 
+# dma_test_formats un-gates the gl/tests.rs zero-copy tier on macOS
+# (IOSurface-backed @Dma fixtures). MUST be identical across the build
+# and every nextest invocation below — a feature mismatch between the
+# coverage passes triggers a rebuild between the codesign step and the
+# run, leaving pass 2 with unsigned binaries (GL tests SIGKILL/skip).
+FEATURES=(--features edgefirst-image/dma_test_formats)
+
 sign_test_binaries() {
     # Sign every test binary in the given deps dir with the library-
     # validation-disabled entitlement so dlopen() of ad-hoc-signed ANGLE
@@ -65,12 +72,12 @@ if [[ "$COVERAGE" != "1" ]]; then
     # ----- Normal path: build → sign → run -----
     DEPS_DIR="target/$PROFILE/deps"
     echo "→ Building workspace tests ($PROFILE)…"
-    cargo build --tests ${PROFILE_FLAG[@]+"${PROFILE_FLAG[@]}"} "${WS_EXCLUDES[@]}"
+    cargo build --tests ${PROFILE_FLAG[@]+"${PROFILE_FLAG[@]}"} "${WS_EXCLUDES[@]}" "${FEATURES[@]}"
     echo "→ Codesigning test binaries with library-validation disabled…"
     sign_test_binaries "$DEPS_DIR"
     echo "→ Running nextest…"
     export HAL_TEST_ALLOW_DLOPEN_ANGLE=1
-    exec cargo nextest run ${PROFILE_FLAG[@]+"${PROFILE_FLAG[@]}"} "${WS_EXCLUDES[@]}" "$@"
+    exec cargo nextest run ${PROFILE_FLAG[@]+"${PROFILE_FLAG[@]}"} "${WS_EXCLUDES[@]}" "${FEATURES[@]}" "$@"
 fi
 
 # ----- Coverage path: two-pass so the codesign seam survives -----
@@ -101,14 +108,14 @@ COV_DEPS_DIR="target/llvm-cov-target/$PROFILE/deps"
 
 echo "→ Coverage pass 1/2: build + run (GL dlopen tests self-skip)…"
 cargo llvm-cov nextest --no-report ${PROFILE_FLAG[@]+"${PROFILE_FLAG[@]}"} \
-    "${WS_EXCLUDES[@]}" "$@"
+    "${WS_EXCLUDES[@]}" "${FEATURES[@]}" "$@"
 
 echo "→ Codesigning instrumented test binaries…"
 sign_test_binaries "$COV_DEPS_DIR"
 
 echo "→ Coverage pass 2/2: re-run with ANGLE dlopen enabled…"
 HAL_TEST_ALLOW_DLOPEN_ANGLE=1 cargo llvm-cov nextest --no-report \
-    ${PROFILE_FLAG[@]+"${PROFILE_FLAG[@]}"} "${WS_EXCLUDES[@]}" "$@"
+    ${PROFILE_FLAG[@]+"${PROFILE_FLAG[@]}"} "${WS_EXCLUDES[@]}" "${FEATURES[@]}" "$@"
 
 echo "-> Generating LCOV report -> ${COV_LCOV}"
 cargo llvm-cov report --lcov --output-path "${COV_LCOV}" \


### PR DESCRIPTION
Workstream 1 of the post-convergence hardening effort (follows #113). The GL engine's deepest test module (8,100 lines, 114 tests) was mounted `cfg(target_os = "linux")` — the macOS lane ran none of it. It now runs **58 tests on ANGLE/Metal** with zero runtime skips in the zero-copy tier, structured as three per-item cfg tiers (no file split — 86 items already carried per-item gates):

| Tier | Gate | macOS yield |
|---|---|---|
| Portable | none | 31 — mask/segmentation/box render, proto fused/hybrid/SSIM/churn, src_rect crops, decision tables, F16 roundtrip |
| Zero-copy | `dma_test_formats` | +14 — IOSurface-backed pool/recycle/steady-state, NV12/YUYV→RGBA/BGRA references, subview no-aliasing |
| NV oracles | `dma_test_formats` | +13 — NV16/NV24 Path-B BT.601 references, GPU-vs-CPU odd-geometry `g01–g06`/grey/64×64 |

Stays Linux-gated with documented reasons: display probing, PBO/CUDA destinations, packed-RGB `@Dma` (no IOSurface FourCC — includes the int8 odd-geometry oracles), DMA stride guards, multi-plane fd imports, Neutron scenarios, and the NV path-selection asserts/divergence probes.

## Engine fix found by the port (f220dc1)

The first ported run failed the three `src_rect` no-bleed tests with 0x502: **ES 3 guarantees `glReadPixels` only for `RGBA/UNSIGNED_BYTE` plus one implementation-defined pair.** Mesa and the embedded drivers accept `RGB`/`RED` directly; ANGLE/Metal rejects them (V3D documented the same limitation in the PR-0 baselines) — every `Rgb@Mem`/`Grey@Mem` convert and RGB mask draw silently fell back to CPU on macOS. `read_pixels_into()` probes `IMPLEMENTATION_COLOR_READ_FORMAT/_TYPE` and falls back to an RGBA scratch read + leading-channel repack. Shared by the engine readback and both mask-draw heap arms; this also un-breaks the V3D RGB readback cells noted absent from the PR-0 baselines. The ported src_rect tests are the fails-before regression tests.

## Verification

- macOS harness: gl_tests 31 → 45 → 58 across the phases, all green, **zero runtime skips** in the zero-copy tier; repeated green under `EDGEFIRST_GL_SERIALIZE=full` (the paravirtual-runner acceptance bar); workspace 1264/1264.
- No tolerance changes were needed in Phase 3 — the ±2 BT.601 references and GPU-vs-CPU thresholds hold as-is on ANGLE/Metal.
- **Full board sweep for the engine change: 442/0 on imx8mp (skip env), imx95, rpi5, orin.**
- Lanes: aarch64 minimal + full-features, macOS with `dma_test_formats` — 0 warnings.
- `scripts/test-macos.sh` enables `dma_test_formats` with an identical feature set across both coverage passes (a mismatch would rebuild between codesign and run — documented in the script).
- Once #113's step summary lands, this PR's coverage delta on the `crates/image/src/gl/` slice is directly visible per lane run.

One transient nextest "leaky" flag appeared on a fresh-build run and did not reproduce across 4 reruns — noting for the record.