### PR TITLE
Fix Sonar coverage path remapping and reduce decoder complexity

### DIFF
--- a/.github/scripts/fix_coverage_paths.py
+++ b/.github/scripts/fix_coverage_paths.py
@@ -9,13 +9,44 @@ This script post-processes the Cobertura XML to:
 2. Ensure filenames have the correct package prefix
 3. Make paths resolvable by SonarCloud
 
+Known repo-relative roots (``tests/``, ``crates/``, ``scripts/``,
+``.github/``) are left unchanged. Only bare or otherwise ambiguous
+filenames are prefixed with ``source_dir`` (default ``tests``).
+
 Usage:
-    python scripts/fix_coverage_paths.py coverage.xml tests
+    python .github/scripts/fix_coverage_paths.py coverage.xml tests
 """
+
+from __future__ import annotations
 
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
+
+# Paths that are already repo-relative and must not be rewritten.
+KNOWN_ROOTS = ("tests/", "crates/", "scripts/", ".github/")
+
+
+def normalize_coverage_filename(filename: str, source_dir: str = "tests") -> str:
+    """Return a repo-relative coverage filename for SonarCloud.
+
+    Args:
+        filename: Cobertura ``class`` filename attribute.
+        source_dir: Prefix applied only to bare/ambiguous names.
+
+    Returns:
+        Normalized path that should resolve under the repo root.
+    """
+    if filename.startswith("./"):
+        filename = filename[2:]
+
+    if filename.startswith(source_dir + "/"):
+        return filename
+
+    if any(filename.startswith(root) for root in KNOWN_ROOTS):
+        return filename
+
+    return f"{source_dir}/{filename}"
 
 
 def fix_coverage_xml(xml_file: str, source_dir: str = "tests") -> None:
@@ -23,41 +54,29 @@ def fix_coverage_xml(xml_file: str, source_dir: str = "tests") -> None:
 
     Args:
         xml_file: Path to the coverage XML file to fix
-        source_dir: The source directory prefix for Python test files
+        source_dir: The source directory prefix for bare Python filenames
     """
     tree = ET.parse(xml_file)
     root = tree.getroot()
 
-    # Track how many files were fixed
     fixed_count = 0
 
-    # Fix the <source> tags to use current directory (.)
     # Sonar expects <source> to be the root directory where files are located
     sources = root.findall(".//sources/source")
     if sources:
         for source_elem in sources:
-            source_path = source_elem.text
-            if source_path:
-                # Set source to current directory
+            if source_elem.text:
                 source_elem.text = "."
 
-    # Find all class elements and fix their filename attributes
     for class_elem in root.findall(".//class"):
         filename = class_elem.get("filename")
-        if filename:
-            # Normalize path - remove any leading ./
-            if filename.startswith('./'):
-                filename = filename[2:]
-            # Ensure the path starts with the expected prefix
-            if not filename.startswith(source_dir + "/"):
-                # Check if it should be prefixed
-                if not filename.startswith("tests/") and not filename.startswith("crates/"):
-                    class_elem.set("filename", f"{source_dir}/{filename}")
-                    fixed_count += 1
-            else:
-                class_elem.set("filename", filename)
+        if not filename:
+            continue
+        normalized = normalize_coverage_filename(filename, source_dir)
+        if normalized != filename:
+            fixed_count += 1
+        class_elem.set("filename", normalized)
 
-    # Write the fixed XML back
     tree.write(xml_file, encoding="utf-8", xml_declaration=True)
 
     print(f"Fixed {fixed_count} file paths in {xml_file}")

