### PR TITLE
EDGEAI-1353: Fix EGL loader UB and iOS libEGL resolution

### DIFF
--- a/crates/egl/src/lib.rs
+++ b/crates/egl/src/lib.rs
@@ -2179,8 +2179,16 @@ macro_rules! api {
 					// surfaces as a "successful" NULL symbol.
 					#[cfg(unix)]
 					let addr = symbol.into_raw().into_raw();
+					// On Windows `into_raw()` yields `FARPROC`
+					// (`Option<unsafe extern "system" fn() -> isize>`), not a
+					// data pointer, so it cannot be `as`-cast to `*mut c_void`.
+					// Map `None`/`Some` to a raw address so the null check and
+					// transmute below are shared with the unix path.
 					#[cfg(windows)]
-					let addr = symbol.into_raw().into_raw() as *mut std::os::raw::c_void;
+					let addr = symbol
+						.into_raw()
+						.into_raw()
+						.map_or(std::ptr::null_mut(), |f| f as *mut std::os::raw::c_void);
 					if addr.is_null() {
 						return Err(libloading::Error::DlSymUnknown);
 					}

--- a/crates/egl/src/lib.rs
+++ b/crates/egl/src/lib.rs
@@ -2166,12 +2166,32 @@ macro_rules! api {
 				$(
 					let name = stringify!($name).as_bytes();
 					let symbol = lib.get::<unsafe extern "system" fn($($atype ),*) -> $rtype>(name)?;
+					// Take the raw symbol ADDRESS and transmute it into the fn
+					// pointer directly. The previous formulation took a
+					// reference to the `into_raw()` TEMPORARY, let it die at
+					// the end of its statement, then read through the dangling
+					// pointer — UB that iOS Release codegen turned into a NULL
+					// dispatch-table entry (call to 0x0 on first EGL use,
+					// found on a physical iPhone 17 Pro); its `assert!` only
+					// checked a stack address, never the symbol. Guard the
+					// real address instead: dlsym can return NULL without
+					// setting dlerror on some handles, which libloading
+					// surfaces as a "successful" NULL symbol.
 					#[cfg(unix)]
-					let ptr = (&symbol.into_raw().into_raw()) as *const *mut _ as *const unsafe extern "system" fn($($atype ),*) -> $rtype;
+					let addr = symbol.into_raw().into_raw();
 					#[cfg(windows)]
-					let ptr = (&symbol.into_raw().into_raw()) as *const _ as *const unsafe extern "system" fn($($atype ),*) -> $rtype;
-					assert!(!ptr.is_null());
-					raw.$name = std::mem::MaybeUninit::new(*ptr);
+					let addr = symbol.into_raw().into_raw() as *mut std::os::raw::c_void;
+					if addr.is_null() {
+						return Err(libloading::Error::DlSymUnknown);
+					}
+					// SAFETY: `addr` is the non-null address dlsym resolved for
+					// `$name`; the declared signature is the EGL-spec signature
+					// for that entry point.
+					let fnptr = std::mem::transmute::<
+						*mut std::os::raw::c_void,
+						unsafe extern "system" fn($($atype ),*) -> $rtype,
+					>(addr);
+					raw.$name = std::mem::MaybeUninit::new(fnptr);
 				)*
 
 				Ok(())
@@ -2185,6 +2205,15 @@ macro_rules! api {
 				$(
 					#[inline(always)]
 					unsafe fn $p_name(&self, $($p_arg : $p_atype),*) -> $p_rtype {
+						// Defensive slot guard: a NULL dispatch entry would
+						// otherwise be a jump to address 0 with no symbolized
+						// context. dlsym can return Ok(NULL) without dlerror
+						// on some handles, so a named panic is the honest
+						// failure mode.
+						let slot = self.raw.$p_name.as_ptr() as *const usize;
+						if *slot == 0 {
+							panic!("EGL dispatch slot {} is NULL", stringify!($p_name));
+						}
 						(self.raw.$p_name.assume_init())($($p_arg),*)
 					}
 				)*
@@ -2197,6 +2226,11 @@ macro_rules! api {
 			$(
 				#[inline(always)]
 				unsafe fn $name(&self, $($arg : $atype),*) -> $rtype {
+					// Defensive slot guard — see the $p_name accessors above.
+					let slot = self.raw.$name.as_ptr() as *const usize;
+					if *slot == 0 {
+						panic!("EGL dispatch slot {} is NULL", stringify!($name));
+					}
 					(self.raw.$name.assume_init())($($arg),*)
 				}
 			)*

--- a/crates/image/src/gl/platform/angle.rs
+++ b/crates/image/src/gl/platform/angle.rs
@@ -143,6 +143,7 @@ fn init_shared_display() -> Result<SharedAngleDisplay> {
         >::load_required_from(egl_lib)
     }
     .map_err(|e| Error::Io(std::io::Error::other(format!("EGL load: {e:?}"))))?;
+    debug!("EGL dynamic instance loaded, version = {:?}", egl.version());
 
     // 2. Metal-backed display from ApplePlatform.
     let display = ApplePlatform::create_display(&egl)?;

--- a/crates/image/src/gl/platform/macos.rs
+++ b/crates/image/src/gl/platform/macos.rs
@@ -44,11 +44,12 @@
 use super::super::Egl;
 use crate::Error;
 use edgefirst_egl as egl;
-// `debug!`/`warn!` are only used inside the macOS `load_egl_lib_inner`
-// branch (the iOS path resolves symbols via `Library::this()` with no
-// logging). Gate the import so iOS builds don't warn about unused items.
+// `debug!` is used by both Apple `load_egl_lib_inner` branches; `warn!`
+// only by the macOS one. Gate the `warn` import so iOS builds don't warn
+// about unused items.
+use log::debug;
 #[cfg(target_os = "macos")]
-use log::{debug, warn};
+use log::warn;
 use std::sync::OnceLock;
 
 // ---------------------------------------------------------------------------
@@ -98,10 +99,11 @@ impl ApplePlatform {
     /// same pattern as Linux's `EGL_LIB` in `context.rs`).
     ///
     /// The actual acquisition is OS-specific ([`Self::load_egl_lib_inner`]):
-    /// macOS `dlopen`s a `libEGL.dylib` from the search paths; iOS resolves
-    /// from the main image via `Library::this()` (the ANGLE xcframeworks are
-    /// dynamic frameworks the app links against and embeds, so they load into
-    /// the process image at launch).
+    /// macOS `dlopen`s a `libEGL.dylib` from the search paths; iOS locates
+    /// the already-loaded `libEGL` image in dyld's image list and `dlopen`s
+    /// it by exact path (the ANGLE xcframeworks are dynamic frameworks the
+    /// app or test bundle links against and embeds, so dyld loads them
+    /// before any Rust code runs).
     pub(in super::super) fn load_egl_lib() -> Result<&'static libloading::Library, Error> {
         if let Some(lib) = EGL_LIB.get() {
             return Ok(lib);
@@ -112,22 +114,64 @@ impl ApplePlatform {
     }
 
     /// iOS: ANGLE EGL/GLES symbols come from the `EGL.xcframework` +
-    /// `GLESv2.xcframework` dynamic frameworks that the app links against and
-    /// embeds (see `.cargo/config.toml` and README.md § iOS). Because they are
-    /// linked (not merely bundled), they load into the process image at launch,
-    /// so resolving from the main image via `Library::this()` — equivalent to
-    /// `dlopen(NULL)`, a handle for the whole process image — lets `dlsym` find
-    /// the ANGLE entry points the `edgefirst-egl` `Dynamic` loader requests.
-    /// (The app shell that performs that link/embed is future Swift-bindings
-    /// work; see README.md § iOS.)
+    /// `GLESv2.xcframework` dynamic frameworks that the consuming app (or
+    /// test bundle) links against and embeds. Because they are linked (not
+    /// merely bundled), dyld loads them into the process before any Rust code
+    /// runs — so locate the already-loaded `libEGL` image in dyld's image
+    /// list and `dlopen` it by its exact path.
+    ///
+    /// Deliberately NOT `Library::this()` (`dlopen(NULL)`): that handle only
+    /// searches the main executable and its launch-time dependents. When
+    /// ANGLE is linked by a *plugin* image instead (an XCTest bundle inside a
+    /// test runner — the Device Farm / device-test topology), `dlsym` on the
+    /// main-executable handle returns NULL for every EGL symbol WITHOUT
+    /// setting `dlerror`, which libloading reports as success — the
+    /// `edgefirst-egl` strict loader then builds a dispatch table of NULLs
+    /// and the first EGL call crashes at address 0 (found on a physical
+    /// iPhone 17 Pro; the same lookup succeeds in a plain app because there
+    /// ANGLE *is* a launch dependent of the main executable). Resolving the
+    /// image path first gives a real dlopen handle with honest dlerror
+    /// semantics in both topologies, and a clean `Err` (→ CPU-preprocess
+    /// fallback) when ANGLE is not linked at all.
     #[cfg(target_os = "ios")]
     fn load_egl_lib_inner() -> Result<libloading::Library, Error> {
-        let this = libloading::os::unix::Library::this();
-        // `os::unix::Library` converts into `libloading::Library` via the
-        // crate's `From<os::platform::Library>` impl (libloading 0.9),
-        // avoiding an unannotated `transmute`. The EGL `Dynamic` loader
-        // then accepts the resulting handle.
-        Ok(this.into())
+        unsafe extern "C" {
+            fn _dyld_image_count() -> u32;
+            fn _dyld_get_image_name(image_index: u32) -> *const std::os::raw::c_char;
+        }
+        // SAFETY: `_dyld_image_count` / `_dyld_get_image_name` take no
+        // pointers in and return either an index bound or a NUL-terminated
+        // string owned by dyld that lives for the image's lifetime (the
+        // image cannot unload between the calls and the copy below because
+        // we never dlclose ANGLE and the process is single-shot).
+        let count = unsafe { _dyld_image_count() };
+        for index in 0..count {
+            // SAFETY: index < count per the bound above; a NULL return (image
+            // unloaded concurrently) is skipped.
+            let name = unsafe { _dyld_get_image_name(index) };
+            if name.is_null() {
+                continue;
+            }
+            // SAFETY: dyld guarantees a valid NUL-terminated C string.
+            let path = unsafe { std::ffi::CStr::from_ptr(name) }.to_string_lossy();
+            if path.ends_with("/libEGL.framework/libEGL") || path.ends_with("/libEGL.dylib") {
+                debug!("ApplePlatform: dlopen already-loaded ANGLE libEGL at {path}");
+                // SAFETY: dlopen is unsafe because the loaded library can run
+                // initializers; this image is already loaded (dyld list), so
+                // this only bumps its reference count.
+                return unsafe { libloading::Library::new(path.as_ref()) }.map_err(|e| {
+                    Error::Io(std::io::Error::other(format!(
+                        "dlopen of loaded ANGLE libEGL image {path} failed: {e}"
+                    )))
+                });
+            }
+        }
+        Err(Error::Io(std::io::Error::other(
+            "ANGLE libEGL is not loaded in this process: link AND embed \
+             EGL.xcframework + GLESv2.xcframework into the app or test bundle \
+             (an embed-only copy, or an unused-framework strip at link time, \
+             leaves the image list without libEGL)",
+        )))
     }
 
     /// macOS: locate and `dlopen` ANGLE's libEGL. Search order:


### PR DESCRIPTION
## Summary
- Fixes undefined behavior in the vendored `edgefirst-egl` dynamic dispatch-table loader: symbols were read through a reference to a dead stack temporary, which iOS Release codegen materialized as NULL dispatch entries — the first EGL call jumped to address 0x0 (EXC_BAD_ACCESS / CODESIGNING Invalid Page) on a physical iPhone 17 Pro. The old `assert!` checked a stack address, never the symbol.
- Stores the resolved symbol address via direct transmute with a genuine null check (returns `DlSymUnknown`; dlsym can return NULL without dlerror on some handles).
- Adds permanent named-panic slot guards to the generated EGL accessors: any future NULL dispatch entry fails as a symbolized panic naming the slot instead of a jump to 0.
- Replaces `Library::this()` for iOS EGL resolution with a dyld image-list scan + dlopen-by-exact-path: the `dlopen(NULL)` handle cannot see plugin-linked ANGLE (XCTest runner / AWS Device Farm topology). Clean error → CPU-preprocess fallback when ANGLE is not linked at all.

## Testing
- `cargo test` / `cargo clippy --all-targets` green on host (macOS).
- `cargo check --target aarch64-apple-ios` green via the mobile-sdk consumer.
- On-device (iPhone 17 Pro, iOS 26.5.2, via EdgeFirst Profiler iOS device tests): GL preprocessing initializes and runs — run trace shows `image.gl_init` and the zero-copy IOSurface preprocessing ring; yolo26n FP16 @ CoreML ANE, 8.8 ms mean/frame, two back-to-back traced runs in one process.

## Notes
- crates.io `edgefirst-egl`/`edgefirst-image` 0.27.0 still ship the UB; downstream consumers need a 0.27.1 release or a `[patch.crates-io]` (mobile-sdk PR adds the latter).

JIRA: EDGEAI-1353