### PR TITLE
TOP2-833 Classify imported fds by filesystem magic, not st_dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Byte-identical to the prior full-frame behaviour on all existing NV-family
   golden outputs; see `tiled_convert_benchmark` above for the resulting
   proportionality.
+- **`Tensor::from_fd()` now identifies both buffer types positively**
+  (TOP2-833). An fd that is neither a DMA-BUF nor tmpfs/shm is rejected with
+  the new `Error::UnknownBufferType(magic)` instead of being assumed to be
+  shared memory. Previously any unrecognized fd fell through to the SHM
+  branch, which could succeed nonsensically — a pipe fd imported as a
+  zero-length tensor rather than erroring. Callers importing fds backed by
+  other filesystems (e.g. a regular file, or a `MFD_HUGETLB` memfd) will now
+  see an error where they previously got a tensor.
 
 ### Fixed
 
@@ -47,6 +55,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stride) instead of writing as if the view were the whole buffer, so
   resizing into a sub-rectangle of a larger padded tensor no longer
   corrupts neighboring rows.
+- **DMA-BUF fds imported as shared memory, silently forfeiting zero-copy**
+  (TOP2-833). `Tensor::from_fd()` classified an incoming fd by the *minor*
+  number of its `st_dev`, treating a hardcoded `9 | 10` as "this is a
+  DMA-BUF". Those minors come from `get_anon_bdev()`, an IDA shared by every
+  anonymous pseudo-filesystem (pipefs, sockfs, nsfs, bdev, tracefs, ...),
+  first-come-first-served during boot — so the value a DMA-BUF lands on
+  depends on kernel config, driver load order, initramfs use, and kernel
+  version. It is not part of any ABI. A genuine DMA-BUF is minor 12 on x86
+  desktop and minor 8 on the ADIS Verdin; both missed `9 | 10` and were
+  imported as `ShmTensor`. Because a DMA-BUF is mmap-able, the wrong branch
+  produced a working-but-not-DMA tensor, which surfaced downstream as
+  `ImageProcessor::import_image` rejecting the buffer with "requires
+  DMA-backed fd, got Shm". Classification is now by filesystem magic
+  (`DMA_BUF_MAGIC` / `TMPFS_MAGIC` from `include/uapi/linux/magic.h`), which
+  is stable UAPI.
 
 ## [0.27.1] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   zero-length tensor rather than erroring. Callers importing fds backed by
   other filesystems (e.g. a regular file, or a `MFD_HUGETLB` memfd) will now
   see an error where they previously got a tensor.
+- **`hal_tensor_from_fd()` reports per-variant errnos** (TOP2-833). The C
+  API previously collapsed every import failure to `EIO`. It now maps
+  caller-fault conditions to `EINVAL` — including an fd whose buffer type
+  cannot be determined, which means the fd is the wrong *kind* of object
+  rather than an I/O failure — an undersized buffer to `ENOSPC`, and
+  unsupported operations to `ENOTSUP`, matching the convention already used
+  by `hal_tile_*` and the image entry points. Code branching on `EIO` from
+  this function needs updating; code that only checks for `NULL` is
+  unaffected.
 
 ### Fixed
 

--- a/crates/capi/TESTING.md
+++ b/crates/capi/TESTING.md
@@ -95,6 +95,26 @@ must `cargo build` first.
 - **Hardware gates** — `test_neutron_dmabuf*` requires a live TFLite
   delegate, model, and the i.MX 95 NPU device tree. Run on target with
   `NEUTRON_ENABLE_ZERO_COPY=1`.
