### PR TITLE
feat(tensor): wrap foreign memory via from_foreign / from_foreign_ptr

### DIFF
--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -1549,6 +1549,20 @@ where
         if shape.is_empty() {
             return Err(Error::InvalidSize(0));
         }
+        if ptr.is_null() {
+            return Err(Error::InvalidArgument(
+                "from_foreign: ptr must be non-null".to_owned(),
+            ));
+        }
+        shape
+            .iter()
+            .copied()
+            .try_fold(1usize, |acc, dim| acc.checked_mul(dim))
+            .ok_or_else(|| {
+                Error::InvalidArgument(format!(
+                    "from_foreign: shape.product() overflows usize (shape={shape:?})"
+                ))
+            })?;
         let mem = MemTensor::<T>::from_foreign(ptr, shape, owner, name);
         Ok(Self::wrap(TensorStorage::Mem(mem)))
     }

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -96,6 +96,17 @@ use std::{
 };
 pub use tensor_dyn::TensorDyn;
 
+/// Opaque keep-alive handle for a foreign-memory tensor (see
+/// [`Tensor::from_foreign`] / [`TensorDyn::from_foreign_ptr`]).
+///
+/// The HAL borrows the foreign buffer without owning it; this handle co-owns
+/// the *source* so the borrowed memory stays valid for the tensor's life. Its
+/// `Drop` releases the source — e.g. a small struct that calls `cudaFreeHost`,
+/// or a `Py<PyAny>` that decrements a NumPy array's refcount. Wrapping it in an
+/// `Arc` (then boxing each clone) makes the release fire exactly once, after
+/// the last sharing tensor/view/map drops, regardless of drop order.
+pub type ForeignOwner = Box<dyn std::any::Any + Send + Sync>;
+
 /// Re-export of `half::f16` so downstream crates can write
 /// `Tensor::<edgefirst_tensor::f16>::from_iosurface(…)` without
 /// adding `half` to their own dependency list. The version stays in
@@ -1506,6 +1517,40 @@ where
             m.as_mut_slice().copy_from_slice(values);
         }
         Ok(t)
+    }
+
+    /// Wrap externally-owned memory as a tensor without copying. The tensor
+    /// borrows `[ptr, ptr + shape.product() * size_of::<T>())` as
+    /// [`TensorMemory::Mem`]; `owner`, when `Some`, co-owns the source so it
+    /// outlives the tensor (and all derived views/maps). See [`ForeignOwner`].
+    ///
+    /// The canonical use is CUDA zero-copy: allocate host-coherent memory
+    /// (`cudaHostAlloc`), wrap the host pointer here, and bind the matching
+    /// device pointer to the inference engine — reads and writes hit the same
+    /// physical buffer with no host copy. The identical primitive backs the
+    /// Python `Tensor.from_numpy` zero-copy borrow (owner = the NumPy object).
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null, aligned to `align_of::<T>()`, and valid for
+    /// `shape.product()` elements of `T` for as long as the returned tensor —
+    /// and every view/map sharing its backing — is alive. Pass an `owner` that
+    /// co-owns the source to uphold that contract.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::InvalidSize`] if `shape` is empty.
+    pub unsafe fn from_foreign(
+        ptr: *mut T,
+        shape: &[usize],
+        owner: Option<crate::ForeignOwner>,
+        name: Option<&str>,
+    ) -> Result<Self> {
+        if shape.is_empty() {
+            return Err(Error::InvalidSize(0));
+        }
+        let mem = MemTensor::<T>::from_foreign(ptr, shape, owner, name);
+        Ok(Self::wrap(TensorStorage::Mem(mem)))
     }
 
     /// Construct a tensor from a 3-D ndarray view. Respects strides — one

