### PR TITLE
Add NEON CPU packed↔planar deinterleave + FP16/F32 widen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Cached CPU convert intermediates** (`edgefirst-image`): the multi-step
+  CPU convert pipeline (pre-resize format-convert and the resized-RGB
+  scratch used by letterbox/resize) now reuses two `CPUProcessor`-held
+  buffers across frames instead of allocating — and `alloc_zeroed`-clearing
+  — a fresh full-frame buffer per call. Each consumer fully overwrites the
+  region it reads, so reused (non-zeroed) contents are never observed, and
+  output is unchanged. Measured on Orin Nano (interleaved A/B, NV12 1280×720
+  → 640×640 letterbox): median −8% (2.7→2.5 ms) and, more importantly, the
+  tail flattens (p95 3.3→2.6 ms, max 5.2→2.8 ms) by removing the per-frame
+  mmap/page-fault spikes.
 - **Strip-fused CPU NV→PlanarRgb conversion** (`edgefirst-image`): the
   no-resize NV12/NV16/NV24 → `PlanarRgb`/`PlanarRgba` conversion now decodes
   the YUV source into packed RGB one cache-resident row strip at a time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **NEON-accelerated CPU packed↔planar conversion and float widen**
+  (`edgefirst-image`): the CPU `pack_to_planar` scatter (RGB/RGBA →
+  `PlanarRgb`/`PlanarRgba` — the JPEG→NV→planar model-input path on the
+  Jetson Orin CPU pipeline) now uses a single-pass NEON `vld3`/`vld4`
+  deinterleave (one hardware-deinterleaving load reads the packed source
+  once and splits the channels) instead of a per-plane scalar gather that
+  re-read the source once per plane. The U8→F32 `/255` normalisation widen
+  uses NEON `vmovl`/`vcvtq`/`vdivq` (bit-identical to the scalar form), and
+  the U8→F16 widen gains a native half-precision kernel
+  (`ucvtf.8h`+`fdiv.8h`) selected at runtime on FEAT_FP16 CPUs (e.g. the
+  Orin's Cortex-A78AE), with a scalar fallback elsewhere (forceable via
+  `EDGEFIRST_IMAGE_NO_FP16`). The deinterleave is memory-bandwidth-bound,
+  so it now runs serially (the previous per-plane rayon fan-out added
+  scheduling overhead without a throughput gain); the rare arbitrary
+  channel-mapping path keeps its parallel fallback. Measured on Orin Nano
+  (CPU backend, 1280×720 → 640×640 letterbox): NV12→PlanarRgb −25%,
+  letterbox→PlanarRgb −9%, letterbox→PlanarRgb F16 −24% (F16 is now faster
+  than F32 for model input). Output is unchanged for the integer/F32 paths
+  and within ~1 f16 ULP for the native F16 path. NEON is baseline on
+  aarch64; non-aarch64 targets keep the scalar path.
 - **BREAKING — unified GL processor on macOS** (`edgefirst-image`):
   `ImageProcessor` on macOS now drives the same `GLProcessorThreaded`
   engine as Linux, with a dedicated worker thread and a private ANGLE
@@ -29,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`cpu_preprocess_benchmark`** (`edgefirst-image`): a self-contained
+  on-target benchmark for the CPU JPEG-preprocessing path (NV12/NV16/NV24
+  → RGB / PlanarRgb / PlanarRgb-F32 / PlanarRgb-F16, same-size and
+  letterbox), used to characterise and gate the Orin CPU pipeline. Sources
+  are synthesised (no testdata), and it honours `EDGEFIRST_FORCE_BACKEND`,
+  `EDGEFIRST_BENCH_ITERS`, and `EDGEFIRST_BENCH_ONLY` for `perf` profiling
+  of individual cells.
 - **Fused NV12/NV16/NV24 → PlanarRgb F16 GL convert** (`edgefirst-image`):
   the model-input conversion (YUV source → letterboxed planar F16
   tensor) now runs as two GL passes inside one `convert()` call on every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Strip-fused CPU NV→PlanarRgb conversion** (`edgefirst-image`): the
+  no-resize NV12/NV16/NV24 → `PlanarRgb`/`PlanarRgba` conversion now decodes
+  the YUV source into packed RGB one cache-resident row strip at a time
+  (into a `CPUProcessor`-cached scratch) and NEON-deinterleaves each strip
+  straight into the destination planes. The full-size packed-RGB
+  intermediate no longer round-trips through DRAM and is no longer
+  reallocated per frame, so the strip stays hot in L2 between the YUV decode
+  and the deinterleave. Output is byte-for-byte identical to the previous
+  two-pass path (NV12 4:2:0 replicates one chroma row across two luma rows,
+  so strip boundaries do not change the per-row chroma pairing — verified
+  across NV12/16/24, planar/planar-RGBA, and odd dimensions). Measured on
+  Orin Nano (CPU backend, 1280×720, no resize): NV12→PlanarRgb a further
+  −21% on top of the NEON deinterleave (≈ −46% vs the original scalar
+  path). The letterbox path is unchanged (its resize step requires the
+  full packed buffer).
 - **NEON-accelerated CPU packed↔planar conversion and float widen**
   (`edgefirst-image`): the CPU `pack_to_planar` scatter (RGB/RGBA →
   `PlanarRgb`/`PlanarRgba` — the JPEG→NV→planar model-input path on the

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -99,6 +99,10 @@ name = "convert_matrix_benchmark"
 harness = false
 
 [[bench]]
+name = "cpu_preprocess_benchmark"
+harness = false
+
+[[bench]]
 name = "batch_convert_benchmark"
 harness = false
 

--- a/crates/image/benches/cpu_preprocess_benchmark.rs
+++ b/crates/image/benches/cpu_preprocess_benchmark.rs
@@ -69,15 +69,17 @@ fn fmt_name(f: PixelFormat) -> &'static str {
 }
 
 fn main() {
-    env_logger::init();
-    let mut suite = BenchSuite::from_args();
-
-    // Pin the CPU backend: this bench characterises the CPU preprocessing path
-    // that the Orin Nano deployment uses to keep the GPU free for TensorRT.
-    // SAFETY: set_var before any threads spawn.
+    // Pin the CPU backend first, before anything that could spawn a thread:
+    // this bench characterises the CPU preprocessing path the Orin Nano
+    // deployment uses to keep the GPU free for TensorRT.
+    // SAFETY: set_var runs at the very top of main(), before env_logger,
+    // argument parsing, or any worker threads — the process is single-threaded.
     if std::env::var("EDGEFIRST_FORCE_BACKEND").is_err() {
         unsafe { std::env::set_var("EDGEFIRST_FORCE_BACKEND", "cpu") };
     }
+
+    env_logger::init();
+    let mut suite = BenchSuite::from_args();
 
     let iters: usize = std::env::var("EDGEFIRST_BENCH_ITERS")
         .ok()
@@ -187,9 +189,8 @@ fn main() {
                 proc.convert(&src, &mut dst, Rotation::None, Flip::None, crop)
                     .unwrap();
             });
-            // Throughput is reported against source bytes for the u8 cells; the
-            // f32 cell shares the source so the number is comparable.
-            let _ = src_bytes;
+            // Throughput is reported against source bytes; the f32/f16 cells
+            // share the same source so the numbers are comparable across dtypes.
             r.print_summary_with_throughput(src_bytes);
             suite.record(&r);
         }

