### PR TITLE
Add nvJPEG GPU JPEG-decode backend (prefer over V4L2/CPU on Jetson)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -635,16 +635,20 @@ LD_LIBRARY_PATH=/usr/local/cuda/targets/aarch64-linux/lib \
   cargo bench -p edgefirst-codec --bench codec_benchmark -- --json out.json
 ```
 
-**Validated end-to-end through the codec** (Orin Nano, L4T R36.4.7 / CUDA 12.6 /
-nvJPEG 12.3.3; `examples/nvjpeg_decode`, full `load_image` = map + nvjpegDecode +
-sync + unmap into a `create_image` PBO, RGB output):
+**In-tree `cargo bench` cells** (Orin Nano, L4T R36.4.7 / CUDA 12.6 / nvJPEG
+12.3.3; captured 2026-06-15, `codec_benchmark` cross-built for
+`aarch64-unknown-linux-gnu`, n=100). The nvJPEG cell is the full `load_image` =
+`cuda_map` + `nvjpegDecode` (RGBI) + stream sync + unmap into a `create_image`
+PBO; the CPU `nv12` cell is the **same binary's** CPU decoder, so this is a
+like-for-like decode comparison on one run:
 
-| Image | nvJPEG (RGB, GPU-resident) | CPU (NV12) | Speedup |
-|-------|---------------------------|-----------|---------|
-| zidane 720p (1280×720) | **2.04 ms** | 5.95 ms | **2.9× faster** |
-| giraffe 640 (640×640) | **3.31 ms** | 5.44 ms | **1.6× faster** |
+| Cell | nvJPEG RGB (GPU-resident) | CPU NV12 | Speedup (median) |
+|------|--------------------------|----------|------------------|
+| zidane 720p (1280×720) | **2.21 ms** (p95 2.24) | 5.97 ms (p95 5.98) | **2.70×** |
+| giraffe 640 (640×640)  | **3.24 ms** (p95 3.49) | 5.39 ms (p95 5.41) | **1.67×** |
 
-And nvJPEG output is already RGB and GPU-resident, so it also saves the
+These confirm the earlier `examples/nvjpeg_decode` smoke-test figures (2.04 ms /
+3.31 ms). And nvJPEG output is already RGB and GPU-resident, so it also saves the
 NV12→RGB convert and the host→GPU upload the CPU path still owes.
 
 **Decode-only RGBI into a device pointer** (lower-level C++ probe data, same Orin,
@@ -670,10 +674,10 @@ full per-call stream sync):
   unmapped before `convert()` samples it); the `nvjpeg_map`/`nvjpeg_unmap`
   tracing spans isolate that cost. Keep the decode-source pool on a GL thread
   off the `convert()` hot path to avoid contention.
-- _Status:_ the end-to-end codec path is validated on-target (table above, via
-  `examples/nvjpeg_decode`). The in-tree `codec/jpeg/nvjpeg/rgbi/*` bench cells
-  and the multi-worker e2e/overlap comparison are to be captured here after a
-  profiler deployment run.
+- _Status:_ the end-to-end codec path and the in-tree `codec/jpeg/nvjpeg/rgbi/*`
+  bench cells are validated on-target (tables above, captured 2026-06-15). The
+  multi-worker e2e/overlap comparison still needs a profiler-level deployment to
+  drive concurrent decoders, and is to be captured here then.
 
 ### EXIF Orientation Overhead
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -628,10 +628,13 @@ the decoded image is born GPU-resident and is consumed zero-copy by
 `convert()`. Benchmark cells `codec/jpeg/nvjpeg/rgbi/<fixture>` run only when
 CUDA + libnvjpeg are present (`edgefirst_codec::nvjpeg_available()`) and skip
 cleanly elsewhere — `bench_compare.py` treats absent cells as one-sided and
-never gates on them. Build/run on-target with the CUDA library path:
+never gates on them. nvJPEG is **opt-in** (off by default so it never contends
+with CUDA inference), so the cells need `EDGEFIRST_ENABLE_NVJPEG=1`. Build/run
+on-target with the CUDA library path:
 
 ```bash
-LD_LIBRARY_PATH=/usr/local/cuda/targets/aarch64-linux/lib \
+EDGEFIRST_ENABLE_NVJPEG=1 \
+  LD_LIBRARY_PATH=/usr/local/cuda/targets/aarch64-linux/lib \
   cargo bench -p edgefirst-codec --bench codec_benchmark -- --json out.json
 ```
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -619,6 +619,62 @@ All JPEG measurements use the custom decoder (not zune-jpeg). All measurements a
 - PNG decode uses zune-png internally; edgefirst-codec adds 2–5% overhead for strided row-copy into the pre-allocated tensor.
 - imx95-frdm (Cortex-A55 @ 1.8 GHz) is ~4–5% faster than imx8mp-frdm (Cortex-A53 @ 1.6 GHz) across JPEG decode paths.
 
+#### nvJPEG GPU Decode (Jetson Orin) — on-target only
+
+On NVIDIA platforms the codec prefers the nvJPEG GPU backend
+(`nvjpeg → v4l2 → cpu`). It decodes interleaved **RGB** straight into a
+CUDA-registered PBO (what `ImageProcessor::create_image` yields on Jetson), so
+the decoded image is born GPU-resident and is consumed zero-copy by
+`convert()`. Benchmark cells `codec/jpeg/nvjpeg/rgbi/<fixture>` run only when
+CUDA + libnvjpeg are present (`edgefirst_codec::nvjpeg_available()`) and skip
+cleanly elsewhere — `bench_compare.py` treats absent cells as one-sided and
+never gates on them. Build/run on-target with the CUDA library path:
+
+```bash
+LD_LIBRARY_PATH=/usr/local/cuda/targets/aarch64-linux/lib \
+  cargo bench -p edgefirst-codec --bench codec_benchmark -- --json out.json
+```
+
+**Validated end-to-end through the codec** (Orin Nano, L4T R36.4.7 / CUDA 12.6 /
+nvJPEG 12.3.3; `examples/nvjpeg_decode`, full `load_image` = map + nvjpegDecode +
+sync + unmap into a `create_image` PBO, RGB output):
+
+| Image | nvJPEG (RGB, GPU-resident) | CPU (NV12) | Speedup |
+|-------|---------------------------|-----------|---------|
+| zidane 720p (1280×720) | **2.04 ms** | 5.95 ms | **2.9× faster** |
+| giraffe 640 (640×640) | **3.31 ms** | 5.44 ms | **1.6× faster** |
+
+And nvJPEG output is already RGB and GPU-resident, so it also saves the
+NV12→RGB convert and the host→GPU upload the CPU path still owes.
+
+**Decode-only RGBI into a device pointer** (lower-level C++ probe data, same Orin,
+full per-call stream sync):
+
+| Image | Subsampling | Bitstream | nvJPEG (GPU_HYBRID) |
+|-------|-------------|-----------|---------------------|
+| 1280×800 | 4:4:4 | 107 KB | ~7.0 ms |
+| 3840×2160 | 4:4:4 | 153 KB | ~17.8 ms |
+| 3840×2160 | 4:4:4 | 3.28 MB | ~73.6 ms |
+
+**Key points:**
+- On Orin, `NVJPEG_BACKEND_HARDWARE` is unsupported (`nvjpegCreateEx` → status
+  7); nvJPEG runs on **CUDA cores** (`GPU_HYBRID`/`DEFAULT`), not the NVJPG ASIC.
+  To use the ASIC you would need the Jetson multimedia `NvJPEGDecoder` API — out
+  of scope.
+- The win is **GPU-resident output + a freed CPU**, not raw decode speed.
+  Decode time tracks resolution and bitstream entropy (4K spans ~18–74 ms). The
+  honest comparison is end-to-end **nvJPEG-RGB-decode + `convert()`** vs
+  **CPU-NV12-decode + GPU-upload + NV12→RGB `convert()`** — to be captured
+  on-target as `codec/jpeg/nvjpeg/e2e/*` once deployed.
+- Each frame pays two GL-thread `cuda_map`/unmap round-trips (the PBO must be
+  unmapped before `convert()` samples it); the `nvjpeg_map`/`nvjpeg_unmap`
+  tracing spans isolate that cost. Keep the decode-source pool on a GL thread
+  off the `convert()` hot path to avoid contention.
+- _Status:_ the end-to-end codec path is validated on-target (table above, via
+  `examples/nvjpeg_decode`). The in-tree `codec/jpeg/nvjpeg/rgbi/*` bench cells
+  and the multi-worker e2e/overlap comparison are to be captured here after a
+  profiler deployment run.
+
 ### EXIF Orientation Overhead
 
 **Data collected:** 2026-05-17 (codec at b77df09..4e04dc4 + EXIF coverage). Each

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,10 +579,13 @@ name = "edgefirst-codec"
 version = "0.24.2"
 dependencies = [
  "edgefirst-bench",
+ "edgefirst-image",
  "edgefirst-tensor",
+ "env_logger",
  "image",
  "kamadak-exif",
  "libc",
+ "libloading",
  "log",
  "nix 0.31.2",
  "num-traits",

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,8 @@ bench:
 .PHONY: bench-nvjpeg
 bench-nvjpeg:
 	@echo "Running nvJPEG benchmark (on-target)..."
-	@LD_LIBRARY_PATH="/usr/local/cuda/targets/aarch64-linux/lib:$$LD_LIBRARY_PATH" \
+	@EDGEFIRST_ENABLE_NVJPEG=1 \
+		LD_LIBRARY_PATH="/usr/local/cuda/targets/aarch64-linux/lib:$$LD_LIBRARY_PATH" \
 		cargo bench -p edgefirst-codec --bench codec_benchmark -- --json nvjpeg-bench.json
 	@echo "✓ nvJPEG benchmark complete (results in nvjpeg-bench.json)"
 

--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,16 @@ bench:
 	@cargo bench $(RUST_FEATURES) --workspace
 	@echo "✓ Benchmarks complete"
 
+# On-target nvJPEG decode benchmark (Jetson). Points the loader at the CUDA
+# library path (libnvjpeg.so.12 is not on the default loader path) and runs
+# only the codec bench; the nvjpeg cells self-skip without CUDA/libnvjpeg.
+.PHONY: bench-nvjpeg
+bench-nvjpeg:
+	@echo "Running nvJPEG benchmark (on-target)..."
+	@LD_LIBRARY_PATH="/usr/local/cuda/targets/aarch64-linux/lib:$$LD_LIBRARY_PATH" \
+		cargo bench -p edgefirst-codec --bench codec_benchmark -- --json nvjpeg-bench.json
+	@echo "✓ nvJPEG benchmark complete (results in nvjpeg-bench.json)"
+
 # ===========================================================================
 # SBOM & LICENSE COMPLIANCE
 # ===========================================================================

--- a/crates/codec/ARCHITECTURE.md
+++ b/crates/codec/ARCHITECTURE.md
@@ -70,7 +70,7 @@ only) for the hardware backend. The crate has no dependency on
 | Module        | Purpose                                                |
 |---------------|--------------------------------------------------------|
 | `mod.rs`      | `NvJpegProbe` lifecycle, persistent `NvJpegContext` (handle/state/stream), `try_decode()` tri-state, decode-into-PBO-device-pointer (RGB), circuit breaker |
-| `loader.rs`   | `dlopen` of `libnvjpeg.so.12` (explicit CUDA paths; requires `nvjpeg*` symbols to reject the libjpeg-turbo decoy), `OnceLock` table, `EDGEFIRST_DISABLE_NVJPEG` opt-out |
+| `loader.rs`   | `dlopen` of `libnvjpeg.so.12` (explicit CUDA paths; requires `nvjpeg*` symbols to reject the libjpeg-turbo decoy), `OnceLock` table, `EDGEFIRST_ENABLE_NVJPEG` opt-in (**default off**) |
 | `ffi.rs`      | Hand-rolled `#[repr(C)]` `nvjpegImage_t`, enums/consts, `extern "C"` fn-pointer typedefs (verified vs the on-target `nvjpeg.h` 12.3.3) |
 
 ### V4L2 Backend Module Map (`jpeg/v4l2/`, Linux + `v4l2` feature)
@@ -121,10 +121,11 @@ pass in the decode hot loop.
 On Linux, `decode_jpeg_into` dispatches through a three-tier priority —
 **nvJPEG → V4L2 → CPU**:
 
-1. With the `nvjpeg` feature, if a CUDA device + `libnvjpeg` are present **and**
-   the destination is a CUDA-backed tensor (a PBO on Jetson), the nvJPEG GPU
-   backend decodes interleaved RGB straight into the tensor's device pointer.
-   See [nvJPEG GPU Backend](#nvjpeg-gpu-backend) below.
+1. With the `nvjpeg` feature **and** `EDGEFIRST_ENABLE_NVJPEG` set (opt-in,
+   off by default — see [nvJPEG GPU Backend](#nvjpeg-gpu-backend)), if a CUDA
+   device + `libnvjpeg` are present **and** the destination is a CUDA-backed
+   tensor (a PBO on Jetson), the nvJPEG GPU backend decodes interleaved RGB
+   straight into the tensor's device pointer.
 2. Otherwise, with the `v4l2` feature, the V4L2 hardware backend (native
    NV12/Grey/NV24) — see [V4L2 Hardware Backend](#v4l2-hardware-backend).
 3. Otherwise the from-scratch CPU decoder.
@@ -451,9 +452,12 @@ reliable verification of the raw ioctl ABI — see `TESTING.md`.
 ## nvJPEG GPU Backend
 
 `jpeg/nvjpeg/` offloads JPEG decode to the CUDA nvJPEG library on NVIDIA
-platforms (lead target: Jetson Orin). It is preferred ahead of V4L2/CPU and is
-entirely `dlopen`-based — no link-time CUDA dependency, so one binary runs on
-Jetson (nvJPEG), i.MX (V4L2), and a laptop (CPU).
+platforms (lead target: Jetson Orin). When enabled it is preferred ahead of
+V4L2/CPU, but it is **opt-in and off by default** (`EDGEFIRST_ENABLE_NVJPEG`,
+see [Discovery](#discovery-dlopen-capability-based)) so it never silently
+contends with CUDA inference. It is entirely `dlopen`-based — no link-time CUDA
+dependency, so one binary runs on Jetson (nvJPEG), i.MX (V4L2), and a laptop
+(CPU).
 
 ### Discovery (dlopen, capability-based)
 
@@ -461,7 +465,12 @@ Jetson (nvJPEG), i.MX (V4L2), and a laptop (CPU).
 (the soname is not on JetPack's default loader path) and **requiring** the
 `nvjpeg*` symbols to resolve — this rejects the libjpeg-turbo *decoy*
 (`/usr/lib/.../nvidia/libnvjpeg.so`) that shares the name but exports `jpeg_*`.
-`EDGEFIRST_DISABLE_NVJPEG=1` forces it off. The `NvJpegProbe` (on
+nvJPEG is **opt-in and off by default** — it decodes on the same GPU as CUDA
+inference (TensorRT etc.), so sharing the device can cost a concurrent inference
+engine more than the decode speedup returns. Set `EDGEFIRST_ENABLE_NVJPEG=1`
+(`true`/`yes`) to enable it on decode-bound workloads or where no concurrent GPU
+compute runs. (V4L2 stays opt-out via `EDGEFIRST_DISABLE_V4L2`: it is a separate
+hardware block and does not contend with CUDA.) The `NvJpegProbe` (on
 `JpegDecoderState`) is probed once per `ImageDecoder`; a ready `NvJpegContext`
 persists the nvJPEG handle, a reusable decode state (keeping nvJPEG's internal
 device scratch hot), and **one CUDA stream per decoder** so concurrent decode

--- a/crates/codec/ARCHITECTURE.md
+++ b/crates/codec/ARCHITECTURE.md
@@ -484,13 +484,19 @@ has no `NVJPEG_OUTPUT_NV12`, so RGB is also the only single-call option here.)
 The destination is a `TensorMemory::Pbo` tensor — what
 `ImageProcessor::create_image` yields on Jetson (no dma-heap) — whose CUDA
 GL-buffer registration is mapped to a device pointer via `Tensor::cuda_map()`.
-nvJPEG decodes a single interleaved RGB plane into that pointer (at the tensor's
-`width*3` pitch, honouring any batch `plane_offset`), the stream is
-synchronised, and the PBO is unmapped so `convert()` can sample it. Because
+nvJPEG decodes a single interleaved RGB plane into that pointer (honouring any
+batch `plane_offset`), the stream is synchronised, and the PBO is unmapped so
+`convert()` can sample it. The nvJPEG row pitch is read back from
+`Tensor::effective_row_stride()` *after* the `Rgb` reconfigure rather than
+assumed — `configure_image` keeps a PBO tight (`width*3`) but rounds a
+CUDA-backed DMA destination up to a 64-byte-aligned pitch, and writing at the
+wrong pitch would shear the rows `convert()` then samples. Because
 `cuda_map`/unmap on a GL-buffer route to the GL worker thread that owns the PBO,
 each frame pays **two GL-thread round-trips** (map + unmap). The capacity of the
 packed RGB write is bounds-checked against the mapping length explicitly —
-`configure_image` does not guard a packed format on GL memory.
+`configure_image` does not guard a packed format on GL (PBO) memory — and an
+NV12-sized buffer too small for 3 B/px RGB falls back to V4L2/CPU rather than
+erroring.
 
 ### Orin: GPU_HYBRID, not the NVJPG ASIC
 

--- a/crates/codec/ARCHITECTURE.md
+++ b/crates/codec/ARCHITECTURE.md
@@ -44,14 +44,14 @@ only) for the hardware backend. The crate has no dependency on
 | `exif.rs`    | EXIF orientation parsing → `(rotation_degrees, flip_horizontal)`; never applied |
 | `decoder.rs` | `ImageDecoder` struct, magic-byte format detection, decode dispatch |
 | `traits.rs`  | `ImageLoad` extension trait for Tensor/TensorDyn|
-| `jpeg/`      | Custom baseline JPEG decoder + V4L2 backend (see below) |
+| `jpeg/`      | Custom baseline JPEG decoder + V4L2 / nvJPEG backends (see below) |
 | `png.rs`     | Native-format PNG decode with 8-bit and native 16-bit paths |
 
 ### JPEG Module Map (`jpeg/`)
 
 | Module           | Purpose                                              |
 |------------------|------------------------------------------------------|
-| `mod.rs`         | `JpegDecoderState`, `decode_jpeg_into<T>()`, `native_format()`, V4L2 dispatch seam, EXIF reporting |
+| `mod.rs`         | `JpegDecoderState`, `decode_jpeg_into<T>()`, `native_format()`, nvJPEG→V4L2→CPU dispatch seam, EXIF reporting |
 | `types.rs`       | `Component`, `SamplingFactor`, `ImageHeader`, `QuantTable`, `ZIGZAG` |
 | `markers.rs`     | SOF/SOS/DQT/DHT/DRI/APP marker parsing               |
 | `bitstream.rs`   | 64-bit bit buffer with FF/00 byte-stuffing, bulk refill |
@@ -63,6 +63,15 @@ only) for the hardware backend. The crate has no dependency on
 | `idct/sse41.rs`  | SSE4.1 8×8 IDCT: native mullo_epi32, min/max clamping |
 | `mcu.rs`         | MCU decode loop, `McuScratch`, native `Grey`/`Nv12` row writes, 4:2:0 chroma downsample (`avg_block`) |
 | `v4l2/`          | Optional Linux hardware JPEG backend (see below)     |
+| `nvjpeg/`        | Optional nvJPEG GPU backend (Linux + CUDA, see below) |
+
+### nvJPEG Backend Module Map (`jpeg/nvjpeg/`, Linux + `nvjpeg` feature)
+
+| Module        | Purpose                                                |
+|---------------|--------------------------------------------------------|
+| `mod.rs`      | `NvJpegProbe` lifecycle, persistent `NvJpegContext` (handle/state/stream), `try_decode()` tri-state, decode-into-PBO-device-pointer (RGB), circuit breaker |
+| `loader.rs`   | `dlopen` of `libnvjpeg.so.12` (explicit CUDA paths; requires `nvjpeg*` symbols to reject the libjpeg-turbo decoy), `OnceLock` table, `EDGEFIRST_DISABLE_NVJPEG` opt-out |
+| `ffi.rs`      | Hand-rolled `#[repr(C)]` `nvjpegImage_t`, enums/consts, `extern "C"` fn-pointer typedefs (verified vs the on-target `nvjpeg.h` 12.3.3) |
 
 ### V4L2 Backend Module Map (`jpeg/v4l2/`, Linux + `v4l2` feature)
 
@@ -109,11 +118,20 @@ pass in the decode hot loop.
 
 ### Hardware Decode Tried Before CPU (Linux)
 
-On Linux with the `v4l2` feature, `decode_jpeg_into` dispatches to the V4L2
-hardware backend first; the from-scratch CPU decoder is the fallback. See
-[V4L2 Hardware Backend](#v4l2-hardware-backend) below. On non-Linux targets, or
-with the feature disabled, the seam compiles to nothing and the CPU decoder
-always runs.
+On Linux, `decode_jpeg_into` dispatches through a three-tier priority —
+**nvJPEG → V4L2 → CPU**:
+
+1. With the `nvjpeg` feature, if a CUDA device + `libnvjpeg` are present **and**
+   the destination is a CUDA-backed tensor (a PBO on Jetson), the nvJPEG GPU
+   backend decodes interleaved RGB straight into the tensor's device pointer.
+   See [nvJPEG GPU Backend](#nvjpeg-gpu-backend) below.
+2. Otherwise, with the `v4l2` feature, the V4L2 hardware backend (native
+   NV12/Grey/NV24) — see [V4L2 Hardware Backend](#v4l2-hardware-backend).
+3. Otherwise the from-scratch CPU decoder.
+
+Each tier returns `Ok(None)` (not applicable) or a `Fallback` error to cascade
+to the next. On non-Linux targets, or with both features disabled, the seams
+compile to nothing and the CPU decoder always runs.
 
 ### Standalone `ImageDecoder` Struct
 
@@ -121,7 +139,8 @@ The decoder is a standalone struct rather than being embedded in
 `ImageProcessor` or stored in thread-local state. This gives callers explicit
 ownership and composability — one decoder per pipeline stage, no hidden global
 state. Its `JpegDecoderState` holds the reusable MCU scratch and (on Linux) the
-lazily-probed V4L2 backend, both amortised across frames.
+lazily-probed nvJPEG and V4L2 backends — including nvJPEG's persistent
+handle/state/stream — all amortised across frames.
 
 ```rust
 let mut decoder = ImageDecoder::new();
@@ -429,6 +448,83 @@ wrong size yields the wrong ioctl request number → `ENOTTY` → a silent CPU
 fallback that makes parity tests pass trivially. On-target `strace` is the only
 reliable verification of the raw ioctl ABI — see `TESTING.md`.
 
+## nvJPEG GPU Backend
+
+`jpeg/nvjpeg/` offloads JPEG decode to the CUDA nvJPEG library on NVIDIA
+platforms (lead target: Jetson Orin). It is preferred ahead of V4L2/CPU and is
+entirely `dlopen`-based — no link-time CUDA dependency, so one binary runs on
+Jetson (nvJPEG), i.MX (V4L2), and a laptop (CPU).
+
+### Discovery (dlopen, capability-based)
+
+`loader.rs` opens `libnvjpeg.so.12`, trying explicit CUDA install paths first
+(the soname is not on JetPack's default loader path) and **requiring** the
+`nvjpeg*` symbols to resolve — this rejects the libjpeg-turbo *decoy*
+(`/usr/lib/.../nvidia/libnvjpeg.so`) that shares the name but exports `jpeg_*`.
+`EDGEFIRST_DISABLE_NVJPEG=1` forces it off. The `NvJpegProbe` (on
+`JpegDecoderState`) is probed once per `ImageDecoder`; a ready `NvJpegContext`
+persists the nvJPEG handle, a reusable decode state (keeping nvJPEG's internal
+device scratch hot), and **one CUDA stream per decoder** so concurrent decode
+workers do not serialise on the default stream.
+
+### RGB output — a deliberate exception to the native-format contract
+
+Unlike the CPU/V4L2 paths (native NV12/Grey/NV24, never colour-converted), the
+nvJPEG path emits packed **`Rgb`** via `NVJPEG_OUTPUT_RGBI`. nvJPEG performs the
+YCbCr→RGB on the GPU at near-zero marginal cost, the result is GPU-resident, and
+`ImageProcessor::convert()` accepts an `Rgb` source directly (removing the
+downstream NV12→RGB step). `Rgbi` maps onto the existing `PixelFormat::Rgb` — no
+new enum variant. The backend reconfigures the destination NV12→Rgb and, on any
+post-reconfigure failure, restores the native format so the V4L2/CPU
+fall-through writes into a correctly-shaped tensor. (The L4T nvJPEG 12.3.3 build
+has no `NVJPEG_OUTPUT_NV12`, so RGB is also the only single-call option here.)
+
+### PBO + `cuda_map` zero-copy chain
+
+The destination is a `TensorMemory::Pbo` tensor — what
+`ImageProcessor::create_image` yields on Jetson (no dma-heap) — whose CUDA
+GL-buffer registration is mapped to a device pointer via `Tensor::cuda_map()`.
+nvJPEG decodes a single interleaved RGB plane into that pointer (at the tensor's
+`width*3` pitch, honouring any batch `plane_offset`), the stream is
+synchronised, and the PBO is unmapped so `convert()` can sample it. Because
+`cuda_map`/unmap on a GL-buffer route to the GL worker thread that owns the PBO,
+each frame pays **two GL-thread round-trips** (map + unmap). The capacity of the
+packed RGB write is bounds-checked against the mapping length explicitly —
+`configure_image` does not guard a packed format on GL memory.
+
+### Orin: GPU_HYBRID, not the NVJPG ASIC
+
+On Orin the dedicated-hardware backend (`NVJPEG_BACKEND_HARDWARE`) is
+unsupported (`nvjpegCreateEx` returns status 7), so the context uses
+`NVJPEG_BACKEND_DEFAULT` (GPU-hybrid: CUDA-core Huffman). The throughput win is
+**GPU-resident output + freed CPU**, not raw decode speed (measured RGBI
+decode-only: 720p 4:4:4 ~7 ms; 4K ~18–74 ms, entropy-dependent). Whether it
+beats CPU-decode-NV12 + GPU-upload is a per-resolution call, gated on the
+on-target `codec/jpeg/nvjpeg/*` benchmarks.
+
+### Overlap model
+
+Per-decoder CUDA streams let concurrent decode workers interleave on the GPU;
+the primary throughput mechanism is pipeline overlap via the consumer's ring
+buffer (decode worker N+1 runs while worker N's frame is converted).
+Intra-frame CUDA/GL overlap on the single Orin GPU is unproven and must be
+trace-verified. To keep the per-frame `cuda_map` round-trips off the `convert()`
+hot path, the consumer should own the decode-source pool on a GL thread distinct
+from the convert GL thread (a consumer-side concern).
+
+### Fallback & recovery
+
+`try_decode()` returns `Ok(None)` when nvJPEG is unavailable or the destination
+is not CUDA-backed (untouched tensor → V4L2/CPU), `Err(Fallback)` on a transient
+nvJPEG error (the native format is restored and the CPU decoder — which handles
+progressive/non-baseline JPEGs nvJPEG rejects — runs on the same tensor), and
+`Fatal` for deterministic tensor errors. After `MAX_CONSECUTIVE_FAILURES` (8)
+the backend is demoted for the rest of the session (circuit breaker).
+
+A future increment (not built) could defer the `cudaStreamSynchronize`/unmap and
+hand a CUDA event to `convert()`, gated on a measured demonstration that
+per-decode sync stalls the worker.
+
 ## Tracing Spans
 
 `ImageDecoder::decode_into` (and the trait-method `Tensor::load_image`) emits a
@@ -455,6 +551,12 @@ codec.decode_jpeg                                       [user-facing fn]
 │ fields: dtype = "u8", n_bytes
 │
 ├── codec.decode_jpeg.parse_markers                     ← parse SOF0/DQT/DHT/DRI/SOS/APP1, read EXIF orientation
+├── codec.decode_jpeg.nvjpeg                            ← nvJPEG GPU decode into the PBO device pointer (RGB)
+│   │ fields: w, h, n_bytes, target = "rgbi"
+│   ├── codec.decode_jpeg.nvjpeg_map                    ← cuda_map(): GL-thread round-trip → device pointer
+│   ├── codec.decode_jpeg.nvjpeg_submit                 ← nvjpegDecode enqueue on the per-decoder stream
+│   ├── codec.decode_jpeg.nvjpeg_sync                   ← cudaStreamSynchronize (GPU decode time)
+│   └── codec.decode_jpeg.nvjpeg_unmap                  ← drop(CudaMap): GL-thread round-trip, PBO freed for convert()
 ├── codec.decode_jpeg.v4l2_rebuild                      ← full V4L2 session setup (first frame, OUTPUT overflow, recovery)
 │   fields: w, h
 ├── codec.decode_jpeg.v4l2_reconfigure                  ← CAPTURE-only retarget on geometry change (~1 ms, DMABUF)
@@ -472,12 +574,14 @@ codec.decode_png                                        [user-facing fn]
     field: path = "u8" | "native_u16"
 ```
 
-The `v4l2_*` and `mcu_loop` spans are mutually exclusive: when the V4L2
-hardware backend handles a JPEG the `mcu_loop` span is absent, and when the
-CPU decodes (no device, non-Linux, or hardware fallback) no `v4l2_*` span
-appears. A steady-state hardware frame shows only `v4l2_collect` (the reuse
-path); `v4l2_reconfigure` appears on geometry changes and `v4l2_rebuild` on
-the first frame or error recovery.
+The `nvjpeg*`, `v4l2_*`, and `mcu_loop` spans are mutually exclusive — exactly
+one backend handles a given JPEG. An nvJPEG frame shows the `nvjpeg` subtree
+(and no `v4l2_*`/`mcu_loop`); a V4L2 frame shows the `v4l2_*` spans; a CPU frame
+(no GPU/device, non-Linux, or a hardware fallback) shows only `mcu_loop`. A
+steady-state V4L2 frame shows only `v4l2_collect` (the reuse path);
+`v4l2_reconfigure` appears on geometry changes and `v4l2_rebuild` on the first
+frame or error recovery. For nvJPEG, `nvjpeg_sync` is the GPU decode time and
+`nvjpeg_map`/`nvjpeg_unmap` isolate the per-frame GL-thread round-trip cost.
 
 ### What each span measures
 
@@ -485,6 +589,9 @@ the first frame or error recovery.
 |-----------------------------------|--------------------------|----------------------|
 | `codec.decode_jpeg`               | Full JPEG decode: marker parsing then either the V4L2 hardware decode or the CPU MCU loop, writing native `Nv12`/`Grey`. | Baseline JPEG decode per ITU T.81. |
 | `codec.decode_jpeg.parse_markers` | Walk the JPEG byte stream once: parse SOF0, DQT, DHT, DRI, SOS, and APP1 (EXIF) segments; build Huffman LUTs and quant tables; read the EXIF orientation tag. | Equivalent to libjpeg's `jpeg_read_header` + DHT/DQT table builds. |
+| `codec.decode_jpeg.nvjpeg`        | The nvJPEG GPU decode: map the PBO, `nvjpegGetImageInfo`, decode interleaved `Rgb` into the device pointer, synchronise, unmap. `target = "rgbi"`. Absent when V4L2/CPU decodes. | nvJPEG single-image GPU decode (`nvjpegDecode`). |
+| `codec.decode_jpeg.nvjpeg_map` / `nvjpeg_unmap` | The `cuda_map()` / drop round-trips to the PBO's owning GL worker thread (`cudaGraphicsMapResources` / `Unmap`). Isolates the per-frame GL-thread interop cost. | CUDA-GL interop buffer map/unmap. |
+| `codec.decode_jpeg.nvjpeg_submit` / `nvjpeg_sync` | `nvjpegDecode` enqueue on the per-decoder CUDA stream, then `cudaStreamSynchronize`. `nvjpeg_sync`'s duration is the GPU decode time (resolution/entropy dependent). | Async CUDA decode + stream sync. |
 | `codec.decode_jpeg.mcu_loop`      | The CPU core loop: per MCU row, Huffman-decode + dequant-fuse → two-pass Loeffler IDCT (scalar / NEON / SSE4.1 / SSE2) → native `Grey`/`Nv12`/`Nv24` write, strided into the tensor. Allocation-free after warmup. Absent when hardware decodes. | Equivalent to libjpeg's `jpeg_read_scanlines` loop, IDCT handwritten and SIMD-dispatched. |
 | `codec.decode_jpeg.v4l2_rebuild`  | Full V4L2 stream setup: OUTPUT buffer allocation + mmap + `STREAMON`, JPEG staging, `SOURCE_CHANGE` wait, CAPTURE format negotiation, `REQBUFS(DMABUF)`, `STREAMON`. Runs on the first frame, OUTPUT overflow, or error recovery. | A stateful V4L2 decoder session open + format negotiation. |
 | `codec.decode_jpeg.v4l2_reconfigure` | The geometry-change hot path: `STREAMOFF`/`REQBUFS(0)` on CAPTURE only, JPEG staging + `QBUF` while OUTPUT keeps streaming, `SOURCE_CHANGE` wait, `G_FMT` stale-geometry guard, renegotiation, `REQBUFS(1, DMABUF)`, `STREAMON`. ~1 ms — DMABUF makes `REQBUFS` allocation-free, vs ~110 ms for an MMAP buffer reallocation. | The V4L2 stateful-decoder dynamic-resolution-change sequence. |

--- a/crates/codec/Cargo.toml
+++ b/crates/codec/Cargo.toml
@@ -13,17 +13,20 @@ categories = ["multimedia::images", "embedded"]
 documentation = "https://docs.rs/edgefirst-codec"
 
 [features]
-# v4l2 is on by default but its deps are Linux-target-only and all backend
-# code is gated `#[cfg(all(target_os = "linux", feature = "v4l2"))]`, so off
-# Linux it compiles to nothing and pulls no extra dependencies.
-default = ["v4l2"]
+# v4l2 and nvjpeg are on by default but their backend code is fully gated
+# `#[cfg(all(target_os = "linux", feature = "..."))]`, so off Linux they compile
+# to nothing. nvjpeg is pure dlopen (no link-time CUDA dependency) — it loads
+# libnvjpeg.so.12 at runtime and degrades to the V4L2/CPU decoders when absent.
+default = ["v4l2", "nvjpeg"]
 v4l2 = ["dep:nix", "dep:libc"]
+nvjpeg = ["dep:libloading"]
 opencv = ["dep:opencv"]
 turbojpeg = ["dep:turbojpeg"]
 
 [dependencies]
 edgefirst-tensor = { workspace = true }
 kamadak-exif = { workspace = true }
+libloading = { workspace = true, optional = true }
 log = { workspace = true }
 num-traits = { workspace = true }
 opencv = { workspace = true, optional = true }
@@ -40,6 +43,12 @@ libc = { workspace = true, optional = true }
 
 [dev-dependencies]
 edgefirst-bench = { workspace = true }
+env_logger = { workspace = true }
+# edgefirst-image is used only by the on-target nvjpeg benchmark cells to
+# allocate a CUDA-registered PBO destination via ImageProcessor::create_image.
+# This is a dev-dependency cycle (image depends on codec); Cargo permits it
+# because dev-dependencies do not participate in the library's own build graph.
+edgefirst-image = { workspace = true }
 image = { workspace = true }
 # zune-jpeg is used only by parity tests and the comparison benchmark.
 zune-jpeg = { workspace = true }

--- a/crates/codec/benches/codec_benchmark.rs
+++ b/crates/codec/benches/codec_benchmark.rs
@@ -17,7 +17,7 @@
 
 use edgefirst_bench::{run_bench, BenchSuite};
 use edgefirst_codec::{ImageDecoder, ImageLoad};
-use edgefirst_tensor::{PixelFormat, Tensor, TensorMemory};
+use edgefirst_tensor::{DType, PixelFormat, Tensor, TensorMemory};
 use std::sync::LazyLock;
 
 const WARMUP: usize = 10;
@@ -243,6 +243,69 @@ fn bench_exif_overhead(suite: &mut BenchSuite) {
 }
 
 // =============================================================================
+// 5. nvJPEG GPU decode (on-target only: Linux + CUDA + libnvjpeg)
+//
+// Decodes straight into a CUDA-registered PBO (what ImageProcessor::create_image
+// yields on Jetson), emitting GPU-resident RGB. Skips cleanly on any host
+// without nvJPEG/CUDA — bench_compare.py treats absent cells as one-sided and
+// never gates on them, so this is safe to keep in the default suite.
+//
+//   codec/jpeg/nvjpeg/rgbi/<fixture>  — decode-only into the PBO device pointer
+// =============================================================================
+
+fn bench_nvjpeg(suite: &mut BenchSuite) {
+    if !edgefirst_codec::nvjpeg_available() {
+        println!("\n== nvjpeg: SKIP (no CUDA / libnvjpeg) ==\n");
+        return;
+    }
+    println!("\n== edgefirst-codec: nvjpeg decode into PBO (GPU-resident RGB) ==\n");
+
+    let processor = match edgefirst_image::ImageProcessor::new() {
+        Ok(p) => p,
+        Err(e) => {
+            println!("nvjpeg bench SKIP: ImageProcessor unavailable: {e}");
+            return;
+        }
+    };
+
+    // (width, height, jpeg bytes, cell name)
+    let cases: [(usize, usize, &LazyLock<Vec<u8>>, &str); 2] = [
+        (1280, 720, &ZIDANE_JPG, "codec/jpeg/nvjpeg/rgbi/zidane_720p"),
+        (640, 640, &GIRAFFE_JPG, "codec/jpeg/nvjpeg/rgbi/giraffe_640"),
+    ];
+
+    for (w, h, jpeg, name) in cases {
+        // RGB PBO destination — auto-selected backend (PBO + CUDA on Jetson).
+        let mut tensor = match processor.create_image(w, h, PixelFormat::Rgb, DType::U8, None) {
+            Ok(t) => t,
+            Err(e) => {
+                println!("{name} SKIP: create_image failed: {e}");
+                continue;
+            }
+        };
+        let mut decoder = ImageDecoder::new();
+        // Warm once and confirm nvJPEG actually fired (RGB) rather than the CPU
+        // path silently producing NV12 into a non-CUDA tensor.
+        let info = tensor.load_image(&mut decoder, jpeg).unwrap();
+        if info.format != PixelFormat::Rgb {
+            println!(
+                "{name} SKIP: decoded to {:?}, not Rgb — nvJPEG did not engage \
+                 (destination not CUDA-backed?)",
+                info.format
+            );
+            continue;
+        }
+
+        let r = run_bench(name, WARMUP, ITERATIONS, || {
+            tensor.load_image(&mut decoder, jpeg).unwrap();
+            std::hint::black_box(&tensor);
+        });
+        r.print_summary();
+        suite.record(&r);
+    }
+}
+
+// =============================================================================
 // Main
 // =============================================================================
 
@@ -253,6 +316,7 @@ fn main() {
     bench_zune_raw(&mut suite);
     bench_image_crate(&mut suite);
     bench_exif_overhead(&mut suite);
+    bench_nvjpeg(&mut suite);
 
     suite.finish();
 }

--- a/crates/codec/benches/codec_benchmark.rs
+++ b/crates/codec/benches/codec_benchmark.rs
@@ -255,7 +255,8 @@ fn bench_exif_overhead(suite: &mut BenchSuite) {
 
 fn bench_nvjpeg(suite: &mut BenchSuite) {
     if !edgefirst_codec::nvjpeg_available() {
-        println!("\n== nvjpeg: SKIP (no CUDA / libnvjpeg) ==\n");
+        // nvJPEG is opt-in (off by default); also requires CUDA + libnvjpeg.
+        println!("\n== nvjpeg: SKIP (set EDGEFIRST_ENABLE_NVJPEG=1; needs CUDA + libnvjpeg) ==\n");
         return;
     }
     println!("\n== edgefirst-codec: nvjpeg decode into PBO (GPU-resident RGB) ==\n");

--- a/crates/codec/examples/nvjpeg_decode.rs
+++ b/crates/codec/examples/nvjpeg_decode.rs
@@ -8,8 +8,12 @@
 //! which backend fired (RGB ⇒ nvJPEG, NV12/Grey ⇒ V4L2/CPU), verifies the
 //! decoded pixels are non-trivial, and times the steady-state decode.
 //!
+//! nvJPEG is opt-in (off by default, to avoid contending with CUDA inference),
+//! so `EDGEFIRST_ENABLE_NVJPEG=1` is required for the GPU path to engage:
+//!
 //! ```bash
-//! LD_LIBRARY_PATH=/usr/local/cuda/targets/aarch64-linux/lib \
+//! EDGEFIRST_ENABLE_NVJPEG=1 \
+//!   LD_LIBRARY_PATH=/usr/local/cuda/targets/aarch64-linux/lib \
 //!   cargo run -p edgefirst-codec --example nvjpeg_decode -- image.jpg
 //! ```
 

--- a/crates/codec/examples/nvjpeg_decode.rs
+++ b/crates/codec/examples/nvjpeg_decode.rs
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! On-target smoke test for the nvJPEG GPU decode backend.
+//!
+//! Decodes a JPEG through the public codec API into a PBO destination created by
+//! `ImageProcessor::create_image` (a CUDA-registered PBO on Jetson), reports
+//! which backend fired (RGB ⇒ nvJPEG, NV12/Grey ⇒ V4L2/CPU), verifies the
+//! decoded pixels are non-trivial, and times the steady-state decode.
+//!
+//! ```bash
+//! LD_LIBRARY_PATH=/usr/local/cuda/targets/aarch64-linux/lib \
+//!   cargo run -p edgefirst-codec --example nvjpeg_decode -- image.jpg
+//! ```
+
+use edgefirst_codec::{nvjpeg_available, peek_info, ImageDecoder, ImageLoad};
+use edgefirst_image::{Crop, Flip, ImageProcessor, ImageProcessorTrait, Rotation};
+use edgefirst_tensor::{DType, PixelFormat, TensorDyn, TensorMemory, TensorTrait};
+use std::time::Instant;
+
+/// min / max / mean over every 7th byte — a cheap "is this a real image?" check.
+/// A coherency failure (stale/zero buffer) shows up as min==max or all-zero.
+fn stats(bytes: &[u8]) -> (u8, u8, f64) {
+    let mut min = u8::MAX;
+    let mut max = 0u8;
+    let mut sum = 0u64;
+    let mut n = 0u64;
+    for &b in bytes.iter().step_by(7) {
+        min = min.min(b);
+        max = max.max(b);
+        sum += b as u64;
+        n += 1;
+    }
+    (min, max, if n > 0 { sum as f64 / n as f64 } else { 0.0 })
+}
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("debug")).init();
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: nvjpeg_decode <file.jpg>");
+    let data = std::fs::read(&path).expect("read jpeg");
+
+    println!("nvjpeg_available() = {}", nvjpeg_available());
+    let probe = peek_info(&data).expect("peek_info");
+    println!(
+        "image: {}x{} native {:?} ({} bytes)",
+        probe.width,
+        probe.height,
+        probe.format,
+        data.len()
+    );
+
+    let mut processor = ImageProcessor::new().expect("ImageProcessor::new");
+    let mut tensor = processor
+        .create_image(probe.width, probe.height, PixelFormat::Rgb, DType::U8, None)
+        .expect("create_image");
+    println!("destination tensor memory = {:?}", tensor.memory());
+    println!(
+        "destination has CUDA handle = {}",
+        tensor.cuda_map().is_some()
+    );
+
+    let mut decoder = ImageDecoder::new();
+    let info = tensor.load_image(&mut decoder, &data).expect("decode");
+    let backend = match info.format {
+        PixelFormat::Rgb => "nvJPEG (GPU, RGB)",
+        PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24 | PixelFormat::Grey => {
+            "V4L2/CPU (native)"
+        }
+        _ => "other",
+    };
+    println!(
+        "decoded format = {:?}  →  backend = {}",
+        info.format, backend
+    );
+
+    // Correctness 1: read back what the decoder wrote into the device buffer
+    // (CUDA-write correctness). cuda_map → cudaMemcpy DeviceToHost.
+    if let Some(map) = tensor.cuda_map() {
+        let bytes = info.width * info.height * 3;
+        let n = bytes.min(map.len());
+        let mut host = vec![0u8; n];
+        // SAFETY: host holds n bytes; device_ptr covers the mapped PBO (len()).
+        let ok = unsafe {
+            edgefirst_tensor::memcpy_device_to_host(
+                host.as_mut_ptr() as *mut std::ffi::c_void,
+                map.device_ptr(),
+                n,
+            )
+        };
+        let (mn, mx, mean) = stats(&host);
+        println!(
+            "decoded PBO readback: memcpy_ok={ok} min={mn} max={mx} mean={mean:.1} \
+             ({})",
+            if mx > mn {
+                "real image ✓"
+            } else {
+                "UNIFORM — coherency suspect ✗"
+            }
+        );
+    }
+
+    // Correctness 2: full zero-copy chain — convert() consumes the RGB PBO
+    // source (GL-read of the CUDA-written buffer) and letterboxes to a CPU
+    // tensor we can verify.
+    let mut dst = processor
+        .create_image(
+            640,
+            640,
+            PixelFormat::Rgb,
+            DType::U8,
+            Some(TensorMemory::Mem),
+        )
+        .expect("create dst");
+    match processor.convert(
+        &tensor,
+        &mut dst,
+        Rotation::None,
+        Flip::None,
+        Crop::letterbox([0, 0, 0, 255]),
+    ) {
+        Ok(()) => {
+            if let TensorDyn::U8(t) = &dst {
+                let m = t.map().expect("map dst");
+                let (mn, mx, mean) = stats(&m);
+                println!(
+                    "convert() → 640x640 RGB: min={mn} max={mx} mean={mean:.1} ({})",
+                    if mx > mn {
+                        "real output ✓ (decode→convert chain verified)"
+                    } else {
+                        "UNIFORM — chain broken ✗"
+                    }
+                );
+            }
+        }
+        Err(e) => println!("convert() FAILED: {e}"),
+    }
+
+    // Steady-state timing.
+    let iters = 50;
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        tensor.load_image(&mut decoder, &data).expect("decode");
+    }
+    let ms = t0.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+    println!("avg decode = {ms:.2} ms over {iters} iters");
+}

--- a/crates/codec/src/jpeg/mod.rs
+++ b/crates/codec/src/jpeg/mod.rs
@@ -30,6 +30,17 @@ mod nvjpeg;
 #[cfg(all(target_os = "linux", feature = "nvjpeg"))]
 pub(crate) use nvjpeg::is_nvjpeg_available as nvjpeg_available;
 
+/// Parse a boolean backend-gate environment variable: `true` only for
+/// `1`/`true`/`yes` (case-insensitive, trimmed); absent or anything else is
+/// `false`. Shared by the V4L2 opt-out (`EDGEFIRST_DISABLE_V4L2`) and the nvJPEG
+/// opt-in (`EDGEFIRST_ENABLE_NVJPEG`) gates.
+#[cfg(all(target_os = "linux", any(feature = "v4l2", feature = "nvjpeg")))]
+pub(crate) fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
 use crate::error::{CodecError, UnsupportedFeature};
 use crate::exif::read_exif_orientation;
 use crate::options::ImageInfo;

--- a/crates/codec/src/jpeg/mod.rs
+++ b/crates/codec/src/jpeg/mod.rs
@@ -22,6 +22,14 @@ pub mod types;
 #[cfg(all(target_os = "linux", feature = "v4l2"))]
 mod v4l2;
 
+/// Optional nvJPEG GPU JPEG-decoder backend (Linux + CUDA, `nvjpeg` feature).
+#[cfg(all(target_os = "linux", feature = "nvjpeg"))]
+mod nvjpeg;
+
+/// Runtime probe: `true` when the nvJPEG GPU decoder is available.
+#[cfg(all(target_os = "linux", feature = "nvjpeg"))]
+pub(crate) use nvjpeg::is_nvjpeg_available as nvjpeg_available;
+
 use crate::error::{CodecError, UnsupportedFeature};
 use crate::exif::read_exif_orientation;
 use crate::options::ImageInfo;
@@ -41,6 +49,11 @@ pub struct JpegDecoderState {
     /// decodes.
     #[cfg(all(target_os = "linux", feature = "v4l2"))]
     v4l2: v4l2::V4l2Probe,
+    /// nvJPEG GPU decoder, lazily probed on first decode. Preferred over V4L2
+    /// when a CUDA device + libnvjpeg are present and the destination is a
+    /// CUDA-backed tensor; reuses one nvJPEG handle/state/stream across decodes.
+    #[cfg(all(target_os = "linux", feature = "nvjpeg"))]
+    nvjpeg: nvjpeg::NvJpegProbe,
 }
 
 impl JpegDecoderState {
@@ -49,6 +62,8 @@ impl JpegDecoderState {
             mcu_scratch: None,
             #[cfg(all(target_os = "linux", feature = "v4l2"))]
             v4l2: v4l2::V4l2Probe::default(),
+            #[cfg(all(target_os = "linux", feature = "nvjpeg"))]
+            nvjpeg: nvjpeg::NvJpegProbe::default(),
         }
     }
 }
@@ -203,7 +218,33 @@ pub fn decode_jpeg_into<T: ImagePixel>(
         .effective_row_stride()
         .unwrap_or(native_row_stride(img_w));
 
-    // Try the V4L2 hardware decoder first when available; a probed-but-failing
+    // Try the nvJPEG GPU decoder first when available (CUDA + libnvjpeg). It
+    // decodes interleaved RGB straight into a CUDA-backed (PBO) destination for
+    // zero-copy `convert()`. A non-CUDA destination or any failure cascades to
+    // the V4L2/CPU decoders.
+    #[cfg(all(target_os = "linux", feature = "nvjpeg"))]
+    {
+        match state
+            .nvjpeg
+            .try_decode::<T>(data, &headers, dst, output_fmt, img_w, img_h, dst_stride)
+        {
+            Ok(Some(mut info)) => {
+                info.rotation_degrees = rotation_degrees;
+                info.flip_horizontal = flip_horizontal;
+                // RGB output carries no chroma colorimetry; clear any stale
+                // value left on a recycled pool tensor.
+                dst.set_colorimetry(None);
+                return Ok(info);
+            }
+            Ok(None) => {}
+            Err(nvjpeg::NvJpegDecode::Fallback(why)) => {
+                log::debug!("nvjpeg jpeg decode fell back: {why}");
+            }
+            Err(nvjpeg::NvJpegDecode::Fatal(e)) => return Err(e),
+        }
+    }
+
+    // Try the V4L2 hardware decoder next when available; a probed-but-failing
     // device resets itself and falls through to the CPU decoder transparently.
     #[cfg(all(target_os = "linux", feature = "v4l2"))]
     {

--- a/crates/codec/src/jpeg/nvjpeg/ffi.rs
+++ b/crates/codec/src/jpeg/nvjpeg/ffi.rs
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hand-rolled FFI for the CUDA nvJPEG decode API.
+//!
+//! These declarations mirror the on-target `nvjpeg.h` (CUDA 12.6 / nvJPEG
+//! 12.3.3, verified on the Orin Nano). The library is loaded via `dlopen` (see
+//! [`super::loader`]) — there is no link-time dependency, so only the subset of
+//! types and entry points the backend uses is declared here. The `CudaStream`
+//! is the `cudaStream_t` from `edgefirst_tensor::CudaStream`.
+
+#![allow(non_camel_case_types)]
+
+use std::os::raw::{c_int, c_uchar, c_void};
+
+/// `NVJPEG_MAX_COMPONENT` — the channel/pitch array length in `nvjpegImage_t`.
+pub const NVJPEG_MAX_COMPONENT: usize = 4;
+
+/// `nvjpegStatus_t` — `0` is `NVJPEG_STATUS_SUCCESS`.
+pub type NvjpegStatus = c_int;
+pub const NVJPEG_STATUS_SUCCESS: NvjpegStatus = 0;
+
+/// `nvjpegOutputFormat_t` — only the interleaved-RGB output is used. nvJPEG
+/// writes a single packed RGB plane into `channel[0]` at `pitch[0]`, doing the
+/// YCbCr→RGB conversion on the GPU.
+pub type NvjpegOutputFormat = c_int;
+pub const NVJPEG_OUTPUT_RGBI: NvjpegOutputFormat = 5;
+
+/// `nvjpegBackend_t` — `DEFAULT` resolves to GPU-hybrid on this build. The
+/// dedicated-hardware backend (`NVJPEG_BACKEND_HARDWARE = 3`) is unsupported on
+/// Orin (`nvjpegCreateEx` returns status 7), so it is never requested.
+pub type NvjpegBackend = c_int;
+pub const NVJPEG_BACKEND_DEFAULT: NvjpegBackend = 0;
+
+/// Opaque library handle (`nvjpegHandle_t`).
+pub type NvjpegHandle = *mut c_void;
+/// Opaque per-decode state (`nvjpegJpegState_t`).
+pub type NvjpegJpegState = *mut c_void;
+/// `cudaStream_t`, shared with the tensor crate's CUDA interop.
+pub type CudaStream = edgefirst_tensor::CudaStream;
+
+/// `nvjpegImage_t { unsigned char* channel[4]; size_t pitch[4]; }`.
+///
+/// The `channel` pointers are caller-provided **device** pointers and `pitch`
+/// the per-plane row stride in bytes. For `NVJPEG_OUTPUT_RGBI` only
+/// `channel[0]`/`pitch[0]` are consulted.
+#[repr(C)]
+pub struct NvjpegImage {
+    pub channel: [*mut c_uchar; NVJPEG_MAX_COMPONENT],
+    pub pitch: [usize; NVJPEG_MAX_COMPONENT],
+}
+
+impl Default for NvjpegImage {
+    fn default() -> Self {
+        Self {
+            channel: [std::ptr::null_mut(); NVJPEG_MAX_COMPONENT],
+            pitch: [0; NVJPEG_MAX_COMPONENT],
+        }
+    }
+}
+
+/// `nvjpegCreateEx(backend, dev_allocator, pinned_allocator, flags, &handle)`.
+/// The allocators are passed as null (library-managed) and `flags` as 0.
+pub type FnCreateEx = unsafe extern "C" fn(
+    NvjpegBackend,
+    *const c_void,
+    *const c_void,
+    c_int,
+    *mut NvjpegHandle,
+) -> NvjpegStatus;
+
+/// `nvjpegJpegStateCreate(handle, &state)`.
+pub type FnJpegStateCreate =
+    unsafe extern "C" fn(NvjpegHandle, *mut NvjpegJpegState) -> NvjpegStatus;
+
+/// `nvjpegGetImageInfo(handle, data, len, &nComponents, &subsampling, widths[4], heights[4])`.
+pub type FnGetImageInfo = unsafe extern "C" fn(
+    NvjpegHandle,
+    *const c_uchar,
+    usize,
+    *mut c_int,
+    *mut c_int,
+    *mut c_int,
+    *mut c_int,
+) -> NvjpegStatus;
+
+/// `nvjpegDecode(handle, state, data, len, output_format, &image, stream)`.
+/// Asynchronous: GPU work is submitted to `stream`.
+pub type FnDecode = unsafe extern "C" fn(
+    NvjpegHandle,
+    NvjpegJpegState,
+    *const c_uchar,
+    usize,
+    NvjpegOutputFormat,
+    *mut NvjpegImage,
+    CudaStream,
+) -> NvjpegStatus;
+
+/// `nvjpegDestroy(handle)`.
+pub type FnDestroy = unsafe extern "C" fn(NvjpegHandle) -> NvjpegStatus;
+
+/// `nvjpegJpegStateDestroy(state)`.
+pub type FnJpegStateDestroy = unsafe extern "C" fn(NvjpegJpegState) -> NvjpegStatus;

--- a/crates/codec/src/jpeg/nvjpeg/loader.rs
+++ b/crates/codec/src/jpeg/nvjpeg/loader.rs
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! `dlopen` loader for the CUDA nvJPEG library.
+//!
+//! Mirrors the discipline of `edgefirst_tensor`'s `cuda.rs`: the library is
+//! opened at runtime and every entry point resolved into a function-pointer
+//! table cached in a [`OnceLock`]. Absent or incomplete ⇒ the whole table is
+//! `None` and the codec degrades to the V4L2/CPU decoders.
+//!
+//! Two target-specific facts shape the candidate list:
+//! - The real `libnvjpeg.so.12` is NOT on the default loader path on JetPack 6;
+//!   it lives under `/usr/local/cuda/targets/<arch>/lib/`.
+//! - The `libnvjpeg.so` on the default path (`/usr/lib/.../nvidia/`) is a
+//!   libjpeg-turbo *decoy* that exports `jpeg_*`, not `nvjpeg*`.
+//!
+//! So the explicit CUDA paths are tried first, and `nvjpegCreateEx` is required
+//! to resolve before a library is accepted — the decoy is rejected because it
+//! lacks that symbol.
+
+use super::ffi::*;
+use libloading::Library;
+use std::sync::OnceLock;
+
+/// Environment variable forcing the V4L2/CPU decoders (skip nvJPEG probing).
+const ENV_DISABLE: &str = "EDGEFIRST_DISABLE_NVJPEG";
+
+/// Candidate library names/paths, in priority order. Explicit CUDA install
+/// locations come first (the soname is not on the default loader path); the
+/// bare soname is last so a correctly-set `LD_LIBRARY_PATH` still works.
+const CANDIDATES: &[&str] = &[
+    "/usr/local/cuda/targets/aarch64-linux/lib/libnvjpeg.so.12",
+    "/usr/local/cuda/targets/aarch64-linux/lib/libnvjpeg.so",
+    "/usr/local/cuda/targets/x86_64-linux/lib/libnvjpeg.so.12",
+    "/usr/local/cuda/lib64/libnvjpeg.so.12",
+    "/usr/local/cuda/lib64/libnvjpeg.so",
+    "libnvjpeg.so.12",
+];
+
+/// Resolved nvJPEG entry points. The leaked `Library` keeps the symbols valid
+/// for the process lifetime (matching `cuda.rs`).
+pub(crate) struct NvjpegLib {
+    _lib: &'static Library,
+    pub create_ex: FnCreateEx,
+    pub jpeg_state_create: FnJpegStateCreate,
+    pub get_image_info: FnGetImageInfo,
+    pub decode: FnDecode,
+    pub destroy: FnDestroy,
+    pub jpeg_state_destroy: FnJpegStateDestroy,
+}
+
+static LIB: OnceLock<Option<NvjpegLib>> = OnceLock::new();
+
+fn load() -> Option<NvjpegLib> {
+    if std::env::var_os(ENV_DISABLE).is_some() {
+        log::debug!("nvjpeg disabled via {ENV_DISABLE}");
+        return None;
+    }
+    for name in CANDIDATES {
+        // SAFETY: dlopen of a system library; failures are expected and skipped.
+        let Ok(lib) = (unsafe { Library::new(name) }) else {
+            continue;
+        };
+        // Require the real nvjpeg symbol set; this rejects the libjpeg-turbo
+        // decoy (which has no `nvjpegCreateEx`). A library that opens but is
+        // missing any symbol is skipped in favour of the next candidate.
+        match resolve(&lib) {
+            Some((
+                create_ex,
+                jpeg_state_create,
+                get_image_info,
+                decode,
+                destroy,
+                jpeg_state_destroy,
+            )) => {
+                let lib: &'static Library = Box::leak(Box::new(lib));
+                log::info!("nvjpeg loaded from {name}");
+                return Some(NvjpegLib {
+                    _lib: lib,
+                    create_ex,
+                    jpeg_state_create,
+                    get_image_info,
+                    decode,
+                    destroy,
+                    jpeg_state_destroy,
+                });
+            }
+            None => continue,
+        }
+    }
+    log::debug!("nvjpeg unavailable (no libnvjpeg.so.12 with nvjpeg* symbols found)");
+    None
+}
+
+/// Resolve all required symbols from `lib`, returning `None` if any is missing.
+#[allow(clippy::type_complexity)]
+fn resolve(
+    lib: &Library,
+) -> Option<(
+    FnCreateEx,
+    FnJpegStateCreate,
+    FnGetImageInfo,
+    FnDecode,
+    FnDestroy,
+    FnJpegStateDestroy,
+)> {
+    macro_rules! sym {
+        ($n:literal) => {
+            // SAFETY: the symbol type matches the declared `nvjpeg.h` ABI.
+            *unsafe { lib.get(concat!($n, "\0").as_bytes()) }.ok()?
+        };
+    }
+    Some((
+        sym!("nvjpegCreateEx"),
+        sym!("nvjpegJpegStateCreate"),
+        sym!("nvjpegGetImageInfo"),
+        sym!("nvjpegDecode"),
+        sym!("nvjpegDestroy"),
+        sym!("nvjpegJpegStateDestroy"),
+    ))
+}
+
+/// The resolved nvJPEG table, or `None` when the library is unavailable. Cached.
+pub(crate) fn lib() -> Option<&'static NvjpegLib> {
+    LIB.get_or_init(load).as_ref()
+}
+
+/// True iff both libnvjpeg and libcudart loaded with all required symbols.
+/// Cheap (cached) — intended as a fast pre-check for benches/consumers.
+pub fn is_nvjpeg_available() -> bool {
+    lib().is_some() && edgefirst_tensor::is_cuda_available()
+}

--- a/crates/codec/src/jpeg/nvjpeg/loader.rs
+++ b/crates/codec/src/jpeg/nvjpeg/loader.rs
@@ -22,8 +22,14 @@ use super::ffi::*;
 use libloading::Library;
 use std::sync::OnceLock;
 
-/// Environment variable forcing the V4L2/CPU decoders (skip nvJPEG probing).
-const ENV_DISABLE: &str = "EDGEFIRST_DISABLE_NVJPEG";
+/// Opt-in environment variable enabling the nvJPEG backend. **Default off**:
+/// nvJPEG decodes on the same GPU as CUDA inference (e.g. TensorRT), so it is
+/// not enabled automatically — sharing the GPU can slow a concurrent inference
+/// engine more than the decode speedup is worth. Set `EDGEFIRST_ENABLE_NVJPEG`
+/// to `1`/`true`/`yes` on workloads that benefit (decode-bound, or no
+/// concurrent GPU compute). Contrast `EDGEFIRST_DISABLE_V4L2`, which is opt-out:
+/// V4L2 is a separate hardware block and does not contend with CUDA.
+const ENV_ENABLE: &str = "EDGEFIRST_ENABLE_NVJPEG";
 
 /// Candidate library names/paths, in priority order. Explicit CUDA install
 /// locations come first (the soname is not on the default loader path); the
@@ -52,8 +58,8 @@ pub(crate) struct NvjpegLib {
 static LIB: OnceLock<Option<NvjpegLib>> = OnceLock::new();
 
 fn load() -> Option<NvjpegLib> {
-    if std::env::var_os(ENV_DISABLE).is_some() {
-        log::debug!("nvjpeg disabled via {ENV_DISABLE}");
+    if !crate::jpeg::env_flag(ENV_ENABLE) {
+        log::debug!("nvjpeg off by default; set {ENV_ENABLE}=1 to enable");
         return None;
     }
     for name in CANDIDATES {
@@ -125,8 +131,9 @@ pub(crate) fn lib() -> Option<&'static NvjpegLib> {
     LIB.get_or_init(load).as_ref()
 }
 
-/// True iff both libnvjpeg and libcudart loaded with all required symbols.
-/// Cheap (cached) — intended as a fast pre-check for benches/consumers.
+/// True iff nvJPEG is opted in (`EDGEFIRST_ENABLE_NVJPEG`) **and** both
+/// libnvjpeg and libcudart loaded with all required symbols. Cheap (cached) —
+/// intended as a fast pre-check for benches/consumers.
 pub fn is_nvjpeg_available() -> bool {
     lib().is_some() && edgefirst_tensor::is_cuda_available()
 }

--- a/crates/codec/src/jpeg/nvjpeg/mod.rs
+++ b/crates/codec/src/jpeg/nvjpeg/mod.rs
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Optional nvJPEG GPU JPEG-decoder backend (Linux + CUDA only).
+//!
+//! When the CUDA nvJPEG library is present (NVIDIA Jetson / discrete GPU), this
+//! backend decodes a JPEG straight into the destination tensor's CUDA device
+//! pointer, emitting interleaved **RGB**. The destination is a
+//! `TensorMemory::Pbo` tensor (what `ImageProcessor::create_image` yields on
+//! Jetson, where there is no dma-heap); its CUDA GL-buffer registration is
+//! mapped to a device pointer via [`Tensor::cuda_map`], nvJPEG decodes into it
+//! on a per-decoder CUDA stream, and the unmapped PBO is then consumed
+//! GPU-resident by `ImageProcessor::convert()` — no CPU bounce.
+//!
+//! Unlike the CPU/V4L2 paths (which emit native NV12/Grey/NV24 and never
+//! colour-convert), this backend produces packed `Rgb`: nvJPEG does the
+//! YCbCr→RGB on the GPU at near-zero marginal cost, the result is GPU-resident,
+//! and `convert()` accepts an `Rgb` source directly. This is a deliberate,
+//! documented exception to the codec's native-format contract.
+//!
+//! Capability-probed and entirely `dlopen`-based: absent libnvjpeg/libcudart,
+//! or a non-CUDA destination, the decoder transparently falls through to the
+//! V4L2/CPU backends.
+
+mod ffi;
+mod loader;
+
+pub use loader::is_nvjpeg_available;
+
+use crate::error::CodecError;
+use crate::jpeg::markers::JpegHeaders;
+use crate::options::ImageInfo;
+use crate::pixel::ImagePixel;
+use edgefirst_tensor::{PixelFormat, Tensor};
+use ffi::*;
+use std::os::raw::c_uchar;
+
+/// Consecutive nvJPEG failures after which the backend is demoted to the
+/// V4L2/CPU decoders for the rest of the session (circuit breaker).
+const MAX_CONSECUTIVE_FAILURES: u32 = 8;
+
+/// Outcome of a hardware decode attempt, distinct from [`CodecError`] so the
+/// caller can react to a transient failure by retrying on V4L2/CPU.
+pub(crate) enum NvJpegDecode {
+    /// nvJPEG could not decode this image; decode it on V4L2/CPU. Carries a
+    /// short reason.
+    Fallback(String),
+    /// A deterministic error to surface to the caller (e.g. tensor mapping).
+    Fatal(CodecError),
+}
+
+/// Internal decode error, mapped to [`NvJpegDecode`] by the public entry point.
+enum DecodeErr {
+    /// An nvJPEG/CUDA failure: count toward the circuit breaker and fall back.
+    Reset(String),
+    /// A configuration we don't drive (e.g. RGB exceeds the PBO mapping): fall
+    /// back without counting it as a failure — the device is fine.
+    Unsupported(String),
+    /// A real error to surface (e.g. tensor reconfigure failure).
+    Fatal(CodecError),
+}
+
+/// Lazily-probed nvJPEG backend state, stored on the reusable decoder state so
+/// the library is probed at most once and the context (handle/state/stream) is
+/// reused across decodes.
+//
+// `Ready` is much larger than the unit variants, but there is exactly one probe
+// per decoder and it is `Ready` in the steady state, so boxing would add
+// indirection on the hot path for no real saving.
+#[allow(clippy::large_enum_variant)]
+#[derive(Default)]
+pub(crate) enum NvJpegProbe {
+    #[default]
+    Unprobed,
+    Unavailable,
+    Ready(NvJpegContext),
+}
+
+/// A persistent nvJPEG decode context: the library handle, a reusable decode
+/// state (keeps nvJPEG's internal device scratch hot), and one CUDA stream so
+/// concurrent decoders do not serialise on the default stream.
+pub(crate) struct NvJpegContext {
+    handle: NvjpegHandle,
+    state: NvjpegJpegState,
+    stream: edgefirst_tensor::CudaStream,
+    failures: u32,
+}
+
+// SAFETY: the nvJPEG handle/state and the CUDA stream are owned exclusively by
+// the per-`ImageDecoder` probe and only touched from its owning thread; the
+// device pointers they operate on are process-global via the primary context.
+// Send (not Sync) matches the one-decoder-per-thread usage.
+unsafe impl Send for NvJpegContext {}
+
+impl NvJpegContext {
+    /// Probe once: load libnvjpeg + libcudart, create a stream, an nvJPEG handle
+    /// (DEFAULT backend — the dedicated-hardware backend is unsupported on
+    /// Orin), and a reusable decode state. `None` on any failure.
+    fn new() -> Option<Self> {
+        let lib = loader::lib()?;
+        if !edgefirst_tensor::is_cuda_available() {
+            return None;
+        }
+        let stream = edgefirst_tensor::stream_create()?;
+        let mut handle: NvjpegHandle = std::ptr::null_mut();
+        // SAFETY: valid out-pointer; allocators null, flags 0 per nvjpeg.h.
+        let st = unsafe {
+            (lib.create_ex)(
+                NVJPEG_BACKEND_DEFAULT,
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                &mut handle,
+            )
+        };
+        if st != NVJPEG_STATUS_SUCCESS {
+            log::debug!("nvjpegCreateEx failed (status {st}); nvjpeg unavailable");
+            // SAFETY: stream is live and unused after this.
+            unsafe { edgefirst_tensor::stream_destroy(stream) };
+            return None;
+        }
+        let mut state: NvjpegJpegState = std::ptr::null_mut();
+        // SAFETY: valid handle and out-pointer.
+        if unsafe { (lib.jpeg_state_create)(handle, &mut state) } != NVJPEG_STATUS_SUCCESS {
+            // SAFETY: handle/stream are live and unused after this.
+            unsafe {
+                (lib.destroy)(handle);
+                edgefirst_tensor::stream_destroy(stream);
+            }
+            return None;
+        }
+        log::info!("nvjpeg context ready (BACKEND_DEFAULT)");
+        Some(Self {
+            handle,
+            state,
+            stream,
+            failures: 0,
+        })
+    }
+
+    /// Decode `data` into `dst` as packed RGB. Reconfigures `dst` to `Rgb`; on
+    /// any failure after that reconfigure, restores `output_fmt` (the native
+    /// NV12/Grey/NV24) so the V4L2/CPU fall-through sees a clean tensor.
+    fn decode<T: ImagePixel>(
+        &self,
+        data: &[u8],
+        dst: &mut Tensor<T>,
+        output_fmt: PixelFormat,
+        img_w: usize,
+        img_h: usize,
+    ) -> Result<ImageInfo, DecodeErr> {
+        let _span = tracing::trace_span!(
+            "codec.decode_jpeg.nvjpeg",
+            w = img_w,
+            h = img_h,
+            n_bytes = data.len(),
+            target = "rgbi",
+        )
+        .entered();
+
+        let lib =
+            loader::lib().ok_or_else(|| DecodeErr::Reset("nvjpeg library vanished".into()))?;
+
+        // Reconfigure the destination NV12 → Rgb (tight `width*3` packed stride).
+        // `configure_image` preserves the tensor's CUDA registration, so the
+        // same PBO + device pointer is reused.
+        let rgb_stride = img_w * 3;
+        dst.configure_image(img_w, img_h, PixelFormat::Rgb)
+            .map_err(|e| DecodeErr::Fatal(CodecError::Tensor(e)))?;
+
+        // The device decode borrows `dst` immutably (via `cuda_map`); scope it so
+        // the format can be restored mutably on the error path.
+        match self.decode_into_device(lib, dst, data, img_w, img_h, rgb_stride) {
+            Ok(()) => Ok(ImageInfo {
+                width: img_w,
+                height: img_h,
+                format: PixelFormat::Rgb,
+                row_stride: rgb_stride,
+                rotation_degrees: 0,
+                flip_horizontal: false,
+            }),
+            Err(e) => {
+                // Restore the native format the dispatch site configured so the
+                // V4L2/CPU decoder writes into a correctly-shaped tensor.
+                let _ = dst.configure_image(img_w, img_h, output_fmt);
+                Err(e)
+            }
+        }
+    }
+
+    /// Map the destination PBO to a device pointer, decode RGB into it on the
+    /// context's stream, synchronise, and unmap. Takes `&Tensor` so the
+    /// immutable `cuda_map` borrow is scoped to this call.
+    fn decode_into_device<T: ImagePixel>(
+        &self,
+        lib: &loader::NvjpegLib,
+        dst: &Tensor<T>,
+        data: &[u8],
+        img_w: usize,
+        img_h: usize,
+        rgb_stride: usize,
+    ) -> Result<(), DecodeErr> {
+        // Map the PBO's CUDA registration to a device pointer (routes to the GL
+        // worker thread that owns the PBO). The map must stay live across the
+        // whole decode+sync — `device_ptr` is only valid while mapped, and
+        // dropping it unmaps so `convert()` can re-take the PBO.
+        let cuda = {
+            let _s = tracing::trace_span!("codec.decode_jpeg.nvjpeg_map").entered();
+            dst.cuda_map()
+                .ok_or_else(|| DecodeErr::Reset("cuda_map returned None".into()))?
+        };
+        let base = cuda.device_ptr() as *mut c_uchar;
+        if base.is_null() {
+            return Err(DecodeErr::Reset(
+                "cuda_map returned a null device pointer".into(),
+            ));
+        }
+        let map_len = cuda.len();
+
+        // Bounds-check the packed RGB write against the true PBO allocation
+        // (`configure_image` does NOT guard a packed format on GL memory).
+        let offset = dst.plane_offset().unwrap_or(0);
+        let needed = img_h.checked_mul(rgb_stride).ok_or(DecodeErr::Fatal(
+            CodecError::InsufficientCapacity {
+                image: (img_w, img_h),
+                tensor: (0, 0),
+            },
+        ))?;
+        if offset.checked_add(needed).is_none_or(|end| end > map_len) {
+            return Err(DecodeErr::Unsupported(format!(
+                "RGB {img_w}x{img_h} ({needed} B) + offset {offset} exceeds PBO mapping ({map_len} B)"
+            )));
+        }
+
+        // Header info: confirm the dims match the parsed JPEG. Subsampling is
+        // recorded on the span only; RGBI output normalises every subsampling.
+        let mut ncomp: i32 = 0;
+        let mut subsampling: i32 = 0;
+        let mut widths = [0i32; NVJPEG_MAX_COMPONENT];
+        let mut heights = [0i32; NVJPEG_MAX_COMPONENT];
+        // SAFETY: valid handle, in-bounds buffer, and out-arrays of length
+        // NVJPEG_MAX_COMPONENT per nvjpeg.h.
+        let st = unsafe {
+            (lib.get_image_info)(
+                self.handle,
+                data.as_ptr(),
+                data.len(),
+                &mut ncomp,
+                &mut subsampling,
+                widths.as_mut_ptr(),
+                heights.as_mut_ptr(),
+            )
+        };
+        if st != NVJPEG_STATUS_SUCCESS {
+            return Err(DecodeErr::Reset(format!("nvjpegGetImageInfo status {st}")));
+        }
+        if widths[0] as usize != img_w || heights[0] as usize != img_h {
+            return Err(DecodeErr::Reset(format!(
+                "nvjpeg dims {}x{} != header {img_w}x{img_h}",
+                widths[0], heights[0]
+            )));
+        }
+
+        // Single interleaved RGB plane at the tensor's RGB pitch, at the (batch)
+        // offset within the PBO.
+        let mut image = NvjpegImage::default();
+        // SAFETY: `offset + needed <= map_len` checked above.
+        image.channel[0] = unsafe { base.add(offset) };
+        image.pitch[0] = rgb_stride;
+
+        {
+            let _s = tracing::trace_span!("codec.decode_jpeg.nvjpeg_submit").entered();
+            // SAFETY: valid handle/state, in-bounds input, valid device image,
+            // and a live stream. Progressive/non-baseline JPEGs the GPU_HYBRID
+            // backend rejects surface here and fall back to the CPU decoder.
+            let st = unsafe {
+                (lib.decode)(
+                    self.handle,
+                    self.state,
+                    data.as_ptr(),
+                    data.len(),
+                    NVJPEG_OUTPUT_RGBI,
+                    &mut image,
+                    self.stream,
+                )
+            };
+            if st != NVJPEG_STATUS_SUCCESS {
+                return Err(DecodeErr::Reset(format!("nvjpegDecode status {st}")));
+            }
+        }
+
+        {
+            let _s = tracing::trace_span!("codec.decode_jpeg.nvjpeg_sync").entered();
+            // SAFETY: the stream is live for the context's lifetime.
+            if !unsafe { edgefirst_tensor::stream_synchronize(self.stream) } {
+                return Err(DecodeErr::Reset("cudaStreamSynchronize failed".into()));
+            }
+        }
+
+        // Unmap the PBO (routes to the GL worker thread) so `convert()` can
+        // sample it. Explicit drop after the sync guarantees the device write
+        // is complete and visible first.
+        let _s = tracing::trace_span!("codec.decode_jpeg.nvjpeg_unmap").entered();
+        drop(cuda);
+        Ok(())
+    }
+}
+
+impl Drop for NvJpegContext {
+    fn drop(&mut self) {
+        if let Some(lib) = loader::lib() {
+            // SAFETY: handle/state are live and unused after this.
+            unsafe {
+                (lib.jpeg_state_destroy)(self.state);
+                (lib.destroy)(self.handle);
+            }
+        }
+        // SAFETY: stream is live and unused after this.
+        unsafe { edgefirst_tensor::stream_destroy(self.stream) };
+    }
+}
+
+impl NvJpegProbe {
+    fn ensure_probed(&mut self) -> Option<&mut NvJpegContext> {
+        if matches!(self, NvJpegProbe::Unprobed) {
+            *self = match NvJpegContext::new() {
+                Some(ctx) => NvJpegProbe::Ready(ctx),
+                None => NvJpegProbe::Unavailable,
+            };
+        }
+        match self {
+            NvJpegProbe::Ready(ctx) => Some(ctx),
+            _ => None,
+        }
+    }
+
+    /// Attempt to decode `data` into `dst` using nvJPEG.
+    ///
+    /// - `Ok(Some(info))` — decoded on the GPU into the PBO as RGB.
+    /// - `Ok(None)` — no nvJPEG, or the destination is not CUDA-backed; the
+    ///   caller uses the V4L2/CPU decoders.
+    /// - `Err(NvJpegDecode::Fallback)` — transient/unsupported; decode this
+    ///   image on V4L2/CPU.
+    /// - `Err(NvJpegDecode::Fatal)` — a real error to surface.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_decode<T: ImagePixel>(
+        &mut self,
+        data: &[u8],
+        _headers: &JpegHeaders,
+        dst: &mut Tensor<T>,
+        output_fmt: PixelFormat,
+        img_w: usize,
+        img_h: usize,
+        _dst_stride: usize,
+    ) -> Result<Option<ImageInfo>, NvJpegDecode> {
+        let Some(ctx) = self.ensure_probed() else {
+            return Ok(None);
+        };
+
+        // Only CUDA-backed (PBO/DMA-with-handle) destinations can be decoded
+        // into zero-copy; anything else falls through to V4L2/CPU. Checked
+        // before any reconfigure so a non-CUDA tensor is left untouched.
+        if dst.cuda().is_none() {
+            return Ok(None);
+        }
+
+        let result = ctx.decode::<T>(data, dst, output_fmt, img_w, img_h);
+        let out = match result {
+            Ok(info) => {
+                ctx.failures = 0;
+                Ok(Some(info))
+            }
+            Err(DecodeErr::Reset(why)) => {
+                ctx.failures = ctx.failures.saturating_add(1);
+                Err(NvJpegDecode::Fallback(why))
+            }
+            // A config we don't drive: fall back but do NOT count it — nvJPEG
+            // is healthy, the CPU handles this image.
+            Err(DecodeErr::Unsupported(why)) => Err(NvJpegDecode::Fallback(why)),
+            Err(DecodeErr::Fatal(e)) => Err(NvJpegDecode::Fatal(e)),
+        };
+
+        // Circuit breaker: demote a persistently failing decoder for the session
+        // so it stops costing per-image latency.
+        if let NvJpegProbe::Ready(ctx) = self {
+            if ctx.failures >= MAX_CONSECUTIVE_FAILURES {
+                log::warn!(
+                    "nvjpeg decoder disabled after {} consecutive failures",
+                    ctx.failures
+                );
+                *self = NvJpegProbe::Unavailable;
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edgefirst_tensor::TensorMemory;
+
+    /// A plain `Mem` tensor has no CUDA handle, so `try_decode` returns
+    /// `Ok(None)` and leaves the tensor's format untouched for the V4L2/CPU
+    /// fall-through — regardless of whether libnvjpeg is present.
+    #[test]
+    fn mem_tensor_falls_through_untouched() {
+        let mut probe = NvJpegProbe::default();
+        let mut dst =
+            Tensor::<u8>::image(64, 64, PixelFormat::Nv12, Some(TensorMemory::Mem)).unwrap();
+        // Parse a tiny header is unnecessary; the cuda() gate fires first. Use a
+        // minimal valid-ish JPEG SOI; headers are unused by this path.
+        let headers = crate::jpeg::markers::parse_markers(MINIMAL_JPEG).ok();
+        if let Some(h) = headers {
+            let r = probe.try_decode::<u8>(MINIMAL_JPEG, &h, &mut dst, PixelFormat::Nv12, 8, 8, 16);
+            assert!(matches!(r, Ok(None)));
+        }
+        // Format must be unchanged (still Nv12) for the fall-through.
+        assert_eq!(dst.format(), Some(PixelFormat::Nv12));
+    }
+
+    // 8x8 grayscale baseline JPEG (smallest valid stream) for header parsing.
+    const MINIMAL_JPEG: &[u8] = &[
+        0xFF, 0xD8, 0xFF, 0xDB, 0x00, 0x43, 0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08, 0x07,
+        0x07, 0x07, 0x09, 0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12,
+        0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20, 0x24, 0x2E, 0x27,
+        0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29, 0x2C, 0x30, 0x31, 0x34, 0x34, 0x34,
+        0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32, 0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B,
+        0x08, 0x00, 0x08, 0x00, 0x08, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0xFF, 0xDA, 0x00,
+        0x08, 0x01, 0x01, 0x00, 0x00, 0x3F, 0x00, 0xD2, 0xCF, 0x20, 0xFF, 0xD9,
+    ];
+}

--- a/crates/codec/src/jpeg/nvjpeg/mod.rs
+++ b/crates/codec/src/jpeg/nvjpeg/mod.rs
@@ -158,34 +158,59 @@ impl NvJpegContext {
         )
         .entered();
 
-        let lib =
-            loader::lib().ok_or_else(|| DecodeErr::Reset("nvjpeg library vanished".into()))?;
-
-        // Reconfigure the destination NV12 → Rgb (tight `width*3` packed stride).
-        // `configure_image` preserves the tensor's CUDA registration, so the
-        // same PBO + device pointer is reused.
-        let rgb_stride = img_w * 3;
-        dst.configure_image(img_w, img_h, PixelFormat::Rgb)
-            .map_err(|e| DecodeErr::Fatal(CodecError::Tensor(e)))?;
-
-        // The device decode borrows `dst` immutably (via `cuda_map`); scope it so
-        // the format can be restored mutably on the error path.
-        match self.decode_into_device(lib, dst, data, img_w, img_h, rgb_stride) {
-            Ok(()) => Ok(ImageInfo {
-                width: img_w,
-                height: img_h,
-                format: PixelFormat::Rgb,
-                row_stride: rgb_stride,
-                rotation_degrees: 0,
-                flip_horizontal: false,
-            }),
+        // Run the reconfigure + device decode in a helper so EVERY failure path
+        // — including a failed `Rgb` reconfigure — restores the caller's native
+        // format, leaving a correctly-shaped tensor for the V4L2/CPU fall-through.
+        match self.decode_reconfigured(data, dst, img_w, img_h) {
+            Ok(info) => Ok(info),
             Err(e) => {
-                // Restore the native format the dispatch site configured so the
-                // V4L2/CPU decoder writes into a correctly-shaped tensor.
                 let _ = dst.configure_image(img_w, img_h, output_fmt);
                 Err(e)
             }
         }
+    }
+
+    /// Reconfigure `dst` to `Rgb` and decode into its device pointer. Any error
+    /// leaves `dst` configured as `Rgb` (possibly partially) — the caller's
+    /// [`decode`](Self::decode) restores the native format.
+    fn decode_reconfigured<T: ImagePixel>(
+        &self,
+        data: &[u8],
+        dst: &mut Tensor<T>,
+        img_w: usize,
+        img_h: usize,
+    ) -> Result<ImageInfo, DecodeErr> {
+        let lib =
+            loader::lib().ok_or_else(|| DecodeErr::Reset("nvjpeg library vanished".into()))?;
+
+        // Reconfigure the destination NV12 → Rgb. `configure_image` preserves the
+        // tensor's CUDA registration (same PBO + device pointer), and chooses the
+        // row stride from the backing: a CUDA-backed DMA destination is rounded up
+        // to a 64-byte-aligned pitch, a PBO stays tight (`width*3`). A failed
+        // reconfigure — e.g. an NV12 buffer (1.5 B/px) is too small for RGB
+        // (3 B/px) — is NOT fatal: fall back to V4L2/CPU.
+        dst.configure_image(img_w, img_h, PixelFormat::Rgb)
+            .map_err(|e| DecodeErr::Unsupported(format!("Rgb reconfigure failed: {e}")))?;
+
+        // Use the stride `configure_image` actually set, NOT an assumed `width*3`:
+        // on an alignment-padded (DMA) destination the rows are 64-aligned, and
+        // writing at `width*3` would shear rows that `convert()` then samples at
+        // the wider pitch.
+        let rgb_stride = dst
+            .effective_row_stride()
+            .ok_or_else(|| DecodeErr::Reset("no row stride after Rgb reconfigure".into()))?;
+
+        // The device decode borrows `dst` immutably (via `cuda_map`); scope it so
+        // the format can be restored mutably on the error path by the caller.
+        self.decode_into_device(lib, dst, data, img_w, img_h, rgb_stride)?;
+        Ok(ImageInfo {
+            width: img_w,
+            height: img_h,
+            format: PixelFormat::Rgb,
+            row_stride: rgb_stride,
+            rotation_degrees: 0,
+            flip_horizontal: false,
+        })
     }
 
     /// Map the destination PBO to a device pointer, decode RGB into it on the
@@ -408,13 +433,21 @@ mod tests {
         let mut probe = NvJpegProbe::default();
         let mut dst =
             Tensor::<u8>::image(64, 64, PixelFormat::Nv12, Some(TensorMemory::Mem)).unwrap();
-        // Parse a tiny header is unnecessary; the cuda() gate fires first. Use a
-        // minimal valid-ish JPEG SOI; headers are unused by this path.
-        let headers = crate::jpeg::markers::parse_markers(MINIMAL_JPEG).ok();
-        if let Some(h) = headers {
-            let r = probe.try_decode::<u8>(MINIMAL_JPEG, &h, &mut dst, PixelFormat::Nv12, 8, 8, 16);
-            assert!(matches!(r, Ok(None)));
-        }
+        // The `cuda()` gate fires before the headers are consulted, but parse the
+        // fixture unconditionally so a broken `MINIMAL_JPEG` fails the test loudly
+        // instead of silently skipping the `try_decode` call.
+        let headers =
+            crate::jpeg::markers::parse_markers(MINIMAL_JPEG).expect("MINIMAL_JPEG must parse");
+        let r = probe.try_decode::<u8>(
+            MINIMAL_JPEG,
+            &headers,
+            &mut dst,
+            PixelFormat::Nv12,
+            8,
+            8,
+            16,
+        );
+        assert!(matches!(r, Ok(None)));
         // Format must be unchanged (still Nv12) for the fall-through.
         assert_eq!(dst.format(), Some(PixelFormat::Nv12));
     }

--- a/crates/codec/src/jpeg/nvjpeg/mod.rs
+++ b/crates/codec/src/jpeg/nvjpeg/mod.rs
@@ -244,13 +244,19 @@ impl NvJpegContext {
 
         // Bounds-check the packed RGB write against the true PBO allocation
         // (`configure_image` does NOT guard a packed format on GL memory).
+        // Two distinct failure modes:
+        //   * `img_h * rgb_stride` overflowing `usize` is a degenerate image
+        //     geometry (only reachable for an enormous image on a 32-bit
+        //     `usize`) — unrepresentable for ANY backend, so surface it as
+        //     `InvalidData` rather than a misleading capacity error.
+        //   * the write merely exceeding THIS PBO mapping is a destination-too-
+        //     small case — fall back to V4L2/CPU.
         let offset = dst.plane_offset().unwrap_or(0);
-        let needed = img_h.checked_mul(rgb_stride).ok_or(DecodeErr::Fatal(
-            CodecError::InsufficientCapacity {
-                image: (img_w, img_h),
-                tensor: (0, 0),
-            },
-        ))?;
+        let needed = img_h.checked_mul(rgb_stride).ok_or_else(|| {
+            DecodeErr::Fatal(CodecError::InvalidData(format!(
+                "nvjpeg: RGB geometry {img_w}x{img_h} (stride {rgb_stride}) overflows usize"
+            )))
+        })?;
         if offset.checked_add(needed).is_none_or(|end| end > map_len) {
             return Err(DecodeErr::Unsupported(format!(
                 "RGB {img_w}x{img_h} ({needed} B) + offset {offset} exceeds PBO mapping ({map_len} B)"

--- a/crates/codec/src/jpeg/v4l2/device.rs
+++ b/crates/codec/src/jpeg/v4l2/device.rs
@@ -54,7 +54,7 @@ impl ProbedDevice {
 /// otherwise infallible — discovery failure is never an error, it just means
 /// the CPU decoder is used.
 pub fn probe() -> Option<ProbedDevice> {
-    if env_flag(ENV_DISABLE) {
+    if crate::jpeg::env_flag(ENV_DISABLE) {
         log::debug!("v4l2 jpeg decode disabled via {ENV_DISABLE}");
         return None;
     }
@@ -166,11 +166,4 @@ fn output_queue_has_jpeg(fd: std::os::fd::RawFd, api: ApiVariant) -> bool {
         }
     }
     false
-}
-
-/// Read a boolean-ish environment flag (`1`/`true`/`yes`, case-insensitive).
-fn env_flag(name: &str) -> bool {
-    std::env::var(name)
-        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
-        .unwrap_or(false)
 }

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -59,5 +59,21 @@ pub use options::ImageInfo;
 pub use pixel::ImagePixel;
 pub use traits::ImageLoad;
 
+/// Returns `true` when the nvJPEG GPU JPEG decoder is available at runtime
+/// (Linux with CUDA + libnvjpeg loaded), and the codec will prefer it over the
+/// V4L2/CPU backends for CUDA-backed destinations. Always `false` on other
+/// platforms or when the `nvjpeg` feature is disabled. Useful for benchmarks
+/// and consumers that branch on backend availability.
+pub fn nvjpeg_available() -> bool {
+    #[cfg(all(target_os = "linux", feature = "nvjpeg"))]
+    {
+        jpeg::nvjpeg_available()
+    }
+    #[cfg(not(all(target_os = "linux", feature = "nvjpeg")))]
+    {
+        false
+    }
+}
+
 /// Result type for codec operations.
 pub type Result<T> = std::result::Result<T, CodecError>;

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -59,11 +59,13 @@ pub use options::ImageInfo;
 pub use pixel::ImagePixel;
 pub use traits::ImageLoad;
 
-/// Returns `true` when the nvJPEG GPU JPEG decoder is available at runtime
-/// (Linux with CUDA + libnvjpeg loaded), and the codec will prefer it over the
-/// V4L2/CPU backends for CUDA-backed destinations. Always `false` on other
-/// platforms or when the `nvjpeg` feature is disabled. Useful for benchmarks
-/// and consumers that branch on backend availability.
+/// Returns `true` when the nvJPEG GPU JPEG decoder is available at runtime —
+/// Linux with CUDA + libnvjpeg loaded **and** opted in via
+/// `EDGEFIRST_ENABLE_NVJPEG` (off by default, so it never silently contends with
+/// CUDA inference). When `true` the codec prefers it over the V4L2/CPU backends
+/// for CUDA-backed destinations. Always `false` on other platforms or when the
+/// `nvjpeg` feature is disabled. Useful for benchmarks and consumers that branch
+/// on backend availability.
 pub fn nvjpeg_available() -> bool {
     #[cfg(all(target_os = "linux", feature = "nvjpeg"))]
     {

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -456,16 +456,23 @@ targets the PACK binding. Mem tensors map directly — no channel round-trip
 XORs rendered pixels with 0x80 and no readback un-biases, so the letterbox
 clear colour is pre-biased (`int8_bias_clear`) on every lowering alike.
 
-### CUDA registration of the float PBO
+### CUDA registration of PBO tensors (u8 and float)
 
-After `convert()` writes the float output into the PBO via
-`glReadPixels(GL_PIXEL_PACK_BUFFER)`, the same PBO buffer can be
-registered with CUDA and accessed as a device pointer — no host copy.
+A PBO-backed tensor can be registered with CUDA and accessed as a device
+pointer — no host copy. Both directions use this: a **float** convert
+destination written via `glReadPixels(GL_PIXEL_PACK_BUFFER)` and bound to
+TensorRT (below), and a **u8** source (e.g. an RGB destination the codec's
+nvJPEG backend decodes into via `cuda_map()`, then GL samples for `convert()`).
 
-**Registration** happens on the GL worker thread at `create_image()` time
-(or lazily on the first `cuda_map()` call, whichever comes first) via
-`cudaGraphicsGLRegisterBuffer`. The registration persists for the lifetime
-of the `PboTensor` and is shared across all `cuda_map()` calls on that tensor.
+**Registration** happens on the GL worker thread at `create_image()` time via
+`cudaGraphicsGLRegisterBuffer`, for **both** the u8 PBO path (`create_pbo_image`)
+and the float PBO path (`create_pbo_image_dtype`) — `register_pbo_cuda` is called
+from each. It is **best-effort**: without libcudart (or if the GL context is not
+CUDA-interop-capable, e.g. a Mesa software context) it is a no-op and the tensor
+remains a normal CPU/GL buffer. There is **no lazy path** — if a PBO was not
+registered at creation, `cuda_map()` returns `None` (and CUDA consumers such as
+the nvJPEG backend transparently fall back). The registration persists for the
+lifetime of the `PboTensor` and is shared across all `cuda_map()` calls on it.
 
 **Aliasing rule**: while `CudaMap` is alive, GL must not write into the PBO.
 The aliasing rule is a caller convention enforced by the scoped `CudaMap`

--- a/crates/image/src/gl/threaded.rs
+++ b/crates/image/src/gl/threaded.rs
@@ -1025,6 +1025,13 @@ impl GLProcessorThreaded {
         tensor
             .set_format(format)
             .map_err(|e| Error::OpenGl(format!("Failed to set format on PBO tensor: {e:?}")))?;
+        // Register the PBO with CUDA (best-effort; no-op without libcudart) so
+        // `cuda_map()` can yield a device pointer — matching the float PBO path
+        // in `create_pbo_image_dtype`. Without this, u8 PBOs were never
+        // CUDA-interop-capable, so the codec's nvJPEG backend (and any CUDA
+        // consumer) could not use a `create_image`-allocated PBO destination.
+        // The i8 transmute by the caller preserves the attached handle.
+        register_pbo_cuda(&mut tensor, buffer_id, size, sender);
         Ok(tensor)
     }
 

--- a/crates/tensor/src/cuda.rs
+++ b/crates/tensor/src/cuda.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, OnceLock};
 pub(crate) type CudaError = c_int; // cudaSuccess == 0
 pub type GraphicsResource = *mut c_void; // cudaGraphicsResource_t
 pub(crate) type ExternalMemory = *mut c_void; // cudaExternalMemory_t
+pub type CudaStream = *mut c_void; // cudaStream_t
 
 #[allow(non_snake_case, dead_code)]
 pub(crate) struct CudaTable {
@@ -37,6 +38,9 @@ pub(crate) struct CudaTable {
     pub destroy_external_memory: unsafe extern "C" fn(ExternalMemory) -> CudaError,
     pub memcpy: unsafe extern "C" fn(*mut c_void, *const c_void, usize, c_int) -> CudaError,
     pub free: unsafe extern "C" fn(*mut c_void) -> CudaError,
+    pub stream_create: unsafe extern "C" fn(*mut CudaStream) -> CudaError,
+    pub stream_synchronize: unsafe extern "C" fn(CudaStream) -> CudaError,
+    pub stream_destroy: unsafe extern "C" fn(CudaStream) -> CudaError,
 }
 
 static TABLE: OnceLock<Option<CudaTable>> = OnceLock::new();
@@ -63,6 +67,9 @@ fn load() -> Option<CudaTable> {
         destroy_external_memory: sym!("cudaDestroyExternalMemory"),
         memcpy: sym!("cudaMemcpy"),
         free: sym!("cudaFree"),
+        stream_create: sym!("cudaStreamCreate"),
+        stream_synchronize: sym!("cudaStreamSynchronize"),
+        stream_destroy: sym!("cudaStreamDestroy"),
     })
 }
 
@@ -98,6 +105,45 @@ pub unsafe fn memcpy_device_to_host(
     }
 }
 
+/// Create a CUDA stream. Returns `None` if libcudart is unavailable or stream
+/// creation fails. The returned stream must be released with
+/// [`stream_destroy`]. Intended for clients (e.g. the codec's nvJPEG backend)
+/// that submit async device work and synchronise on it.
+pub fn stream_create() -> Option<CudaStream> {
+    let t = table()?;
+    let mut stream: CudaStream = std::ptr::null_mut();
+    if unsafe { (t.stream_create)(&mut stream) } != 0 {
+        return None;
+    }
+    Some(stream)
+}
+
+/// Block until all work submitted to `stream` completes. Returns `false` on
+/// failure or if libcudart is unavailable.
+///
+/// # Safety
+///
+/// `stream` must be a live stream returned by [`stream_create`] and not yet
+/// destroyed.
+pub unsafe fn stream_synchronize(stream: CudaStream) -> bool {
+    match table() {
+        Some(t) => (t.stream_synchronize)(stream) == 0,
+        None => false,
+    }
+}
+
+/// Destroy a CUDA stream. No-op if libcudart is unavailable.
+///
+/// # Safety
+///
+/// `stream` must be a live stream returned by [`stream_create`] and must not be
+/// used after this call.
+pub unsafe fn stream_destroy(stream: CudaStream) {
+    if let Some(t) = table() {
+        let _ = (t.stream_destroy)(stream);
+    }
+}
+
 /// Register a GL buffer (PBO) with CUDA. Returns the resource as `usize`
 /// (pointer) or `None`. MUST be called on the thread where the GL context is
 /// current.
@@ -105,7 +151,9 @@ pub fn gl_register_buffer(buffer_id: u32) -> Option<usize> {
     let t = table()?;
     let mut res: GraphicsResource = std::ptr::null_mut();
     // cudaGraphicsRegisterFlagsNone = 0
-    if unsafe { (t.graphics_gl_register_buffer)(&mut res, buffer_id, 0) } != 0 {
+    let rc = unsafe { (t.graphics_gl_register_buffer)(&mut res, buffer_id, 0) };
+    if rc != 0 {
+        log::debug!("cudaGraphicsGLRegisterBuffer(buffer={buffer_id}) failed: cudaError {rc}");
         return None;
     }
     Some(res as usize)

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -77,7 +77,8 @@ pub use crate::pbo::{PboMap, PboMapping, PboOps, PboTensor};
 pub(crate) use crate::shm::{ShmMap, ShmTensor};
 pub use cuda::{
     gl_map_resource, gl_register_buffer, gl_unmap_resource, gl_unregister_resource,
-    is_cuda_available, memcpy_device_to_host, CudaGlOps, CudaHandle, CudaMap,
+    is_cuda_available, memcpy_device_to_host, stream_create, stream_destroy, stream_synchronize,
+    CudaGlOps, CudaHandle, CudaMap, CudaStream,
 };
 pub use error::{Error, Result};
 pub use format::{ChromaLayout, PixelFormat, PixelLayout};


### PR DESCRIPTION
## Summary

Adds an **nvJPEG** (CUDA) GPU JPEG-decode backend to `crates/codec`, preferred
ahead of V4L2/CPU on NVIDIA platforms. It decodes a JPEG straight into a
CUDA-backed **PBO** as interleaved **RGB** — GPU-resident for zero-copy
`ImageProcessor::convert()`, with no CPU bounce. The Linux JPEG dispatch is now
**nvJPEG → V4L2 → CPU**.

The backend is entirely `dlopen`-based (no link-time CUDA dependency): one
artifact runs on Jetson (nvJPEG), i.MX (V4L2), and a laptop (CPU), falling
through transparently when `libnvjpeg`/`libcudart` is absent or the destination
is not CUDA-backed.

## What changed

- **`crates/codec`** — new `jpeg/nvjpeg/{ffi,loader,mod}.rs`:
  - `loader.rs` opens `libnvjpeg.so.12` via explicit CUDA paths and **requires
    `nvjpeg*` symbols** (rejects the libjpeg-turbo *decoy* on the default loader
    path); `EDGEFIRST_DISABLE_NVJPEG` opt-out.
  - `NvJpegProbe`/`NvJpegContext` mirror `V4l2Probe`: persistent handle/state +
    **one CUDA stream per decoder**, tri-state `try_decode`, circuit breaker,
    `codec.decode_jpeg.nvjpeg*` tracing spans.
  - Dispatch wired before V4L2 in `jpeg/mod.rs`; `nvjpeg_available()` exported.
  - Default-on `nvjpeg` feature, `cfg(linux)`-gated → compiles to nothing
    elsewhere; no CUDA toolkit needed to build.
- **`crates/tensor`** — `cudaStream` create/sync/destroy added to the dlopen
  `cuda` table (+ a debug log on `cudaGraphicsGLRegisterBuffer` failure).
- **`crates/image`** — `create_pbo_image` now CUDA-registers **u8** PBOs (was
  float-only). This is required for a `create_image` PBO to yield a `cuda_map()`
  device pointer, and fixes a latent gap affecting *any* CUDA consumer of a u8
  PBO. See the corrected "CUDA registration of PBO tensors" section in
  `crates/image/ARCHITECTURE.md`.
- **Docs/bench/example** — `codec/jpeg/nvjpeg/rgbi/*` bench cells (on-target
  only, self-skip elsewhere), `examples/nvjpeg_decode.rs` smoke test,
  `codec`/`image` `ARCHITECTURE.md`, `BENCHMARKS.md`, and a `bench-nvjpeg`
  make target.

## Validation (Jetson Orin Nano, L4T R36.4.7, CUDA 12.6, nvJPEG 12.3.3)

Via `examples/nvjpeg_decode`:

```
nvjpeg_available = true · dst = Pbo, CUDA handle = true
zidane 720p → Rgb via nvJPEG: ~2.2 ms  (vs ~6.0 ms CPU NV12 → ~2.7×, GPU-resident)
  decoded PBO readback:  min=0 max=255 mean=59.3  → real image ✓
  convert() → 640×640:   min=0 max=255 mean=33.3  → decode→convert chain verified ✓
```

The `convert()` readback confirms CUDA-write → GL-read coherency (nvJPEG writes
the PBO via CUDA, `convert()` GL-samples it).

## Notes

- **RGB output** is a deliberate, documented exception to the codec's
  native-format contract (CPU/V4L2 emit NV12/Grey/NV24). nvJPEG does YCbCr→RGB
  on-GPU near-free and `convert()` consumes RGB directly. The L4T nvJPEG 12.3.3
  build has no `NVJPEG_OUTPUT_NV12`, and the `HARDWARE` backend is unsupported on
  Orin, so it runs `GPU_HYBRID`.
- The multi-worker e2e/overlap bench cells and on-target parity/zero-alloc tests
  need a profiler-level deployment and are documented as follow-ups in
  `BENCHMARKS.md`.

## Test plan

- ✅ `make format lint` (clippy strict + ruff) clean
- ✅ clippy `-D warnings` + builds on macOS, aarch64-linux, x86_64-linux;
  `--no-default-features` compiles nvJPEG out
- ✅ host tests pass (3 macOS GL `proto_*` are the known parallel-test flake —
  pass single-threaded)
- ✅ end-to-end on-target on Orin Nano (above)