--- a/crates/tensor/src/mem.rs
+++ b/crates/tensor/src/mem.rs
@@ -29,8 +29,21 @@ use std::{
 /// whose `mmap` likewise hands out independent `&mut` windows of one buffer).
 /// `UnsafeCell` makes the *non-overlapping* case sound; overlapping mutable
 /// windows held simultaneously remain UB by the documented `subview` contract.
-struct MemBacking<T> {
-    cells: Box<[UnsafeCell<T>]>,
+enum MemBacking<T> {
+    /// HAL-owned allocation; the `Box` frees it when the last `Arc` drops.
+    Owned(Box<[UnsafeCell<T>]>),
+    /// Externally-owned memory the HAL borrows but never frees. `ptr`/`len`
+    /// describe the borrowed region (`len` in elements); `_owner`, when
+    /// present, is an opaque keep-alive whose `Drop` releases the source (e.g.
+    /// `cudaFreeHost`, a NumPy ref decrement). Dropping this arm runs
+    /// `_owner`'s destructor but leaves the foreign pointer untouched. The
+    /// elements are still `UnsafeCell` so the shared-`Arc` write-provenance
+    /// contract documented above holds for foreign buffers too.
+    Foreign {
+        ptr: *mut UnsafeCell<T>,
+        len: usize,
+        _owner: Option<crate::ForeignOwner>,
+    },
 }
 
 // SAFETY: `UnsafeCell<T>` is `!Sync`, but a `MemBacking` is only mutated through
@@ -42,23 +55,28 @@ unsafe impl<T: Sync> Sync for MemBacking<T> {}
 
 impl<T: fmt::Debug> fmt::Debug for MemBacking<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MemBacking")
-            .field("len", &self.cells.len())
-            .finish()
+        let len = self.len();
+        f.debug_struct("MemBacking").field("len", &len).finish()
     }
 }
 
 impl<T> MemBacking<T> {
     /// Number of elements in the allocation.
     fn len(&self) -> usize {
-        self.cells.len()
+        match self {
+            MemBacking::Owned(cells) => cells.len(),
+            MemBacking::Foreign { len, .. } => *len,
+        }
     }
 
     /// Base pointer with write provenance (the cells are `UnsafeCell`, so
     /// interior mutation through the shared `Arc` is sound). `UnsafeCell<T>`
     /// is `#[repr(transparent)]`, so the address equals the `T` element's.
     fn base_ptr(&self) -> *mut T {
-        self.cells.as_ptr() as *mut T
+        match self {
+            MemBacking::Owned(cells) => cells.as_ptr() as *mut T,
+            MemBacking::Foreign { ptr, .. } => *ptr as *mut T,
+        }
     }
 
     /// Build a zeroed backing of `n` elements by writing `T::zero()` into each
@@ -70,9 +88,7 @@ impl<T> MemBacking<T> {
         T: Num + Clone,
     {
         let cells: Vec<UnsafeCell<T>> = (0..n).map(|_| UnsafeCell::new(T::zero())).collect();
-        Self {
-            cells: cells.into_boxed_slice(),
-        }
+        MemBacking::Owned(cells.into_boxed_slice())
     }
 
     /// Build a zeroed backing of `n` elements, using the allocator's zeroed
@@ -93,9 +109,7 @@ impl<T> MemBacking<T> {
         T: Num + Clone + 'static,
     {
         if n == 0 {
-            return Self {
-                cells: Vec::new().into_boxed_slice(),
-            };
+            return MemBacking::Owned(Vec::new().into_boxed_slice());
         }
         if crate::dtype_of::<T>().is_some() {
             // SAFETY: `dtype_of` is `Some` only for HAL's primitive numeric
@@ -128,9 +142,7 @@ impl<T> MemBacking<T> {
         // `(ptr, n)` and element type deallocates with the matching
         // `Layout::array::<UnsafeCell<T>>(n)` on drop.
         let slice = std::slice::from_raw_parts_mut(ptr, n);
-        Self {
-            cells: Box::from_raw(slice),
-        }
+        MemBacking::Owned(Box::from_raw(slice))
     }
 }
 
@@ -300,6 +312,40 @@ where
             // allocations.
             identity: parent.identity.clone(),
         })
+    }
+
+    /// Wrap externally-owned memory as a `MemTensor` without taking ownership
+    /// of the allocation (no copy). The tensor borrows
+    /// `[ptr, ptr + shape.product() * size_of::<T>())`; `owner`, when `Some`,
+    /// co-owns the *source* so the borrowed memory outlives this tensor (and
+    /// any [`view`](Self::view) or map derived from it). The foreign pointer is
+    /// never freed by this type — only `owner`'s destructor runs on drop.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null, aligned to `align_of::<T>()`, and valid for
+    /// `shape.product()` elements of `T` for as long as this tensor — and every
+    /// view/map sharing its backing — is alive. Passing an `owner` that co-owns
+    /// the source (e.g. an `Arc` whose `Drop` frees it) is the supported way to
+    /// uphold that lifetime contract.
+    pub(crate) unsafe fn from_foreign(
+        ptr: *mut T,
+        shape: &[usize],
+        owner: Option<crate::ForeignOwner>,
+        name: Option<&str>,
+    ) -> Self {
+        let len: usize = shape.iter().product();
+        MemTensor {
+            name: name.unwrap_or("foreign_mem_tensor").to_owned(),
+            shape: shape.to_vec(),
+            data: Arc::new(MemBacking::Foreign {
+                ptr: ptr as *mut UnsafeCell<T>,
+                len,
+                _owner: owner,
+            }),
+            offset: 0,
+            identity: crate::BufferIdentity::new(),
+        }
     }
 
     /// Set the byte offset of the logical window into the backing allocation.
@@ -675,5 +721,81 @@ mod tests {
             "debug should name MemBacking: {s}"
         );
         assert!(s.contains("len"), "debug should report len: {s}");
+    }
+
+    #[test]
+    fn from_foreign_without_owner_borrows_caller_memory() {
+        // No owner: the caller guarantees the buffer outlives the tensor. Writes
+        // through the tensor must land in the caller's own allocation (zero-copy).
+        let mut vec: Vec<i32> = vec![0; 4];
+        let ptr = vec.as_mut_ptr();
+        let t = unsafe { MemTensor::<i32>::from_foreign(ptr, &[4], None, None) };
+        assert_eq!(t.shape(), &[4]);
+        assert_eq!(t.memory(), TensorMemory::Mem);
+        {
+            let mut m = t.map().unwrap();
+            m.as_mut_slice().copy_from_slice(&[10, 20, 30, 40]);
+        }
+        drop(t);
+        // The writes are visible in the caller's Vec — same physical buffer.
+        assert_eq!(vec, vec![10, 20, 30, 40]);
+    }
+
+    #[test]
+    fn from_foreign_views_share_the_borrowed_buffer() {
+        // A `view()` shares the backing `Arc`, so it addresses the same foreign
+        // memory as the parent (with an offset) — the zero-copy export path.
+        let mut vec: Vec<u8> = vec![0u8; 6];
+        let ptr = vec.as_mut_ptr();
+        let owner: crate::ForeignOwner = Box::new(vec); // keep the heap buffer alive
+        let t = unsafe { MemTensor::<u8>::from_foreign(ptr, &[2, 3], Some(owner), Some("foreign")) };
+        {
+            let mut m = t.map().unwrap();
+            m.as_mut_slice().copy_from_slice(&[1, 2, 3, 4, 5, 6]);
+        }
+        // Second row [4,5,6] via a sub-region view of the same buffer.
+        let v = MemTensor::view(&t, 3, &[3]).unwrap();
+        assert_eq!(v.map().unwrap().as_slice(), &[4, 5, 6]);
+    }
+
+    #[test]
+    fn from_foreign_owner_drop_fires_on_last_reference() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // The owner co-owns the source; its `Drop` (the "free") must fire exactly
+        // once, after the last tensor/map sharing the backing is gone — regardless
+        // of whether the source tensor or a derived map outlives the other.
+        struct DropFlag {
+            _buf: Box<[u8]>,
+            flag: Arc<AtomicBool>,
+        }
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.flag.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let mut buf = vec![7u8; 4].into_boxed_slice();
+        let ptr = buf.as_mut_ptr();
+        let owner: crate::ForeignOwner = Box::new(DropFlag {
+            _buf: buf,
+            flag: flag.clone(),
+        });
+        let t = unsafe { MemTensor::<u8>::from_foreign(ptr, &[4], Some(owner), None) };
+
+        // `map()` returns an owned `Arc` clone, so the map outlives the tensor.
+        let m = t.map().unwrap();
+        assert_eq!(m.as_slice()[0], 7);
+        drop(t);
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "owner must stay alive while a map still references the backing"
+        );
+        drop(m);
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "owner Drop (the free) must fire on the last reference drop"
+        );
     }
 }