--- a/crates/decoder/src/decoder/postprocess.rs
+++ b/crates/decoder/src/decoder/postprocess.rs
@@ -2145,20 +2145,17 @@ impl Decoder {
         // see EDGEAI-1303.
         crate::yolo::maybe_normalize_boxes_in_place(&mut boxes, self.normalized, self.input_dims);
 
-        let (new_boxes, old_boxes) =
-            Self::update_tracker_yolo_segdet(tracker, timestamp, boxes, output_tracks);
-
-        let mask_data = mask_fn(
-            new_boxes,
+        Ok(Self::finish_tracked_yolo_segdet_with_masks(
+            tracker,
+            timestamp,
+            boxes,
             mask_tensor,
             protos_tensor,
             output_boxes,
             output_masks,
-        );
-
-        output_boxes.extend(old_boxes);
-
-        Ok(mask_data)
+            output_tracks,
+            mask_fn,
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2263,20 +2260,17 @@ impl Decoder {
         // `decode_tracked_proto`) — see EDGEAI-1303.
         crate::yolo::maybe_normalize_boxes_in_place(&mut boxes, self.normalized, self.input_dims);
 
-        let (new_boxes, old_boxes) =
-            Self::update_tracker_yolo_segdet(tracker, timestamp, boxes, output_tracks);
-
-        let mask_data = mask_fn(
-            new_boxes,
+        Ok(Self::finish_tracked_yolo_segdet_with_masks(
+            tracker,
+            timestamp,
+            boxes,
             mask_tensor,
             protos_tensor,
             output_boxes,
             output_masks,
-        );
-
-        output_boxes.extend(old_boxes);
-
-        Ok(mask_data)
+            output_tracks,
+            mask_fn,
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2376,20 +2370,18 @@ impl Decoder {
             self.max_det,
         );
 
-        let (new_boxes, old_boxes) =
-            Self::update_tracker_yolo_segdet(tracker, timestamp, boxes, output_tracks);
-
         // No NMS — model output is already post-NMS
-
-        let mask_data = mask_fn(
-            new_boxes,
+        Ok(Self::finish_tracked_yolo_segdet_with_masks(
+            tracker,
+            timestamp,
+            boxes,
             mask_coeff,
             protos_tensor,
             output_boxes,
             output_masks,
-        );
-        output_boxes.extend(old_boxes);
-        Ok(mask_data)
+            output_tracks,
+            mask_fn,
+        ))
     }
 
     /// Decodes end-to-end YOLO detection + segmentation outputs (post-NMS from
@@ -2490,21 +2482,18 @@ impl Decoder {
             self.max_det,
         );
 
-        let (new_boxes, old_boxes) =
-            Self::update_tracker_yolo_segdet(tracker, timestamp, boxes, output_tracks);
-
         // No NMS — model output is already post-NMS
-
-        let mask_data = mask_fn(
-            new_boxes,
+        Ok(Self::finish_tracked_yolo_segdet_with_masks(
+            tracker,
+            timestamp,
+            boxes,
             mask_coeff,
             protos_tensor,
             output_boxes,
             output_masks,
-        );
-        output_boxes.extend(old_boxes);
-
-        Ok(mask_data)
+            output_tracks,
+            mask_fn,
+        ))
     }
 
     /// Decodes monolithic end-to-end YOLO seg detection from quantized tensors.
@@ -2625,20 +2614,17 @@ impl Decoder {
             self.max_det,
         );
 
-        let (new_boxes, old_boxes) =
-            Self::update_tracker_yolo_segdet(tracker, timestamp, boxes, output_tracks);
-
-        let mask_data = mask_fn(
-            new_boxes,
+        Ok(Self::finish_tracked_yolo_segdet_with_masks(
+            tracker,
+            timestamp,
+            boxes,
             mask_coeff,
             protos_tensor,
             output_boxes,
             output_masks,
-        );
-
-        output_boxes.extend(old_boxes);
-
-        Ok(mask_data)
+            output_tracks,
+            mask_fn,
+        ))
     }
 
     /// Decodes split end-to-end YOLO seg detection from float tensors.
@@ -2774,20 +2760,17 @@ impl Decoder {
             self.max_det,
         );
 
-        let (new_boxes, old_boxes) =
-            Self::update_tracker_yolo_segdet(tracker, timestamp, boxes, output_tracks);
-
-        let mask_data = mask_fn(
-            new_boxes,
+        Ok(Self::finish_tracked_yolo_segdet_with_masks(
+            tracker,
+            timestamp,
+            boxes,
             mask_coeff,
             dequant_p.view(),
             output_boxes,
             output_masks,
-        );
-
-        output_boxes.extend(old_boxes);
-
-        Ok(mask_data)
+            output_tracks,
+            mask_fn,
+        ))
     }
 
     /// Decodes split end-to-end YOLO seg detection from quantized tensors.
@@ -3366,6 +3349,47 @@ impl Decoder {
         )
     }
 
+    /// Shared tracked-segdet finish stage: update the tracker, run `mask_fn`
+    /// on live boxes, then append aged-out boxes without masks.
+    ///
+    /// Extracted from the six `process_tracked_yolo_*` variants so the
+    /// tracker/mask/extend tail is not duplicated (cognitive-complexity).
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn finish_tracked_yolo_segdet_with_masks<
+        TR: edgefirst_tracker::Tracker<DetectBox>,
+        MaskT,
+        ProtoT,
+        M,
+    >(
+        tracker: &mut TR,
+        timestamp: u64,
+        boxes: Vec<(DetectBox, usize)>,
+        mask_tensor: ArrayView2<MaskT>,
+        protos_tensor: ArrayView3<ProtoT>,
+        output_boxes: &mut Vec<DetectBox>,
+        output_masks: &mut Vec<Segmentation>,
+        output_tracks: &mut Vec<TrackInfo>,
+        mask_fn: impl FnOnce(
+            Vec<(DetectBox, usize)>,
+            ArrayView2<MaskT>,
+            ArrayView3<ProtoT>,
+            &mut Vec<DetectBox>,
+            &mut Vec<Segmentation>,
+        ) -> M,
+    ) -> M {
+        let (new_boxes, old_boxes) =
+            Self::update_tracker_yolo_segdet(tracker, timestamp, boxes, output_tracks);
+        let mask_data = mask_fn(
+            new_boxes,
+            mask_tensor,
+            protos_tensor,
+            output_boxes,
+            output_masks,
+        );
+        output_boxes.extend(old_boxes);
+        mask_data
+    }
+
     pub(super) fn update_tracker_yolo_segdet<TR: edgefirst_tracker::Tracker<DetectBox>>(
         tracker: &mut TR,
         timestamp: u64,
@@ -3433,5 +3457,78 @@ impl Decoder {
         output_boxes.extend(new_boxes);
         output_tracks.clear();
         output_tracks.extend(new_tracks);
+    }
+}
+
+#[cfg(all(test, feature = "tracker"))]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tracked_finish_tests {
+    use super::*;
+    use crate::{BoundingBox, DetectBox};
+    use edgefirst_tracker::{ActiveTrackInfo, DetectionBox, TrackInfo, Tracker, Uuid};
+    use ndarray::{Array2, Array3};
+
+    /// Passthrough tracker: every detection becomes a live track at `timestamp`.
+    struct PassthroughTracker;
+
+    impl Tracker<DetectBox> for PassthroughTracker {
+        fn update(&mut self, boxes: &[DetectBox], timestamp: u64) -> Vec<Option<TrackInfo>> {
+            boxes
+                .iter()
+                .map(|b| {
+                    Some(TrackInfo {
+                        uuid: Uuid::nil(),
+                        tracked_location: b.bbox(),
+                        count: 1,
+                        created: timestamp,
+                        last_updated: timestamp,
+                    })
+                })
+                .collect()
+        }
+
+        fn get_active_tracks(&self) -> Vec<ActiveTrackInfo<DetectBox>> {
+            Vec::new()
+        }
+    }
+
+    #[test]
+    fn finish_tracked_yolo_segdet_with_masks_runs_mask_fn_and_keeps_boxes() {
+        let mut tracker = PassthroughTracker;
+        let mut output_boxes = Vec::new();
+        let mut output_masks = Vec::new();
+        let mut output_tracks = Vec::new();
+
+        let boxes = vec![(
+            DetectBox {
+                bbox: BoundingBox::new(0.1, 0.2, 0.3, 0.4),
+                score: 0.9,
+                label: 1,
+            },
+            0usize,
+        )];
+        let mask: Array2<f32> = Array2::zeros((1, 4));
+        let protos: Array3<f32> = Array3::zeros((4, 4, 4));
+
+        let marker = Decoder::finish_tracked_yolo_segdet_with_masks(
+            &mut tracker,
+            42,
+            boxes,
+            mask.view(),
+            protos.view(),
+            &mut output_boxes,
+            &mut output_masks,
+            &mut output_tracks,
+            |new_boxes, _mask, _protos, out_boxes, _out_masks| {
+                assert_eq!(new_boxes.len(), 1);
+                out_boxes.push(new_boxes[0].0);
+                7u8
+            },
+        );
+
+        assert_eq!(marker, 7);
+        assert_eq!(output_boxes.len(), 1);
+        assert_eq!(output_tracks.len(), 1);
+        assert_eq!(output_tracks[0].last_updated, 42);
     }
 }

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -1293,13 +1293,13 @@ fn logical_to_legacy_config_output(logical: &LogicalOutput) -> DecoderResult<Con
         LogicalType::Detection | LogicalType::Detections => Ok(detection_to_legacy(&ctx)),
         // Objectness / Landmarks have no direct v1 equivalent; the v1
         // YOLOv5 path embedded objectness in the combined Detection.
-        LogicalType::Objectness | LogicalType::Landmarks => Err(DecoderError::NotSupported(
-            format!(
+        LogicalType::Objectness | LogicalType::Landmarks => {
+            Err(DecoderError::NotSupported(format!(
                 "logical type {:?} has no legacy v1 equivalent; use the \
                  native v2 decoder path",
                 ty
-            ),
-        )),
+            )))
+        }
     }
 }
 