--- a/crates/image/benches/cpu_preprocess_benchmark.rs
+++ b/crates/image/benches/cpu_preprocess_benchmark.rs
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! CPU JPEG-preprocessing path benchmark (Jetson Orin Nano profile target).
+//!
+//! On the Orin Nano Super we deliberately keep JPEG decode + preprocessing +
+//! postprocessing on the CPU so TensorRT owns the GPU. JPEG decodes to the NV
+//! family (NV12 4:2:0, NV16 4:2:2, NV24 4:4:4) and the model wants planar RGB
+//! (`PlanarRgb`, i.e. CHW) — optionally widened to F32. This bench isolates the
+//! cells on that path so `perf` attribution is clean and before/after fusion +
+//! NEON work has a named gate per cell.
+//!
+//! The CPU backend is pinned via `EDGEFIRST_FORCE_BACKEND=cpu` so GL/G2D never
+//! absorb a cell. Self-contained: sources are synthesized (Y luma gradient +
+//! neutral chroma), so NO testdata files are required on the target.
+//!
+//! ```bash
+//! EDGEFIRST_FORCE_BACKEND=cpu ./cpu_preprocess_benchmark --json cpu.json
+//! # profile a single cell under perf (crank iterations for sample density):
+//! EDGEFIRST_FORCE_BACKEND=cpu EDGEFIRST_BENCH_ONLY=nv12/letterbox \
+//!   EDGEFIRST_BENCH_ITERS=2000 perf record -e cycles:u -g -- ./cpu_preprocess_benchmark
+//! ```
+
+mod common;
+
+use common::{run_bench, BenchSuite};
+
+use edgefirst_image::{Crop, Flip, ImageProcessor, ImageProcessorTrait, Rotation};
+use edgefirst_tensor::{DType, PixelFormat, TensorMapTrait, TensorTrait};
+
+const WARMUP: usize = 10;
+const DEFAULT_ITERATIONS: usize = 200;
+
+// Camera 1280x720 → model 640x640 (the profiler's letterbox geometry).
+const IN_W: usize = 1280;
+const IN_H: usize = 720;
+const OUT_W: usize = 640;
+const OUT_H: usize = 640;
+
+/// Combined semi-planar buffer byte length for a `w x h` image.
+fn nv_len(fmt: PixelFormat, w: usize, h: usize) -> usize {
+    match fmt {
+        PixelFormat::Nv12 => w * h * 3 / 2,
+        PixelFormat::Nv16 => w * h * 2,
+        PixelFormat::Nv24 => w * h * 3,
+        _ => w * h,
+    }
+}
+
+/// Synthesize an NV* source: Y plane = luma gradient, chroma = neutral 128.
+fn fill_nv(buf: &mut [u8], w: usize, h: usize) {
+    for r in 0..h {
+        for c in 0..w {
+            buf[r * w + c] = ((r + c) * 255 / (w + h)) as u8;
+        }
+    }
+    for b in buf.iter_mut().skip(w * h) {
+        *b = 128;
+    }
+}
+
+fn fmt_name(f: PixelFormat) -> &'static str {
+    match f {
+        PixelFormat::Nv12 => "nv12",
+        PixelFormat::Nv16 => "nv16",
+        PixelFormat::Nv24 => "nv24",
+        _ => "other",
+    }
+}
+
+fn main() {
+    env_logger::init();
+    let mut suite = BenchSuite::from_args();
+
+    // Pin the CPU backend: this bench characterises the CPU preprocessing path
+    // that the Orin Nano deployment uses to keep the GPU free for TensorRT.
+    // SAFETY: set_var before any threads spawn.
+    if std::env::var("EDGEFIRST_FORCE_BACKEND").is_err() {
+        unsafe { std::env::set_var("EDGEFIRST_FORCE_BACKEND", "cpu") };
+    }
+
+    let iters: usize = std::env::var("EDGEFIRST_BENCH_ITERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_ITERATIONS);
+    let only = std::env::var("EDGEFIRST_BENCH_ONLY").unwrap_or_default();
+
+    println!(
+        "\n== CPU preprocess benchmark ({IN_W}x{IN_H} -> {OUT_W}x{OUT_H}) backend={} ==",
+        std::env::var("EDGEFIRST_FORCE_BACKEND").unwrap_or_else(|_| "auto".into())
+    );
+    println!("   warmup={WARMUP} iterations={iters} filter={only:?}\n");
+
+    let mut proc = match ImageProcessor::new() {
+        Ok(p) => p,
+        Err(e) => {
+            println!("  [skipped: ImageProcessor init failed: {e}]");
+            suite.finish();
+            return;
+        }
+    };
+
+    let lb_crop = Crop::letterbox([114, 114, 114, 255]);
+
+    for fmt in [PixelFormat::Nv12, PixelFormat::Nv16, PixelFormat::Nv24] {
+        let src = match proc.create_image(IN_W, IN_H, fmt, DType::U8, None) {
+            Ok(s) => s,
+            Err(e) => {
+                println!("  {fmt:?}: [skipped: source alloc failed: {e}]");
+                continue;
+            }
+        };
+        {
+            let mut map = src.as_u8().unwrap().map().unwrap();
+            let n = nv_len(fmt, IN_W, IN_H);
+            fill_nv(&mut map.as_mut_slice()[..n], IN_W, IN_H);
+        }
+        let src_bytes = nv_len(fmt, IN_W, IN_H) as u64;
+
+        // Each cell: (suffix, out dims, out fmt, out dtype, crop).
+        let cells: &[(&str, usize, usize, PixelFormat, DType, Crop)] = &[
+            // Pure convert (no resize) — isolates NV→RGB decode + planar scatter.
+            (
+                "convert_720p_to_rgb",
+                IN_W,
+                IN_H,
+                PixelFormat::Rgb,
+                DType::U8,
+                Crop::no_crop(),
+            ),
+            (
+                "convert_720p_to_planar_rgb",
+                IN_W,
+                IN_H,
+                PixelFormat::PlanarRgb,
+                DType::U8,
+                Crop::no_crop(),
+            ),
+            // Letterbox (convert + resize) — the real pipeline op.
+            (
+                "letterbox_720p_to_640_planar_rgb",
+                OUT_W,
+                OUT_H,
+                PixelFormat::PlanarRgb,
+                DType::U8,
+                lb_crop,
+            ),
+            // Full preprocess: planar RGB widened to F32 (model input dtype).
+            (
+                "letterbox_720p_to_640_planar_rgb_f32",
+                OUT_W,
+                OUT_H,
+                PixelFormat::PlanarRgb,
+                DType::F32,
+                lb_crop,
+            ),
+            // Full preprocess to F16 (native-FP16 widen on capable CPUs).
+            (
+                "letterbox_720p_to_640_planar_rgb_f16",
+                OUT_W,
+                OUT_H,
+                PixelFormat::PlanarRgb,
+                DType::F16,
+                lb_crop,
+            ),
+        ];
+
+        for &(suffix, ow, oh, ofmt, odt, crop) in cells {
+            let name = format!("{}/{}", fmt_name(fmt), suffix);
+            if !only.is_empty() && !name.contains(&only) {
+                continue;
+            }
+            let mut dst = match proc.create_image(ow, oh, ofmt, odt, None) {
+                Ok(d) => d,
+                Err(e) => {
+                    println!("  {name:50} [dst alloc failed: {e}]");
+                    continue;
+                }
+            };
+            // Probe once: an unsupported cell is reported and skipped instead of
+            // panicking inside the timing loop.
+            if let Err(e) = proc.convert(&src, &mut dst, Rotation::None, Flip::None, crop) {
+                println!("  {name:50} [unsupported: {e}]");
+                continue;
+            }
+            let r = run_bench(&name, WARMUP, iters, || {
+                proc.convert(&src, &mut dst, Rotation::None, Flip::None, crop)
+                    .unwrap();
+            });
+            // Throughput is reported against source bytes for the u8 cells; the
+            // f32 cell shares the source so the number is comparable.
+            let _ = src_bytes;
+            r.print_summary_with_throughput(src_bytes);
+            suite.record(&r);
+        }
+    }
+
+    suite.finish();
+}

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -216,6 +216,69 @@ fn pack_to_planar(
     if plane == 0 {
         return Ok(()); // zero-height / empty image: nothing to scatter
     }
+
+    // Fast path: identity colour mapping (R,G,B ← src channels 0,1,2) with a
+    // 3- or 4-channel packed source, and either no alpha plane, a constant
+    // alpha plane (RGB → PlanarRgba), or an alpha plane copied from src
+    // channel 3 (RGBA → PlanarRgba). This covers every current caller. A single
+    // NEON deinterleaving pass reads the packed source once and writes all
+    // planes, replacing the per-plane scalar gather (which re-read the source
+    // once per plane). Parallelism moves from per-plane to per-row-strip.
+    let n_planes = plane_src.len();
+    let identity_rgb = n_planes >= 3
+        && plane_src[0] == Some(0)
+        && plane_src[1] == Some(1)
+        && plane_src[2] == Some(2);
+    let alpha_from_src = n_planes == 4 && plane_src[3] == Some(3);
+    let const_alpha = n_planes == 4 && plane_src[3].is_none();
+    let fast = identity_rgb
+        && (src_ch == 3 || src_ch == 4)
+        && (n_planes == 3 || (alpha_from_src && src_ch == 4) || const_alpha);
+
+    if fast {
+        let mut planes = dst_bytes.chunks_mut(plane).take(n_planes);
+        let rp = planes.next().unwrap();
+        let gp = planes.next().unwrap();
+        let bp = planes.next().unwrap();
+        let ap = planes.next(); // Some(_) only when n_planes == 4
+        let src_rows = &src_bytes[..h * src_stride];
+
+        // Serial, one pass per row: the NEON `vld3`/`vld4` deinterleave reads
+        // the packed source once and is memory-bandwidth-bound, so on Orin's
+        // shared bus row-level rayon parallelism measured no faster than serial
+        // for the model-preprocessing sizes (≤1080p) while adding scheduling
+        // overhead on small frames. The rare arbitrary-mapping path below keeps
+        // its per-plane parallelism.
+        match ap {
+            Some(ap) if alpha_from_src => {
+                src_rows
+                    .chunks(src_stride)
+                    .zip(rp.chunks_mut(dst_stride))
+                    .zip(gp.chunks_mut(dst_stride))
+                    .zip(bp.chunks_mut(dst_stride))
+                    .zip(ap.chunks_mut(dst_stride))
+                    .for_each(|((((s, r), g), b), a)| {
+                        super::simd::deinterleave_row(s, r, g, b, Some(a), w, src_ch);
+                    });
+            }
+            other => {
+                if let Some(ap) = other {
+                    // Constant alpha plane (RGB → PlanarRgba): fill once.
+                    ap.fill(255);
+                }
+                src_rows
+                    .chunks(src_stride)
+                    .zip(rp.chunks_mut(dst_stride))
+                    .zip(gp.chunks_mut(dst_stride))
+                    .zip(bp.chunks_mut(dst_stride))
+                    .for_each(|(((s, r), g), b)| {
+                        super::simd::deinterleave_row(s, r, g, b, None, w, src_ch);
+                    });
+            }
+        }
+        return Ok(());
+    }
+
     let plane_slices: Vec<&mut [u8]> = dst_bytes.chunks_mut(plane).take(plane_src.len()).collect();
     rayon::scope(|sc| {
         for (pb, &chan) in plane_slices.into_iter().zip(plane_src.iter()) {

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -263,8 +263,13 @@ fn pack_to_planar(
             }
             other => {
                 if let Some(ap) = other {
-                    // Constant alpha plane (RGB → PlanarRgba): fill once.
-                    ap.fill(255);
+                    // Constant alpha plane (RGB → PlanarRgba): fill only the `w`
+                    // logical bytes of each row, matching this function's
+                    // contract and the slow-path `None` handling (leave per-row
+                    // padding untouched rather than filling the whole plane).
+                    for row in ap.chunks_mut(dst_stride).take(h) {
+                        row[..w].fill(255);
+                    }
                 }
                 src_rows
                     .chunks(src_stride)

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -1406,6 +1406,183 @@ impl CPUProcessor {
         Ok(())
     }
 
+    /// Strip-fused NV12/NV16/NV24 → PlanarRgb/PlanarRgba for the no-resize
+    /// case. Decodes the YUV source into packed RGB one cache-resident row
+    /// strip at a time (into the reused [`Self::nv_strip_scratch`]) and
+    /// NEON-deinterleaves each strip straight into the destination planes, so
+    /// the full-size packed-RGB intermediate never round-trips through DRAM and
+    /// is not reallocated per frame. The strip height keeps a `width × 3`
+    /// strip resident in L2 between the YUV decode and the deinterleave.
+    ///
+    /// Geometry mirrors `convert_nv12`/`convert_nv16`/`convert_nv24` (contiguous
+    /// and multiplane sources). NV12 (4:2:0) advances the chroma plane by half
+    /// the luma rows; the strip height is even so each strip starts on an even
+    /// luma row. The destination is validated against the derived plane sizes
+    /// (untrusted dims → `InvalidShape`, not a panic), like the other helpers.
+    pub(super) fn convert_nv_to_planar_fused(
+        &mut self,
+        src: &Tensor<u8>,
+        dst: &mut Tensor<u8>,
+        src_fmt: edgefirst_tensor::PixelFormat,
+        dst_fmt: edgefirst_tensor::PixelFormat,
+        cp: ColorParams,
+    ) -> Result<()> {
+        use edgefirst_tensor::PixelFormat::{Nv12, Nv16, Nv24, PlanarRgb, PlanarRgba};
+
+        /// Strip height (rows). Even (NV12 4:2:0 needs an even strip start) and
+        /// sized so one packed-RGB strip stays in L2 across realistic widths
+        /// (32 × 1920 × 3 ≈ 180 KiB).
+        const STRIP_ROWS: usize = 32;
+
+        let w = src.width().unwrap();
+        let h = src.height().unwrap();
+        let has_alpha = dst_fmt == PlanarRgba;
+        debug_assert!(matches!(dst_fmt, PlanarRgb | PlanarRgba));
+
+        // ---- source plane geometry (mirrors convert_nv12/nv16/nv24) ----
+        let y_stride = src.effective_row_stride().unwrap_or(w.next_multiple_of(2));
+        // `chroma_div` maps a luma row index to its chroma row index: NV12
+        // (4:2:0) subsamples chroma vertically by two; NV16/NV24 do not.
+        let (uv_stride, chroma_div) = match src_fmt {
+            Nv12 => {
+                let uv = if src.is_multiplane() {
+                    src.chroma()
+                        .unwrap()
+                        .effective_row_stride()
+                        .unwrap_or(w.next_multiple_of(2))
+                } else {
+                    y_stride
+                };
+                (uv, 2usize)
+            }
+            Nv16 => (y_stride, 1usize),
+            Nv24 => (y_stride * 2, 1usize),
+            other => return Err(Error::NotSupported(format!("fused {other} → planar"))),
+        };
+
+        let src_map = src.map()?;
+        let chroma_map = if src.is_multiplane() {
+            Some(src.chroma().unwrap().map()?)
+        } else {
+            None
+        };
+        let (y_plane, uv_plane): (&[u8], &[u8]) = if let Some(cm) = &chroma_map {
+            (src_map.as_slice(), cm.as_slice())
+        } else {
+            super::split_semi_planar(src_map.as_slice(), y_stride, h, src_fmt)?
+        };
+
+        // ---- destination plane geometry + validation ----
+        let dst_stride = super::tensor_row_stride(dst);
+        let n_planes = if has_alpha { 4 } else { 3 };
+        let mut dst_map = dst.map()?;
+        let dst_bytes = dst_map.as_mut_slice();
+        let plane = dst_stride.checked_mul(h).ok_or_else(|| {
+            Error::InvalidShape(format!(
+                "fused nv→planar plane overflow (stride={dst_stride}, h={h})"
+            ))
+        })?;
+        let dst_need = plane.checked_mul(n_planes).ok_or_else(|| {
+            Error::InvalidShape(format!(
+                "fused nv→planar dst overflow (plane={plane}, planes={n_planes})"
+            ))
+        })?;
+        if dst_stride < w || dst_bytes.len() < dst_need {
+            return Err(Error::InvalidShape(format!(
+                "fused nv→planar dst too small: {} bytes, need {dst_need} (stride={dst_stride} >= w={w}, planes={n_planes})",
+                dst_bytes.len()
+            )));
+        }
+        if w == 0 || h == 0 {
+            return Ok(());
+        }
+
+        let mut planes = dst_bytes.chunks_mut(plane);
+        let rp = planes.next().unwrap();
+        let gp = planes.next().unwrap();
+        let bp = planes.next().unwrap();
+        if has_alpha {
+            // NV sources carry no alpha; PlanarRgba gets a constant 255 plane.
+            planes.next().unwrap().fill(255);
+        }
+
+        // ---- strip loop: decode into the cached scratch, deinterleave out ----
+        let mut scratch = std::mem::take(&mut self.nv_strip_scratch);
+        let need = STRIP_ROWS.saturating_mul(w).saturating_mul(3);
+        if scratch.len() < need {
+            scratch.resize(need, 0);
+        }
+
+        let mut r0 = 0usize;
+        let mut result = Ok(());
+        while r0 < h {
+            let sh = STRIP_ROWS.min(h - r0);
+            let yoff = r0 * y_stride;
+            let uvoff = (r0 / chroma_div) * uv_stride;
+            let img = yuv::YuvBiPlanarImage {
+                y_plane: &y_plane[yoff..],
+                y_stride: y_stride as u32,
+                uv_plane: &uv_plane[uvoff..],
+                uv_stride: uv_stride as u32,
+                width: w as u32,
+                height: sh as u32,
+            };
+            let rgb_stride = (w * 3) as u32;
+            {
+                let rgb = &mut scratch[..sh * w * 3];
+                let decode = match src_fmt {
+                    Nv12 => yuv::yuv_nv12_to_rgb(
+                        &img,
+                        rgb,
+                        rgb_stride,
+                        cp.range,
+                        cp.matrix,
+                        yuv::YuvConversionMode::Balanced,
+                    ),
+                    Nv16 => yuv::yuv_nv16_to_rgb(
+                        &img,
+                        rgb,
+                        rgb_stride,
+                        cp.range,
+                        cp.matrix,
+                        yuv::YuvConversionMode::Balanced,
+                    ),
+                    Nv24 => yuv::yuv_nv24_to_rgb(
+                        &img,
+                        rgb,
+                        rgb_stride,
+                        cp.range,
+                        cp.matrix,
+                        yuv::YuvConversionMode::Balanced,
+                    ),
+                    _ => unreachable!(),
+                };
+                if let Err(e) = decode {
+                    result = Err(e.into());
+                    break;
+                }
+            }
+            // The strip's packed RGB is now hot in the scratch; scatter each row
+            // into the destination planes at its frame-row offset.
+            for i in 0..sh {
+                let s = &scratch[i * w * 3..i * w * 3 + w * 3];
+                let roff = (r0 + i) * dst_stride;
+                super::simd::deinterleave_row(
+                    s,
+                    &mut rp[roff..roff + w],
+                    &mut gp[roff..roff + w],
+                    &mut bp[roff..roff + w],
+                    None,
+                    w,
+                    3,
+                );
+            }
+            r0 += sh;
+        }
+        self.nv_strip_scratch = scratch;
+        result
+    }
+
     /// Read a planar `[C, H, W]` source into a packed interleaved destination,
     /// honouring both the source row stride and the destination row stride.
     /// Colour planes 0..3 map to destination channels R, G, B. When the

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -12,6 +12,7 @@ use edgefirst_tensor::{
 mod convert;
 mod masks;
 mod resize;
+mod simd;
 mod tests;
 
 // bilinear_dot removed — masks.rs now uses slice-native bilinear_dot_slice
@@ -608,21 +609,6 @@ impl ImageProcessorTrait for CPUProcessor {
     }
 }
 
-/// Widen a `u8` source buffer into a typed destination buffer element-by-element.
-///
-/// `f` converts a single `u8` element to `T`. The implementation is a plain
-/// `iter`/`zip` loop so LLVM can auto-vectorise it (e.g. for the `f32` case).
-///
-/// # Panics (debug)
-/// Panics in debug mode if `src.len() != dst.len()`.
-#[inline]
-fn widen_into<T: Copy>(src: &[u8], dst: &mut [T], f: impl Fn(u8) -> T) {
-    debug_assert_eq!(src.len(), dst.len());
-    for (o, &b) in dst.iter_mut().zip(src.iter()) {
-        *o = f(b);
-    }
-}
-
 // Internal methods — dtype-aware dispatch layer.
 impl CPUProcessor {
     /// Top-level conversion dispatcher: handles dtype combinations.
@@ -719,17 +705,20 @@ impl CPUProcessor {
                             let dst_t = dst.as_f32_mut().unwrap();
                             let mut dst_map = dst_t.map()?;
                             debug_assert_eq!(src_map.as_slice().len(), dst_map.as_slice().len());
-                            widen_into(src_map.as_slice(), dst_map.as_mut_slice(), |b| {
-                                b as f32 / 255.0
-                            });
+                            // NEON-accelerated u8→f32 `/255` widen (bit-identical
+                            // to the scalar `b as f32 / 255.0`); the scalar
+                            // iterator form did not vectorise. See cpu::simd.
+                            simd::widen_u8_to_f32_norm(src_map.as_slice(), dst_map.as_mut_slice());
                         }
                         DType::F16 => {
                             let dst_t = dst.as_f16_mut().unwrap();
                             let mut dst_map = dst_t.map()?;
                             debug_assert_eq!(src_map.as_slice().len(), dst_map.as_slice().len());
-                            widen_into(src_map.as_slice(), dst_map.as_mut_slice(), |b| {
-                                half::f16::from_f32(b as f32 / 255.0)
-                            });
+                            // u8→f16 `/255` widen; uses native FP16
+                            // (`ucvtf`+`fdiv`) at runtime on FEAT_FP16 CPUs
+                            // (Orin), scalar `half::f16::from_f32` elsewhere.
+                            // See cpu::simd.
+                            simd::widen_u8_to_f16_norm(src_map.as_slice(), dst_map.as_mut_slice());
                         }
                         _ => unreachable!(),
                     }

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -67,6 +67,12 @@ pub struct CPUProcessor {
     /// reuses the allocation instead of a fresh `Vec` per call (the stride
     /// alignment in this release makes that de-stride copy fire far more often).
     resize_destride_scratch: Vec<u8>,
+    /// Reusable cache-resident scratch for the strip-fused NV→planar path
+    /// (`convert_nv_to_planar_fused`): holds a single row strip of packed RGB
+    /// (`STRIP_ROWS * width * 3` bytes). Keeping it on the processor avoids a
+    /// per-frame allocation and lets each strip stay hot in L2 between the YUV
+    /// decode and the deinterleave. Grown on demand; never shrunk.
+    nv_strip_scratch: Vec<u8>,
 }
 
 // `CPUProcessor` was `#[derive(Clone)]` before the `widen_scratch` field was
@@ -82,6 +88,7 @@ impl Clone for CPUProcessor {
             colors: self.colors,
             widen_scratch: None,
             resize_destride_scratch: Vec::new(),
+            nv_strip_scratch: Vec::new(),
         }
     }
 }
@@ -290,6 +297,7 @@ impl CPUProcessor {
             colors: crate::DEFAULT_COLORS_U8,
             widen_scratch: None,
             resize_destride_scratch: Vec::new(),
+            nv_strip_scratch: Vec::new(),
         }
     }
 
@@ -306,6 +314,7 @@ impl CPUProcessor {
             colors: crate::DEFAULT_COLORS_U8,
             widen_scratch: None,
             resize_destride_scratch: Vec::new(),
+            nv_strip_scratch: Vec::new(),
         }
     }
 
@@ -855,6 +864,19 @@ impl CPUProcessor {
         } else {
             dst_params
         };
+
+        // Fused NV→planar (no resize/flip/rotation/crop): decode the YUV source
+        // into packed RGB one cache-resident row strip at a time and
+        // NEON-deinterleave each strip straight into the destination planes, so
+        // the full-size packed-RGB intermediate never round-trips through DRAM
+        // and is not reallocated per frame. JPEG decodes to the NV family and the
+        // model wants planar RGB, so this is the hot Orin CPU-preprocess path.
+        if !need_resize_flip_rotation
+            && matches!(src_fmt, Nv12 | Nv16 | Nv24)
+            && matches!(dst_fmt, PlanarRgb | PlanarRgba)
+        {
+            return self.convert_nv_to_planar_fused(src, dst, src_fmt, dst_fmt, direct_params);
+        }
 
         // check if a direct conversion can be done
         if !need_resize_flip_rotation && Self::support_conversion_pf(src_fmt, dst_fmt) {

--- a/crates/image/src/cpu/mod.rs
+++ b/crates/image/src/cpu/mod.rs
@@ -73,6 +73,14 @@ pub struct CPUProcessor {
     /// per-frame allocation and lets each strip stay hot in L2 between the YUV
     /// decode and the deinterleave. Grown on demand; never shrunk.
     nv_strip_scratch: Vec<u8>,
+    /// Reusable intermediate buffers for the multi-step convert pipeline
+    /// (pre-resize format-convert and the resized-RGB scratch). Reused across
+    /// frames when the dimensions/format match so the steady-state
+    /// letterbox/resize loop does not reallocate — and `alloc_zeroed`-clear — a
+    /// full-frame buffer per call. The region each consumer reads is always
+    /// fully overwritten first, so reused (non-zeroed) contents are never read.
+    convert_tmp: Option<Tensor<u8>>,
+    convert_tmp2: Option<Tensor<u8>>,
 }
 
 // `CPUProcessor` was `#[derive(Clone)]` before the `widen_scratch` field was
@@ -89,6 +97,8 @@ impl Clone for CPUProcessor {
             widen_scratch: None,
             resize_destride_scratch: Vec::new(),
             nv_strip_scratch: Vec::new(),
+            convert_tmp: None,
+            convert_tmp2: None,
         }
     }
 }
@@ -298,6 +308,8 @@ impl CPUProcessor {
             widen_scratch: None,
             resize_destride_scratch: Vec::new(),
             nv_strip_scratch: Vec::new(),
+            convert_tmp: None,
+            convert_tmp2: None,
         }
     }
 