--- a/crates/tensor/src/tensor_dyn.rs
+++ b/crates/tensor/src/tensor_dyn.rs
@@ -531,6 +531,40 @@ impl TensorDyn {
         }
     }
 
+    /// Wrap externally-owned memory as a type-erased tensor without copying.
+    /// The tensor borrows `[ptr, ptr + shape.product() * dtype.size())` as
+    /// [`TensorMemory::Mem`]; `owner`, when `Some`, co-owns the source so it
+    /// outlives the tensor (and all derived views/maps). See
+    /// [`crate::ForeignOwner`] and [`Tensor::from_foreign`].
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be non-null, aligned to the element type, and valid for
+    /// `shape.product()` elements of `dtype` for as long as the returned
+    /// tensor — and every view/map sharing its backing — is alive. Pass an
+    /// `owner` that co-owns the source to uphold that contract.
+    pub unsafe fn from_foreign_ptr(
+        ptr: *mut u8,
+        shape: &[usize],
+        dtype: DType,
+        owner: Option<crate::ForeignOwner>,
+        name: Option<&str>,
+    ) -> crate::Result<Self> {
+        match dtype {
+            DType::U8 => Tensor::<u8>::from_foreign(ptr.cast(), shape, owner, name).map(Self::U8),
+            DType::I8 => Tensor::<i8>::from_foreign(ptr.cast(), shape, owner, name).map(Self::I8),
+            DType::U16 => Tensor::<u16>::from_foreign(ptr.cast(), shape, owner, name).map(Self::U16),
+            DType::I16 => Tensor::<i16>::from_foreign(ptr.cast(), shape, owner, name).map(Self::I16),
+            DType::U32 => Tensor::<u32>::from_foreign(ptr.cast(), shape, owner, name).map(Self::U32),
+            DType::I32 => Tensor::<i32>::from_foreign(ptr.cast(), shape, owner, name).map(Self::I32),
+            DType::U64 => Tensor::<u64>::from_foreign(ptr.cast(), shape, owner, name).map(Self::U64),
+            DType::I64 => Tensor::<i64>::from_foreign(ptr.cast(), shape, owner, name).map(Self::I64),
+            DType::F16 => Tensor::<f16>::from_foreign(ptr.cast(), shape, owner, name).map(Self::F16),
+            DType::F32 => Tensor::<f32>::from_foreign(ptr.cast(), shape, owner, name).map(Self::F32),
+            DType::F64 => Tensor::<f64>::from_foreign(ptr.cast(), shape, owner, name).map(Self::F64),
+        }
+    }
+
     /// Wrap an externally-allocated IOSurface as a type-erased tensor
     /// (macOS only).
     ///