@@ -1316,7 +1316,7 @@ struct LegacyConvertCtx {
 fn boxes_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
     ConfigOutput::Boxes(configs::Boxes {
         decoder: ctx.decoder,
-        quantization: ctx.quantization.clone(),
+        quantization: ctx.quantization,
         shape: ctx.shape.clone(),
         dshape: ctx.dshape.clone(),
         normalized: ctx.normalized,
@@ -1326,7 +1326,7 @@ fn boxes_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
 fn scores_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
     ConfigOutput::Scores(configs::Scores {
         decoder: ctx.decoder,
-        quantization: ctx.quantization.clone(),
+        quantization: ctx.quantization,
         shape: ctx.shape.clone(),
         dshape: ctx.dshape.clone(),
     })
@@ -1335,7 +1335,7 @@ fn scores_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
 fn protos_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
     ConfigOutput::Protos(configs::Protos {
         decoder: ctx.decoder,
-        quantization: ctx.quantization.clone(),
+        quantization: ctx.quantization,
         shape: ctx.shape.clone(),
         dshape: ctx.dshape.clone(),
     })
@@ -1344,7 +1344,7 @@ fn protos_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
 fn mask_coefs_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
     ConfigOutput::MaskCoefficients(configs::MaskCoefficients {
         decoder: ctx.decoder,
-        quantization: ctx.quantization.clone(),
+        quantization: ctx.quantization,
         shape: ctx.shape.clone(),
         dshape: ctx.dshape.clone(),
     })
@@ -1353,7 +1353,7 @@ fn mask_coefs_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
 fn segmentation_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
     ConfigOutput::Segmentation(configs::Segmentation {
         decoder: ctx.decoder,
-        quantization: ctx.quantization.clone(),
+        quantization: ctx.quantization,
         shape: ctx.shape.clone(),
         dshape: ctx.dshape.clone(),
     })
@@ -1362,7 +1362,7 @@ fn segmentation_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
 fn masks_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
     ConfigOutput::Mask(configs::Mask {
         decoder: ctx.decoder,
-        quantization: ctx.quantization.clone(),
+        quantization: ctx.quantization,
         shape: ctx.shape.clone(),
         dshape: ctx.dshape.clone(),
     })
@@ -1371,7 +1371,7 @@ fn masks_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
 fn classes_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
     ConfigOutput::Classes(configs::Classes {
         decoder: ctx.decoder,
-        quantization: ctx.quantization.clone(),
+        quantization: ctx.quantization,
         shape: ctx.shape.clone(),
         dshape: ctx.dshape.clone(),
     })
@@ -1384,7 +1384,7 @@ fn detection_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
     ConfigOutput::Detection(configs::Detection {
         anchors: ctx.anchors.clone(),
         decoder: ctx.decoder,
-        quantization: ctx.quantization.clone(),
+        quantization: ctx.quantization,
         shape: ctx.shape.clone(),
         dshape: ctx.dshape.clone(),
         normalized: ctx.normalized,

--- a/crates/decoder/src/schema.rs
+++ b/crates/decoder/src/schema.rs
@@ -1273,72 +1273,121 @@ fn logical_to_legacy_config_output(logical: &LogicalOutput) -> DecoderResult<Con
         ))
     })?;
 
-    Ok(match ty {
-        LogicalType::Boxes => ConfigOutput::Boxes(configs::Boxes {
-            decoder,
-            quantization,
-            shape,
-            dshape,
-            normalized: logical.normalized,
-        }),
-        LogicalType::Scores => ConfigOutput::Scores(configs::Scores {
-            decoder,
-            quantization,
-            shape,
-            dshape,
-        }),
-        LogicalType::Protos => ConfigOutput::Protos(configs::Protos {
-            decoder,
-            quantization,
-            shape,
-            dshape,
-        }),
-        LogicalType::MaskCoefs => ConfigOutput::MaskCoefficients(configs::MaskCoefficients {
-            decoder,
-            quantization,
-            shape,
-            dshape,
-        }),
-        LogicalType::Segmentation => ConfigOutput::Segmentation(configs::Segmentation {
-            decoder,
-            quantization,
-            shape,
-            dshape,
-        }),
-        LogicalType::Masks => ConfigOutput::Mask(configs::Mask {
-            decoder,
-            quantization,
-            shape,
-            dshape,
-        }),
-        LogicalType::Classes => ConfigOutput::Classes(configs::Classes {
-            decoder,
-            quantization,
-            shape,
-            dshape,
-        }),
-        // Detection covers ModelPack anchor-grid and legacy YOLO combined.
-        // Detections (plural) is end-to-end; maps to Detection with the
-        // appropriate dimension layout.
-        LogicalType::Detection | LogicalType::Detections => {
-            ConfigOutput::Detection(configs::Detection {
-                anchors: logical.anchors.clone(),
-                decoder,
-                quantization,
-                shape,
-                dshape,
-                normalized: logical.normalized,
-            })
-        }
+    let ctx = LegacyConvertCtx {
+        decoder,
+        quantization,
+        shape,
+        dshape,
+        normalized: logical.normalized,
+        anchors: logical.anchors.clone(),
+    };
+
+    match ty {
+        LogicalType::Boxes => Ok(boxes_to_legacy(&ctx)),
+        LogicalType::Scores => Ok(scores_to_legacy(&ctx)),
+        LogicalType::Protos => Ok(protos_to_legacy(&ctx)),
+        LogicalType::MaskCoefs => Ok(mask_coefs_to_legacy(&ctx)),
+        LogicalType::Segmentation => Ok(segmentation_to_legacy(&ctx)),
+        LogicalType::Masks => Ok(masks_to_legacy(&ctx)),
+        LogicalType::Classes => Ok(classes_to_legacy(&ctx)),
+        LogicalType::Detection | LogicalType::Detections => Ok(detection_to_legacy(&ctx)),
         // Objectness / Landmarks have no direct v1 equivalent; the v1
         // YOLOv5 path embedded objectness in the combined Detection.
-        LogicalType::Objectness | LogicalType::Landmarks => {
-            return Err(DecoderError::NotSupported(format!(
+        LogicalType::Objectness | LogicalType::Landmarks => Err(DecoderError::NotSupported(
+            format!(
                 "logical type {:?} has no legacy v1 equivalent; use the \
                  native v2 decoder path",
                 ty
-            )));
-        }
+            ),
+        )),
+    }
+}
+
+/// Shared fields for per-`LogicalType` legacy conversion helpers.
+struct LegacyConvertCtx {
+    decoder: configs::DecoderType,
+    quantization: Option<QuantTuple>,
+    shape: Vec<usize>,
+    dshape: Vec<(DimName, usize)>,
+    normalized: Option<bool>,
+    anchors: Option<Vec<[f32; 2]>>,
+}
+
+fn boxes_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
+    ConfigOutput::Boxes(configs::Boxes {
+        decoder: ctx.decoder,
+        quantization: ctx.quantization.clone(),
+        shape: ctx.shape.clone(),
+        dshape: ctx.dshape.clone(),
+        normalized: ctx.normalized,
+    })
+}
+
+fn scores_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
+    ConfigOutput::Scores(configs::Scores {
+        decoder: ctx.decoder,
+        quantization: ctx.quantization.clone(),
+        shape: ctx.shape.clone(),
+        dshape: ctx.dshape.clone(),
+    })
+}
+
+fn protos_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
+    ConfigOutput::Protos(configs::Protos {
+        decoder: ctx.decoder,
+        quantization: ctx.quantization.clone(),
+        shape: ctx.shape.clone(),
+        dshape: ctx.dshape.clone(),
+    })
+}
+
+fn mask_coefs_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
+    ConfigOutput::MaskCoefficients(configs::MaskCoefficients {
+        decoder: ctx.decoder,
+        quantization: ctx.quantization.clone(),
+        shape: ctx.shape.clone(),
+        dshape: ctx.dshape.clone(),
+    })
+}
+
+fn segmentation_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
+    ConfigOutput::Segmentation(configs::Segmentation {
+        decoder: ctx.decoder,
+        quantization: ctx.quantization.clone(),
+        shape: ctx.shape.clone(),
+        dshape: ctx.dshape.clone(),
+    })
+}
+
+fn masks_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
+    ConfigOutput::Mask(configs::Mask {
+        decoder: ctx.decoder,
+        quantization: ctx.quantization.clone(),
+        shape: ctx.shape.clone(),
+        dshape: ctx.dshape.clone(),
+    })
+}
+
+fn classes_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
+    ConfigOutput::Classes(configs::Classes {
+        decoder: ctx.decoder,
+        quantization: ctx.quantization.clone(),
+        shape: ctx.shape.clone(),
+        dshape: ctx.dshape.clone(),
+    })
+}
+
+fn detection_to_legacy(ctx: &LegacyConvertCtx) -> ConfigOutput {
+    // Detection covers ModelPack anchor-grid and legacy YOLO combined.
+    // Detections (plural) is end-to-end; maps to Detection with the
+    // appropriate dimension layout.
+    ConfigOutput::Detection(configs::Detection {
+        anchors: ctx.anchors.clone(),
+        decoder: ctx.decoder,
+        quantization: ctx.quantization.clone(),
+        shape: ctx.shape.clone(),
+        dshape: ctx.dshape.clone(),
+        normalized: ctx.normalized,
     })
 }
 