+- **`hal_tensor_from_fd` import tests skip without DMA-heap access.**
+  `tensor_from_fd_dma_roundtrip` asserts that a DMA-BUF fd imports as
+  `HAL_TENSOR_MEMORY_DMA` through the ABI — the C-side guard against the
+  buffer-type misclassification fixed in TOP2-833. It self-skips where
+  `hal_tensor_new(..., HAL_TENSOR_MEMORY_DMA, ...)` returns NULL, which on
+  a typical workstation means the DMA-heap node is root-only, so an
+  unprivileged run reports `[SKIP]` and proves nothing. Run the binary
+  under `sudo` to get real coverage:
+
+  ```bash
+  cargo build -p edgefirst-hal-capi
+  # cargo emits libedgefirst_hal.so but the cdylib's SONAME is
+  # libedgefirst_hal.so.0 — link the two before running:
+  ln -sf libedgefirst_hal.so target/debug/libedgefirst_hal.so.0
+  make -C crates/capi/tests test_tensor      # unprivileged: DMA cases skip
+  sudo ./crates/capi/build/test_tensor       # privileged: DMA cases run
+  ```
+
+  `tensor_from_fd_unknown_type_einval` needs no privileges — it feeds a
+  pipe fd and asserts `NULL` + `EINVAL`.
 - **No special features required** for the Rust-side tests; default
   features build the full FFI surface.
 - **The C suite is gcc-built and invisible to cargo.** The `test_*.c`

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -3037,11 +3037,23 @@ struct hal_tensor *hal_tensor_new(enum hal_dtype dtype,
                                   const char *name);
 
 /**
- * Create a new tensor from an existing file descriptor (Linux only).
+ * Create a new tensor from an existing file descriptor (Unix only).
  *
  * The fd is duplicated internally — the caller retains ownership of the
  * original fd and must close it when done. This is consistent with all
  * other fd-accepting APIs in this library.
+ *
+ * **Buffer type is detected, not specified.** On Linux the backend is
+ * determined by the fd's filesystem magic: a `dma_buf` fd
+ * (`DMA_BUF_MAGIC`) becomes a DMA tensor, a tmpfs fd (`TMPFS_MAGIC` —
+ * both `/dev/shm` and `memfd`) becomes an SHM tensor, and any other
+ * filesystem is **rejected** rather than assumed to be shared memory.
+ * On macOS/iOS/Android the fd is always adopted as SHM.
+ *
+ * Call `hal_tensor_memory()` on the result if the buffer type matters —
+ * for example before handing the tensor to `hal_import_image()`, which
+ * requires DMA-backed planes. A successful return is not by itself proof
+ * of DMA backing.
  *
  * **EGL image cache interaction**: Each call to this function allocates a
  * new `BufferIdentity` with a globally unique ID. The OpenGL backend uses
@@ -3058,14 +3070,19 @@ struct hal_tensor *hal_tensor_new(enum hal_dtype dtype,
  * `convert()` is in progress.
  *
  * @param dtype Data type of tensor elements (HAL_DTYPE_*)
- * @param fd File descriptor for DMA/SHM buffer (caller retains ownership)
+ * @param fd File descriptor for a DMA-BUF or tmpfs/shm buffer (caller
+ *           retains ownership)
  * @param shape Array of dimension sizes (ndim elements)
  * @param ndim Number of dimensions (1-8)
  * @param name Optional tensor name for debugging (can be NULL)
  * @return New tensor handle on success, NULL on error
  * @par Errors (errno):
  * - EINVAL: Invalid argument (NULL shape, ndim is 0, invalid fd)
- * - EIO: Failed to duplicate fd or create tensor
+ * - EIO: Failed to duplicate fd, or the fd could not be imported —
+ *   including an fd whose buffer type could not be determined because it
+ *   is neither a DMA-BUF nor tmpfs-backed (e.g. a regular file, a pipe or
+ *   socket, or a `MFD_HUGETLB` memfd). Enable debug logging to see the
+ *   observed filesystem magic.
  * - ENOTSUP: Not supported on this platform (non-Unix)
  */
 struct hal_tensor *hal_tensor_from_fd(enum hal_dtype dtype,

--- a/crates/capi/include/edgefirst/hal.h
+++ b/crates/capi/include/edgefirst/hal.h
@@ -3077,12 +3077,15 @@ struct hal_tensor *hal_tensor_new(enum hal_dtype dtype,
  * @param name Optional tensor name for debugging (can be NULL)
  * @return New tensor handle on success, NULL on error
  * @par Errors (errno):
- * - EINVAL: Invalid argument (NULL shape, ndim is 0, invalid fd)
- * - EIO: Failed to duplicate fd, or the fd could not be imported —
- *   including an fd whose buffer type could not be determined because it
- *   is neither a DMA-BUF nor tmpfs-backed (e.g. a regular file, a pipe or
- *   socket, or a `MFD_HUGETLB` memfd). Enable debug logging to see the
- *   observed filesystem magic.
+ * - EINVAL: Invalid argument — NULL shape, ndim is 0 or > 8, negative fd,
+ *   a shape that does not fit the buffer, or an fd whose buffer type could
+ *   not be determined because it is neither a DMA-BUF nor tmpfs-backed
+ *   (e.g. a regular file, a pipe or socket, or a `MFD_HUGETLB` memfd).
+ *   The last case means the fd is the wrong *kind* of object; enable debug
+ *   logging to see the observed filesystem magic.
+ * - ENOSPC: The buffer is smaller than the requested shape requires
+ * - EIO: Failed to duplicate the fd, or the import failed for another
+ *   reason
  * - ENOTSUP: Not supported on this platform (non-Unix)
  */
 struct hal_tensor *hal_tensor_from_fd(enum hal_dtype dtype,

--- a/crates/capi/src/tensor.rs
+++ b/crates/capi/src/tensor.rs
@@ -455,11 +455,23 @@ pub unsafe extern "C" fn hal_tensor_new(
     Box::into_raw(Box::new(HalTensor { inner: tensor }))
 }
 
-/// Create a new tensor from an existing file descriptor (Linux only).
+/// Create a new tensor from an existing file descriptor (Unix only).
 ///
 /// The fd is duplicated internally — the caller retains ownership of the
 /// original fd and must close it when done. This is consistent with all
 /// other fd-accepting APIs in this library.
+///
+/// **Buffer type is detected, not specified.** On Linux the backend is
+/// determined by the fd's filesystem magic: a `dma_buf` fd
+/// (`DMA_BUF_MAGIC`) becomes a DMA tensor, a tmpfs fd (`TMPFS_MAGIC` —
+/// both `/dev/shm` and `memfd`) becomes an SHM tensor, and any other
+/// filesystem is **rejected** rather than assumed to be shared memory.
+/// On macOS/iOS/Android the fd is always adopted as SHM.
+///
+/// Call `hal_tensor_memory()` on the result if the buffer type matters —
+/// for example before handing the tensor to `hal_import_image()`, which
+/// requires DMA-backed planes. A successful return is not by itself proof
+/// of DMA backing.
 ///
 /// **EGL image cache interaction**: Each call to this function allocates a
 /// new `BufferIdentity` with a globally unique ID. The OpenGL backend uses
@@ -476,14 +488,19 @@ pub unsafe extern "C" fn hal_tensor_new(
 /// `convert()` is in progress.
 ///
 /// @param dtype Data type of tensor elements (HAL_DTYPE_*)
-/// @param fd File descriptor for DMA/SHM buffer (caller retains ownership)
+/// @param fd File descriptor for a DMA-BUF or tmpfs/shm buffer (caller
+///           retains ownership)
 /// @param shape Array of dimension sizes (ndim elements)
 /// @param ndim Number of dimensions (1-8)
 /// @param name Optional tensor name for debugging (can be NULL)
 /// @return New tensor handle on success, NULL on error
 /// @par Errors (errno):
 /// - EINVAL: Invalid argument (NULL shape, ndim is 0, invalid fd)
-/// - EIO: Failed to duplicate fd or create tensor
+/// - EIO: Failed to duplicate fd, or the fd could not be imported —
+///   including an fd whose buffer type could not be determined because it
+///   is neither a DMA-BUF nor tmpfs-backed (e.g. a regular file, a pipe or
+///   socket, or a `MFD_HUGETLB` memfd). Enable debug logging to see the
+///   observed filesystem magic.
 /// - ENOTSUP: Not supported on this platform (non-Unix)
 #[no_mangle]
 pub unsafe extern "C" fn hal_tensor_from_fd(

--- a/crates/capi/src/tensor.rs
+++ b/crates/capi/src/tensor.rs
@@ -15,6 +15,34 @@ use libc::{c_char, c_int, size_t};
 #[cfg(unix)]
 use std::os::fd::IntoRawFd;
 
+/// Map an `edgefirst_tensor::Error` to a POSIX errno, consistent with
+/// `image_err_to_errno` in `tiling.rs`: caller-fault argument/shape/fd-type
+/// -> EINVAL, unsupported -> ENOTSUP, I/O -> the underlying errno,
+/// otherwise EIO.
+///
+/// Buffer-type misidentification is a caller fault, not an I/O failure —
+/// handing `hal_tensor_from_fd()` a pipe, a socket, a regular file, or a
+/// `MFD_HUGETLB` memfd means the fd is the wrong *kind* of thing, which is
+/// what EINVAL is for.
+#[cfg(unix)]
+fn tensor_err_to_errno(e: &edgefirst_tensor::Error) -> c_int {
+    use edgefirst_tensor::Error as E;
+    match e {
+        E::InvalidArgument(_)
+        | E::InvalidShape(_)
+        | E::ShapeMismatch(_)
+        | E::InvalidSize(_)
+        | E::InvalidMemoryType(_) => libc::EINVAL,
+        #[cfg(target_os = "linux")]
+        E::UnknownBufferType(_) | E::UnknownDeviceType(_, _) => libc::EINVAL,
+        E::NotImplemented(_) => libc::ENOTSUP,
+        E::InsufficientCapacity { .. } => libc::ENOSPC,
+        E::IoError(io) => io.raw_os_error().unwrap_or(libc::EIO),
+        E::NixError(errno) => *errno as c_int,
+        _ => libc::EIO,
+    }
+}
+
 /// Data type of tensor elements.
 ///
 /// Used to query the type of elements stored in a tensor and interpret
@@ -495,12 +523,15 @@ pub unsafe extern "C" fn hal_tensor_new(
 /// @param name Optional tensor name for debugging (can be NULL)
 /// @return New tensor handle on success, NULL on error
 /// @par Errors (errno):
-/// - EINVAL: Invalid argument (NULL shape, ndim is 0, invalid fd)
-/// - EIO: Failed to duplicate fd, or the fd could not be imported —
-///   including an fd whose buffer type could not be determined because it
-///   is neither a DMA-BUF nor tmpfs-backed (e.g. a regular file, a pipe or
-///   socket, or a `MFD_HUGETLB` memfd). Enable debug logging to see the
-///   observed filesystem magic.
+/// - EINVAL: Invalid argument — NULL shape, ndim is 0 or > 8, negative fd,
+///   a shape that does not fit the buffer, or an fd whose buffer type could
+///   not be determined because it is neither a DMA-BUF nor tmpfs-backed
+///   (e.g. a regular file, a pipe or socket, or a `MFD_HUGETLB` memfd).
+///   The last case means the fd is the wrong *kind* of object; enable debug
+///   logging to see the observed filesystem magic.
+/// - ENOSPC: The buffer is smaller than the requested shape requires
+/// - EIO: Failed to duplicate the fd, or the import failed for another
+///   reason
 /// - ENOTSUP: Not supported on this platform (non-Unix)
 #[no_mangle]
 pub unsafe extern "C" fn hal_tensor_from_fd(
@@ -527,10 +558,10 @@ pub unsafe extern "C" fn hal_tensor_from_fd(
         };
         let dt: DType = dtype.into();
 
-        let tensor = try_or_null!(
-            TensorDyn::from_fd(owned_fd, shape_slice, dt, name_opt),
-            libc::EIO
-        );
+        let tensor = match TensorDyn::from_fd(owned_fd, shape_slice, dt, name_opt) {
+            Ok(t) => t,
+            Err(e) => return set_error_null(tensor_err_to_errno(&e)),
+        };
         Box::into_raw(Box::new(HalTensor { inner: tensor }))
     }
     #[cfg(not(unix))]

--- a/crates/capi/tests/test_tensor.c
+++ b/crates/capi/tests/test_tensor.c
@@ -425,6 +425,58 @@ static void test_tensor_clone_fd_mem_fails(void) {
     TEST_PASS();
 }
 
+#ifdef __linux__
+// An fd whose buffer type cannot be determined is a caller error (EINVAL),
+// not an I/O failure (EIO). A pipe is the convenient probe: pipefs is another
+// get_anon_bdev() pseudo-filesystem, so it shares st_dev major 0 with the
+// buffer types we do support and is distinguishable only by filesystem magic.
+static void test_tensor_from_fd_unknown_type_einval(void) {
+    TEST("tensor_from_fd_unknown_type_einval");
+
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        TEST_SKIP("pipe() unavailable");
+        return;
+    }
+
+    size_t shape[] = {64};
+    errno = 0;
+    struct hal_tensor* t = hal_tensor_from_fd(HAL_DTYPE_U8, pipefd[0], shape, 1, NULL);
+    ASSERT_NULL(t);
+    ASSERT_ERRNO(EINVAL);
+
+    close(pipefd[0]);
+    close(pipefd[1]);
+    TEST_PASS();
+}
+
+// A DMA-BUF fd must import as a DMA tensor, not be silently downgraded to
+// SHM. Skipped when DMA-heap permissions are unavailable.
+static void test_tensor_from_fd_dma_roundtrip(void) {
+    TEST("tensor_from_fd_dma_roundtrip");
+
+    size_t shape[] = {64, 64};
+    struct hal_tensor* src =
+        hal_tensor_new(HAL_DTYPE_U8, shape, 2, HAL_TENSOR_MEMORY_DMA, NULL);
+    if (src == NULL) {
+        TEST_SKIP("DMA memory not available");
+        return;
+    }
+
+    int fd = hal_tensor_clone_fd(src);
+    ASSERT_TRUE(fd >= 0);
+
+    struct hal_tensor* imported = hal_tensor_from_fd(HAL_DTYPE_U8, fd, shape, 2, NULL);
+    ASSERT_NOT_NULL(imported);
+    ASSERT_EQ(HAL_TENSOR_MEMORY_DMA, hal_tensor_memory_type(imported));
+
+    hal_tensor_free(imported);
+    close(fd);
+    hal_tensor_free(src);
+    TEST_PASS();
+}
+#endif // __linux__
+
 // =============================================================================
 // Quantization Metadata Tests
 // =============================================================================
@@ -575,6 +627,10 @@ void run_tensor_tests(void) {
     // DMA tests (Linux DMA-BUF + macOS IOSurface)
     test_tensor_dma_memory();
     test_tensor_clone_fd_mem_fails();
+#ifdef __linux__
+    test_tensor_from_fd_unknown_type_einval();
+    test_tensor_from_fd_dma_roundtrip();
+#endif
 #ifdef __APPLE__
     test_tensor_iosurface_roundtrip();
 #endif

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -5,8 +5,6 @@
 #[cfg(feature = "opengl")]
 #[allow(deprecated)]
 mod gl_tests {
-    #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
-    use crate::opengl_headless::processor::GLProcessorST;
     #[cfg(target_os = "linux")]
     use crate::{probe_egl_displays, EglDisplayKind};
     use crate::{Crop, Flip, GLProcessorThreaded, ImageProcessorTrait, Rotation};

--- a/crates/python/edgefirst_hal.pyi
+++ b/crates/python/edgefirst_hal.pyi
@@ -789,14 +789,45 @@ class Tensor:
             name: None | str = None,
         ) -> Tensor: ...
         """
-        Create a new tensor using the given file descriptor, shape, and optional
-        name. If no name is given, a random name will be generated.
+        Import an existing buffer as a tensor, without copying. If no name is
+        given, a random name will be generated.
 
-        Inspects the file descriptor to determine the appropriate tensor type
-        (DMA or SHM) based on the device major and minor numbers.
+        The buffer type is **detected, not chosen**. On Linux it is determined
+        by the file descriptor's filesystem magic:
+
+        =========================================  ===================
+        File descriptor                            ``Tensor.memory``
+        =========================================  ===================
+        ``dma_buf`` (``DMA_BUF_MAGIC``)            ``TensorMemory.DMA``
+        ``tmpfs`` — ``/dev/shm`` and ``memfd``     ``TensorMemory.SHM``
+        anything else                              raises (see below)
+        =========================================  ===================
+
+        On macOS the fd is always imported as ``TensorMemory.SHM``.
+
+        Both supported types are identified positively; an unrecognized
+        filesystem raises rather than silently falling back to shared memory.
+        That fallback would not fail loudly — a DMA-BUF is mmap-able, so it
+        would import as a working tensor that merely isn't DMA, and the lost
+        zero-copy would only surface later as ``ImageProcessor.import_image``
+        refusing the buffer.
 
         The fd is ``dup()``'d immediately — the caller retains ownership
         of the original fd and must close it when done.
+
+        Raises:
+            RuntimeError: The fd could not be imported. Most commonly its
+                buffer type could not be determined because it is neither a
+                DMA-BUF nor tmpfs-backed (a regular file, a pipe or socket, or
+                a ``MFD_HUGETLB`` memfd) — the message reports the observed
+                filesystem magic, e.g. ``Tensor error: UnknownBufferType: fd
+                is on an unrecognized filesystem (magic 0x50495045)``. Also
+                raised for a negative ``fd``, an unsupported ``dtype``, a
+                shape larger than the buffer, or a failed syscall.
+
+        Note:
+            Check ``tensor.memory`` if you require zero-copy — a successful
+            import is not by itself proof of DMA backing.
         """
 
         @property

--- a/crates/python/src/tensor.rs
+++ b/crates/python/src/tensor.rs
@@ -32,7 +32,11 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::Tensor(e) => write!(f, "Tensor error: {e:?}"),
+            // Display, not Debug: variants with a hand-written Display arm
+            // (UnknownBufferType's hex magic, InsufficientCapacity,
+            // RegionOutOfBounds, BatchIndexOutOfBounds) render legibly, and
+            // the rest fall back to Debug inside tensor::Error's own Display.
+            Error::Tensor(e) => write!(f, "Tensor error: {e}"),
             Error::UnsupportedMemoryType(msg) => write!(f, "Invalid memory type: {msg}"),
             Error::UnsupportedDataType(msg) => write!(f, "Invalid data type: {msg}"),
             Error::TensorMap(msg) => write!(f, "Tensor map error: {msg}"),
@@ -737,6 +741,19 @@ impl PyTensor {
         Ok(PyTensor(tensor))
     }
 
+    /// Import an existing buffer as a tensor, without copying.
+    ///
+    /// The buffer type is detected, not chosen. On Linux a `dma_buf` fd
+    /// imports as `TensorMemory.DMA` and a tmpfs fd (`/dev/shm` or `memfd`)
+    /// as `TensorMemory.SHM`, decided by filesystem magic; any other
+    /// filesystem raises `RuntimeError` rather than silently falling back to
+    /// shared memory. On macOS the fd is always imported as SHM.
+    ///
+    /// The fd is `dup()`'d immediately — the caller retains ownership of the
+    /// original and must close it.
+    ///
+    /// Check `tensor.memory` if you require zero-copy; a successful import
+    /// is not by itself proof of DMA backing.
     #[cfg(unix)]
     #[staticmethod]
     #[pyo3(signature = (fd, shape, dtype = "float32", name = None))]

--- a/crates/tensor/ARCHITECTURE.md
+++ b/crates/tensor/ARCHITECTURE.md
@@ -158,6 +158,45 @@ The fallback chain is **DMA → SHM → Heap**. `EDGEFIRST_TENSOR_FORCE_MEM=1`
 short-circuits the chain to `MemTensor`, primarily for unit tests on hosts
 without DMA-heap permissions.
 
+### Import classification (`from_fd`, Linux)
+
+`Tensor::from_fd()` is the mirror of the selection logic above: rather than
+choosing a backend, it must *recognize* which backend a foreign fd already
+belongs to. On Linux this is decided by **filesystem magic**, never by the
+device number.
+
+| `fstatfs` `f_type` | Constant | Backend |
+|--------------------|----------|---------|
+| `0x444d4142` | `DMA_BUF_MAGIC` | `DmaTensor` |
+| `0x01021994` | `TMPFS_MAGIC` | `ShmTensor` (both `/dev/shm` and `memfd`) |
+| anything else | — | `Error::UnknownBufferType(magic)` |
+
+**Do not classify on `st_dev`.** `dma_buf` files do not live on a real
+filesystem; they live on an internal kernel mount (`dma_buf_mnt`, created
+with `kern_mount`) whose superblock takes its device number from
+`get_anon_bdev()`. That allocator is an IDA shared by *every* anonymous
+pseudo-filesystem — pipefs, sockfs, anon_inodefs, nsfs, bdev, tracefs —
+handed out first-come-first-served during boot. The minor a DMA-BUF ends up
+with is therefore an artifact of which pseudo-filesystems registered first
+on that kernel build, and moves with kernel config, driver load order,
+initramfs use, and kernel version. Nothing in the kernel documents it and it
+is not part of any ABI. Measured values for a genuine DMA-BUF: **12** on x86
+desktop, **8** on the ADIS Verdin. The kernel exports `DMA_BUF_MAGIC` for
+exactly this purpose and exports nothing at all for the minor.
+
+Both branches are identified **positively**, and an unrecognized filesystem
+is an error rather than an assumption. This matters because the wrong branch
+does not fail loudly: a DMA-BUF is mmap-able, so importing one as SHM yields
+a perfectly functional tensor that merely isn't DMA — the loss only surfaces
+much later, as `ImageProcessor::import_image` refusing a non-DMA plane. A
+pipe fd is worse still, importing as a zero-length tensor. Guessing is the
+failure mode; `UnknownBufferType` is the fix.
+
+The portable alternative probe would be `dmabuf::phys()`
+(`DMA_BUF_IOCTL_PHYS`), but that is an NXP vendor ioctl and fails on
+mainline kernels. `fstatfs` is the portable answer and costs one syscall
+with no side effects.
+
 ### CPU access declaration (CpuAccess)
 
 There is no usage/role enum. The allocation model assumes what is true for

--- a/crates/tensor/ARCHITECTURE.md
+++ b/crates/tensor/ARCHITECTURE.md
@@ -171,6 +171,18 @@ device number.
 | `0x01021994` | `TMPFS_MAGIC` | `ShmTensor` (both `/dev/shm` and `memfd`) |
 | anything else | — | `Error::UnknownBufferType(magic)` |
 
+**Normalize `f_type` before comparing or reporting it.** Its width and
+signedness vary by target — `__fsword_t` on Linux/gnu (`i64` on 64-bit,
+`i32` on 32-bit), `c_int` on uclibc, `c_ulong` on musl, `c_uint` on s390x.
+Where it is signed and 32 bits wide, widening it sign-extends any magic with
+bit 31 set (hugetlbfs `0x958458f6`, btrfs `0x9123683e`, f2fs `0xf2f52010`),
+which would make the value carried by `UnknownBufferType` impossible to look
+up in `magic.h`. `fs_magic()` truncates back to `u32`, which is lossless for
+every magic and is why the variant's payload is `u32` rather than a wider
+signed type. The two magics we classify on are both below 2³¹, so the
+DMA-vs-SHM decision itself is unaffected by signedness — only the reported
+value was.
+
 **Do not classify on `st_dev`.** `dma_buf` files do not live on a real
 filesystem; they live on an internal kernel mount (`dma_buf_mnt`, created
 with `kern_mount`) whose superblock takes its device number from

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -50,6 +50,29 @@ cargo test -p edgefirst-tensor --features ndarray -- --test-threads=1
   DMA tests are skipped at runtime and the suite falls back to heap-only
   coverage; nothing fails outright. Set `EDGEFIRST_TENSOR_FORCE_MEM=1` to
   skip even the probe.
+
+  **A green run therefore says nothing about the DMA paths.** This is how the
+  `from_fd` minor-number misclassification reached a release: the only test
+  covering the import path skipped on every unprivileged host, and asserted
+  fd counts rather than the backend it got back. When touching DMA import or
+  allocation, confirm the tests actually ran — build unprivileged and run the
+  binary under `sudo` if the heap device is root-only:
+
+  ```bash
+  cargo test -p edgefirst-tensor --lib --no-run     # build as your user
+  sudo ./target/debug/deps/edgefirst_tensor-<hash> --test-threads=1
+  ```
+- **Import classification tests** (`test_from_fd_dma_imports_as_dma`,
+  `test_from_fd_shm_imports_as_shm`,
+  `test_from_fd_rejects_unknown_filesystem`) pin the `from_fd` contract:
+  a DMA-BUF fd must come back as `TensorMemory::Dma`, a tmpfs fd as
+  `Shm`, and anything else must be rejected with `UnknownBufferType`
+  rather than assumed to be shared memory. The unknown case uses a pipe —
+  `pipefs` is another `get_anon_bdev()` pseudo-filesystem, so it shares
+  major 0 with the buffer types we do support and is distinguishable only
+  by magic. Assert on `memory()`, never merely on "the import succeeded":
+  the wrong branch mmaps fine and looks healthy (a pipe even imports as a
+  zero-length tensor). See ARCHITECTURE.md § Import classification.
 - **PBO tests** live in
   [`crates/tensor/src/pbo.rs`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/src/pbo.rs)
   and exercise `PboTensor` against a mock `PboOps` implementation. They

--- a/crates/tensor/src/error.rs
+++ b/crates/tensor/src/error.rs
@@ -16,10 +16,12 @@ pub enum Error {
     /// An imported fd sits on a filesystem we cannot classify as either a
     /// DMA-BUF (`DMA_BUF_MAGIC`) or shared memory (`TMPFS_MAGIC`).
     ///
-    /// Carries the `f_type` magic reported by `fstatfs`; cross-reference it
-    /// against `include/uapi/linux/magic.h` to identify the filesystem.
+    /// Carries the `f_type` magic reported by `fstatfs`, normalized to the
+    /// 32-bit unsigned value used by `include/uapi/linux/magic.h`, so it can
+    /// be cross-referenced against that header directly on both 32- and
+    /// 64-bit targets.
     #[cfg(target_os = "linux")]
-    UnknownBufferType(i64),
+    UnknownBufferType(u32),
     InvalidMemoryType(String),
     /// The GL context backing a PBO tensor has been destroyed.
     PboDisconnected,

--- a/crates/tensor/src/error.rs
+++ b/crates/tensor/src/error.rs
@@ -13,6 +13,13 @@ pub enum Error {
     ShapeMismatch(String),
     #[cfg(target_os = "linux")]
     UnknownDeviceType(u64, u64),
+    /// An imported fd sits on a filesystem we cannot classify as either a
+    /// DMA-BUF (`DMA_BUF_MAGIC`) or shared memory (`TMPFS_MAGIC`).
+    ///
+    /// Carries the `f_type` magic reported by `fstatfs`; cross-reference it
+    /// against `include/uapi/linux/magic.h` to identify the filesystem.
+    #[cfg(target_os = "linux")]
+    UnknownBufferType(i64),
     InvalidMemoryType(String),
     /// The GL context backing a PBO tensor has been destroyed.
     PboDisconnected,
@@ -95,6 +102,12 @@ impl std::fmt::Display for Error {
             Error::BatchIndexOutOfBounds { index, batch } => write!(
                 f,
                 "batch index {index} out of bounds for batch size {batch}"
+            ),
+            #[cfg(target_os = "linux")]
+            Error::UnknownBufferType(magic) => write!(
+                f,
+                "UnknownBufferType: fd is on an unrecognized filesystem \
+                 (magic {magic:#010x}); expected a DMA-BUF or tmpfs/shm fd"
             ),
             _ => write!(f, "{self:?}"),
         }

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -1265,6 +1265,20 @@ impl Default for BufferIdentity {
 #[cfg(target_os = "linux")]
 use nix::sys::stat::{major, minor};
 
+/// Filesystem magic of the internal `dma_buf` mount, from
+/// `include/uapi/linux/magic.h` (`DMA_BUF_MAGIC`, "DMAB").
+///
+/// This is stable UAPI and is the only reliable way to recognize a DMA-BUF
+/// fd — see [`TensorStorage::from_fd`] for why `st_dev` cannot be used.
+#[cfg(target_os = "linux")]
+const DMA_BUF_MAGIC: i64 = 0x444d_4142;
+
+/// Filesystem magic of tmpfs, from `include/uapi/linux/magic.h`
+/// (`TMPFS_MAGIC`). Covers both POSIX `shm_open` segments under `/dev/shm`
+/// and anonymous `memfd_create` files.
+#[cfg(target_os = "linux")]
+const TMPFS_MAGIC: i64 = 0x0102_1994;
+
 pub trait TensorTrait<T>: Send + Sync
 where
     T: Num + Clone + fmt::Debug,
@@ -1276,11 +1290,80 @@ where
         Self: Sized;
 
     #[cfg(unix)]
-    /// Create a new tensor using the given file descriptor, shape, and optional
-    /// name. If no name is given, a random name will be generated.
+    /// Import an existing buffer as a tensor, taking ownership of its file
+    /// descriptor. The buffer is adopted in place — no bytes are copied.
     ///
-    /// On Linux: Inspects the fd to determine DMA vs SHM based on device major/minor.
-    /// On other Unix (macOS): Always creates SHM tensor.
+    /// The backend is **detected**, not chosen: the fd already belongs to a
+    /// buffer type, and this call's job is to recognize which. On Linux that
+    /// is decided by the fd's filesystem magic, which is stable UAPI
+    /// (`include/uapi/linux/magic.h`):
+    ///
+    /// | Filesystem | Magic | Resulting [`TensorMemory`] |
+    /// |------------|-------|----------------------------|
+    /// | `dma_buf` | `DMA_BUF_MAGIC` (`0x444d4142`) | [`TensorMemory::Dma`] |
+    /// | `tmpfs` (`/dev/shm` **and** `memfd`) | `TMPFS_MAGIC` (`0x01021994`) | [`TensorMemory::Shm`] |
+    /// | anything else | — | *rejected* — see Errors |
+    ///
+    /// Both supported types are identified **positively**. An unrecognized
+    /// filesystem is an error, never a fallback to shared memory: the wrong
+    /// branch does not fail loudly (a DMA-BUF is mmap-able, so it would
+    /// import as a perfectly functional tensor that merely isn't DMA, and a
+    /// pipe would import as a zero-length one), so guessing would trade a
+    /// clear error here for silent loss of zero-copy far downstream.
+    ///
+    /// The device number is deliberately **not** consulted. `dma_buf` files
+    /// live on an internal kernel mount whose `st_dev` comes from
+    /// `get_anon_bdev()` — an IDA shared with every other anonymous
+    /// pseudo-filesystem and allocated in boot order — so the minor a
+    /// DMA-BUF lands on varies by kernel build and is not part of any ABI.
+    ///
+    /// On non-Linux Unix (macOS/iOS/Android) there is no fd-based DMA import;
+    /// the fd is always adopted as [`TensorMemory::Shm`].
+    ///
+    /// # Arguments
+    ///
+    /// * `fd` - Owned descriptor for the buffer to import. Ownership
+    ///   transfers to the returned tensor and the fd is closed on drop; pass
+    ///   [`clone_fd`](TensorTrait::clone_fd) output to keep your own handle.
+    /// * `shape` - Logical shape to interpret the buffer with. Must describe
+    ///   no more elements than the buffer holds.
+    /// * `name` - Optional name; a random one is generated when `None`.
+    ///
+    /// # Returns
+    ///
+    /// A tensor sharing the imported buffer's memory, whose
+    /// [`memory()`](TensorTrait::memory) reports the detected backend.
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::UnknownBufferType`] - the fd is on a filesystem that is
+    ///   neither `dma_buf` nor `tmpfs`, so its buffer type cannot be
+    ///   determined. Carries the observed `fstatfs` magic for diagnosis.
+    ///   Typical causes: a regular file, a pipe or socket, or a
+    ///   `MFD_HUGETLB` memfd (hugetlbfs, not tmpfs). Linux only.
+    /// * [`Error::UnknownDeviceType`] - the fd's `st_dev` major is non-zero,
+    ///   i.e. it lives on a real block device rather than an anonymous or
+    ///   in-memory filesystem. Linux only.
+    /// * [`Error::InvalidSize`] - `shape` is empty or describes zero
+    ///   elements.
+    /// * [`Error::NixError`] - `fstat`, `fstatfs`, or `mmap` failed on the
+    ///   descriptor.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use edgefirst_tensor::{Tensor, TensorMemory, TensorTrait};
+    ///
+    /// # fn main() -> edgefirst_tensor::Result<()> {
+    /// let src = Tensor::<u8>::new(&[480, 640, 3], Some(TensorMemory::Dma), None)?;
+    ///
+    /// // Round-tripping a DMA-BUF fd preserves the backend — the import is
+    /// // still zero-copy, and still eligible for GPU/NPU paths.
+    /// let imported = Tensor::<u8>::from_fd(src.clone_fd()?, src.shape(), None)?;
+    /// assert_eq!(imported.memory(), TensorMemory::Dma);
+    /// # Ok(())
+    /// # }
+    /// ```
     fn from_fd(fd: std::os::fd::OwnedFd, shape: &[usize], name: Option<&str>) -> Result<Self>
     where
         Self: Sized;
@@ -1757,27 +1840,50 @@ where
         #[cfg(target_os = "linux")]
         {
             use nix::sys::stat::fstat;
+            use nix::sys::statfs::fstatfs;
 
             let stat = fstat(&fd)?;
             let major = major(stat.st_dev);
             let minor = minor(stat.st_dev);
-
-            log::debug!("Creating tensor from fd: major={major}, minor={minor}");
 
             if major != 0 {
                 // Dma and Shm tensors are expected to have major number 0
                 return Err(Error::UnknownDeviceType(major, minor));
             }
 
-            match minor {
-                9 | 10 => {
-                    // minor number 9 & 10 indicates DMA memory
-                    DmaTensor::<T>::from_fd(fd, shape, name).map(TensorStorage::Dma)
-                }
-                _ => {
-                    // other minor numbers are assumed to be shared memory
-                    ShmTensor::<T>::from_fd(fd, shape, name).map(TensorStorage::Shm)
-                }
+            // Classify by filesystem magic, never by the st_dev minor.
+            //
+            // dma_buf files live on an internal kernel mount (`dma_buf_mnt`,
+            // created with `kern_mount`) whose superblock draws its device
+            // number from `get_anon_bdev()` — an IDA allocated first-come,
+            // first-served during boot, shared with every other anonymous
+            // pseudo-filesystem (pipefs, sockfs, anon_inodefs, nsfs, bdev,
+            // tracefs, ...). The minor a DMA-BUF lands on is therefore a
+            // function of which pseudo-filesystems registered first on that
+            // kernel build: it moves with kernel config, driver load order,
+            // initramfs use, and kernel version. It is not part of any ABI.
+            //
+            // Observed values for a genuine DMA-BUF: 12 on x86 desktop, 8 on
+            // the ADIS Verdin. An earlier revision hardcoded `9 | 10` here,
+            // which silently imported real DMA-BUFs as shared memory
+            // everywhere else.
+            //
+            // The filesystem magic, by contrast, is stable UAPI
+            // (include/uapi/linux/magic.h). Both branches are identified
+            // positively; anything else is genuinely unknown and is rejected
+            // rather than guessed at. Falling back to SHM would "work" — a
+            // DMA-BUF is mmap-able, and even a pipe imports as a zero-length
+            // tensor — which is exactly why it must not be the default.
+            let magic = fstatfs(&fd)?.filesystem_type().0 as i64;
+
+            log::debug!(
+                "Creating tensor from fd: major={major}, minor={minor}, magic={magic:#010x}"
+            );
+
+            match magic {
+                DMA_BUF_MAGIC => DmaTensor::<T>::from_fd(fd, shape, name).map(TensorStorage::Dma),
+                TMPFS_MAGIC => ShmTensor::<T>::from_fd(fd, shape, name).map(TensorStorage::Shm),
+                other => Err(Error::UnknownBufferType(other)),
             }
         }
         #[cfg(all(unix, not(target_os = "linux")))]
@@ -5985,6 +6091,11 @@ mod tests {
         for _ in 0..100 {
             let tensor =
                 Tensor::<u8>::from_fd(orig.clone_fd().unwrap(), orig.shape(), None).unwrap();
+            assert_eq!(
+                tensor.memory(),
+                TensorMemory::Dma,
+                "DMA-BUF fd must import as Dma, not be silently downgraded"
+            );
             let mut map = tensor.map().unwrap();
             map.as_mut_slice().fill(233);
         }
@@ -5997,6 +6108,87 @@ mod tests {
             "File descriptor leak detected: {} -> {}",
             start_open_fds, end_open_fds
         );
+    }
+
+    /// A DMA-BUF fd must import as [`TensorMemory::Dma`].
+    ///
+    /// Regression test for the `st_dev` minor-number classifier, which
+    /// hardcoded `9 | 10` as "this is DMA". Those minors come from
+    /// `get_anon_bdev()` and are assigned first-come-first-served at boot,
+    /// so they vary by kernel build and boot order — a real DMA-BUF is
+    /// minor 12 on x86 desktop and minor 8 on the ADIS Verdin. Both fell
+    /// into the `_` arm and imported as SHM, which "works" (a DMA-BUF is
+    /// mmap-able) but silently forfeits zero-copy.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_from_fd_dma_imports_as_dma() {
+        let _lock = FD_LOCK.read().unwrap();
+        if !is_dma_available() {
+            log::warn!("SKIPPED: {} - DMA memory not available", function!());
+            return;
+        }
+
+        let orig = Tensor::<u8>::new(&[64, 64], Some(TensorMemory::Dma), None).unwrap();
+        assert_eq!(orig.memory(), TensorMemory::Dma);
+
+        let imported = Tensor::<u8>::from_fd(orig.clone_fd().unwrap(), orig.shape(), None).unwrap();
+
+        assert_eq!(
+            imported.memory(),
+            TensorMemory::Dma,
+            "a DMA-BUF fd must import as Dma"
+        );
+    }
+
+    /// A tmpfs/SHM fd must import as [`TensorMemory::Shm`].
+    ///
+    /// The companion to `test_from_fd_dma_imports_as_dma`: confirms the
+    /// magic-based classifier identifies SHM positively rather than by
+    /// falling through.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_from_fd_shm_imports_as_shm() {
+        let _lock = FD_LOCK.read().unwrap();
+        if !is_shm_available() {
+            log::warn!("SKIPPED: {} - SHM memory not available", function!());
+            return;
+        }
+
+        let orig = Tensor::<u8>::new(&[64, 64], Some(TensorMemory::Shm), None).unwrap();
+        assert_eq!(orig.memory(), TensorMemory::Shm);
+
+        let imported = Tensor::<u8>::from_fd(orig.clone_fd().unwrap(), orig.shape(), None).unwrap();
+
+        assert_eq!(
+            imported.memory(),
+            TensorMemory::Shm,
+            "a tmpfs fd must import as Shm"
+        );
+    }
+
+    /// An fd that is neither a DMA-BUF nor tmpfs must be rejected.
+    ///
+    /// A pipe is the convenient probe: it lives on `pipefs`, another
+    /// `get_anon_bdev()` pseudo-filesystem, so it shares major 0 with the
+    /// buffer types we do support and is only distinguishable by magic.
+    /// Importing one as SHM is meaningless — `mmap` on a pipe fails — so
+    /// the classifier must say "unknown" rather than guess.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_from_fd_rejects_unknown_filesystem() {
+        let _lock = FD_LOCK.read().unwrap();
+
+        let (read_end, _write_end) = nix::unistd::pipe().unwrap();
+
+        let result = Tensor::<u8>::from_fd(read_end, &[64], None);
+
+        match result {
+            Err(Error::UnknownBufferType(magic)) => {
+                // PIPEFS_MAGIC, from include/uapi/linux/magic.h
+                assert_eq!(magic, 0x5049_5045, "expected PIPEFS_MAGIC");
+            }
+            other => panic!("expected UnknownBufferType for a pipe fd, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -1271,13 +1271,32 @@ use nix::sys::stat::{major, minor};
 /// This is stable UAPI and is the only reliable way to recognize a DMA-BUF
 /// fd — see [`TensorStorage::from_fd`] for why `st_dev` cannot be used.
 #[cfg(target_os = "linux")]
-const DMA_BUF_MAGIC: i64 = 0x444d_4142;
+const DMA_BUF_MAGIC: u32 = 0x444d_4142;
 
 /// Filesystem magic of tmpfs, from `include/uapi/linux/magic.h`
 /// (`TMPFS_MAGIC`). Covers both POSIX `shm_open` segments under `/dev/shm`
 /// and anonymous `memfd_create` files.
 #[cfg(target_os = "linux")]
-const TMPFS_MAGIC: i64 = 0x0102_1994;
+const TMPFS_MAGIC: u32 = 0x0102_1994;
+
+/// Normalize a raw `fstatfs` `f_type` to the 32-bit unsigned magic that
+/// `include/uapi/linux/magic.h` documents.
+///
+/// The width and signedness of `f_type` are target-dependent: `__fsword_t`
+/// on Linux/gnu (`i64` on 64-bit, `i32` on 32-bit targets such as armv7,
+/// i686 and aarch64-ilp32), `c_int` on uclibc, `c_ulong` on musl, and
+/// `c_uint` on s390x. Where it is signed and 32 bits wide, widening it
+/// sign-extends every magic with bit 31 set — hugetlbfs (`0x958458f6`),
+/// btrfs (`0x9123683e`), f2fs (`0xf2f52010`) — which would make the value
+/// reported by [`Error::UnknownBufferType`] impossible to find in the
+/// header the docs point callers at.
+///
+/// Every magic is a 32-bit quantity, so truncating back to `u32` recovers
+/// the true value from all four representations and loses nothing.
+#[cfg(target_os = "linux")]
+const fn fs_magic(raw: i64) -> u32 {
+    raw as u32
+}
 
 pub trait TensorTrait<T>: Send + Sync
 where
@@ -1338,9 +1357,10 @@ where
     ///
     /// * [`Error::UnknownBufferType`] - the fd is on a filesystem that is
     ///   neither `dma_buf` nor `tmpfs`, so its buffer type cannot be
-    ///   determined. Carries the observed `fstatfs` magic for diagnosis.
-    ///   Typical causes: a regular file, a pipe or socket, or a
-    ///   `MFD_HUGETLB` memfd (hugetlbfs, not tmpfs). Linux only.
+    ///   determined. Carries the observed `fstatfs` magic as a `u32`,
+    ///   normalized so it can be looked up in `magic.h` directly on both
+    ///   32- and 64-bit targets. Typical causes: a regular file, a pipe or
+    ///   socket, or a `MFD_HUGETLB` memfd (hugetlbfs, not tmpfs). Linux only.
     /// * [`Error::UnknownDeviceType`] - the fd's `st_dev` major is non-zero,
     ///   i.e. it lives on a real block device rather than an anonymous or
     ///   in-memory filesystem. Linux only.
@@ -1874,7 +1894,7 @@ where
             // rather than guessed at. Falling back to SHM would "work" — a
             // DMA-BUF is mmap-able, and even a pipe imports as a zero-length
             // tensor — which is exactly why it must not be the default.
-            let magic = fstatfs(&fd)?.filesystem_type().0 as i64;
+            let magic = fs_magic(fstatfs(&fd)?.filesystem_type().0 as i64);
 
             log::debug!(
                 "Creating tensor from fd: major={major}, minor={minor}, magic={magic:#010x}"
@@ -6108,6 +6128,55 @@ mod tests {
             "File descriptor leak detected: {} -> {}",
             start_open_fds, end_open_fds
         );
+    }
+
+    /// A filesystem magic must report its true 32-bit value regardless of
+    /// how wide, and how signed, `fstatfs`'s `f_type` is on the target.
+    ///
+    /// `fs_type_t` is `__fsword_t` on Linux/gnu — `i64` on 64-bit but `i32`
+    /// on 32-bit (armv7, i686, aarch64-ilp32) — `c_int` on uclibc, and
+    /// unsigned on musl and s390x. Widening a *signed* 32-bit `f_type`
+    /// sign-extends every magic with bit 31 set, so a naive widening cast
+    /// reports e.g. `0xffffffff958458f6` for hugetlbfs. The docs tell
+    /// callers to look the reported value up in `include/uapi/linux/magic.h`,
+    /// so a sign-extended value is actively misleading.
+    ///
+    /// This cannot be reproduced on a 64-bit host — the defect only exists
+    /// where `f_type` is a signed 32-bit type — so the test drives the
+    /// conversion directly with the value such a target would produce.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_fs_magic_normalizes_sign_extended_values() {
+        // Magics whose bit 31 is set. HUGETLBFS is the one that matters
+        // most in practice: a MFD_HUGETLB memfd is the likeliest fd to land
+        // in the UnknownBufferType arm.
+        const HUGETLBFS_MAGIC: u32 = 0x9584_58f6;
+        const F2FS_MAGIC: u32 = 0xf2f5_2010;
+        const BTRFS_MAGIC: u32 = 0x9123_683e;
+
+        for magic in [HUGETLBFS_MAGIC, F2FS_MAGIC, BTRFS_MAGIC] {
+            // 64-bit gnu: f_type is i64 and already holds the true value.
+            assert_eq!(fs_magic(i64::from(magic)), magic);
+
+            // 32-bit gnu / uclibc: f_type is i32, so the value arrives
+            // sign-extended once widened. It must still report its true
+            // 32 bits.
+            let sign_extended = i64::from(magic as i32);
+            assert!(sign_extended < 0, "{magic:#x} should have bit 31 set");
+            assert_eq!(
+                fs_magic(sign_extended),
+                magic,
+                "{magic:#x} must survive a signed 32-bit f_type"
+            );
+        }
+
+        // The two magics we actually classify on are below 2^31, so they are
+        // unaffected by signedness either way — this is why the DMA-vs-SHM
+        // decision is correct on 32-bit even without this normalization.
+        for magic in [DMA_BUF_MAGIC, TMPFS_MAGIC] {
+            assert!(magic < 0x8000_0000);
+            assert_eq!(fs_magic(i64::from(magic as i32)), magic);
+        }
     }
 
     /// A DMA-BUF fd must import as [`TensorMemory::Dma`].

--- a/crates/tensor/src/tensor_dyn.rs
+++ b/crates/tensor/src/tensor_dyn.rs
@@ -508,7 +508,32 @@ impl TensorDyn {
         }
     }
 
-    /// Create a type-erased tensor from a file descriptor.
+    /// Import an existing buffer as a type-erased tensor, taking ownership
+    /// of its file descriptor. No bytes are copied.
+    ///
+    /// Dispatches to [`Tensor::from_fd`](crate::TensorTrait::from_fd) for
+    /// `dtype` and inherits its contract in full: on Linux the backend is
+    /// detected from the fd's filesystem magic — `DMA_BUF_MAGIC` imports as
+    /// [`TensorMemory::Dma`](crate::TensorMemory::Dma), `TMPFS_MAGIC` (both
+    /// `/dev/shm` and `memfd`) as [`TensorMemory::Shm`](crate::TensorMemory::Shm)
+    /// — and any other filesystem is rejected rather than assumed to be
+    /// shared memory. On non-Linux Unix the fd is always adopted as SHM.
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::UnknownBufferType`](crate::Error::UnknownBufferType) - the
+    ///   fd is neither a DMA-BUF nor tmpfs-backed; carries the observed
+    ///   `fstatfs` magic. Linux only.
+    /// * [`Error::UnknownDeviceType`](crate::Error::UnknownDeviceType) - the
+    ///   fd lives on a real block device. Linux only.
+    /// * [`Error::InvalidSize`](crate::Error::InvalidSize) - `shape` is empty
+    ///   or describes zero elements.
+    /// * [`Error::NixError`](crate::Error::NixError) - a syscall on the
+    ///   descriptor failed.
+    ///
+    /// Callers that require zero-copy must check
+    /// [`memory()`](crate::TensorDyn::memory) on the result rather than
+    /// treating a successful import as proof of DMA backing.
     #[cfg(unix)]
     pub fn from_fd(
         fd: std::os::fd::OwnedFd,


### PR DESCRIPTION
Fixes [TOP2-833](https://au-zone.atlassian.net/browse/TOP2-833). Found during Ocean Cleanup ADIS work: camera frames were being refused by `ImageProcessor::import_image` with *"requires DMA-backed fd, got Shm"*.

## The defect

`TensorStorage::from_fd` decided whether an incoming fd was a DMA-BUF from the **minor number of its `st_dev`**, with `9 | 10` hardcoded as "this is DMA". Everything else fell through to shared memory.

That value is not an ABI. `dma_buf` files live on an internal kernel mount (`dma_buf_mnt`, `kern_mount`) whose superblock takes its device number from `get_anon_bdev()` — an IDA shared with every other anonymous pseudo-filesystem (pipefs, sockfs, anon_inodefs, nsfs, bdev, tracefs) and handed out first-come-first-served during boot. The minor a DMA-BUF lands on is a function of which pseudo-filesystems registered first on that kernel build, and moves with kernel config, driver load order, initramfs use, and kernel version.

**It was wrong on the dev host too.** Probing directly:

```
memfd     minor=1   f_type=0x1021994   /memfd:probe (deleted)
shm_open  minor=27  f_type=0x1021994   /dev/shm/probe_shm
dma_buf   minor=12  f_type=0x444d4142  /dmabuf:
```

A genuine DMA-BUF is **minor 12** on x86 desktop and **minor 8** on the ADIS Verdin. Both miss `9 | 10`.

Because a DMA-BUF is mmap-able, the wrong branch produced a working tensor that merely wasn't DMA — nothing failed at import, and the loss of zero-copy only surfaced downstream.

## The fix

Classify on the `fstatfs` magic, which is stable UAPI (`include/uapi/linux/magic.h`):

| Filesystem | Magic | Result |
|---|---|---|
| `dma_buf` | `DMA_BUF_MAGIC` `0x444d4142` | `TensorMemory::Dma` |
| `tmpfs` (`/dev/shm` **and** `memfd`) | `TMPFS_MAGIC` `0x01021994` | `TensorMemory::Shm` |
| anything else | — | `Error::UnknownBufferType(magic)` |

Both types are identified **positively**. An unrecognized filesystem is rejected rather than assumed to be SHM — the old fallthrough could succeed nonsensically, importing a **pipe fd as a zero-length tensor**. One syscall, no side effects, no new dependency (`nix::sys::statfs` sits beside the `fstat` already in use).

`dmabuf::phys()` was considered as the probe but rejected: `DMA_BUF_IOCTL_PHYS` is an NXP vendor ioctl and fails on mainline.

## Why it reached a release

The only test on this path (`test_dma_from_fd_no_fd_leaks`) asserted **fd counts**, never the backend it got back — and skipped entirely on hosts without DMA-heap permissions. It passed green under complete misclassification.

Added the missing `memory()` assertion plus dedicated tests on both sides of the FFI, including the first C-side coverage of `hal_tensor_from_fd`:

- Rust: DMA→Dma, tmpfs→Shm, pipe→`UnknownBufferType`
- C: pipe→`NULL`+`EINVAL` (no privileges needed), DMA-BUF→`HAL_TENSOR_MEMORY_DMA`

## Also in this PR

**`hal_tensor_from_fd` errno mapping.** It collapsed every failure to `EIO`. Passing the wrong *kind* of fd is a caller error, so it now maps to `EINVAL` via a new `tensor_err_to_errno()` mirroring `image_err_to_errno()` in `tiling.rs` (also `ENOSPC` for undersized buffers, `ENOTSUP` for unsupported). **Breaking:** code branching on `EIO` from this function needs updating; code checking only for `NULL` is unaffected.

**Python error legibility.** `Error::Tensor` formatted with `{e:?}`, bypassing `Display`, so Python showed the magic in decimal. Now renders `magic 0x50495045`.

**Drive-by:** removed a dead `GLProcessorST` import in the image GL tests that broke `clippy --features dma_test_formats` (pre-existing on `main`, unrelated, but it blocked a pre-push gate).

## Docs

`from_fd` contract documented at all four public surfaces — `TensorTrait`, `TensorDyn`, the C API (+ regenerated `hal.h`), and the Python `.pyi`, which still described the old major/minor mechanism. Each carries a `# Errors` section and the same warning: **check `memory()`, because a successful import is not proof of DMA backing.** Plus `crates/tensor/ARCHITECTURE.md` § Import classification and TESTING.md notes on the skip hazard.

## Verification

- Rust workspace: 34 test binaries, 0 failures; tensor 218/218 **both privileged and unprivileged**
- C API: 87 passed / 0 failed unprivileged; **18/18 under `sudo`** with both DMA tests exercised
- `make format`, `make lint`, clippy with `--features dma_test_formats`, doc-tests, `make sbom` (license policy clean, `NOTICE` unchanged)
- Cross-compiles clean for `aarch64-unknown-linux-gnu` — checked specifically because `filesystem_type().0` is `__fsword_t`, which is narrower on 32-bit

> [!IMPORTANT]
> DMA tests **self-skip** on hosts without DMA-heap access, which is how this shipped. `/dev/dma_heap/system` is root-only on a typical workstation, so an unprivileged run proves nothing. To reproduce or verify:
> ```bash
> cargo test -p edgefirst-tensor --lib --no-run
> sudo ./target/debug/deps/edgefirst_tensor-<hash> --test-threads=1
> ```
> Reverting the classifier and running that reproduces the bug: `left: Shm, right: Dma`.

Not verified: the Python binding at runtime (`maturin` isn't installed locally and the module in `venv/` is a stale build). CI builds the wheels; `tests/test_tensor.py::test_from_fd_dma` already asserts the round-trip.

[TOP2-833]: https://au-zone.atlassian.net/browse/TOP2-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