@@ -809,6 +843,29 @@ mod tests {
         let dyn_t: TensorDyn = t.into();
         assert_eq!(dyn_t.dtype(), DType::U8);
         assert_eq!(dyn_t.shape(), &[10]);
+    }
+
+    #[test]
+    fn from_foreign_ptr_wraps_borrowed_memory() {
+        use crate::TensorMapTrait;
+        // The CUDA zero-copy export shape: wrap an externally-allocated buffer as
+        // a type-erased Mem tensor, with an owner that frees it on last drop.
+        let mut vec: Vec<f32> = vec![0.0; 4];
+        let ptr = vec.as_mut_ptr() as *mut u8;
+        let owner: crate::ForeignOwner = Box::new(vec);
+        let t = unsafe {
+            TensorDyn::from_foreign_ptr(ptr, &[2, 2], DType::F32, Some(owner), Some("trt_output"))
+        }
+        .unwrap();
+        assert_eq!(t.dtype(), DType::F32);
+        assert_eq!(t.memory(), TensorMemory::Mem);
+        assert_eq!(t.shape(), &[2, 2]);
+        {
+            let mut m = t.as_f32().unwrap().map().unwrap();
+            m.as_mut_slice().copy_from_slice(&[1.0, 2.0, 3.0, 4.0]);
+        }
+        let m = t.as_f32().unwrap().map().unwrap();
+        assert_eq!(m.as_slice(), &[1.0, 2.0, 3.0, 4.0]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a non-owning **foreign-memory backing** to `MemTensor` so an externally
allocated buffer can be wrapped as a `Tensor` with no copy:

- `MemBacking<T>` becomes an enum `{ Owned(Box<[UnsafeCell<T>]>), Foreign { ptr, len, _owner } }`.
  `base_ptr()`/`len()` dispatch over both arms, so every existing map / view /
  read path works unchanged for foreign buffers.
- `Tensor::from_foreign` / `TensorDyn::from_foreign_ptr` (both `unsafe`) wrap a
  raw host pointer + shape/dtype as `TensorMemory::Mem`. An optional
  `ForeignOwner` (`Box<dyn Any + Send + Sync>`) co-owns the *source* and releases
  it on the last drop — order-independent via the shared backing `Arc`.

The `crates/tensor` source is unchanged between the `main` line and this branch's
base, so the diff is purely the additive foreign-memory support.

## Motivation

This is the general primitive behind two use cases:

1. **CUDA zero-copy inference outputs** (EdgeFirst profiler, TensorRT on Jetson):
   allocate `cudaHostAlloc(...Mapped)` host-coherent memory, wrap the host
   pointer here, bind the matching device pointer to the engine — the GPU writes
   and the decoder reads the same physical buffer with no host copy. Measured
   +5.3% end-to-end on Orin Nano (yolov5n fp16) once paired with a rebindable
   output-buffer pool.
2. **Python `Tensor.from_numpy` zero-copy borrow** (planned fast-follow): wrap a
   NumPy array's buffer with the `PyArray` object as the `ForeignOwner`.

## Testing

`cargo test -p edgefirst-tensor` — 179 pass, including 4 new tests:
- `from_foreign_without_owner_borrows_caller_memory` (writes land in the caller's Vec)
- `from_foreign_views_share_the_borrowed_buffer` (view() shares the foreign backing)
- `from_foreign_owner_drop_fires_on_last_reference` (free fires once, after the last tensor/map drop — order-independent)
- `from_foreign_ptr_wraps_borrowed_memory` (type-erased path)

clippy clean.

## Safety

`from_foreign*` are `unsafe`: the caller guarantees the pointer is valid for
`shape.product() * size_of::<T>()` bytes and outlives the tensor (and any
view/map). Passing an `owner` that co-owns the source is the supported way to
uphold that — its `Drop` is the "free" (e.g. `cudaFreeHost`, a NumPy decref).