@@ -2388,6 +2437,74 @@ outputs:
         let (shape, dshape) = squeeze_padding_dims(vec![1, 4, 8400], vec![]);
         assert_eq!(shape, vec![1, 4, 8400]);
         assert!(dshape.is_empty());
+    }
+
+    fn sample_logical(ty: LogicalType) -> LogicalOutput {
+        LogicalOutput {
+            name: Some("sample".into()),
+            type_: Some(ty),
+            shape: vec![1, 4, 100],
+            dshape: vec![],
+            decoder: None,
+            encoding: None,
+            score_format: None,
+            normalized: Some(true),
+            anchors: None,
+            stride: None,
+            dtype: None,
+            quantization: None,
+            outputs: vec![],
+            activation_applied: None,
+            activation_required: None,
+        }
+    }
+
+    #[test]
+    fn logical_to_legacy_maps_each_supported_type() {
+        let cases = [
+            (LogicalType::Boxes, "Boxes"),
+            (LogicalType::Scores, "Scores"),
+            (LogicalType::Protos, "Protos"),
+            (LogicalType::MaskCoefs, "MaskCoefficients"),
+            (LogicalType::Segmentation, "Segmentation"),
+            (LogicalType::Masks, "Mask"),
+            (LogicalType::Classes, "Classes"),
+            (LogicalType::Detection, "Detection"),
+            (LogicalType::Detections, "Detection"),
+        ];
+        for (ty, expected) in cases {
+            let out = logical_to_legacy_config_output(&sample_logical(ty)).unwrap();
+            let name = match &out {
+                ConfigOutput::Boxes(_) => "Boxes",
+                ConfigOutput::Scores(_) => "Scores",
+                ConfigOutput::Protos(_) => "Protos",
+                ConfigOutput::MaskCoefficients(_) => "MaskCoefficients",
+                ConfigOutput::Segmentation(_) => "Segmentation",
+                ConfigOutput::Mask(_) => "Mask",
+                ConfigOutput::Classes(_) => "Classes",
+                ConfigOutput::Detection(_) => "Detection",
+            };
+            assert_eq!(name, expected, "type {ty:?}");
+        }
+    }
+
+    #[test]
+    fn logical_to_legacy_rejects_objectness_and_landmarks() {
+        for ty in [LogicalType::Objectness, LogicalType::Landmarks] {
+            let err = logical_to_legacy_config_output(&sample_logical(ty)).unwrap_err();
+            assert!(
+                matches!(err, DecoderError::NotSupported(_)),
+                "expected NotSupported for {ty:?}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn logical_to_legacy_rejects_typeless_output() {
+        let mut logical = sample_logical(LogicalType::Boxes);
+        logical.type_ = None;
+        let err = logical_to_legacy_config_output(&logical).unwrap_err();
+        assert!(matches!(err, DecoderError::InvalidConfig(_)));
     }
 
     #[test]

--- a/scripts/decoder_generate_fixture.py
+++ b/scripts/decoder_generate_fixture.py
@@ -494,6 +494,126 @@ def _file_sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+def build_stage_intermediates(layout, raw: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    """Capture per-level and protos intermediate tensors for a fixture.
+
+    Pure helper extracted from :func:`main` so stage capture can be unit-tested
+    without running TFLite inference.
+    """
+    tensors: dict[str, np.ndarray] = {}
+    for lvl_idx, lvl in enumerate(layout.fpn_levels):
+        box_q_t = raw[f"raw.boxes_{lvl_idx}"]
+        sco_q_t = raw[f"raw.scores_{lvl_idx}"]
+        mc_q_t = raw.get(f"raw.mc_{lvl_idx}")
+        box_scale, box_zp = lvl["box_quant"]
+        sco_scale, sco_zp = lvl["score_quant"]
+        mc_scale = mc_zp = None
+        if mc_q_t is not None and lvl.get("mc_quant") is not None:
+            mc_scale, mc_zp = lvl["mc_quant"]
+        inter = capture_box_score_mc_intermediates(
+            level_index=lvl_idx,
+            encoding=layout.box_encoding,
+            reg_max=lvl.get("reg_max"),
+            h=lvl["h"],
+            w=lvl["w"],
+            stride=int(lvl["stride"]),
+            box_q=box_q_t,
+            box_q_scale=float(box_scale),
+            box_q_zp=int(box_zp),
+            sco_q=sco_q_t,
+            sco_q_scale=float(sco_scale),
+            sco_q_zp=int(sco_zp),
+            mc_q=mc_q_t,
+            mc_q_scale=float(mc_scale) if mc_scale is not None else None,
+            mc_q_zp=int(mc_zp) if mc_zp is not None else None,
+        )
+        tensors.update(inter)
+    if "raw.protos" in raw and layout.protos_quant is not None:
+        p_scale, p_zp = layout.protos_quant
+        tensors.update(
+            capture_protos_intermediate(
+                raw["raw.protos"], float(p_scale), int(p_zp),
+            )
+        )
+    return tensors
+
+
+def build_quant_map(layout) -> dict[str, dict]:
+    """Build the fixture quantization map keyed by loader lookup name."""
+    quant_map: dict[str, dict] = {}
+    for lvl_idx, lvl in enumerate(layout.fpn_levels):
+        if lvl.get("box_quant") is not None:
+            scale, zp = lvl["box_quant"]
+            quant_map[f"boxes_{lvl_idx}"] = {
+                "scale": float(scale),
+                "zero_point": int(zp),
+                "dtype": "int8",
+            }
+        if lvl.get("score_quant") is not None:
+            scale, zp = lvl["score_quant"]
+            quant_map[f"scores_{lvl_idx}"] = {
+                "scale": float(scale),
+                "zero_point": int(zp),
+                "dtype": "int8",
+            }
+        if lvl.get("mc_quant") is not None:
+            scale, zp = lvl["mc_quant"]
+            quant_map[f"mc_{lvl_idx}"] = {
+                "scale": float(scale),
+                "zero_point": int(zp),
+                "dtype": "int8",
+            }
+    if layout.protos_quant is not None:
+        scale, zp = layout.protos_quant
+        quant_map["protos"] = {
+            "scale": float(scale),
+            "zero_point": int(zp),
+            "dtype": "int8",
+        }
+    return quant_map
+
+
+def build_fixture_metadata(
+    *,
+    cfg: FixtureConfig,
+    layout,
+    edgefirst_metadata: dict,
+    quant_map: dict[str, dict],
+    tensor_keys: list[str],
+) -> dict[str, str]:
+    """Assemble string-valued safetensors metadata for a fixture write."""
+    nms_config = {
+        "iou_threshold": cfg.iou_threshold,
+        "score_threshold": cfg.score_threshold,
+        "max_detections": 300,
+    }
+    documentation_md = build_documentation_md(
+        decoder_family="per_scale_yolo_seg",
+        model_basename=cfg.output_path.stem,
+        encoding=layout.box_encoding,
+        keys=tensor_keys,
+        nms_config=nms_config,
+        expected_count_min=cfg.expected_count_min,
+    )
+    return {
+        "format_version": "1",
+        "decoder_family": "per_scale_yolo_seg",
+        "model_basename": cfg.output_path.stem,
+        "model_path": str(cfg.model_path),
+        "image_path": str(cfg.image_path),
+        "schema_json": json.dumps(_patch_schema_dshape(edgefirst_metadata)),
+        "quantization_json": json.dumps(quant_map),
+        "nms_config_json": json.dumps(nms_config),
+        "expected_count_min": str(cfg.expected_count_min),
+        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "reference_script_sha256": _file_sha256(
+            Path(__file__).resolve().parent / "per_scale_decode_reference.py"
+        ),
+        "generator_git_sha": _git_sha(),
+        "documentation_md": documentation_md,
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     cfg = parse_args(argv)
 
@@ -511,34 +631,8 @@ def main(argv: list[str] | None = None) -> int:
     tensors: dict[str, np.ndarray] = {"input.image": image_uint8[np.newaxis]}
     tensors.update(raw)
 
-    # Per-stage intermediates
     if cfg.include_stages:
-        for lvl_idx, lvl in enumerate(layout.fpn_levels):
-            box_q_t = raw[f"raw.boxes_{lvl_idx}"]
-            sco_q_t = raw[f"raw.scores_{lvl_idx}"]
-            mc_q_t  = raw.get(f"raw.mc_{lvl_idx}")
-            box_scale, box_zp = lvl["box_quant"]
-            sco_scale, sco_zp = lvl["score_quant"]
-            mc_scale = mc_zp = None
-            if mc_q_t is not None and lvl.get("mc_quant") is not None:
-                mc_scale, mc_zp = lvl["mc_quant"]
-            inter = capture_box_score_mc_intermediates(
-                level_index=lvl_idx,
-                encoding=layout.box_encoding,
-                reg_max=lvl.get("reg_max"),
-                h=lvl["h"], w=lvl["w"], stride=int(lvl["stride"]),
-                box_q=box_q_t, box_q_scale=float(box_scale), box_q_zp=int(box_zp),
-                sco_q=sco_q_t, sco_q_scale=float(sco_scale), sco_q_zp=int(sco_zp),
-                mc_q=mc_q_t,
-                mc_q_scale=float(mc_scale) if mc_scale is not None else None,
-                mc_q_zp=int(mc_zp) if mc_zp is not None else None,
-            )
-            tensors.update(inter)
-        if "raw.protos" in raw and layout.protos_quant is not None:
-            p_scale, p_zp = layout.protos_quant
-            tensors.update(capture_protos_intermediate(
-                raw["raw.protos"], float(p_scale), int(p_zp),
-            ))
+        tensors.update(build_stage_intermediates(layout, raw))
 
     # Build shape_map directly (avoid bind_outputs' ndarray dance)
     outputs_in_order = list(raw_outputs_by_shape.values())
@@ -557,61 +651,14 @@ def main(argv: list[str] | None = None) -> int:
     if decoded.get("masks") is not None and decoded["masks"].size > 0:
         tensors["decoded.masks"] = (decoded["masks"] > 0).astype(np.uint8) * 255
 
-    # Build quantization map keyed by lookup name (matches loader's key shape)
-    quant_map: dict[str, dict] = {}
-    for lvl_idx, lvl in enumerate(layout.fpn_levels):
-        if lvl.get("box_quant") is not None:
-            scale, zp = lvl["box_quant"]
-            quant_map[f"boxes_{lvl_idx}"] = {
-                "scale": float(scale), "zero_point": int(zp), "dtype": "int8",
-            }
-        if lvl.get("score_quant") is not None:
-            scale, zp = lvl["score_quant"]
-            quant_map[f"scores_{lvl_idx}"] = {
-                "scale": float(scale), "zero_point": int(zp), "dtype": "int8",
-            }
-        if lvl.get("mc_quant") is not None:
-            scale, zp = lvl["mc_quant"]
-            quant_map[f"mc_{lvl_idx}"] = {
-                "scale": float(scale), "zero_point": int(zp), "dtype": "int8",
-            }
-    if layout.protos_quant is not None:
-        scale, zp = layout.protos_quant
-        quant_map["protos"] = {
-            "scale": float(scale), "zero_point": int(zp), "dtype": "int8",
-        }
-
-    nms_config = {
-        "iou_threshold": cfg.iou_threshold,
-        "score_threshold": cfg.score_threshold,
-        "max_detections": 300,
-    }
-
-    documentation_md = build_documentation_md(
-        decoder_family="per_scale_yolo_seg",
-        model_basename=cfg.output_path.stem,
-        encoding=layout.box_encoding,
-        keys=list(tensors.keys()),
-        nms_config=nms_config,
-        expected_count_min=cfg.expected_count_min,
+    quant_map = build_quant_map(layout)
+    metadata = build_fixture_metadata(
+        cfg=cfg,
+        layout=layout,
+        edgefirst_metadata=edgefirst_metadata,
+        quant_map=quant_map,
+        tensor_keys=list(tensors.keys()),
     )
-
-    metadata: dict[str, str] = {
-        "format_version": "1",
-        "decoder_family": "per_scale_yolo_seg",
-        "model_basename": cfg.output_path.stem,
-        "model_path": str(cfg.model_path),
-        "image_path": str(cfg.image_path),
-        "schema_json": json.dumps(_patch_schema_dshape(edgefirst_metadata)),
-        "quantization_json": json.dumps(quant_map),
-        "nms_config_json": json.dumps(nms_config),
-        "expected_count_min": str(cfg.expected_count_min),
-        "generated_at": datetime.datetime.utcnow().isoformat() + "Z",
-        "reference_script_sha256": _file_sha256(
-            Path(__file__).resolve().parent / "per_scale_decode_reference.py"),
-        "generator_git_sha": _git_sha(),
-        "documentation_md": documentation_md,
-    }
 
     n_det = len(tensors["decoded.boxes_xyxy"])
     if n_det < cfg.expected_count_min:

--- a/scripts/per_scale_decode_reference.py
+++ b/scripts/per_scale_decode_reference.py
@@ -256,59 +256,20 @@ class PerScaleLayout:
             if mc_meta else {}
         )
 
-        assert set(box_by_stride) == set(score_by_stride), (
-            f"Stride mismatch: boxes={set(box_by_stride)}, "
-            f"scores={set(score_by_stride)}"
-        )
-        if mc_by_stride:
-            assert set(mc_by_stride) == set(box_by_stride), (
-                f"Stride mismatch: mask_coefs={set(mc_by_stride)}, "
-                f"boxes={set(box_by_stride)}"
-            )
+        _validate_stride_sets(box_by_stride, score_by_stride, mc_by_stride)
 
         self.fpn_levels: List[dict] = []
         self.nc = 0
 
         for stride in sorted(box_by_stride):
-            bx = box_by_stride[stride]
-            sc = score_by_stride[stride]
-
-            bx_ds = _dshape_dict(bx.get("dshape", []))
-            sc_ds = _dshape_dict(sc.get("dshape", []))
-
-            h = bx_ds.get("height", bx["shape"][1])
-            w = bx_ds.get("width", bx["shape"][2])
-            nc = sc_ds.get("num_classes",
-                           sc_ds.get("num_features", sc["shape"][-1]))
-            reg_max = bx_ds.get("num_features", bx["shape"][-1]) // 4
-            self.nc = nc
-
-            level = {
-                "stride": float(stride),
-                "h": int(h),
-                "w": int(w),
-                "reg_max": int(reg_max),
-                "nc": int(nc),
-                "box_shape": tuple(bx["shape"]),
-                "score_shape": tuple(sc["shape"]),
-                "box_quant": _extract_quant(bx),
-                "score_quant": _extract_quant(sc),
-                "score_activation": sc.get("activation_required",
-                                           scores_meta.get(
-                                               "activation_required")),
-            }
-
-            if stride in mc_by_stride:
-                mc = mc_by_stride[stride]
-                mc_ds = _dshape_dict(mc.get("dshape", []))
-                level["nm"] = mc_ds.get("num_features", mc["shape"][-1])
-                level["mc_shape"] = tuple(mc["shape"])
-                level["mc_quant"] = _extract_quant(mc)
-            else:
-                level["nm"] = 0
-                level["mc_shape"] = None
-                level["mc_quant"] = None
-
+            level = _build_fpn_level(
+                stride,
+                box_by_stride[stride],
+                score_by_stride[stride],
+                mc_by_stride.get(stride),
+                scores_meta,
+            )
+            self.nc = level["nc"]
             self.fpn_levels.append(level)
 
         self.total_anchors = sum(
@@ -318,6 +279,68 @@ class PerScaleLayout:
             tuple(protos_meta["shape"]) if protos_meta else None)
         self.protos_quant = (
             _extract_quant(protos_meta) if protos_meta else None)
+
+
+def _validate_stride_sets(
+    box_by_stride: Dict[int, dict],
+    score_by_stride: Dict[int, dict],
+    mc_by_stride: Dict[int, dict],
+) -> None:
+    """Assert boxes/scores/(optional mask_coefs) share the same stride set."""
+    assert set(box_by_stride) == set(score_by_stride), (
+        f"Stride mismatch: boxes={set(box_by_stride)}, "
+        f"scores={set(score_by_stride)}"
+    )
+    if mc_by_stride:
+        assert set(mc_by_stride) == set(box_by_stride), (
+            f"Stride mismatch: mask_coefs={set(mc_by_stride)}, "
+            f"boxes={set(box_by_stride)}"
+        )
+
+
+def _build_fpn_level(
+    stride: int,
+    bx: dict,
+    sc: dict,
+    mc: Optional[dict],
+    scores_meta: dict,
+) -> dict:
+    """Assemble one FPN level dict from per-scale physical output metadata."""
+    bx_ds = _dshape_dict(bx.get("dshape", []))
+    sc_ds = _dshape_dict(sc.get("dshape", []))
+
+    h = bx_ds.get("height", bx["shape"][1])
+    w = bx_ds.get("width", bx["shape"][2])
+    nc = sc_ds.get("num_classes",
+                   sc_ds.get("num_features", sc["shape"][-1]))
+    reg_max = bx_ds.get("num_features", bx["shape"][-1]) // 4
+
+    level = {
+        "stride": float(stride),
+        "h": int(h),
+        "w": int(w),
+        "reg_max": int(reg_max),
+        "nc": int(nc),
+        "box_shape": tuple(bx["shape"]),
+        "score_shape": tuple(sc["shape"]),
+        "box_quant": _extract_quant(bx),
+        "score_quant": _extract_quant(sc),
+        "score_activation": sc.get("activation_required",
+                                   scores_meta.get(
+                                       "activation_required")),
+    }
+
+    if mc is not None:
+        mc_ds = _dshape_dict(mc.get("dshape", []))
+        level["nm"] = mc_ds.get("num_features", mc["shape"][-1])
+        level["mc_shape"] = tuple(mc["shape"])
+        level["mc_quant"] = _extract_quant(mc)
+    else:
+        level["nm"] = 0
+        level["mc_shape"] = None
+        level["mc_quant"] = None
+
+    return level
 
 
 def _index_by_stride(children: List[dict]) -> Dict[int, dict]:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,8 +9,8 @@ sonar.projectKey=EdgeFirstAI_hal
 sonar.projectName=EdgeFirst HAL
 
 # Source code directories
-# Rust crates (core library code)
-sonar.sources=crates
+# Rust crates (core library code) plus Python utility scripts exercised by tests
+sonar.sources=crates,scripts
 
 # Test directories (excluded from coverage metrics)
 sonar.tests=tests
@@ -42,7 +42,7 @@ sonar.objc.file.suffixes=-
 sonar.exclusions=**/target/**,**/build/**,**/venv/**,**/__pycache__/**,**/testdata/**,**/*.lock
 
 # Coverage exclusions (dev tools and benchmarks don't need test coverage)
-sonar.coverage.exclusions=**/benches/**/*.rs,crates/bench/**,crates/gpu-probe/**
+sonar.coverage.exclusions=**/benches/**/*.rs,crates/bench/**,crates/gpu-probe/**,scripts/bench_compare.py,scripts/fetch-angle.sh,scripts/build-ios.sh,scripts/test-macos.sh,scripts/validate-ios-link.sh,scripts/audit_f16_codegen.sh
 
 # Quality gate settings
 # Note: Quality gate is checked via PR decoration, not workflow failure.

--- a/tests/python/test_decoder_generate_fixture.py
+++ b/tests/python/test_decoder_generate_fixture.py
@@ -490,3 +490,93 @@ def test_assemble_and_write_safetensors_round_trips(tmp_path):
     assert loaded_meta["format_version"] == "1"
     assert loaded_input.dtype == np.uint8
     assert loaded_input.shape == (1, 8, 8, 3)
+
+
+def test_build_quant_map_from_synthetic_layout():
+    mod = _import_generator()
+    layout = _synthetic_layout_three_levels()
+    quant_map = mod.build_quant_map(layout)
+    assert set(quant_map) == {
+        "boxes_0",
+        "boxes_1",
+        "boxes_2",
+        "scores_0",
+        "scores_1",
+        "scores_2",
+        "mc_0",
+        "mc_1",
+        "mc_2",
+        "protos",
+    }
+    assert quant_map["boxes_0"] == {
+        "scale": 0.157,
+        "zero_point": -42,
+        "dtype": "int8",
+    }
+    assert quant_map["protos"]["zero_point"] == -119
+
+
+def test_build_stage_intermediates_includes_protos():
+    import numpy as np
+
+    mod = _import_generator()
+    layout = _synthetic_layout_three_levels()
+    # Tiny spatial dims so DFL intermediates stay cheap.
+    layout.fpn_levels = [
+        {
+            "stride": 8.0,
+            "h": 2,
+            "w": 2,
+            "reg_max": 16,
+            "nc": 2,
+            "nm": 4,
+            "box_shape": (1, 2, 2, 64),
+            "score_shape": (1, 2, 2, 2),
+            "mc_shape": (1, 2, 2, 4),
+            "box_quant": (0.1, 0),
+            "score_quant": (0.2, 0),
+            "mc_quant": (0.3, 0),
+            "score_activation": "sigmoid",
+        }
+    ]
+    layout.protos_shape = (1, 4, 4, 4)
+    layout.protos_quant = (0.05, 0)
+    raw = {
+        "raw.boxes_0": np.zeros((1, 2, 2, 64), dtype=np.int8),
+        "raw.scores_0": np.zeros((1, 2, 2, 2), dtype=np.int8),
+        "raw.mc_0": np.zeros((1, 2, 2, 4), dtype=np.int8),
+        "raw.protos": np.zeros((1, 4, 4, 4), dtype=np.int8),
+    }
+    inter = mod.build_stage_intermediates(layout, raw)
+    assert "intermediate.boxes_0.dequant" in inter
+    assert "intermediate.scores_0.dequant" in inter
+    assert "intermediate.mc_0.dequant" in inter
+    assert "intermediate.protos.dequant" in inter
+
+
+def test_build_fixture_metadata_keys():
+    mod = _import_generator()
+    layout = _synthetic_layout_three_levels()
+    cfg = mod.FixtureConfig(
+        model_path=__import__("pathlib").Path("model.tflite"),
+        image_path=__import__("pathlib").Path("image.jpg"),
+        output_path=__import__("pathlib").Path("out.safetensors"),
+        include_stages=True,
+        score_threshold=0.001,
+        iou_threshold=0.7,
+        expected_count_min=10,
+    )
+    meta = mod.build_fixture_metadata(
+        cfg=cfg,
+        layout=layout,
+        edgefirst_metadata={"outputs": []},
+        quant_map=mod.build_quant_map(layout),
+        tensor_keys=["input.image", "decoded.boxes_xyxy"],
+    )
+    assert meta["format_version"] == "1"
+    assert meta["decoder_family"] == "per_scale_yolo_seg"
+    assert meta["model_basename"] == "out"
+    assert "quantization_json" in meta
+    assert "nms_config_json" in meta
+    assert "documentation_md" in meta
+    assert len(meta["reference_script_sha256"]) == 64

--- a/tests/python/test_fix_coverage_paths.py
+++ b/tests/python/test_fix_coverage_paths.py
@@ -1,0 +1,87 @@
+"""Tests for .github/scripts/fix_coverage_paths.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "fix_coverage_paths.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("fix_coverage_paths", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def fix_mod():
+    return _load_module()
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        ("scripts/decoder_generate_fixture.py", "scripts/decoder_generate_fixture.py"),
+        (
+            "scripts/per_scale_decode_reference.py",
+            "scripts/per_scale_decode_reference.py",
+        ),
+        ("foo.py", "tests/foo.py"),
+        ("tests/python/test_foo.py", "tests/python/test_foo.py"),
+        ("crates/python/src/lib.rs", "crates/python/src/lib.rs"),
+        (".github/scripts/fix_coverage_paths.py", ".github/scripts/fix_coverage_paths.py"),
+        ("./scripts/decoder_generate_fixture.py", "scripts/decoder_generate_fixture.py"),
+        ("./foo.py", "tests/foo.py"),
+    ],
+)
+def test_normalize_coverage_filename(fix_mod, filename, expected):
+    assert fix_mod.normalize_coverage_filename(filename, "tests") == expected
+
+
+def test_fix_coverage_xml_preserves_scripts(fix_mod, tmp_path):
+    xml_path = tmp_path / "coverage.xml"
+    xml_path.write_text(
+        """<?xml version="1.0" ?>
+<coverage>
+  <sources>
+    <source>/tmp/build</source>
+  </sources>
+  <packages>
+    <package name="scripts">
+      <classes>
+        <class filename="scripts/decoder_generate_fixture.py" name="decoder_generate_fixture"/>
+        <class filename="scripts/per_scale_decode_reference.py" name="per_scale_decode_reference"/>
+        <class filename="foo.py" name="foo"/>
+        <class filename="tests/python/test_foo.py" name="test_foo"/>
+        <class filename="crates/python/src/x.py" name="x"/>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+""",
+        encoding="utf-8",
+    )
+
+    fix_mod.fix_coverage_xml(str(xml_path), "tests")
+
+    root = ET.parse(xml_path).getroot()
+    sources = [s.text for s in root.findall(".//sources/source")]
+    assert sources == ["."]
+
+    filenames = [c.get("filename") for c in root.findall(".//class")]
+    assert filenames == [
+        "scripts/decoder_generate_fixture.py",
+        "scripts/per_scale_decode_reference.py",
+        "tests/foo.py",
+        "tests/python/test_foo.py",
+        "crates/python/src/x.py",
+    ]

--- a/tests/python/test_per_scale_decode_reference.py
+++ b/tests/python/test_per_scale_decode_reference.py
@@ -1,0 +1,206 @@
+"""Tests for scripts/per_scale_decode_reference.py helpers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+def _import_ref():
+    repo_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(repo_root / "scripts"))
+    try:
+        return importlib.import_module("per_scale_decode_reference")
+    finally:
+        sys.path.pop(0)
+
+
+def _child(name: str, stride: int, shape, dshape=None, quant=None):
+    out = {
+        "name": name,
+        "stride": stride,
+        "shape": list(shape),
+    }
+    if dshape is not None:
+        out["dshape"] = dshape
+    if quant is not None:
+        out["quantization"] = {
+            "scale": quant[0],
+            "zero_point": quant[1],
+            "dtype": "int8",
+        }
+    return out
+
+
+def test_validate_stride_sets_ok():
+    mod = _import_ref()
+    boxes = {8: {}, 16: {}}
+    scores = {8: {}, 16: {}}
+    mod._validate_stride_sets(boxes, scores, {})
+    mod._validate_stride_sets(boxes, scores, {8: {}, 16: {}})
+
+
+def test_validate_stride_sets_mismatch_raises():
+    mod = _import_ref()
+    with pytest.raises(AssertionError, match="Stride mismatch"):
+        mod._validate_stride_sets({8: {}}, {16: {}}, {})
+    with pytest.raises(AssertionError, match="mask_coefs"):
+        mod._validate_stride_sets({8: {}}, {8: {}}, {16: {}})
+
+
+def test_build_fpn_level_with_and_without_mc():
+    mod = _import_ref()
+    bx = _child(
+        "boxes_0",
+        8,
+        (1, 80, 80, 64),
+        dshape=[{"batch": 1}, {"height": 80}, {"width": 80}, {"num_features": 64}],
+        quant=(0.1, -1),
+    )
+    sc = _child(
+        "scores_0",
+        8,
+        (1, 80, 80, 80),
+        dshape=[{"batch": 1}, {"height": 80}, {"width": 80}, {"num_classes": 80}],
+        quant=(0.2, 0),
+    )
+    mc = _child(
+        "mc_0",
+        8,
+        (1, 80, 80, 32),
+        dshape=[{"batch": 1}, {"height": 80}, {"width": 80}, {"num_features": 32}],
+        quant=(0.3, 1),
+    )
+    scores_meta = {"activation_required": "sigmoid"}
+
+    level = mod._build_fpn_level(8, bx, sc, mc, scores_meta)
+    assert level["stride"] == 8.0
+    assert level["h"] == 80 and level["w"] == 80
+    assert level["reg_max"] == 16
+    assert level["nc"] == 80
+    assert level["nm"] == 32
+    assert level["mc_shape"] == (1, 80, 80, 32)
+    assert level["score_activation"] == "sigmoid"
+
+    det_only = mod._build_fpn_level(8, bx, sc, None, scores_meta)
+    assert det_only["nm"] == 0
+    assert det_only["mc_shape"] is None
+    assert det_only["mc_quant"] is None
+
+
+def test_per_scale_layout_from_metadata():
+    mod = _import_ref()
+    metadata = {
+        "outputs": [
+            {
+                "type": "boxes",
+                "encoding": "dfl",
+                "outputs": [
+                    _child(
+                        "b8",
+                        8,
+                        (1, 2, 2, 64),
+                        dshape=[
+                            {"batch": 1},
+                            {"height": 2},
+                            {"width": 2},
+                            {"num_features": 64},
+                        ],
+                        quant=(0.1, 0),
+                    ),
+                    _child(
+                        "b16",
+                        16,
+                        (1, 1, 1, 64),
+                        dshape=[
+                            {"batch": 1},
+                            {"height": 1},
+                            {"width": 1},
+                            {"num_features": 64},
+                        ],
+                        quant=(0.1, 0),
+                    ),
+                ],
+            },
+            {
+                "type": "scores",
+                "activation_required": "sigmoid",
+                "outputs": [
+                    _child(
+                        "s8",
+                        8,
+                        (1, 2, 2, 3),
+                        dshape=[
+                            {"batch": 1},
+                            {"height": 2},
+                            {"width": 2},
+                            {"num_classes": 3},
+                        ],
+                        quant=(0.2, 0),
+                    ),
+                    _child(
+                        "s16",
+                        16,
+                        (1, 1, 1, 3),
+                        dshape=[
+                            {"batch": 1},
+                            {"height": 1},
+                            {"width": 1},
+                            {"num_classes": 3},
+                        ],
+                        quant=(0.2, 0),
+                    ),
+                ],
+            },
+        ]
+    }
+    layout = mod.PerScaleLayout(metadata)
+    assert layout.box_encoding == "dfl"
+    assert len(layout.fpn_levels) == 2
+    assert layout.fpn_levels[0]["stride"] == 8.0
+    assert layout.total_anchors == 2 * 2 + 1 * 1
+    assert layout.nc == 3
+    assert layout.protos_shape is None
+
+
+def test_nms_class_agnostic_empty_and_basic():
+    mod = _import_ref()
+    boxes = np.zeros((0, 4), dtype=np.float32)
+    scores = np.zeros((0, 2), dtype=np.float32)
+    out_boxes, out_scores, out_classes, indices = mod.nms_class_agnostic(
+        boxes, scores, score_threshold=0.5
+    )
+    assert out_boxes.shape == (0, 4)
+    assert out_scores.shape == (0,)
+    assert out_classes.shape == (0,)
+    assert indices.shape == (0,)
+
+    boxes = np.array(
+        [
+            [10.0, 10.0, 20.0, 20.0],
+            [11.0, 11.0, 20.0, 20.0],
+            [100.0, 100.0, 10.0, 10.0],
+        ],
+        dtype=np.float32,
+    )
+    scores = np.array(
+        [
+            [0.9, 0.1],
+            [0.85, 0.05],
+            [0.1, 0.8],
+        ],
+        dtype=np.float32,
+    )
+    out_boxes, out_scores, out_classes, indices = mod.nms_class_agnostic(
+        boxes,
+        scores,
+        iou_threshold=0.5,
+        score_threshold=0.5,
+        max_detections=10,
+    )
+    assert len(out_boxes) >= 1
+    assert len(out_boxes) == len(out_scores) == len(out_classes) == len(indices)


### PR DESCRIPTION
## Summary
- Fix Cobertura path remapping so `scripts/` coverage files are not rewritten to non-existent `tests/scripts/...` paths, and index `scripts` in `sonar.sources`
- Split high-complexity fixture generator, per-scale reference, tracked YOLO postprocess, and schema legacy-conversion helpers into smaller testable units
- Expand Python and Rust unit tests for the new helpers and coverage remapper

## Test plan
- [ ] `./venv/bin/pytest tests/python/test_fix_coverage_paths.py tests/python/test_decoder_generate_fixture.py tests/python/test_per_scale_decode_reference.py -q`
- [ ] `cargo test -p edgefirst-decoder logical_to_legacy`
- [ ] `cargo test -p edgefirst-decoder --features tracker tracked_finish`
- [ ] Confirm SonarCloud scan no longer reports unresolved `tests/scripts/...` coverage paths
- [ ] Confirm coverage appears for `scripts/decoder_generate_fixture.py` and `scripts/per_scale_decode_reference.py`