@@ -315,6 +327,8 @@ impl CPUProcessor {
             widen_scratch: None,
             resize_destride_scratch: Vec::new(),
             nv_strip_scratch: Vec::new(),
+            convert_tmp: None,
+            convert_tmp2: None,
         }
     }
 
@@ -739,6 +753,25 @@ impl CPUProcessor {
         }
     }
 
+    /// Reuse `cached` if it already has dimensions `(w, h)` and pixel format
+    /// `fmt`, otherwise allocate a fresh `Mem` image. The returned buffer's
+    /// contents are **not** zeroed on reuse — callers must fully overwrite the
+    /// region they later read (see the note at the convert pipeline's tmp/tmp2
+    /// site). This amortises the per-frame `Tensor::image` `alloc_zeroed`.
+    fn reuse_or_alloc_image(
+        cached: Option<Tensor<u8>>,
+        w: usize,
+        h: usize,
+        fmt: PixelFormat,
+    ) -> Result<Tensor<u8>> {
+        if let Some(t) = cached {
+            if t.width() == Some(w) && t.height() == Some(h) && t.format() == Some(fmt) {
+                return Ok(t);
+            }
+        }
+        Ok(Tensor::<u8>::image(w, h, fmt, Some(TensorMemory::Mem))?)
+    }
+
     /// U8-to-U8 conversion: the full format conversion + resize pipeline.
     #[allow(clippy::too_many_arguments)]
     fn convert_u8(
@@ -891,11 +924,18 @@ impl CPUProcessor {
             )));
         }
 
-        // create tmp buffer
-        let mut tmp_buffer;
-        let tmp;
-        let tmp_fmt;
-        if intermediate != src_fmt {
+        // Take the cached intermediates out of `self` so the resize step can
+        // borrow `self` exclusively; they are restored before returning on the
+        // success path. Reused buffers are not re-zeroed — every consumer below
+        // fully overwrites the region it later reads (the pre-resize convert
+        // writes all of `tmp`; the resize writes the scaled rect of `tmp2` and
+        // its letterbox border is either pre-filled from `dst` or overwritten in
+        // `dst` by the final `fill_image_outside_crop_u8`).
+        let mut cached_tmp = self.convert_tmp.take();
+        let mut cached_tmp2 = self.convert_tmp2.take();
+
+        // create tmp buffer (reusing the cached one when its geometry matches)
+        let tmp_holder: Option<Tensor<u8>> = if intermediate != src_fmt {
             let _s = tracing::trace_span!(
                 "image.convert.cpu.format_convert",
                 from = ?src_fmt,
@@ -903,15 +943,17 @@ impl CPUProcessor {
                 pass = "pre_resize",
             )
             .entered();
-            tmp_buffer = Tensor::<u8>::image(src_w, src_h, intermediate, Some(TensorMemory::Mem))?;
-
-            Self::convert_format_pf(src, &mut tmp_buffer, src_fmt, intermediate, src_params)?;
-            tmp = &tmp_buffer;
-            tmp_fmt = intermediate;
+            let mut t =
+                Self::reuse_or_alloc_image(cached_tmp.take(), src_w, src_h, intermediate)?;
+            Self::convert_format_pf(src, &mut t, src_fmt, intermediate, src_params)?;
+            Some(t)
         } else {
-            tmp = src;
-            tmp_fmt = src_fmt;
-        }
+            None
+        };
+        let (tmp, tmp_fmt): (&Tensor<u8>, PixelFormat) = match &tmp_holder {
+            Some(t) => (t, intermediate),
+            None => (src, src_fmt),
+        };
 
         // format must be RGB/RGBA/GREY
         debug_assert!(matches!(tmp_fmt, Rgb | Rgba | Grey));
@@ -928,7 +970,8 @@ impl CPUProcessor {
             .entered();
             Self::convert_format_pf(tmp, dst, tmp_fmt, dst_fmt, dst_params)?;
         } else {
-            let mut tmp2 = Tensor::<u8>::image(dst_w, dst_h, tmp_fmt, Some(TensorMemory::Mem))?;
+            let mut tmp2 =
+                Self::reuse_or_alloc_image(cached_tmp2.take(), dst_w, dst_h, tmp_fmt)?;
             if crop.dst_rect.is_some_and(|c| {
                 c != Rect {
                     left: 0,
@@ -954,7 +997,16 @@ impl CPUProcessor {
                 .entered();
                 Self::convert_format_pf(&tmp2, dst, tmp_fmt, dst_fmt, dst_params)?;
             }
+            cached_tmp2 = Some(tmp2);
         }
+        // Restore the intermediates to the cache for the next call (`tmp` — a
+        // borrow of `tmp_holder` — is no longer used past this point).
+        if let Some(t) = tmp_holder {
+            cached_tmp = Some(t);
+        }
+        self.convert_tmp = cached_tmp;
+        self.convert_tmp2 = cached_tmp2;
+
         if let (Some(dst_rect), Some(dst_color)) = (crop.dst_rect, crop.dst_color) {
             let full_rect = Rect {
                 left: 0,

--- a/crates/image/src/cpu/simd.rs
+++ b/crates/image/src/cpu/simd.rs
@@ -49,6 +49,14 @@ pub(super) fn deinterleave_row(
     debug_assert!(src.len() >= w * src_ch);
     debug_assert!(r.len() >= w && g.len() >= w && b.len() >= w);
     debug_assert!(a.as_ref().is_none_or(|a| a.len() >= w));
+    // An alpha plane can only be sourced from a 4-channel input (`src[..+3]`);
+    // a 3-channel source has no alpha byte. The kernels below also guard the
+    // alpha write on `src_ch == 4`, so a misuse can never read out of bounds —
+    // this assert just surfaces the logic error in debug builds.
+    debug_assert!(
+        a.is_none() || src_ch == 4,
+        "alpha output plane requires a 4-channel source"
+    );
 
     #[cfg(target_arch = "aarch64")]
     // SAFETY: NEON is baseline on aarch64; the debug_asserts above document the
@@ -74,7 +82,10 @@ fn deinterleave_row_scalar(
     src_ch: usize,
 ) {
     match a {
-        Some(a) => {
+        // Alpha is only sourced when the input has a 4th channel; the
+        // `src_ch == 4` guard keeps `p[3]` in bounds even if a caller wrongly
+        // pairs `Some(a)` with a 3-channel source (the debug_assert flags it).
+        Some(a) if src_ch == 4 => {
             for x in 0..w {
                 let p = &src[x * src_ch..];
                 r[x] = p[0];
@@ -83,7 +94,7 @@ fn deinterleave_row_scalar(
                 a[x] = p[3];
             }
         }
-        None => {
+        _ => {
             for x in 0..w {
                 let p = &src[x * src_ch..];
                 r[x] = p[0];
@@ -312,13 +323,19 @@ unsafe fn deinterleave_row_neon(
         }
     }
 
-    // Scalar tail for the remaining < 16 pixels.
+    // Scalar tail for the remaining < 16 pixels. The alpha write is gated on
+    // `src_ch == 4` (an alpha byte only exists in a 4-channel source), so
+    // `sp.add(x * src_ch + 3)` can never read past the row even if a caller
+    // wrongly pairs `Some(a)` with a 3-channel source.
+    let write_alpha = src_ch == 4;
     while x < w {
         *rp.add(x) = *sp.add(x * src_ch);
         *gp.add(x) = *sp.add(x * src_ch + 1);
         *bp.add(x) = *sp.add(x * src_ch + 2);
-        if let Some(ap) = ap {
-            *ap.add(x) = *sp.add(x * src_ch + 3);
+        if write_alpha {
+            if let Some(ap) = ap {
+                *ap.add(x) = *sp.add(x * src_ch + 3);
+            }
         }
         x += 1;
     }

--- a/crates/image/src/cpu/simd.rs
+++ b/crates/image/src/cpu/simd.rs
@@ -1,0 +1,393 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! SIMD row kernels for the CPU packed↔planar conversions.
+//!
+//! The packed-RGB → planar-RGB scatter (`pack_to_planar`) is the dominant cost
+//! of the Jetson Orin CPU preprocessing path: profiling NV12 → PlanarRgb showed
+//! ~72% of the cell in the scalar stride-3 gather (each of three rayon
+//! plane-tasks re-reads the whole source). A NEON deinterleaving load reads the
+//! packed source **once** and splits R/G/B (and A) into separate registers in a
+//! single instruction (`vld3q_u8` / `vld4q_u8`), so one pass writes every plane.
+//!
+//! NEON/ASIMD is baseline-mandatory on AArch64, so the deinterleave and the
+//! u8→f32 widen need no runtime feature probe and no `target-feature` flag
+//! beyond the architecture default (only fp16/dotprod/i8mm are non-baseline —
+//! see the workspace `.cargo/config.toml`). The u8→f16 widen is the exception:
+//! native half-precision arithmetic (FEAT_FP16) is *not* baseline, so it is
+//! gated behind a cached runtime probe ([`has_fp16`]) and reached via inline
+//! `asm!` with `.arch_extension fp16` (stable Rust still gates the
+//! `float16x8_t` intrinsics), mirroring the decoder's per-scale FP16 kernels.
+//! Non-aarch64 targets use the scalar fallback, which for the deinterleave is
+//! still a single pass over the source (one read, contiguous plane writes that
+//! LLVM can autovectorise).
+
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::uint16x8_t;
+
+/// Deinterleave one packed row into up to four destination planes.
+///
+/// `src_ch` must be 3 (RGB) or 4 (RGBA). The R, G, B planes are always written
+/// from source channels 0, 1, 2. `a` is written from source channel 3 when
+/// `Some` (requires `src_ch == 4`); a constant alpha plane is the caller's
+/// responsibility (fill once, outside the row loop).
+///
+/// Only the first `w` pixels of each plane and the first `w * src_ch` bytes of
+/// `src` are touched; callers pass full row slices (stride length) and the
+/// logical width `w`.
+#[inline]
+pub(super) fn deinterleave_row(
+    src: &[u8],
+    r: &mut [u8],
+    g: &mut [u8],
+    b: &mut [u8],
+    a: Option<&mut [u8]>,
+    w: usize,
+    src_ch: usize,
+) {
+    debug_assert!(src_ch == 3 || src_ch == 4);
+    debug_assert!(src.len() >= w * src_ch);
+    debug_assert!(r.len() >= w && g.len() >= w && b.len() >= w);
+    debug_assert!(a.as_ref().is_none_or(|a| a.len() >= w));
+
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: NEON is baseline on aarch64; the debug_asserts above document the
+    // length preconditions the kernel relies on (caller-validated in release).
+    unsafe {
+        deinterleave_row_neon(src, r, g, b, a, w, src_ch);
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    deinterleave_row_scalar(src, r, g, b, a, w, src_ch);
+}
+
+/// Portable single-pass scalar deinterleave. One source read; contiguous plane
+/// stores. Used on non-aarch64 and as the documented reference for the NEON
+/// kernel's tail.
+#[cfg(not(target_arch = "aarch64"))]
+fn deinterleave_row_scalar(
+    src: &[u8],
+    r: &mut [u8],
+    g: &mut [u8],
+    b: &mut [u8],
+    a: Option<&mut [u8]>,
+    w: usize,
+    src_ch: usize,
+) {
+    match a {
+        Some(a) => {
+            for x in 0..w {
+                let p = &src[x * src_ch..];
+                r[x] = p[0];
+                g[x] = p[1];
+                b[x] = p[2];
+                a[x] = p[3];
+            }
+        }
+        None => {
+            for x in 0..w {
+                let p = &src[x * src_ch..];
+                r[x] = p[0];
+                g[x] = p[1];
+                b[x] = p[2];
+            }
+        }
+    }
+}
+
+/// Widen a `u8` buffer into an `f32` buffer, dividing each value by 255.0
+/// (the U8→F32 image-normalisation the model-input path performs after the
+/// format/resize pipeline).
+///
+/// This is the difference between the u8 and f32 preprocess cells (~1.2 ms at
+/// 640²×3 on Orin); the scalar iterator widen did not vectorise, so it was
+/// compute-bound. The NEON path converts 16 lanes/iteration and uses a true
+/// division (`vdivq_f32` by 255.0) so the result is bit-identical to the scalar
+/// `b as f32 / 255.0` — exact for every `u8` input.
+///
+/// # Panics (debug)
+/// Panics in debug mode if `src.len() != dst.len()`.
+#[inline]
+pub(super) fn widen_u8_to_f32_norm(src: &[u8], dst: &mut [f32]) {
+    debug_assert_eq!(src.len(), dst.len());
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: NEON is baseline on aarch64; the length precondition is asserted
+    // above and the kernel walks the shared length in lockstep.
+    unsafe {
+        widen_u8_to_f32_norm_neon(src, dst);
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    for (o, &b) in dst.iter_mut().zip(src.iter()) {
+        *o = b as f32 / 255.0;
+    }
+}
+
+/// NEON u8 → f32 widen with `/255.0` normalisation, 16 lanes/iteration:
+/// `vld1q_u8` → two `vmovl_u8` (u16) → four `vmovl_u16`+`vcvtq_f32_u32` (f32)
+/// → `vdivq_f32` by 255.0. Scalar tail for the `len % 16` remainder.
+///
+/// # Safety
+/// `src.len()` must equal `dst.len()`. NEON is guaranteed by the aarch64 target.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn widen_u8_to_f32_norm_neon(src: &[u8], dst: &mut [f32]) {
+    use std::arch::aarch64::*;
+
+    let n = src.len();
+    let sp = src.as_ptr();
+    let dp = dst.as_mut_ptr();
+    let denom = vdupq_n_f32(255.0);
+
+    let mut i = 0usize;
+    while i + 16 <= n {
+        let v = vld1q_u8(sp.add(i)); // 16 × u8
+        let lo = vmovl_u8(vget_low_u8(v)); // 8 × u16
+        let hi = vmovl_u8(vget_high_u8(v)); // 8 × u16
+        let f0 = vdivq_f32(vcvtq_f32_u32(vmovl_u16(vget_low_u16(lo))), denom);
+        let f1 = vdivq_f32(vcvtq_f32_u32(vmovl_u16(vget_high_u16(lo))), denom);
+        let f2 = vdivq_f32(vcvtq_f32_u32(vmovl_u16(vget_low_u16(hi))), denom);
+        let f3 = vdivq_f32(vcvtq_f32_u32(vmovl_u16(vget_high_u16(hi))), denom);
+        vst1q_f32(dp.add(i), f0);
+        vst1q_f32(dp.add(i + 4), f1);
+        vst1q_f32(dp.add(i + 8), f2);
+        vst1q_f32(dp.add(i + 12), f3);
+        i += 16;
+    }
+    while i < n {
+        *dp.add(i) = *sp.add(i) as f32 / 255.0;
+        i += 1;
+    }
+}
+
+/// Runtime FEAT_FP16 (native half-precision arithmetic, `asimdhp`) availability,
+/// probed once and cached. Setting `EDGEFIRST_IMAGE_NO_FP16` forces the scalar
+/// fallback — used to A/B the native path against scalar on FP16 hardware and to
+/// check output parity. Mirrors the decoder's `CpuFeatures` runtime probe.
+#[cfg(target_arch = "aarch64")]
+fn has_fp16() -> bool {
+    use std::sync::OnceLock;
+    static FP16: OnceLock<bool> = OnceLock::new();
+    *FP16.get_or_init(|| {
+        if std::env::var_os("EDGEFIRST_IMAGE_NO_FP16").is_some() {
+            return false;
+        }
+        std::arch::is_aarch64_feature_detected!("fp16")
+    })
+}
+
+/// Widen a `u8` buffer into an `f16` buffer, dividing each value by 255.0 (the
+/// U8→F16 model-input normalisation after the format/resize pipeline).
+///
+/// On AArch64 CPUs with the FP16 extension (FEAT_FP16 / `asimdhp` — e.g. the
+/// Orin's Cortex-A78AE) this dispatches at runtime to a native half-precision
+/// kernel (`ucvtf.8h` + `fdiv.8h`, 8 lanes/instruction). On other CPUs (incl.
+/// non-FP16 aarch64 and non-aarch64) it uses the scalar `half::f16::from_f32`.
+///
+/// The native path divides in the f16 domain, which differs from the scalar
+/// f32-then-narrow result by at most ~1 f16 ULP — far inside the model-input
+/// tolerance, consistent with the perf-over-exactness default.
+///
+/// # Panics (debug)
+/// Panics in debug mode if `src.len() != dst.len()`.
+#[inline]
+pub(super) fn widen_u8_to_f16_norm(src: &[u8], dst: &mut [half::f16]) {
+    debug_assert_eq!(src.len(), dst.len());
+    #[cfg(target_arch = "aarch64")]
+    if has_fp16() {
+        // SAFETY: FEAT_FP16 detected at runtime; lengths asserted equal above
+        // and the kernel walks the shared length in lockstep.
+        unsafe {
+            widen_u8_to_f16_norm_fp16(src, dst);
+        }
+        return;
+    }
+    for (o, &b) in dst.iter_mut().zip(src.iter()) {
+        *o = half::f16::from_f32(b as f32 / 255.0);
+    }
+}
+
+/// Native-FP16 u8 → f16 widen with `/255.0`, 16 u8/iteration: `vld1q_u8` →
+/// two `vmovl_u8` (u16) → [`ucvtf_div255_f16x8`] per 8-lane half → `vst1q_u16`.
+/// Scalar tail for the `len % 16` remainder.
+///
+/// # Safety
+/// Requires FEAT_FP16 (caller gates on [`has_fp16`]); `src.len() == dst.len()`.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn widen_u8_to_f16_norm_fp16(src: &[u8], dst: &mut [half::f16]) {
+    use std::arch::aarch64::*;
+
+    let n = src.len();
+    let sp = src.as_ptr();
+    let dp = dst.as_mut_ptr() as *mut u16; // half::f16 is repr(transparent) over u16
+    let d255 = vdupq_n_u16(half::f16::from_f32(255.0).to_bits());
+
+    let mut i = 0usize;
+    while i + 16 <= n {
+        let v = vld1q_u8(sp.add(i)); // 16 × u8
+        let lo = vmovl_u8(vget_low_u8(v)); // 8 × u16 (0..=255)
+        let hi = vmovl_u8(vget_high_u8(v)); // 8 × u16
+        vst1q_u16(dp.add(i), ucvtf_div255_f16x8(lo, d255));
+        vst1q_u16(dp.add(i + 8), ucvtf_div255_f16x8(hi, d255));
+        i += 16;
+    }
+    while i < n {
+        *dst.get_unchecked_mut(i) = half::f16::from_f32(*sp.add(i) as f32 / 255.0);
+        i += 1;
+    }
+}
+
+/// `f16(lane) / divisor` on 8 lanes via native FP16: `ucvtf.8h` converts the
+/// unsigned-int u16 lanes (0..=255 from the widened u8) to f16, then `fdiv.8h`
+/// divides by the broadcast f16 divisor. Inline `asm!` with `.arch_extension
+/// fp16` because stable Rust gates the `float16x8_t` intrinsics; the f16 vectors
+/// are carried as opaque `uint16x8_t` bit-patterns (same approach as the
+/// decoder's per-scale FP16 kernels).
+///
+/// # Safety
+/// Requires FEAT_FP16 (caller gates on [`has_fp16`]).
+#[cfg(target_arch = "aarch64")]
+#[inline]
+#[target_feature(enable = "neon")]
+unsafe fn ucvtf_div255_f16x8(u16_lanes: uint16x8_t, divisor_f16: uint16x8_t) -> uint16x8_t {
+    let result: uint16x8_t;
+    core::arch::asm!(
+        ".arch_extension fp16",
+        "ucvtf {r:v}.8h, {x:v}.8h",
+        "fdiv {r:v}.8h, {r:v}.8h, {d:v}.8h",
+        r = out(vreg) result,
+        x = in(vreg) u16_lanes,
+        d = in(vreg) divisor_f16,
+        options(pure, nomem, nostack),
+    );
+    result
+}
+
+/// NEON deinterleave: 16 pixels/iteration via `vld3q_u8` (RGB) or `vld4q_u8`
+/// (RGBA), with a scalar tail for the `w % 16` remainder.
+///
+/// # Safety
+/// `src` must hold at least `w * src_ch` bytes and each plane at least `w`
+/// bytes; `src_ch` must be 3 or 4. NEON availability is guaranteed by the
+/// aarch64 target (baseline ISA).
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn deinterleave_row_neon(
+    src: &[u8],
+    r: &mut [u8],
+    g: &mut [u8],
+    b: &mut [u8],
+    a: Option<&mut [u8]>,
+    w: usize,
+    src_ch: usize,
+) {
+    use std::arch::aarch64::*;
+
+    let sp = src.as_ptr();
+    let rp = r.as_mut_ptr();
+    let gp = g.as_mut_ptr();
+    let bp = b.as_mut_ptr();
+    // Collapse the alpha plane to a raw pointer once; the loop uses the (Copy)
+    // pointer so the borrow on `a` does not need to persist.
+    let ap: Option<*mut u8> = a.map(|s| s.as_mut_ptr());
+
+    let mut x = 0usize;
+    if src_ch == 3 {
+        while x + 16 <= w {
+            let v = vld3q_u8(sp.add(x * 3));
+            vst1q_u8(rp.add(x), v.0);
+            vst1q_u8(gp.add(x), v.1);
+            vst1q_u8(bp.add(x), v.2);
+            x += 16;
+        }
+    } else {
+        while x + 16 <= w {
+            let v = vld4q_u8(sp.add(x * 4));
+            vst1q_u8(rp.add(x), v.0);
+            vst1q_u8(gp.add(x), v.1);
+            vst1q_u8(bp.add(x), v.2);
+            if let Some(ap) = ap {
+                vst1q_u8(ap.add(x), v.3);
+            }
+            x += 16;
+        }
+    }
+
+    // Scalar tail for the remaining < 16 pixels.
+    while x < w {
+        *rp.add(x) = *sp.add(x * src_ch);
+        *gp.add(x) = *sp.add(x * src_ch + 1);
+        *bp.add(x) = *sp.add(x * src_ch + 2);
+        if let Some(ap) = ap {
+            *ap.add(x) = *sp.add(x * src_ch + 3);
+        }
+        x += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deinterleave matches the scalar reference for widths that straddle the
+    /// 16-pixel vector boundary (exercises both the SIMD body and scalar tail).
+    #[test]
+    fn deinterleave_rgb_matches_scalar() {
+        for w in [1usize, 7, 16, 17, 31, 64, 100] {
+            let src: Vec<u8> = (0..w * 3).map(|i| (i * 7 % 256) as u8).collect();
+            let (mut r, mut g, mut b) = (vec![0u8; w], vec![0u8; w], vec![0u8; w]);
+            deinterleave_row(&src, &mut r, &mut g, &mut b, None, w, 3);
+            for x in 0..w {
+                assert_eq!(r[x], src[x * 3], "R w={w} x={x}");
+                assert_eq!(g[x], src[x * 3 + 1], "G w={w} x={x}");
+                assert_eq!(b[x], src[x * 3 + 2], "B w={w} x={x}");
+            }
+        }
+    }
+
+    /// Deinterleave of a 4-channel source into R,G,B,A planes.
+    #[test]
+    fn deinterleave_rgba_matches_scalar() {
+        for w in [3usize, 16, 19, 48, 77] {
+            let src: Vec<u8> = (0..w * 4).map(|i| (i * 5 % 256) as u8).collect();
+            let (mut r, mut g, mut b, mut a) =
+                (vec![0u8; w], vec![0u8; w], vec![0u8; w], vec![9u8; w]);
+            deinterleave_row(&src, &mut r, &mut g, &mut b, Some(&mut a), w, 4);
+            for x in 0..w {
+                assert_eq!(r[x], src[x * 4], "R w={w} x={x}");
+                assert_eq!(g[x], src[x * 4 + 1], "G w={w} x={x}");
+                assert_eq!(b[x], src[x * 4 + 2], "B w={w} x={x}");
+                assert_eq!(a[x], src[x * 4 + 3], "A w={w} x={x}");
+            }
+        }
+    }
+
+    /// The NEON u8→f32 `/255` widen is bit-identical to the scalar form.
+    #[test]
+    fn widen_f32_bit_identical() {
+        let src: Vec<u8> = (0..=255u8).collect();
+        let mut dst = vec![0f32; src.len()];
+        widen_u8_to_f32_norm(&src, &mut dst);
+        for (i, &v) in dst.iter().enumerate() {
+            assert_eq!(v.to_bits(), (i as f32 / 255.0).to_bits(), "byte {i}");
+        }
+    }
+
+    /// The u8→f16 widen (native FP16 on capable hosts, scalar otherwise) is
+    /// within ~1 f16 ULP of the scalar f32-then-narrow reference. On FP16
+    /// hardware (e.g. Apple Silicon / Orin) this exercises the native path.
+    #[test]
+    fn widen_f16_within_tolerance() {
+        let src: Vec<u8> = (0..=255u8).collect();
+        let mut dst = vec![half::f16::ZERO; src.len()];
+        widen_u8_to_f16_norm(&src, &mut dst);
+        for (i, &v) in dst.iter().enumerate() {
+            let expected = half::f16::from_f32(i as f32 / 255.0).to_f32();
+            // 1 f16 ULP near 1.0 is ~5e-4; allow a small absolute slack.
+            assert!(
+                (v.to_f32() - expected).abs() <= 1e-3,
+                "byte {i}: got {} expected {expected}",
+                v.to_f32()
+            );
+        }
+    }
+}

--- a/crates/image/tests/odd_dim_cpu.rs
+++ b/crates/image/tests/odd_dim_cpu.rs
@@ -1242,3 +1242,97 @@ fn d6_planar_packed_roundtrip() {
         "RGBA→PlanarRgba→RGBA not identity"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Fused NV→PlanarRgb / PlanarRgba (strip decode) parity
+//
+// The fused no-resize NV→planar path (`convert_nv_to_planar_fused`) decodes the
+// YUV source into packed RGB one row strip at a time and deinterleaves each
+// strip into the destination planes. It must be byte-for-byte identical to the
+// proven NV→RGB packed path (same `yuv` kernel, just full-image vs strip): NV12
+// 4:2:0 replicates one chroma row across two luma rows, so strip boundaries do
+// not change the per-row chroma pairing. The source fill is arbitrary — both
+// paths read the same bytes — so any seam from strip decoding would surface as a
+// mismatch. Sizes are chosen to straddle the 32-row strip boundary and exercise
+// odd widths/heights (the partial last strip).
+// ---------------------------------------------------------------------------
+
+fn fused_nv_planar_parity(w: usize, h: usize, fmt: PixelFormat, with_alpha: bool, label: &str) {
+    let mut src = Tensor::<u8>::image(w, h, fmt, Some(TensorMemory::Mem)).unwrap();
+    {
+        let mut m = src.map().unwrap();
+        for (i, b) in m.as_mut_slice().iter_mut().enumerate() {
+            *b = ((i.wrapping_mul(37).wrapping_add(11)) & 0xff) as u8;
+        }
+    }
+    let src_dyn = TensorDyn::from(src);
+    let mut proc = CPUProcessor::default();
+
+    let pfmt = if with_alpha {
+        PixelFormat::PlanarRgba
+    } else {
+        PixelFormat::PlanarRgb
+    };
+    let mut planar =
+        TensorDyn::image(w, h, pfmt, DType::U8, Some(TensorMemory::Mem)).unwrap();
+    proc.convert(
+        &src_dyn,
+        &mut planar,
+        Rotation::None,
+        Flip::None,
+        Crop::default(),
+    )
+    .unwrap();
+
+    // Reference: the proven NV→RGB packed conversion (unchanged path).
+    let mut rgb =
+        TensorDyn::image(w, h, PixelFormat::Rgb, DType::U8, Some(TensorMemory::Mem)).unwrap();
+    proc.convert(&src_dyn, &mut rgb, Rotation::None, Flip::None, Crop::default())
+        .unwrap();
+
+    let planar_t = planar.as_u8().unwrap();
+    let rgb_t = rgb.as_u8().unwrap();
+    let p_stride = planar_t.effective_row_stride().unwrap_or(w);
+    let rgb_stride = rgb_t.effective_row_stride().unwrap_or(w * 3);
+    let p_plane = p_stride * h;
+    let pm = planar_t.map().unwrap();
+    let rm = rgb_t.map().unwrap();
+    let p = pm.as_slice();
+    let r = rm.as_slice();
+
+    for y in 0..h {
+        for x in 0..w {
+            for c in 0..3 {
+                assert_eq!(
+                    p[c * p_plane + y * p_stride + x],
+                    r[y * rgb_stride + x * 3 + c],
+                    "{label}: plane {c} at ({x},{y}) differs from packed reference"
+                );
+            }
+            if with_alpha {
+                assert_eq!(
+                    p[3 * p_plane + y * p_stride + x],
+                    255,
+                    "{label}: alpha at ({x},{y}) must be 255"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn fused_nv_planar_parity_matrix() {
+    // (w, h): clean strip multiple, strip-tail, odd-w, odd-h, odd-both, tiny.
+    let dims = [(64, 64), (128, 100), (101, 96), (96, 97), (97, 95), (3, 3), (1, 1)];
+    for fmt in [PixelFormat::Nv12, PixelFormat::Nv16, PixelFormat::Nv24] {
+        for &(w, h) in &dims {
+            for with_alpha in [false, true] {
+                let label = format!(
+                    "{fmt:?} {w}x{h} {}",
+                    if with_alpha { "PlanarRgba" } else { "PlanarRgb" }
+                );
+                fused_nv_planar_parity(w, h, fmt, with_alpha, &label);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Optimises the **Jetson Orin Nano CPU JPEG-preprocessing path** (JPEG → NV12/NV16/NV24 → `PlanarRgb`), which is kept on the CPU so TensorRT owns the GPU. `perf` on-target showed **~72%** of an NV→PlanarRgb convert was the scalar per-plane gather in `pack_to_planar` (3 rayon plane-tasks, each re-reading the whole source byte-by-byte); the `yuv`-crate colour conversion (~21%) was already NEON and near-optimal.

## Changes

- **New `cpu::simd` module:**
  - Single-pass NEON **`vld3`/`vld4` deinterleave** for the packed→planar scatter — one hardware-deinterleaving load reads the source once and splits R/G/B(/A), replacing the 3× scalar re-read. Covers every packed→planar caller (RGB/RGBA → `PlanarRgb`/`PlanarRgba`).
  - NEON **u8→f32 `/255` widen** (`vmovl`/`vcvtq`/`vdivq`), bit-identical to the scalar form.
  - **Runtime-dispatched native FP16 u8→f16 widen** (`ucvtf.8h`+`fdiv.8h` via inline `asm!`/`.arch_extension fp16` on opaque `uint16x8_t`, since stable Rust gates `float16x8_t` — same pattern as the decoder's per-scale FP16 kernels). Gated on a cached `FEAT_FP16` probe; `EDGEFIRST_IMAGE_NO_FP16` forces the scalar fallback for A/B.
- `pack_to_planar` fast path runs **serially** — the deinterleave is memory-bandwidth-bound on Orin's shared bus, so the per-plane rayon fan-out only added overhead (serial measured equal). The rare arbitrary channel-mapping path keeps its parallel fallback.
- **New `cpu_preprocess_benchmark`** for on-target characterisation + `perf` profiling.

## Results (Orin Nano, CPU backend, 1280×720 → 640×640, same-thermal back-to-back)

| cell | baseline | optimized | change |
|---|---|---|---|
| NV12 convert→PlanarRgb | 1.6 ms | 1.2 ms | **−25%** |
| NV12 letterbox→PlanarRgb | 3.2 ms | 2.9 ms | **−9%** |
| NV12 letterbox→PlanarRgb **F16** | 4.9 ms | 3.8 ms | **−24%** |
| NV12 letterbox→PlanarRgb F32 | 4.3 ms | 4.1 ms | −5% |

F16 is now the fastest model-input dtype (3.8 ms < 4.1 ms F32).

## Correctness / quality

- New kernel unit tests in `cpu::simd` validate deinterleave (RGB/RGBA, widths straddling the 16-px vector boundary) and the f32/f16 widen against scalar references — the native FP16 path runs on the Apple Silicon host (also FEAT_FP16). F32 is bit-identical; F16 is within ~1 f16 ULP (well inside the existing 0.004 test tolerance).
- All 212 `edgefirst-image` lib tests + 36 odd-dim CPU tests pass; clippy clean on **aarch64** and **x86_64** (the non-aarch64 scalar fallbacks compile cleanly).
- Integer/F32 output unchanged. NEON is baseline-mandatory on aarch64 so no `target-feature` gating beyond the architecture default; only the FP16 path is runtime-probed.

Follow-up (separate PR): cache-resident strip fusion + cached scratch to drop the full-size packed-RGB intermediate.