### PR TITLE
Rewrite the JPEG decoder hot paths for in-order cores; opt-in fast DCT

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -367,54 +367,88 @@ JSON files are collected in `benchmarks/<platform>/` and processed by `.github/s
 
 **Scope:** JPEG bytes → decoded raster in memory. Letterbox / model-input
 preprocessing (`ImageProcessor::convert()`) is a separate measurement and is not
-included here. Two arms:
+included here. Six arms:
 
-| Arm | EdgeFirst | libjpeg-turbo |
-|-----|-----------|---------------|
-| **YUV** | `--decode-only --decode-fmt native` (NV12/16/24) | `--decode-only --format yuv` (`tjDecompressToYUV2`) |
-| **RGB** | `--decode-only --decode-fmt rgb` (fused MCU write) | `--decode-only --format rgb` (`TJPF_RGB`) |
+| Arm | Command |
+|-----|---------|
+| **EdgeFirst** | `hal_cpu --decode-only` — accurate `islow`-class IDCT, the default |
+| **EdgeFirst `fast`** | same, `EDGEFIRST_CODEC_DCT=fast` — opt-in AAN `ifast`-class IDCT (`DctMethod::Fast`) |
+| **Turbo `islow`** | `turbojpeg_bench --dct accurate` — libjpeg-turbo's default IDCT |
+| **Turbo `ifast`** | `turbojpeg_bench --dct fast` |
+| **zune-jpeg** | `rust_jpeg --engine zune` — YCbCr out on the YUV arm, RGB on the RGB arm |
+| **image crate** | `rust_jpeg --engine image` — `load_from_memory` + `to_rgb8` (allocates per call; RGB only, its API exposes no raw-YUV output) |
 
-Layouts differ on the YUV arm (semi-planar NV* vs planar YUV); both stop after
-decode into a YUV buffer with no RGB colour step. COCO `val2017` is 4:4:4, so
-the fused RGB write engages.
+The YUV arm stops after decode into a YUV layout with no RGB colour step
+(EdgeFirst `--decode-fmt native` NV12/16/24, turbo `tjDecompressToYUV2`
+planar, zune interleaved YCbCr); the RGB arm decodes to interleaved RGB
+(EdgeFirst's fused MCU write, `TJPF_RGB`, zune/image RGB). COCO `val2017`
+is 4:4:4, so the fused RGB write engages. zune's YUV arm skips COCO's few
+greyscale images (its Luma→YCbCr mapping is unimplemented); the other arms
+decode them.
 
-Both arms are native binaries — `hal_cpu` (Rust) and `modules/turbojpeg/bench.c`
-(C) — measured by harnesses that agree on image selection, preload before
-timing, `CLOCK_MONOTONIC` around decode alone, percentile index and MP/s. A
-Python driver on one side only would put interpreter dispatch and FFI
-marshalling inside the timed region.
+All arms are native binaries — `hal_cpu` / `rust_jpeg` (Rust) and
+`modules/turbojpeg/bench.c` (C) — measured by harnesses that agree on image
+selection, preload before timing, `CLOCK_MONOTONIC` around decode alone,
+percentile index and MP/s. A Python driver on one side only would put
+interpreter dispatch and FFI marshalling inside the timed region.
 
-**On the two IDCT columns.** libjpeg-turbo can decompress with either the
-accurate `islow` IDCT or the faster, lower-accuracy `ifast` one. **`islow` is
-its default**, and it is the kernel EdgeFirst implements, so the `islow` columns
-are the like-for-like comparison and the one claims should quote. `ifast` is
-reported alongside because it is what a caller gets when asking for speed over
-fidelity; comparing against it silently would compare two different accuracy
-classes.
+**On the IDCT accuracy classes.** libjpeg-turbo decompresses with either the
+accurate `islow` IDCT or the faster, lower-accuracy `ifast` one; **`islow` is
+its default**, and it is the kernel EdgeFirst's default implements, so
+EdgeFirst↔`islow` is the like-for-like comparison and the one claims should
+quote. EdgeFirst's opt-in `fast` mode is the same trade turbo's `ifast`
+makes, so `fast`↔`ifast` is the like-for-like comparison within the fast
+class. Measured on 1000 COCO images (`dct_compare`), EdgeFirst `fast` vs the
+default kernel: cosine similarity mean 0.99998 / worst 0.99985, PSNR mean
+51.4 dB / worst 42.1 dB, max pixel delta 24. mAP impact is not yet measured;
+`fast` stays opt-in.
 
-Interleaved best-of-N in a single session per host with all arms alternating,
-pinned to one core; x86 n=800 best-of-5, boards n=200 best-of-3. Positive means
-EdgeFirst is faster.
+Interleaved best-of-3 in a single session per host with all arms alternating,
+pinned to one core, n=200 (`decode-ab-sweep.sh`, `CARGO_PROFILE=release`, no
+perf/trace). Captured 2026-08-13: register-cached bit cursor, fast-AC
+terminator baking, entropy-derived IDCT tiers, paired-coefficient probe (High
+tier), dedicated 4:4:4 MCU loop, SSE4.1 fused-RGB block kernel. The orin-nano
+row was captured on the fallback unit (`adis-uav1`, Orin Nano Super devkit) —
+its turbo baseline matches the prior orin-nano capture within 0.1%, so the
+rows are comparable. x86-desktop is `sebstation` (same i9-11900K host as the
+prior x86 captures).
 
-| Board | Core | Arm | EdgeFirst | Turbo `islow` | vs `islow` | Turbo `ifast` | vs `ifast` |
-|-------|------|-----|-----------|---------------|------------|---------------|------------|
-| rpi5-hailo | A76 | YUV | **2.661 ms** | 3.162 ms | **+18.8%** | 2.890 ms | **+8.6%** |
-| | | RGB | **2.812 ms** | 3.355 ms | **+19.3%** | 3.093 ms | **+10.0%** |
-| x86-desktop | Rocket Lake i9-11900K | YUV | **1.276 ms** | 1.359 ms | **+6.5%** | 1.280 ms | +0.3% |
-| | | RGB | **1.330 ms** | 1.439 ms | **+8.2%** | 1.362 ms | **+2.4%** |
-| imx95-pro | A55 | YUV | 7.070 ms | 7.036 ms | −0.5% | **6.547 ms** | −7.4% |
-| | | RGB | **7.404 ms** | 7.518 ms | +1.5% | **7.074 ms** | −4.5% |
-| imx8mp-frdm | A53 | YUV | 7.890 ms | **7.515 ms** | −4.8% | **6.901 ms** | −12.5% |
-| | | RGB | 8.202 ms | **7.961 ms** | −2.9% | **7.317 ms** | −10.8% |
+All numbers are p50 ms; lower is better. **Bold** marks the fastest arm in
+each accuracy class (accurate: EdgeFirst vs turbo `islow`; fast: EdgeFirst
+`fast` vs turbo `ifast`).
 
-- **Out-of-order cores are a clear win.** The A76 is 18.8% / 19.3% faster than
-  libjpeg-turbo at matching accuracy and still 8.6% / 10.0% faster than its
-  `ifast` kernel. x86 is 6.5% / 8.2% faster at matching accuracy; against
-  `ifast` the YUV arm is parity and RGB holds +2.4%.
-- **The A55 is parity** at matching accuracy, 4.5–7.4% behind `ifast`.
-- **The A53 is behind**, 2.9–4.8% at matching accuracy and 10.8–12.5% against
-  `ifast`. In-order cores pay for every instruction, and our remaining cost is
-  in the IDCT and the MCU write stage.
+| Board | Core | Arm | EdgeFirst | EF `fast` | Turbo `islow` | Turbo `ifast` | zune-jpeg | image |
+|-------|------|-----|-----------|-----------|---------------|---------------|-----------|-------|
+| rpi5-hailo | A76 | YUV | **2.392** | **2.100** | 3.156 | 2.889 | 3.973 | — |
+| | | RGB | **2.604** | **2.298** | 3.361 | 3.110 | 4.237 | 4.709 |
+| orin-nano | A78AE | YUV | **3.664** | **3.130** | 5.137 | 4.612 | 6.131 | — |
+| | | RGB | **3.991** | **3.437** | 5.481 | 4.960 | 6.554 | 8.050 |
+| x86-desktop | Rocket Lake i9-11900K | YUV | **1.207** | 1.212 | 1.437 | 1.358 | 1.810 | — |
+| | | RGB | **1.300** | 1.294 | 1.490 | 1.418 | 1.822 | 1.919 |
+| imx95-pro | A55 | YUV | **6.067** | **5.310** | 7.031 | 6.562 | 11.150 | — |
+| | | RGB | **6.385** | **5.669** | 7.507 | 7.044 | 11.656 | 12.129 |
+| imx8mp-frdm | A53 | YUV | **6.729** | **5.963** | 7.620 | 6.927 | 12.378 | — |
+| | | RGB | **7.079** | **6.340** | 7.945 | 7.332 | 12.980 | 13.722 |
+
+- **EdgeFirst's accurate default beats turbo's `islow` everywhere** — +11.7%
+  / +10.9% on the A53, +13.7% / +14.9% on the A55, +24.2% / +22.5% on the
+  A76, +28.7% / +27.2% on the A78AE, +16.0% / +12.8% on Rocket Lake — and it
+  also beats turbo's **`ifast`** on every platform (+2.9% A53 … +20.6%
+  A78AE) while producing `islow`-class pixels.
+- **The opt-in `fast` mode extends the lead within the fast class**: +13.9%
+  / +13.5% over `ifast` on the A53, +19.1% / +19.5% on the A55, +27.3% /
+  +26.1% on the A76, +32.1% / +30.7% on the A78AE. On x86 there is no fast
+  kernel yet — the option is advisory and runs the accurate path (the
+  `fast` and default rows measure the same code there).
+- **Against the Rust ecosystem**, EdgeFirst is 1.5× faster than zune-jpeg
+  on Rocket Lake, 1.7× on the A76/A78AE, and 1.8–1.9× on the in-order
+  A53/A55 (zune has no strong in-order tuning); the image crate (zune-jpeg
+  internally, plus a per-call allocation and RGB conversion) trails
+  further.
+- COCO val2017 contains no restart-interval (DRI) files (1000 checked), so
+  turbo's fast Huffman path — which its own ChangeLog documents as disabled
+  for DRI streams at a ~20% cost — ran for the whole corpus. On DRI camera
+  streams EdgeFirst's lead grows: its fast entropy path handles restarts.
 
 ### SIMD tier value (x86-desktop)
 
@@ -440,7 +474,19 @@ the A53.
 ### Reproduce
 
 ```bash
-# Decoder A/B, aarch64 boards over SSH (cross-builds both arms)
+# Full six-arm decoder sweep, aarch64 boards + x86_64 hosts over SSH
+# (release profile, interleaved best-of-3; EdgeFirst accurate/fast, turbo
+# islow/ifast, zune-jpeg, image crate)
+./benchmarks/scripts/decode-ab-sweep.sh imx8mp-frdm imx95-pro rpi5-hailo adis-uav1 sebstation
+
+# Three-arm publish subset (EdgeFirst accurate vs turbo islow/ifast only)
+CARGO_PROFILE=release EDGEFIRST_BENCH_ORIN_FALLBACK=adis-uav1 \
+  ./benchmarks/scripts/decode-ab-publish.sh imx8mp-frdm imx95-pro rpi5-hailo orin-nano
+
+# Fast-vs-accurate DCT pixel similarity (cosine/PSNR/max delta) over a corpus
+cargo run --release -p dct_compare -- --dir /path/to/coco/val2017
+
+# Smoke / investigation (profiling profile, sequential, islow only)
 ./benchmarks/scripts/decode-ab-matrix.sh imx95-pro rpi5-hailo
 
 # Decoder A/B, x86 / AWS Batch
@@ -1391,6 +1437,7 @@ allocation.
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3.10 | 2026-08-12 | JPEG decode A/B refresh (`CARGO_PROFILE=release`, no perf/trace, interleaved best-of-3, n=200, pinned): A53 within 1% of turbo `islow`; A55 ahead of `islow`; add orin-nano A78AE row. x86 unchanged. |
 | 3.9 | 2026-06-16 | 0.25.0 release refresh: full bench matrix re-collected on the converged-GL-engine code across imx8mp-frdm, imx95-frdm, rpi5-hailo, and jetson-orin-nano, plus the existing mbp-m2-max rows. Confirms the GL-convergence captures within measurement noise (imx95 GL 1080p YUYV→RGBA letterbox 1.2 ms → 957 µs, NV12→RGBA 1.2 ms → 830 µs); no GPU regressions. Allocation table updated for the imx8mp DMA-alloc improvement (38 ms → 1.8 ms at 720p). macOS GL rows remain the pre-convergence capture (Known Gap #17). |
 | 3.8 | 2026-05-24 | macOS GL backend lands via ANGLE + IOSurface. `TensorMemory::Dma` extended to back IOSurface on macOS, with `is_gpu_buffer_available()` as the portable probe. Capture buffer-infrastructure numbers on mbp-m2-max for Mem/Shm/Dma (alloc 16 µs constant for IOSurface, memcpy 2–2.7× faster than SHM at every resolution). YUYV→RGBA same-size convert: 1.3× at 1080p, 4.8× at 4K vs CPU. Add mbp-m2-max **CPU-only** rows to letterbox / decoder / mask-decode / codec tables; add mbp-m2-max **GL** rows (YUYV→RGBA only) to the same-size format-conversion and 4K-convert tables. Letterbox GL rows pending Gap #17 closure. |
 | 3.7 | 2026-05-22 | Add macOS platform (Apple M2 Max, `mbp-m2-max`) with CPU baseline benchmarks. |

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # EdgeFirst HAL - Benchmarks
 
-**Version:** 3.9
+**Version:** 3.10
 **Last Updated:** June 16, 2026
 **Status:** 0.25.0 release refresh. The full bench matrix was re-collected on the 0.25.0
 converged-GL-engine code across imx8mp-frdm (Vivante GC7000UL + G2D), imx95-frdm
@@ -1437,7 +1437,7 @@ allocation.
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 3.10 | 2026-08-12 | JPEG decode A/B refresh (`CARGO_PROFILE=release`, no perf/trace, interleaved best-of-3, n=200, pinned): A53 within 1% of turbo `islow`; A55 ahead of `islow`; add orin-nano A78AE row. x86 unchanged. |
+| 3.10 | 2026-08-13 | JPEG decode section rebuilt as the six-arm sweep (`decode-ab-sweep.sh`): EdgeFirst accurate + opt-in `fast` (`DctMethod::Fast`) vs turbo `islow`/`ifast`, zune-jpeg, and the image crate, across A53/A55/A76/A78AE/Rocket Lake. Accurate beats both turbo kernels everywhere (+11.7% A53 … +28.7% A78AE vs `islow`); `fast` beats `ifast` by 14–32% with its accuracy envelope stated (cosine ≥ 0.99985, PSNR ≥ 42 dB, max Δ 24 over 1000 COCO images). x86 re-captured after the SSE4.1 fused-RGB block-kernel fix. orin-nano row captured on the `adis-uav1` fallback (turbo baseline within 0.1% of the prior capture). |
 | 3.9 | 2026-06-16 | 0.25.0 release refresh: full bench matrix re-collected on the converged-GL-engine code across imx8mp-frdm, imx95-frdm, rpi5-hailo, and jetson-orin-nano, plus the existing mbp-m2-max rows. Confirms the GL-convergence captures within measurement noise (imx95 GL 1080p YUYV→RGBA letterbox 1.2 ms → 957 µs, NV12→RGBA 1.2 ms → 830 µs); no GPU regressions. Allocation table updated for the imx8mp DMA-alloc improvement (38 ms → 1.8 ms at 720p). macOS GL rows remain the pre-convergence capture (Known Gap #17). |
 | 3.8 | 2026-05-24 | macOS GL backend lands via ANGLE + IOSurface. `TensorMemory::Dma` extended to back IOSurface on macOS, with `is_gpu_buffer_available()` as the portable probe. Capture buffer-infrastructure numbers on mbp-m2-max for Mem/Shm/Dma (alloc 16 µs constant for IOSurface, memcpy 2–2.7× faster than SHM at every resolution). YUYV→RGBA same-size convert: 1.3× at 1080p, 4.8× at 4K vs CPU. Add mbp-m2-max **CPU-only** rows to letterbox / decoder / mask-decode / codec tables; add mbp-m2-max **GL** rows (YUYV→RGBA only) to the same-size format-conversion and 4K-convert tables. Letterbox GL rows pending Gap #17 closure. |
 | 3.7 | 2026-05-22 | Add macOS platform (Apple M2 Max, `mbp-m2-max`) with CPU baseline benchmarks. |

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -358,6 +358,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dct_compare"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "edgefirst-codec",
+ "edgefirst-tensor",
+]
+
+[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +882,8 @@ dependencies = [
  "num-traits",
  "ravif",
  "rayon",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1625,6 +1637,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
+name = "rust_jpeg"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "image",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -8,7 +8,9 @@
 resolver = "3"
 members = [
     "common",
+    "modules/dct_compare",
     "modules/hal_cpu",
+    "modules/rust_jpeg",
     "modules/hal_gl",
     "modules/hal_g2d",
     "modules/hal_v4l2_gl",

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -279,24 +279,31 @@ costs it a further 0.489 ms (A55) / 0.614 ms (A53) end to end. Since the flag
 selects nothing but the IDCT, that premium is added to the IDCT row. Re-profile
 with `--dct accurate` to measure it directly rather than by difference.
 
-**Still open:** a residual 1.0% A53 YUV gap vs turbo `islow` (published
-interleaved best-of-3, n=200, release profile). A two-block IDCT is deferred
-(A53 spill risk). A55 is ahead of `islow`. Two-block AVX2 IDCT on x86 is still
-untried. The JPEG Decode A/B table in `BENCHMARKS.md` is hand-maintained from
-`decode-ab-publish.sh`; the generated tables further down that file must not be
-typed in by hand.
+**Still open:** the entropy↔IDCT instruction interleave on in-order cores
+needs a hand-scheduled fused block loop (compiler-level fusion measured a
+wash on A53/A55 and −2.9% on A76); x86 has no fast-DCT kernel yet
+(`DctMethod::Fast` is advisory there); the fast mode's mAP impact is
+unmeasured. Two-block AVX2 IDCT on x86 is still untried. The JPEG Decode A/B
+table in `BENCHMARKS.md` is hand-maintained from `decode-ab-sweep.sh`; the
+generated tables further down that file must not be typed in by hand.
 
 ### Settled — do not re-test
 
 Each of these was measured and rejected; the reasons generalise.
 
-- **Folding AC EOB/ZRL into the combined `fast_ac` table**: −6%. Terminating the
-  block from inside the hit path costs a test on every coefficient to save one
-  miss per block.
+- **Folding AC EOB/ZRL into `fast_ac` with an in-path terminator test**: −6%.
+  Testing for EOB on every coefficient to save one miss per block loses.
+  What *did* land is the run-0xFF sentinel encoding: EOB resolves through the
+  `k >= 64` bounds branch the loop already executes, so the common exit costs
+  no extra hot-path compare — the lesson is about where the branch lives, not
+  whether the fold is possible.
 - **Passing the bit buffer as a by-value `BitState` struct**: +17% instructions.
   LLVM would not scalarise the aggregate and copied 24 bytes between stack slots
-  in the loop header. The fix that did work was inlining the *cold* refill and
-  slow-symbol paths, so the buffer stays in registers instead of a stack slot.
+  in the loop header. The design that superseded it is the `BitCursor` copy
+  owned by an `#[inline(never)]` `decode_block`: the cursor is a provably
+  non-escaping local of the outlined function, so it lives in registers — and
+  the outlining is load-bearing (inlined into the MCU loop it cost ~20% on the
+  A53 from merged register pressure).
 - **Raising the refill threshold**: refill already early-outs on `avail >= 32`
   and a bulk refill leaves ≥57 bits, so it touches memory about every fourth
   coefficient. A higher threshold makes refills more frequent, not fewer.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -154,8 +154,12 @@ The image is the portable OSS contract. How you schedule it on cloud CPUs
 # One-time dataset sync (~820 MB)
 ./benchmarks/scripts/sync-coco.sh imx8mp-frdm rpi5-hailo orin-nano
 
-# Decode-only HAL vs TurboJPEG (YUV + RGB) — supports PR decoder claims
+# Decode-only HAL vs TurboJPEG (YUV + RGB) — smoke / investigation
 ./benchmarks/scripts/decode-ab-matrix.sh imx8mp-frdm imx95-pro rpi5-hailo orin-nano
+
+# Published decoder A/B (release, interleaved best-of-3, n=200)
+CARGO_PROFILE=release EDGEFIRST_BENCH_ORIN_FALLBACK=adis-uav1 \
+  ./benchmarks/scripts/decode-ab-publish.sh imx8mp-frdm imx95-pro rpi5-hailo orin-nano
 
 # Full HAL COCO matrix (decode + letterbox convert, all HAL backends)
 ./benchmarks/scripts/deploy-and-run.sh imx8mp-frdm imx95-pro rpi5-hailo
@@ -275,8 +279,12 @@ costs it a further 0.489 ms (A55) / 0.614 ms (A53) end to end. Since the flag
 selects nothing but the IDCT, that premium is added to the IDCT row. Re-profile
 with `--dct accurate` to measure it directly rather than by difference.
 
-**Still open:** the residual IDCT deficit, the `mcu loop / write` stage (now the
-larger of the two on the A55), and a two-block AVX2 IDCT on x86.
+**Still open:** a residual 1.0% A53 YUV gap vs turbo `islow` (published
+interleaved best-of-3, n=200, release profile). A two-block IDCT is deferred
+(A53 spill risk). A55 is ahead of `islow`. Two-block AVX2 IDCT on x86 is still
+untried. The JPEG Decode A/B table in `BENCHMARKS.md` is hand-maintained from
+`decode-ab-publish.sh`; the generated tables further down that file must not be
+typed in by hand.
 
 ### Settled — do not re-test
 

--- a/benchmarks/common/src/lib.rs
+++ b/benchmarks/common/src/lib.rs
@@ -250,6 +250,14 @@ pub fn peak_rss_mb() -> f64 {
             }
         }
     }
+    #[cfg(target_os = "macos")]
+    {
+        // Darwin reports ru_maxrss in bytes (Linux uses kilobytes).
+        let mut ru: libc::rusage = unsafe { std::mem::zeroed() };
+        if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut ru) } == 0 {
+            return ru.ru_maxrss as f64 / (1024.0 * 1024.0);
+        }
+    }
     0.0
 }
 

--- a/benchmarks/modules/dct_compare/Cargo.toml
+++ b/benchmarks/modules/dct_compare/Cargo.toml
@@ -16,5 +16,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
-edgefirst-codec = { path = "../../../crates/codec" }
+# default-features off: the v4l2/nvjpeg hardware decoders would bypass the
+# software IDCT this harness exists to compare.
+edgefirst-codec = { path = "../../../crates/codec", default-features = false }
 edgefirst-tensor = { path = "../../../crates/tensor" }

--- a/benchmarks/modules/dct_compare/Cargo.toml
+++ b/benchmarks/modules/dct_compare/Cargo.toml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dct_compare"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Fast-vs-accurate DCT pixel similarity over a JPEG corpus"
+
+[[bin]]
+name = "dct_compare"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+edgefirst-codec = { path = "../../../crates/codec" }
+edgefirst-tensor = { path = "../../../crates/tensor" }

--- a/benchmarks/modules/dct_compare/src/main.rs
+++ b/benchmarks/modules/dct_compare/src/main.rs
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fast-vs-accurate DCT pixel similarity over a JPEG corpus.
+//!
+//! Decodes every image twice — `DctMethod::Accurate` (the default `islow`
+//! kernel) and `DctMethod::Fast` (opt-in AAN) — and reports per-corpus
+//! cosine similarity, PSNR, and worst pixel delta of the raw decoded planes.
+//! This is the interim accuracy evidence for the fast mode until the mAP
+//! comparison lands (measure the model, not just the pixels).
+//!
+//! ```bash
+//! dct_compare --dir /data/coco/val2017 --limit 500
+//! ```
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use edgefirst_codec::{DctMethod, ImageDecoder, ImageLoad};
+use edgefirst_tensor::{PixelFormat, Tensor, TensorMemory, TensorTrait};
+
+#[derive(Parser)]
+struct Args {
+    /// JPEG corpus directory (searched non-recursively for *.jpg/*.jpeg).
+    #[arg(long, env = "EDGEFIRST_BENCH_COCO")]
+    dir: std::path::PathBuf,
+    /// Maximum number of images (0 = all).
+    #[arg(long, default_value_t = 0)]
+    limit: usize,
+    /// Print each image's stats, not just the aggregate.
+    #[arg(long)]
+    verbose: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let mut files: Vec<_> = std::fs::read_dir(&args.dir)
+        .with_context(|| format!("reading {}", args.dir.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e.eq_ignore_ascii_case("jpg") || e.eq_ignore_ascii_case("jpeg"))
+        })
+        .collect();
+    files.sort();
+    if args.limit > 0 {
+        files.truncate(args.limit);
+    }
+    anyhow::ensure!(!files.is_empty(), "no JPEGs in {}", args.dir.display());
+
+    let mut t_acc = Tensor::<u8>::image(
+        8192,
+        8192,
+        PixelFormat::Nv24,
+        Some(TensorMemory::Mem),
+        edgefirst_tensor::CpuAccess::ReadWrite,
+    )?;
+    let mut t_fast = Tensor::<u8>::image(
+        8192,
+        8192,
+        PixelFormat::Nv24,
+        Some(TensorMemory::Mem),
+        edgefirst_tensor::CpuAccess::ReadWrite,
+    )?;
+    let mut dec_acc = ImageDecoder::new();
+    dec_acc.set_dct_method(DctMethod::Accurate);
+    let mut dec_fast = ImageDecoder::new();
+    dec_fast.set_dct_method(DctMethod::Fast);
+
+    let mut n_images = 0usize;
+    let mut worst_cosine = 1.0f64;
+    let mut worst_psnr = f64::INFINITY;
+    let mut global_max_diff = 0i32;
+    let mut sum_cosine = 0.0f64;
+    let mut sum_psnr = 0.0f64;
+    let mut exceeds_8 = 0usize;
+
+    for path in &files {
+        let data = std::fs::read(path)?;
+        let ia = match t_acc.load_image(&mut dec_acc, &data) {
+            Ok(i) => i,
+            Err(_) => continue, // corrupt / unsupported: skip both arms
+        };
+        let _ = t_fast.load_image(&mut dec_fast, &data)?;
+
+        // Compare the decoded planes over the valid image region only: rows
+        // of `width` bytes at the tensor stride, over the combined plane
+        // height (Y + interleaved UV for Nv24; Y-only for Grey).
+        let stride = t_acc.effective_row_stride().unwrap_or(ia.width);
+        let plane_rows = match ia.format {
+            PixelFormat::Grey => ia.height,
+            _ => ia.height * 3, // Nv24: Y rows + UV rows (2 bytes/px over w/2… full-res UV)
+        };
+        let a = t_acc.map()?;
+        let f = t_fast.map()?;
+        let (mut dot, mut na, mut nf, mut se) = (0f64, 0f64, 0f64, 0f64);
+        let mut max_diff = 0i32;
+        let mut count = 0usize;
+        for r in 0..plane_rows {
+            let off = r * stride;
+            let w = ia.width.min(stride);
+            for i in off..off + w {
+                let (x, y) = (a[i] as f64, f[i] as f64);
+                dot += x * y;
+                na += x * x;
+                nf += y * y;
+                let d = (a[i] as i32 - f[i] as i32).abs();
+                se += (d * d) as f64;
+                max_diff = max_diff.max(d);
+                count += 1;
+            }
+        }
+        drop(a);
+        drop(f);
+        let cosine = dot / (na.sqrt() * nf.sqrt()).max(1e-12);
+        let mse = se / count as f64;
+        let psnr = if mse == 0.0 {
+            f64::INFINITY
+        } else {
+            10.0 * (255.0f64 * 255.0 / mse).log10()
+        };
+        n_images += 1;
+        sum_cosine += cosine;
+        sum_psnr += psnr.min(99.0);
+        worst_cosine = worst_cosine.min(cosine);
+        worst_psnr = worst_psnr.min(psnr);
+        global_max_diff = global_max_diff.max(max_diff);
+        if max_diff > 8 {
+            exceeds_8 += 1;
+        }
+        if args.verbose {
+            println!(
+                "{}: cosine={cosine:.7} psnr={psnr:.2} dB max|d|={max_diff}",
+                path.file_name().unwrap().to_string_lossy()
+            );
+        }
+    }
+
+    println!("== fast-vs-accurate DCT similarity over {n_images} images");
+    println!(
+        "  cosine:  mean={:.7}  worst={:.7}",
+        sum_cosine / n_images as f64,
+        worst_cosine
+    );
+    println!(
+        "  psnr:    mean={:.2} dB  worst={:.2} dB",
+        sum_psnr / n_images as f64,
+        worst_psnr
+    );
+    println!(
+        "  max|d|:  {global_max_diff}  (images with max|d| > 8: {exceeds_8}/{n_images})"
+    );
+    Ok(())
+}

--- a/benchmarks/modules/dct_compare/src/main.rs
+++ b/benchmarks/modules/dct_compare/src/main.rs
@@ -83,13 +83,20 @@ fn main() -> Result<()> {
         };
         let _ = t_fast.load_image(&mut dec_fast, &data)?;
 
-        // Compare the decoded planes over the valid image region only: rows
-        // of `width` bytes at the tensor stride, over the combined plane
-        // height (Y + interleaved UV for Nv24; Y-only for Grey).
+        // Compare the decoded planes over the valid image region only: the
+        // luma rows carry `width` bytes; the chroma rows of the semi-planar
+        // formats carry interleaved CbCr — 2·width for Nv24 (full-res),
+        // even(width) for Nv12/Nv16 (2 bytes per 2-wide pair). Row count
+        // comes from the format's combined plane height, so Nv12's half-
+        // height chroma and Grey's absence of chroma are both respected.
         let stride = t_acc.effective_row_stride().unwrap_or(ia.width);
-        let plane_rows = match ia.format {
-            PixelFormat::Grey => ia.height,
-            _ => ia.height * 3, // Nv24: Y rows + UV rows (2 bytes/px over w/2… full-res UV)
+        let plane_rows = ia
+            .format
+            .combined_plane_height(ia.height)
+            .unwrap_or(ia.height);
+        let chroma_row_bytes = match ia.format {
+            PixelFormat::Nv24 => ia.width * 2,
+            _ => ia.width.next_multiple_of(2),
         };
         let a = t_acc.map()?;
         let f = t_fast.map()?;
@@ -98,7 +105,12 @@ fn main() -> Result<()> {
         let mut count = 0usize;
         for r in 0..plane_rows {
             let off = r * stride;
-            let w = ia.width.min(stride);
+            let w = if r < ia.height {
+                ia.width
+            } else {
+                chroma_row_bytes
+            }
+            .min(stride);
             for i in off..off + w {
                 let (x, y) = (a[i] as f64, f[i] as f64);
                 dot += x * y;

--- a/benchmarks/modules/rust_jpeg/Cargo.toml
+++ b/benchmarks/modules/rust_jpeg/Cargo.toml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "rust_jpeg"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Rust-ecosystem JPEG decode reference arms (zune-jpeg, image crate)"
+
+[[bin]]
+name = "rust_jpeg"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+zune-jpeg = "0.5.15"
+zune-core = "0.5"
+image = { version = "0.25.10", default-features = false, features = ["jpeg"] }

--- a/benchmarks/modules/rust_jpeg/src/main.rs
+++ b/benchmarks/modules/rust_jpeg/src/main.rs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Rust-ecosystem JPEG decode reference arms for the decoder A/B.
+//!
+//! Mirrors the `turbojpeg` bench protocol: sorted COCO subset, warmup on the
+//! same set, per-image wall time, p50/p95/p99. Two engines:
+//!
+//! - `--engine zune`: `zune-jpeg` directly, headers + `decode_into` a reused
+//!   buffer. `--format yuv` decodes to interleaved YCbCr (its closest
+//!   native-output analogue); `--format rgb` to RGB.
+//! - `--engine image`: the `image` crate exactly as the codec's historical
+//!   comparison uses it (`load_from_memory_with_format` + `to_rgb8`,
+//!   allocating per call; RGB only). Uses zune-jpeg internally.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::time::Instant;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long, env = "EDGEFIRST_BENCH_COCO")]
+    coco: std::path::PathBuf,
+    #[arg(long, default_value_t = 200)]
+    limit: usize,
+    #[arg(long, default_value_t = 20)]
+    warmup: usize,
+    #[arg(long, default_value = "zune")]
+    engine: String,
+    #[arg(long, default_value = "yuv")]
+    format: String,
+    #[arg(long, default_value = "")]
+    board: String,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let mut files: Vec<_> = std::fs::read_dir(&args.coco)
+        .with_context(|| format!("reading {}", args.coco.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e.eq_ignore_ascii_case("jpg") || e.eq_ignore_ascii_case("jpeg"))
+        })
+        .collect();
+    files.sort();
+    files.truncate(args.limit);
+    anyhow::ensure!(!files.is_empty(), "no JPEGs in {}", args.coco.display());
+
+    let data: Vec<Vec<u8>> = files
+        .iter()
+        .map(|p| std::fs::read(p).map_err(Into::into))
+        .collect::<Result<_>>()?;
+
+    let colorspace = match args.format.as_str() {
+        "yuv" => zune_core::colorspace::ColorSpace::YCbCr,
+        "rgb" => zune_core::colorspace::ColorSpace::RGB,
+        other => anyhow::bail!("unknown --format {other}"),
+    };
+    anyhow::ensure!(
+        args.engine == "zune" || args.format == "rgb",
+        "--engine image supports --format rgb only"
+    );
+
+    let mut buf = vec![0u8; 64 << 20];
+    let mut mp_total = 0f64;
+    let mut decode_one = |jpeg: &[u8]| -> Result<(usize, usize)> {
+        match args.engine.as_str() {
+            "zune" => {
+                let opts = zune_core::options::DecoderOptions::default()
+                    .jpeg_set_out_colorspace(colorspace);
+                let mut dec =
+                    zune_jpeg::JpegDecoder::new_with_options(std::io::Cursor::new(jpeg), opts);
+                dec.decode_headers().context("headers")?;
+                let need = dec.output_buffer_size().context("size")?;
+                if buf.len() < need {
+                    buf.resize(need, 0);
+                }
+                dec.decode_into(&mut buf).context("decode")?;
+                let (w, h) = dec.dimensions().context("dims")?;
+                Ok((w, h))
+            }
+            "image" => {
+                let img =
+                    image::load_from_memory_with_format(jpeg, image::ImageFormat::Jpeg)?
+                        .to_rgb8();
+                Ok((img.width() as usize, img.height() as usize))
+            }
+            other => anyhow::bail!("unknown --engine {other}"),
+        }
+    };
+
+    for jpeg in data.iter().take(args.warmup) {
+        let _ = decode_one(jpeg);
+    }
+
+    // Per-image failures are skipped and counted, not fatal: e.g. zune-jpeg
+    // rejects forced-YCbCr output for COCO's greyscale images.
+    let mut skipped = 0usize;
+    let mut times = Vec::with_capacity(data.len());
+    for jpeg in &data {
+        let t0 = Instant::now();
+        match decode_one(jpeg) {
+            Ok((w, h)) => {
+                times.push(t0.elapsed().as_secs_f64() * 1e3);
+                mp_total += (w * h) as f64 / 1e6;
+            }
+            Err(_) => skipped += 1,
+        }
+    }
+    anyhow::ensure!(!times.is_empty(), "every image failed to decode");
+    if skipped > 0 {
+        eprintln!("  note: {skipped} images skipped (decode error)");
+    }
+    times.sort_by(|a, b| a.total_cmp(b));
+    let pct = |p: f64| times[(((times.len() - 1) as f64) * p) as usize];
+    let total_ms: f64 = times.iter().sum();
+    println!(
+        "  p50={:.3} ms  p95={:.3} ms  p99={:.3} ms  {:.1} MP/s  n={}",
+        pct(0.50),
+        pct(0.95),
+        pct(0.99),
+        mp_total / (total_ms / 1e3),
+        times.len()
+    );
+    let _ = &args.board;
+    Ok(())
+}

--- a/benchmarks/modules/turbojpeg/Makefile
+++ b/benchmarks/modules/turbojpeg/Makefile
@@ -10,10 +10,25 @@
 
 CC      ?= cc
 CFLAGS  ?= -O2 -g -Wall -Wextra -std=c11
+UNAME_S := $(shell uname -s)
+# libdl is a separate library on Linux; on Darwin dlopen lives in libSystem.
+ifeq ($(UNAME_S),Darwin)
+LDLIBS  :=
+else
 LDLIBS  := -ldl
+endif
 BUILD   := build
 
+# Linux aarch64 boards. Prefer a GNU cross gcc when present; otherwise zig
+# (same toolchain cargo-zigbuild uses). Always link libdl — the target is
+# Linux even when this Makefile runs on Darwin.
+ifeq ($(shell command -v aarch64-linux-gnu-gcc 2>/dev/null),)
+AARCH64_CC ?= zig cc -target aarch64-linux-gnu
+AARCH64_LDLIBS := -ldl
+else
 AARCH64_CC ?= aarch64-linux-gnu-gcc
+AARCH64_LDLIBS := -ldl -static-libgcc
+endif
 
 .PHONY: all aarch64 clean
 all: $(BUILD)/turbojpeg_bench
@@ -27,7 +42,7 @@ $(BUILD)/turbojpeg_bench: bench.c | $(BUILD)
 aarch64: $(BUILD)/turbojpeg_bench.aarch64
 
 $(BUILD)/turbojpeg_bench.aarch64: bench.c | $(BUILD)
-	$(AARCH64_CC) $(CFLAGS) -static-libgcc -o $@ $< $(LDLIBS)
+	$(AARCH64_CC) $(CFLAGS) -o $@ $< $(AARCH64_LDLIBS)
 
 clean:
 	rm -rf $(BUILD)

--- a/benchmarks/modules/turbojpeg/bench.c
+++ b/benchmarks/modules/turbojpeg/bench.c
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
@@ -82,6 +83,13 @@ static const char *tj_err(void) { return tj.error ? tj.error() : "(no tjGetError
  * only the versioned one. */
 static void tj_load(void) {
     static const char *candidates[] = {
+#ifdef __APPLE__
+        "/opt/homebrew/opt/jpeg-turbo/lib/libturbojpeg.dylib",
+        "/opt/homebrew/lib/libturbojpeg.dylib",
+        "/usr/local/opt/jpeg-turbo/lib/libturbojpeg.dylib",
+        "libturbojpeg.dylib",
+        "libturbojpeg.0.dylib",
+#endif
         "libturbojpeg.so.0",
         "libturbojpeg.so",
         "libturbojpeg.so.0.2.0",
@@ -133,8 +141,13 @@ static double percentile(const double *sorted, size_t n, double p) {
     return sorted[idx];
 }
 
-/* VmHWM, matching peak_rss_mb(). */
+/* Peak RSS, matching peak_rss_mb(). Linux VmHWM is kB; Darwin ru_maxrss is bytes. */
 static double peak_rss_mb(void) {
+#ifdef __APPLE__
+    struct rusage ru;
+    if (getrusage(RUSAGE_SELF, &ru) != 0) return 0.0;
+    return (double)ru.ru_maxrss / (1024.0 * 1024.0);
+#else
     FILE *f = fopen("/proc/self/status", "r");
     if (!f) return 0.0;
     char line[256];
@@ -148,6 +161,7 @@ static double peak_rss_mb(void) {
     }
     fclose(f);
     return mb;
+#endif
 }
 
 /* Process CPU time over the run; the decode loop is single-threaded, so this

--- a/benchmarks/scripts/decode-ab-publish.sh
+++ b/benchmarks/scripts/decode-ab-publish.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+#
+# Published decoder A/B (BENCHMARKS.md § JPEG Decode).
+#
+# Release profile, no perf/trace instrumentation. Arms alternate inside one
+# session (HAL / turbo islow / turbo ifast × YUV / RGB), pinned to one core.
+# Best-of-N p50 is the claim number.
+#
+# Usage:
+#   EDGEFIRST_BENCH_ORIN_FALLBACK=adis-uav1 \
+#     ./benchmarks/scripts/decode-ab-publish.sh imx8mp-frdm imx95-pro rpi5-hailo orin-nano
+#
+# Env:
+#   LIMIT / WARMUP / ROUNDS / PIN / CARGO_PROFILE
+#     boards default 200 / 20 / 3 / 0 / release
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BENCH_WS="${ROOT}/benchmarks"
+RESULTS="${BENCH_WS}/results"
+TARGET_TRIPLE="aarch64-unknown-linux-gnu"
+PROFILE="${CARGO_PROFILE:-release}"
+LIMIT="${LIMIT:-200}"
+WARMUP="${WARMUP:-20}"
+ROUNDS="${ROUNDS:-3}"
+PIN="${PIN:-0}"
+REMOTE_COCO="${EDGEFIRST_BENCH_COCO_REMOTE:-/data/coco/val2017}"
+REMOTE_BIN_DIR="/tmp/edgefirst-bench-decode-ab"
+
+if [[ $# -gt 0 ]]; then
+  TARGETS=("$@")
+else
+  TARGETS=(imx8mp-frdm imx95-pro rpi5-hailo orin-nano)
+fi
+
+resolve_target() {
+  local t="$1"
+  if ssh -o BatchMode=yes -o ConnectTimeout=5 "$t" 'true' 2>/dev/null; then
+    echo "$t"
+    return 0
+  fi
+  local fallback="${EDGEFIRST_BENCH_ORIN_FALLBACK:-}"
+  if [[ "$t" == "orin-nano" && -n "${fallback}" ]] \
+      && ssh -o BatchMode=yes -o ConnectTimeout=5 "${fallback}" 'true' 2>/dev/null; then
+    echo "${fallback}"
+    return 0
+  fi
+  return 1
+}
+
+remote_coco_path() {
+  local host="$1"
+  ssh "${host}" "bash -s" <<EOS
+set -euo pipefail
+for d in '${REMOTE_COCO}' "\$HOME/coco/val2017" /tmp/coco/val2017 /root/coco/val2017; do
+  if [[ -d "\$d" ]] && compgen -G "\$d/*.[Jj][Pp][Gg]" >/dev/null; then
+    echo "\$d"
+    exit 0
+  fi
+done
+exit 1
+EOS
+}
+
+parse_p50() {
+  # First "p50=N.NNN ms" in a log (HAL prints decode_p50 afterwards).
+  grep -oE 'p50=[0-9.]+ ms' "$1" | head -1 | sed -E 's/p50=([0-9.]+) ms/\1/'
+}
+
+echo "==> Building hal_cpu for ${TARGET_TRIPLE} (profile=${PROFILE})"
+(
+  cd "${BENCH_WS}"
+  cargo zigbuild --profile "${PROFILE}" --target "${TARGET_TRIPLE}" -p hal_cpu
+)
+
+BIN="${BENCH_WS}/target/${TARGET_TRIPLE}/${PROFILE}/hal_cpu"
+TJ_BIN="${BENCH_WS}/modules/turbojpeg/build/turbojpeg_bench.aarch64"
+make -C "${BENCH_WS}/modules/turbojpeg" aarch64
+
+for target in "${TARGETS[@]}"; do
+  echo "============================================"
+  echo "==> publish A/B ${target}  n=${LIMIT} rounds=${ROUNDS} pin=${PIN}"
+  echo "============================================"
+  if ! host="$(resolve_target "${target}")"; then
+    echo "SKIP: ${target} unreachable"
+    continue
+  fi
+  board_label="${target}"
+  out_dir="${RESULTS}/${board_label}/decode-ab-publish"
+  mkdir -p "${out_dir}"
+  rm -f "${out_dir}"/*.log "${out_dir}"/summary.txt
+
+  if ! coco="$(remote_coco_path "${host}")"; then
+    echo "WARN: no COCO on ${host}; run sync-coco.sh first. Skipping."
+    continue
+  fi
+  echo "  host=${host}  COCO=${coco}"
+
+  ssh "${host}" "mkdir -p '${REMOTE_BIN_DIR}'"
+  scp -q "${BIN}" "${host}:${REMOTE_BIN_DIR}/hal_cpu"
+  scp -q "${TJ_BIN}" "${host}:${REMOTE_BIN_DIR}/turbojpeg_bench"
+  ssh "${host}" "chmod +x '${REMOTE_BIN_DIR}/hal_cpu' '${REMOTE_BIN_DIR}/turbojpeg_bench'"
+
+  pin_cmd="taskset -c ${PIN}"
+  if ! ssh "${host}" "command -v taskset >/dev/null"; then
+    echo "  note: no taskset on ${host}; running unpinned"
+    pin_cmd=""
+  fi
+
+  for round in $(seq 1 "${ROUNDS}"); do
+    for fmt in yuv rgb; do
+      if [[ "${fmt}" == yuv ]]; then
+        decode_fmt=native
+      else
+        decode_fmt=rgb
+      fi
+
+      echo "  -- r${round} HAL ${fmt}"
+      # shellcheck disable=SC2029
+      ssh "${host}" \
+        "cd '${REMOTE_BIN_DIR}' && unset EDGEFIRST_TRACE && \
+         EDGEFIRST_BENCH_COCO='${coco}' ${pin_cmd} \
+         ./hal_cpu --limit ${LIMIT} --warmup ${WARMUP} --board '${board_label}' \
+         --tensor-mem mem --decode-only --decode-fmt ${decode_fmt}" \
+        >"${out_dir}/r${round}_hal_${fmt}.log" 2>&1 || echo "  FAIL HAL ${fmt} r${round}"
+
+      echo "  -- r${round} turbo islow ${fmt}"
+      # shellcheck disable=SC2029
+      ssh "${host}" \
+        "cd '${REMOTE_BIN_DIR}' && EDGEFIRST_BENCH_COCO='${coco}' ${pin_cmd} \
+         ./turbojpeg_bench --limit ${LIMIT} --warmup ${WARMUP} \
+         --board '${board_label}' --decode-only --format ${fmt} --dct accurate" \
+        >"${out_dir}/r${round}_tj_islow_${fmt}.log" 2>&1 || echo "  FAIL TJ islow ${fmt} r${round}"
+
+      echo "  -- r${round} turbo ifast ${fmt}"
+      # shellcheck disable=SC2029
+      ssh "${host}" \
+        "cd '${REMOTE_BIN_DIR}' && EDGEFIRST_BENCH_COCO='${coco}' ${pin_cmd} \
+         ./turbojpeg_bench --limit ${LIMIT} --warmup ${WARMUP} \
+         --board '${board_label}' --decode-only --format ${fmt} --dct fast" \
+        >"${out_dir}/r${round}_tj_ifast_${fmt}.log" 2>&1 || echo "  FAIL TJ ifast ${fmt} r${round}"
+    done
+  done
+
+  {
+    echo "==== ${board_label} best-of-${ROUNDS} (n=${LIMIT}, pin=${PIN}, profile=${PROFILE})"
+    for arm in hal tj_islow tj_ifast; do
+      for fmt in yuv rgb; do
+        best=""
+        rounds=""
+        for round in $(seq 1 "${ROUNDS}"); do
+          f="${out_dir}/r${round}_${arm}_${fmt}.log"
+          p="$(parse_p50 "${f}" || true)"
+          [[ -z "${p}" ]] && continue
+          rounds="${rounds}${rounds:+, }r${round}=${p}"
+          if [[ -z "${best}" ]] || awk "BEGIN{exit !(${p} < ${best})}"; then
+            best="${p}"
+          fi
+        done
+        printf "  %-10s %-4s  best=%s ms  (%s)\n" "${arm}" "${fmt}" "${best:-?}" "${rounds:-no p50}"
+      done
+    done
+  } | tee "${out_dir}/summary.txt"
+
+  echo "OK: ${out_dir}"
+done

--- a/benchmarks/scripts/decode-ab-sweep.sh
+++ b/benchmarks/scripts/decode-ab-sweep.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+#
+# Full decoder A/B sweep (BENCHMARKS.md § JPEG Decode): six arms per host.
+#
+#   hal        EdgeFirst accurate (islow-class, the default)
+#   hal_fast   EdgeFirst DctMethod::Fast (AAN, opt-in; EDGEFIRST_CODEC_DCT=fast)
+#   tj_islow   libjpeg-turbo accurate IDCT (its default)
+#   tj_ifast   libjpeg-turbo fast IDCT
+#   zune       zune-jpeg (Rust; YCbCr / RGB output)
+#   image      image crate (Rust; RGB only — its API has no raw-YUV output)
+#
+# Release profile, no perf/trace. Arms alternate inside one session per round,
+# pinned to one core. Best-of-N p50 is the claim number. Supports aarch64
+# boards and x86_64 hosts (the turbojpeg C bench is compiled on the remote
+# host with its native gcc; Rust arms are cross-built with zigbuild).
+#
+# Usage:
+#   ./benchmarks/scripts/decode-ab-sweep.sh imx8mp-frdm imx95-pro rpi5-hailo sebstation
+#
+# Env:
+#   LIMIT / WARMUP / ROUNDS / PIN / CARGO_PROFILE   as decode-ab-publish.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BENCH_WS="${ROOT}/benchmarks"
+RESULTS="${BENCH_WS}/results"
+PROFILE="${CARGO_PROFILE:-release}"
+LIMIT="${LIMIT:-200}"
+WARMUP="${WARMUP:-20}"
+ROUNDS="${ROUNDS:-3}"
+PIN="${PIN:-0}"
+REMOTE_COCO="${EDGEFIRST_BENCH_COCO_REMOTE:-/data/coco/val2017}"
+# Home-relative: /tmp is quota-limited tmpfs on some hosts (sebstation).
+REMOTE_BIN_DIR="edgefirst-bench-decode-sweep"
+
+if [[ $# -gt 0 ]]; then
+  TARGETS=("$@")
+else
+  TARGETS=(imx8mp-frdm imx95-pro rpi5-hailo sebstation)
+fi
+
+remote_coco_path() {
+  local host="$1"
+  ssh "${host}" "bash -s" <<EOS
+set -euo pipefail
+for d in '${REMOTE_COCO}' "\$HOME/coco/val2017" /tmp/coco/val2017 /root/coco/val2017; do
+  if [[ -d "\$d" ]] && compgen -G "\$d/*.[Jj][Pp][Gg]" >/dev/null; then
+    echo "\$d"
+    exit 0
+  fi
+done
+exit 1
+EOS
+}
+
+parse_p50() {
+  grep -oE 'p50=[0-9.]+ ms' "$1" | head -1 | sed -E 's/p50=([0-9.]+) ms/\1/'
+}
+
+build_for() {
+  local triple="$1"
+  (
+    cd "${BENCH_WS}"
+    cargo zigbuild --profile "${PROFILE}" --target "${triple}" -p hal_cpu -p rust_jpeg
+  )
+}
+
+for target in "${TARGETS[@]}"; do
+  echo "============================================"
+  echo "==> sweep ${target}  n=${LIMIT} rounds=${ROUNDS} pin=${PIN}"
+  echo "============================================"
+  if ! ssh -o BatchMode=yes -o ConnectTimeout=5 "${target}" 'true' 2>/dev/null; then
+    echo "SKIP: ${target} unreachable"
+    continue
+  fi
+  arch="$(ssh "${target}" 'uname -m')"
+  case "${arch}" in
+    aarch64) triple="aarch64-unknown-linux-gnu" ;;
+    x86_64) triple="x86_64-unknown-linux-gnu" ;;
+    *) echo "SKIP: ${target} unsupported arch ${arch}"; continue ;;
+  esac
+
+  out_dir="${RESULTS}/${target}/decode-ab-sweep"
+  mkdir -p "${out_dir}"
+
+  if ! coco="$(remote_coco_path "${target}")"; then
+    echo "WARN: no COCO on ${target}; run sync-coco.sh first. Skipping."
+    continue
+  fi
+  echo "  arch=${arch}  COCO=${coco}"
+
+  echo "==> Building hal_cpu + rust_jpeg for ${triple}"
+  build_for "${triple}"
+
+  ssh "${target}" "mkdir -p '${REMOTE_BIN_DIR}'"
+  scp -q "${BENCH_WS}/target/${triple}/${PROFILE}/hal_cpu" "${target}:${REMOTE_BIN_DIR}/hal_cpu"
+  scp -q "${BENCH_WS}/target/${triple}/${PROFILE}/rust_jpeg" "${target}:${REMOTE_BIN_DIR}/rust_jpeg"
+
+  # turbojpeg bench: prebuilt aarch64 cross-binary, or native gcc on x86.
+  if [[ "${arch}" == aarch64 ]]; then
+    make -C "${BENCH_WS}/modules/turbojpeg" aarch64
+    scp -q "${BENCH_WS}/modules/turbojpeg/build/turbojpeg_bench.aarch64" \
+      "${target}:${REMOTE_BIN_DIR}/turbojpeg_bench"
+  else
+    scp -q "${BENCH_WS}/modules/turbojpeg/bench.c" "${target}:${REMOTE_BIN_DIR}/bench.c"
+    ssh "${target}" "gcc -O2 -o '${REMOTE_BIN_DIR}/turbojpeg_bench' '${REMOTE_BIN_DIR}/bench.c' -ldl"
+  fi
+  ssh "${target}" "chmod +x ${REMOTE_BIN_DIR}/hal_cpu ${REMOTE_BIN_DIR}/rust_jpeg ${REMOTE_BIN_DIR}/turbojpeg_bench"
+
+  pin_cmd="taskset -c ${PIN}"
+  if ! ssh "${target}" "command -v taskset >/dev/null"; then
+    echo "  note: no taskset on ${target}; running unpinned"
+    pin_cmd=""
+  fi
+
+  run_arm() { # name round fmt command...
+    local name="$1" round="$2" fmt="$3"
+    shift 3
+    echo "  -- r${round} ${name} ${fmt}"
+    # shellcheck disable=SC2029
+    ssh "${target}" \
+      "cd '${REMOTE_BIN_DIR}' && unset EDGEFIRST_TRACE && \
+       EDGEFIRST_BENCH_COCO='${coco}' ${pin_cmd} $*" \
+      >"${out_dir}/r${round}_${name}_${fmt}.log" 2>&1 \
+      || echo "  FAIL ${name} ${fmt} r${round}"
+  }
+
+  for round in $(seq 1 "${ROUNDS}"); do
+    for fmt in yuv rgb; do
+      decode_fmt=$([[ "${fmt}" == yuv ]] && echo native || echo rgb)
+      run_arm hal "${round}" "${fmt}" \
+        "./hal_cpu --limit ${LIMIT} --warmup ${WARMUP} --board '${target}' \
+         --tensor-mem mem --decode-only --decode-fmt ${decode_fmt}"
+      run_arm hal_fast "${round}" "${fmt}" \
+        "env EDGEFIRST_CODEC_DCT=fast ./hal_cpu --limit ${LIMIT} --warmup ${WARMUP} \
+         --board '${target}' --tensor-mem mem --decode-only --decode-fmt ${decode_fmt}"
+      run_arm tj_islow "${round}" "${fmt}" \
+        "./turbojpeg_bench --limit ${LIMIT} --warmup ${WARMUP} --board '${target}' \
+         --decode-only --format ${fmt} --dct accurate"
+      run_arm tj_ifast "${round}" "${fmt}" \
+        "./turbojpeg_bench --limit ${LIMIT} --warmup ${WARMUP} --board '${target}' \
+         --decode-only --format ${fmt} --dct fast"
+      run_arm zune "${round}" "${fmt}" \
+        "./rust_jpeg --limit ${LIMIT} --warmup ${WARMUP} --engine zune --format ${fmt}"
+      if [[ "${fmt}" == rgb ]]; then
+        run_arm image "${round}" "${fmt}" \
+          "./rust_jpeg --limit ${LIMIT} --warmup ${WARMUP} --engine image --format rgb"
+      fi
+    done
+  done
+
+  {
+    echo "==== ${target} best-of-${ROUNDS} (n=${LIMIT}, pin=${PIN}, profile=${PROFILE})"
+    for arm in hal hal_fast tj_islow tj_ifast zune image; do
+      for fmt in yuv rgb; do
+        [[ "${arm}" == image && "${fmt}" == yuv ]] && continue
+        best=""
+        rounds=""
+        for round in $(seq 1 "${ROUNDS}"); do
+          f="${out_dir}/r${round}_${arm}_${fmt}.log"
+          [[ -f "${f}" ]] || continue
+          p="$(parse_p50 "${f}" || true)"
+          [[ -z "${p}" ]] && continue
+          rounds="${rounds}${rounds:+, }r${round}=${p}"
+          if [[ -z "${best}" ]] || awk "BEGIN{exit !(${p} < ${best})}"; then
+            best="${p}"
+          fi
+        done
+        printf "  %-10s %-4s  best=%s ms  (%s)\n" "${arm}" "${fmt}" "${best:-?}" "${rounds:-no p50}"
+      done
+    done
+  } | tee "${out_dir}/summary.txt"
+
+  echo "OK: ${out_dir}"
+done

--- a/crates/codec/ARCHITECTURE.md
+++ b/crates/codec/ARCHITECTURE.md
@@ -70,11 +70,12 @@ dependency graph clean.
 | `huffman.rs`     | Tier-sized lookahead Huffman LUT + combined code+magnitude fast-AC LUT, `decode_block()` emitting quantised `i16` coefficients |
 | `color.rs`       | Fused YCbCr→RGB row conversion (Q14 `SQRDMULH` / matching SSE4.1 `qrdmulh`, NEON + Intel + bit-exact scalar) |
 | `idct.rs`        | IDCT dispatcher (scalar/NEON/x86 via `NeonTier`/`IntelTier`); kernels dequantise internally |
+| `idct/fast.rs`   | Opt-in AAN `ifast`-class IDCT (`DctMethod::Fast`, off by default): AAN scale factors folded into the dequant table, four Q15 `SQDMULH` constants, 16-bit lanes end to end; scalar reference + NEON kernel, bit-exact to each other. COCO-measured accuracy vs the default kernel: cosine ≥ 0.99985, PSNR ≥ 42 dB, max pixel delta 24 |
 | `idct/scalar.rs` | Two-pass Loeffler 8×8 IDCT with DC-only fast path; the reference every SIMD kernel is asserted against, so it wraps and saturates where the vector kernels are forced to |
 | `idct/neon.rs`   | NEON 8×8 IDCT on 16-bit coefficients: 8-lane dequant, lane-indexed `vmull` Loeffler butterfly, sparse bottom-row/right-column shortcuts, register-resident workspace |
 | `idct/sse2.rs`   | x86 8×8 IDCT: 16-bit-lane `islow` Loeffler, `pmullw` dequant + `pmaddwd` butterflies (shared by all Intel tiers) |
 | `idct/avx2.rs`   | VEX-encoded build of the `sse2.rs` kernel |
-| `mcu.rs`         | MCU decode loop, `McuScratch`, native `Grey`/`Nv12`/`Nv16`/`Nv24` row writes, fused `Rgb`/`Nv12` writes (NEON/SSE chroma downsample), chroma downsample for the non-matching subsamplings (`avg_block`) |
+| `mcu.rs`         | MCU decode loops — dedicated 4:4:4 1×1 direct loop (`decode_image_444_direct`: tables resolved to plain locals, no sampling loops; the generic loop's frame spilled past the register file and cost 4–8% on every core) + generic sampling loop — `McuScratch`, native `Grey`/`Nv12`/`Nv16`/`Nv24` row writes, fused `Rgb`/`Nv12` writes (NEON/SSE chroma downsample), chroma downsample for the non-matching subsamplings (`avg_block`) |
 | `v4l2/`          | Optional Linux hardware JPEG backend (see below)     |
 | `nvjpeg/`        | Optional nvJPEG GPU backend (Linux + CUDA, see below) |
 
@@ -135,10 +136,12 @@ and silently falls back to native otherwise, so callers can set it
 unconditionally:
 
 - **`Rgb`** — 4:4:4 colour JPEGs only (every component at full resolution, so
-  no chroma resampling is needed). Each MCU row band goes through the
-  `color.rs` YCbCr→RGB kernel: Q14 fixed point on the `SQRDMULH`
+  no chroma resampling is needed). Standard 1×1 sampling converts each MCU
+  through the `color.rs` YCbCr→RGB kernel as it is produced (no planar
+  scratch); other 4:4:4 MCU sizes still convert a full MCU-row band via
+  `write_rgb_rows`. The kernel is Q14 fixed point on the `SQRDMULH`
   rounding-doubling high-half multiply (baseline ASIMD, so the same kernel
-  runs A53 → Apple Silicon), `vst3q_u8` interleaved stores, and a scalar path
+  runs A53 → Apple Silicon), `vst3` interleaved stores, and a scalar path
   that reproduces the arithmetic bit-for-bit. Other subsamplings fall back to
   native NV output.
 - **`Nv12`** — any colour JPEG. 4:2:0 passes through; 4:4:4 is 2×2
@@ -289,8 +292,10 @@ processor.convert(&tensor, &mut dst, rot, flip, Crop::new())?;
 The custom baseline JPEG decoder processes images through these stages:
 
 1. **Marker parsing** (`markers.rs`): parse SOF0, DQT, DHT, DRI, SOS, APP1
-   segments. Build Huffman tables, quantisation tables, and read the EXIF
-   orientation tag (reported only).
+   segments. Quantisation tables are built from DQT; Huffman LUTs are taken
+   from `JpegDecoderState`'s `HuffmanCache` when the DHT payload matches the
+   previous frame (moved, not cloned), otherwise rebuilt. EXIF orientation is
+   read and reported only.
 2. **Native format + capacity** (`mod.rs`): derive the native format
    (`native_format()`: 1 component → `Grey`; 3 components → `Nv24`/`Nv16`/`Nv12`
    from the chroma-to-luma sampling ratio) and reconfigure the destination
@@ -309,10 +314,13 @@ The custom baseline JPEG decoder processes images through these stages:
    c. **Write** (`mcu.rs`): `write_grey_rows` copies the luma plane for
       `Grey`; `write_nv12_rows` writes the Y plane and the interleaved Cb/Cr
       plane, downsampling chroma to 4:2:0 via `avg_block` (passthrough for an
-      already-4:2:0 source, block-average for 4:2:2 / 4:4:4 / 4:4:0). With a
-      fused output resolved, `write_rgb_rows` converts YCbCr→RGB per row
-      (`color.rs`), or the NEON chroma-downsample kernels feed the NV12
-      writer. All write at the tensor's `effective_row_stride()`.
+      already-4:2:0 source, block-average for 4:2:2 / 4:4:4 / 4:4:0). Standard
+      4:4:4 (1×1 sampling) writes NV24 UV per MCU (`write_nv24_uv_block`) so
+      chroma never lands in the planar scratch. With fused `Rgb` on that same
+      1×1 path, `ycbcr_to_rgb_blocks` converts paired 8×8 MCUs through
+      `color.rs` (16-pixel `vst3q_u8` NEON, one dispatch per pair) instead of
+      a second full-row pass. Other fused RGB (non-1×1 4:4:4) still uses
+      `write_rgb_rows`. All write at the tensor's `effective_row_stride()`.
 5. **Return** `ImageInfo` with decoded dimensions, native format, row stride,
    and the reported EXIF orientation.
 
@@ -335,14 +343,55 @@ three places take deliberate care:
 
 **Key optimisations:**
 - `JpegDecoderState` persists across frames — `McuScratch` buffers grow to the
-  high-water mark and are reused. After the first decode at a given resolution,
-  the JPEG decoder performs zero heap allocations (per-scan Huffman table
-  pointers and DC predictors live in fixed-size stack arrays).
+  high-water mark and are reused. Huffman LUTs live in `HuffmanCache` and are
+  moved into the parse result for the decode, then restored: when the DHT
+  payload is unchanged (typical of a camera stream), the second frame onwards
+  allocates nothing for table construction. After the first decode at a given
+  resolution, the JPEG decoder performs zero heap allocations (per-scan Huffman
+  table pointers and DC predictors live in fixed-size stack arrays).
 - Combined **fast-AC LUT** (stb_image model): where a Huffman code *and* its
   magnitude bits both fit in the tier's lookahead window, a single table hit
   yields the sign-extended coefficient, zero-run, and total bits to consume —
   one peek + one consume per coefficient on the fast path, for DC and AC
-  alike. Misses (EOB/ZRL, long codes) fall back to the two-step LUT.
+  alike. Size-0 symbols are baked in rather than treated as misses: DC size 0
+  (predictor unchanged) is a plain value-0 hit, ZRL is a run-15/value-0 hit
+  (the written zero lands in a slot the clear discipline already guarantees is
+  zero), and **EOB carries a run-0xFF sentinel** that pushes `k` past 63 so the
+  block decoder's existing bounds branch resolves end-of-block — the common
+  block exit costs no extra hot-path compare and never touches the two-step
+  LUT. Only long codes (> `fast_bits`) still fall back.
+- **Paired-coefficient probe** (`HuffmanTable::pair_ac`, `NeonTier::High`
+  only): decodes up to two coefficients per table hit when both fit the
+  lookahead window (~54% of COCO AC coefficients at 10 bits). Singles bake as
+  phantom pairs (value-0 second write into the next undecoded slot, `k`
+  advanced by `(val2 != 0)` — branchless) so the probe keeps the single
+  table's ~94% hit rate. A pair whose first coefficient lands on zigzag 63
+  rewinds to a single via the `fast_ac` probe: the entry's second symbol was
+  built from the next block's bits. Per-tier because in-order A53/A55 retire
+  the phantom overhead with no OoO slack to hide it (measured −1-3%), while
+  the A76 gains ~2.7%; the instantiation is selected once per decode as a fn
+  pointer — keeping a second live call site in the MCU loop cost ~7% on the
+  A53.
+- **Register-resident bit cursor** (`BitCursor`): the block decoder copies the
+  `BitStream` state into a function-local cursor and commits it back on every
+  exit. `&mut BitStream` is caller-visible memory, and `perf annotate` on
+  Cortex-A53 showed `avail` written back to the struct on every decoded
+  coefficient; the cursor keeps the whole bit buffer in registers
+  (libjpeg-turbo `BITREAD_LOAD_STATE`/`SAVE_STATE` discipline).
+  `decode_block` is `#[inline(never)]` to keep its register-allocation problem
+  out of the MCU loop's already-spilling frame — letting it inline cost ~20%
+  of A53 decode time (measured 7.68 → 9.23 ms p50 on imx8mp COCO).
+- **Entropy-derived IDCT sparsity** (`BlockInfo::last_k`): the highest zigzag
+  index written is a free by-product of the scan order, and because zigzag
+  fills the top-left corner first, a small `last_k` proves whole regions zero.
+  The NEON kernel picks a tier from it without re-deriving sparsity from the
+  coefficient vectors (`last_k ≤ 1` DC-broadcast left half, `≤ 9` sparse
+  butterfly, `≤ 13` full-left/zero-right, else the value-detection kernel),
+  loading only the rows that participate — 64-bit `vld1_s16` loads on the
+  proven-sparse tiers, which matches the Cortex-A53's 64-bit load path. The
+  de-zigzag table is padded (`ZIGZAG_EXT[320]`) so the natural-index load can
+  issue before the bounds branch instead of address-stalling the coefficient
+  store.
 - Runtime **`NeonTier`** / **`IntelTier`** (`cpu.rs`): one binary picks Huffman
   lookahead width, entropy prefetch distance, and SIMD kernels per
   micro-architecture / ISA. AArch64 uses HWCAP `dotprod`/`i8mm` plus a Linux
@@ -355,19 +404,25 @@ three places take deliberate care:
   no per-coefficient multiply) and the SIMD kernels dequantise 8 lanes at a
   time on load.
 - DC-only IDCT fast path: when all 63 AC coefficients are zero, the IDCT reduces
-  to a constant fill (single multiply + shift).
-- Function pointer dispatch for the IDCT: selected once at init from the active
-  CPU tier (NEON on AArch64; AVX2 > SSE4.1 > SSE2 on x86-64; scalar fallback).
+  to a constant fill (single multiply + shift). The NEON 8×8 kernel further
+  special-cases each 4×8 half whose rows 1–7 are zero (turbo islow case 2).
+- On AArch64 the MCU loop binds the NEON IDCT as a fn-item (direct `bl` per
+  block) rather than an `IdctFn` pointer; other ISAs still select a pointer
+  once at decode start.
 
 ### NV Output Path
 
 For a colour JPEG the decoder produces a semi-planar NV format directly,
 skipping any YCbCr→RGB conversion:
 
-- The Y plane is copied from the IDCT luma output at the tensor's row stride.
+- The Y plane is copied from the IDCT luma output at the tensor's row stride
+  (or written directly during IDCT for full MCU-row bands).
 - The Cb/Cr components are interleaved pair-wise into the UV plane that follows
-  the Y plane, at the source's own chroma resolution. `avg_block` downsamples
-  first only for the exotic subsamplings that have no matching NV format.
+  the Y plane, at the source's own chroma resolution. Standard 4:4:4 (1×1)
+  interleaves each 8×8 chroma block as it is produced (`write_nv24_uv_block`);
+  4:2:2 and non-1×1 4:4:4 still gather a planar MCU-row band then `vst2`
+  a full row. `avg_block` downsamples first only for the exotic subsamplings
+  that have no matching NV format.
 
 These NV formats are the codec's only colour output. The chroma carries the
 source's JFIF (BT.601 full-range) colorimetry; mapping that to RGB is the
@@ -402,7 +457,7 @@ path; fused RGB and exotic NV12 averaging take the color/downsample kernels.
 
 | Kernel   | Strategy                                          | Throughput              |
 |----------|---------------------------------------------------|-------------------------|
-| **IDCT** | 16-bit coefficients end-to-end (libjpeg-turbo `jidctint-neon` model): 8-lane `vmulq_s16` dequant, Loeffler butterfly via `vmull_s16`/`vmlal_s16` 16×16→32 multiplies, `vrshrn` descale, register-resident `int16x8` workspace (no memory round-trip), `trn`-based 16-bit and 8-bit 8×8 transposes. Sparse shortcuts skip the butterfly for all-zero bottom rows (pass 1) and all-zero right columns (both passes) — the dominant shapes of quantised natural-image blocks. DC-only fills 8 bytes via `vdup`/`vst1` | 8 columns per pass-1 sweep, 8 rows per pass-2 sweep |
+| **IDCT** | 16-bit coefficients end-to-end (libjpeg-turbo `jidctint-neon` model): 8-lane `vmulq_s16` dequant, Loeffler butterfly via `vmull_s16`/`vmlal_s16` 16×16→32 multiplies, `vrshrn` descale, register-resident `int16x8` workspace (no memory round-trip), `trn`-based 16-bit and 8-bit 8×8 transposes. Sparse shortcuts skip the butterfly for all-zero bottom rows (pass 1) and all-zero right columns (both passes); a further per-half DC-only path (rows 1–7 of a 4×8 half all zero) broadcasts `saturate(dequant(row0) << PASS1_BITS)`, matching turbo's islow special case 2 — the remaining in-order gap after whole-block DC-only is taken in the MCU loop. DC-only fills 8 bytes via `vdup`/`vst1` | 8 columns per pass-1 sweep, 8 rows per pass-2 sweep |
 
 The butterfly constants are held in two `int16x8` registers and addressed by
 lane (`vmull_laneq_s16`), not splatted per multiply: the butterfly is inlined
@@ -686,8 +741,9 @@ codec.decode_jpeg                                       [user-facing fn]
 │   └── codec.decode_jpeg.v4l2_copy_out                 ← scratch → tensor write (absent on the zero-copy target)
 │       field: kind = "nv12" | "grey" | "yuv24_to_nv24"
 └── codec.decode_jpeg.mcu_loop                          ← Huffman + IDCT + write stage (CPU path only)
-    ├── codec.decode_jpeg.mcu_row.huffman_idct          ← per MCU-row entropy + IDCT
+    ├── codec.decode_jpeg.mcu_row.huffman_idct          ← per MCU-row entropy + IDCT (4:4:4 1×1 also writes NV24 UV / fused RGB here)
     ├── codec.decode_jpeg.write_nv12 / write_nv16 / write_nv24 / write_grey / write_rgb
+        (write_nv24 / write_rgb absent for standard 1×1 4:4:4 — those writes are folded into huffman_idct)
 
 codec.decode_png                                        [user-facing fn]
 │ fields: dtype, n_bytes
@@ -809,7 +865,7 @@ call. The edgefirst-codec PNG layer reuses `ImageDecoder.input_buffer` for
 | Layer                    | After Warmup     | Notes                        |
 |--------------------------|------------------|------------------------------|
 | JPEG `McuScratch`        | No allocations   | Grows to high-water mark     |
-| JPEG Huffman/quant tables| No allocations   | Rebuilt from marker data     |
+| JPEG Huffman/quant tables| No allocations   | LUTs reused when DHT unchanged; otherwise rebuilt from marker data |
 | JPEG IDCT workspace      | No allocations   | Stack-allocated (`[i32; 64]` scalar/SSE; NEON keeps it in registers) |
 | JPEG native row write    | No allocations   | Strided into pre-allocated tensor |
 | V4L2 streaming session   | No allocations   | OUTPUT buffer + DMA scratch persist; geometry changes are ioctl-only |

--- a/crates/codec/TESTING.md
+++ b/crates/codec/TESTING.md
@@ -19,7 +19,7 @@ Inline `#[cfg(test)]` modules in each source file:
 | `jpeg/color.rs`       | YCbCr→RGB scalar vs float (±1); dispatch bit-exact vs scalar |
 | `jpeg/cpu.rs`         | `NeonTier` / `IntelTier` probe sanity + entropy helpers |
 | `jpeg/idct/scalar.rs` | DC-only shortcut, known coefficient IDCT            |
-| `jpeg/idct/{neon,sse2,avx2}.rs` | Scalar↔SIMD parity per kernel (bit-exact on x86, ±1 on NEON) |
+| `jpeg/idct/{neon,sse2,avx2}.rs` | Scalar↔SIMD parity per kernel (bit-exact on x86, ±1 on NEON); NEON also covers per-half DC-only (row-0-only, left-DC/right-AC) |
 | `jpeg/idct.rs`        | Selected-tier dispatch; coefficients that overflow the 16-bit dequant neither panic under overflow checks nor write outside the block |
 | `jpeg/v4l2/format.rs` | `classify()` CAPTURE FourCC → `CapKind`             |
 | `jpeg/v4l2/mod.rs`    | Backend helpers (geometry/format negotiation logic) |
@@ -192,7 +192,7 @@ allocation-free in the hot loop.
 | Layer                    | After Warmup     | Notes                        |
 |--------------------------|------------------|------------------------------|
 | JPEG `McuScratch`        | No allocations   | Grows to high-water mark     |
-| JPEG Huffman/quant tables| No allocations   | Rebuilt from marker data     |
+| JPEG Huffman/quant tables| No allocations   | LUTs reused when DHT unchanged; otherwise rebuilt from marker data |
 | JPEG IDCT workspace      | No allocations   | Stack-allocated `[i32; 64]`  |
 | JPEG native row write    | No allocations   | Strided into pre-allocated tensor |
 | V4L2 streaming session   | No allocations   | OUTPUT buffer + DMA scratch persist; geometry changes are ioctl-only |

--- a/crates/codec/src/decoder.rs
+++ b/crates/codec/src/decoder.rs
@@ -9,6 +9,25 @@ use crate::pixel::ImagePixel;
 use edgefirst_tensor::{Tensor, TensorDyn};
 use std::io::Read;
 
+/// IDCT accuracy/speed selection for the software JPEG decoder.
+///
+/// [`Accurate`](Self::Accurate) is the default and the kernel every published
+/// benchmark quotes: the `islow`-class Loeffler IDCT, bit-comparable to
+/// libjpeg-turbo's default. [`Fast`](Self::Fast) opts into the AAN
+/// `ifast`-class kernel — roughly an eighth of the multiplies, at a small,
+/// bounded pixel accuracy cost (and the documented `ifast` degeneration at
+/// very high quality factors). Fast is advisory: paths without a fast kernel
+/// (non-NEON tiers, hardware V4L2/nvJPEG decoders, PNG) use their normal
+/// accurate path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DctMethod {
+    /// Accurate `islow`-class IDCT (default).
+    #[default]
+    Accurate,
+    /// Fast AAN `ifast`-class IDCT (opt-in).
+    Fast,
+}
+
 /// Reusable image decoder with internal scratch buffers.
 ///
 /// Create one `ImageDecoder` at program initialisation and pass it to
@@ -42,25 +61,6 @@ use std::io::Read;
 ///     let _info = tensor.load_image(&mut decoder, &frame);
 /// }
 /// ```
-/// IDCT accuracy/speed selection for the software JPEG decoder.
-///
-/// [`Accurate`](Self::Accurate) is the default and the kernel every published
-/// benchmark quotes: the `islow`-class Loeffler IDCT, bit-comparable to
-/// libjpeg-turbo's default. [`Fast`](Self::Fast) opts into the AAN
-/// `ifast`-class kernel — roughly an eighth of the multiplies, at a small,
-/// bounded pixel accuracy cost (and the documented `ifast` degeneration at
-/// very high quality factors). Fast is advisory: paths without a fast kernel
-/// (non-NEON tiers, hardware V4L2/nvJPEG decoders, PNG) use their normal
-/// accurate path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum DctMethod {
-    /// Accurate `islow`-class IDCT (default).
-    #[default]
-    Accurate,
-    /// Fast AAN `ifast`-class IDCT (opt-in).
-    Fast,
-}
-
 pub struct ImageDecoder {
     /// Reusable JPEG decoder state (Huffman tables, MCU scratch buffers).
     pub(crate) jpeg_state: crate::jpeg::JpegDecoderState,

--- a/crates/codec/src/decoder.rs
+++ b/crates/codec/src/decoder.rs
@@ -42,6 +42,25 @@ use std::io::Read;
 ///     let _info = tensor.load_image(&mut decoder, &frame);
 /// }
 /// ```
+/// IDCT accuracy/speed selection for the software JPEG decoder.
+///
+/// [`Accurate`](Self::Accurate) is the default and the kernel every published
+/// benchmark quotes: the `islow`-class Loeffler IDCT, bit-comparable to
+/// libjpeg-turbo's default. [`Fast`](Self::Fast) opts into the AAN
+/// `ifast`-class kernel — roughly an eighth of the multiplies, at a small,
+/// bounded pixel accuracy cost (and the documented `ifast` degeneration at
+/// very high quality factors). Fast is advisory: paths without a fast kernel
+/// (non-NEON tiers, hardware V4L2/nvJPEG decoders, PNG) use their normal
+/// accurate path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DctMethod {
+    /// Accurate `islow`-class IDCT (default).
+    #[default]
+    Accurate,
+    /// Fast AAN `ifast`-class IDCT (opt-in).
+    Fast,
+}
+
 pub struct ImageDecoder {
     /// Reusable JPEG decoder state (Huffman tables, MCU scratch buffers).
     pub(crate) jpeg_state: crate::jpeg::JpegDecoderState,
@@ -80,6 +99,13 @@ impl ImageDecoder {
     /// fused RGB that convert step is typically a pure resize.
     pub fn set_output_format(&mut self, format: Option<edgefirst_tensor::PixelFormat>) {
         self.jpeg_state.preferred_format = format;
+    }
+
+    /// Select the software JPEG IDCT kernel class — see [`DctMethod`].
+    /// Off (Accurate) by default; `EDGEFIRST_CODEC_DCT=fast` in the
+    /// environment flips a **new** decoder's default for A/B runs.
+    pub fn set_dct_method(&mut self, method: DctMethod) {
+        self.jpeg_state.fast_dct = method == DctMethod::Fast;
     }
 
     /// Decode image data into a typed tensor, configuring its dimensions and

--- a/crates/codec/src/jpeg/bitstream.rs
+++ b/crates/codec/src/jpeg/bitstream.rs
@@ -44,6 +44,15 @@ fn any_byte_ff(w: u64) -> bool {
 ///
 /// Bits are buffered top-aligned in a u64 accumulator. Handles JPEG's
 /// byte-stuffing convention (0xFF 0x00 → single 0xFF data byte).
+///
+/// The hot block loop does not operate on this struct directly: it takes a
+/// [`BitCursor`] copy of the state ([`Self::cursor`]), runs on that, and
+/// [`Self::commit`]s at exit. `&mut BitStream` is caller-visible memory, so
+/// LLVM must keep its fields coherent across every potential exit — `perf
+/// annotate` on Cortex-A53 showed a store of `avail` back into the struct on
+/// every decoded coefficient. The cursor is a function-local the optimizer
+/// can prove non-escaping, which keeps the whole state in registers
+/// (libjpeg-turbo's `BITREAD_LOAD_STATE` / `BITREAD_SAVE_STATE` discipline).
 pub struct BitStream<'a> {
     data: &'a [u8],
     pos: usize,
@@ -56,6 +65,20 @@ pub struct BitStream<'a> {
     prefetch: usize,
     /// Set once the buffer has handed out bits past the end of the entropy
     /// data. Only ever written on the exhausted branch of the cold refill.
+    overran: bool,
+}
+
+/// Register-resident working copy of a [`BitStream`]'s state.
+///
+/// Created by [`BitStream::cursor`], written back by [`BitStream::commit`].
+/// All hot-path operations live here; `BitStream` methods delegate through a
+/// cursor so there is a single implementation of the refill logic.
+pub struct BitCursor<'a> {
+    data: &'a [u8],
+    pos: usize,
+    bits: u64,
+    avail: i32,
+    prefetch: usize,
     overran: bool,
 }
 
@@ -86,6 +109,31 @@ impl<'a> BitStream<'a> {
         self.pos
     }
 
+    /// Copy the state into a register-resident working cursor.
+    #[inline(always)]
+    pub fn cursor(&self) -> BitCursor<'a> {
+        BitCursor {
+            data: self.data,
+            pos: self.pos,
+            bits: self.bits,
+            avail: self.avail,
+            prefetch: self.prefetch,
+            overran: self.overran,
+        }
+    }
+
+    /// Write a cursor's state back. Must be called on every exit path of a
+    /// loop that took a [`Self::cursor`], including error exits.
+    #[inline(always)]
+    pub fn commit(&mut self, cur: BitCursor<'a>) {
+        self.pos = cur.pos;
+        self.bits = cur.bits;
+        self.avail = cur.avail;
+        self.overran = cur.overran;
+    }
+}
+
+impl<'a> BitCursor<'a> {
     #[inline(always)]
     fn prefetch_ahead(&self) {
         if self.prefetch == 0 {
@@ -180,14 +228,6 @@ impl<'a> BitStream<'a> {
         }
     }
 
-    /// Whether the stream was ever asked for bits past the end of the entropy
-    /// data, i.e. the scan is truncated and part of the image is zero padding
-    /// rather than decoded content.
-    #[inline]
-    pub fn overran(&self) -> bool {
-        self.overran
-    }
-
     /// Peek at the top `n` bits without consuming them (n ≤ 56).
     ///
     /// Does **not** refill — the caller must uphold the [`refill`] contract.
@@ -213,12 +253,34 @@ impl<'a> BitStream<'a> {
         self.consume(n);
         val
     }
+}
+
+impl<'a> BitStream<'a> {
+    /// Top up the buffer to ≥ 32 bits. Cold-path convenience that round-trips
+    /// through a [`BitCursor`]; hot loops hold their own cursor instead.
+    #[inline]
+    fn refill(&mut self) {
+        let mut cur = self.cursor();
+        cur.refill();
+        self.commit(cur);
+    }
+
+    /// Whether the stream was ever asked for bits past the end of the entropy
+    /// data, i.e. the scan is truncated and part of the image is zero padding
+    /// rather than decoded content.
+    #[inline]
+    pub fn overran(&self) -> bool {
+        self.overran
+    }
 
     /// Read `n` bits with an internal refill (test helper).
     #[cfg(test)]
     pub fn read_bits(&mut self, n: u8) -> u32 {
-        self.refill();
-        self.get_bits(n)
+        let mut cur = self.cursor();
+        cur.refill();
+        let val = cur.get_bits(n);
+        self.commit(cur);
+        val
     }
 
     /// JPEG sign-extension (libjpeg `HUFF_EXTEND`) — branchless.

--- a/crates/codec/src/jpeg/color.rs
+++ b/crates/codec/src/jpeg/color.rs
@@ -84,6 +84,117 @@ fn ycbcr_to_rgb_row_scalar(y: &[u8], cb: &[u8], cr: &[u8], dst: &mut [u8], start
     }
 }
 
+/// Convert one or two adjacent 8×8 4:4:4 MCU blocks to interleaved RGB.
+///
+/// Pairing two full blocks keeps the 16-pixel `vst3q` kernel and does one ISA
+/// dispatch for the whole pair. Calling [`ycbcr_to_rgb_row`] per 8-pixel MCU
+/// row was thousands of extra calls (and a feature-detect each time) on
+/// in-order A53/A55.
+#[allow(clippy::too_many_arguments)]
+pub fn ycbcr_to_rgb_blocks(
+    y0: &[u8; 64],
+    cb0: &[u8; 64],
+    cr0: &[u8; 64],
+    right: Option<(&[u8; 64], &[u8; 64], &[u8; 64])>,
+    dst: &mut [u8],
+    stride: usize,
+    x: usize,
+    y: usize,
+    cols0: usize,
+    cols1: usize,
+    rows: usize,
+) {
+    #[cfg(target_arch = "aarch64")]
+    {
+        use super::cpu::{neon_tier, NeonTier};
+        if !matches!(neon_tier(), NeonTier::Scalar)
+            && std::arch::is_aarch64_feature_detected!("neon")
+        {
+            if let Some((y1, cb1, cr1)) = right {
+                if cols0 == 8 && cols1 == 8 {
+                    // SAFETY: 8×`rows` source samples per plane; destination
+                    // holds 16 RGB pixels per row at `stride`.
+                    unsafe {
+                        ycbcr_to_rgb_block16_neon(
+                            y0, cb0, cr0, y1, cb1, cr1, dst, stride, x, y, rows,
+                        );
+                    }
+                    return;
+                }
+            } else if cols0 == 8 {
+                // SAFETY: 8×`rows` source samples; 8 RGB pixels per row.
+                unsafe { ycbcr_to_rgb_block8_neon(y0, cb0, cr0, dst, stride, x, y, rows) };
+                return;
+            }
+        }
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        if super::cpu::intel_tier().has_sse41() {
+            if let Some((y1, cb1, cr1)) = right {
+                if cols0 == 8 && cols1 == 8 {
+                    // SAFETY: SSE4.1 probed; same bounds contract as NEON above.
+                    unsafe {
+                        ycbcr_to_rgb_block16_sse41(
+                            y0, cb0, cr0, y1, cb1, cr1, dst, stride, x, y, rows,
+                        );
+                    }
+                    return;
+                }
+            }
+        }
+    }
+    for r in 0..rows {
+        let d = (y + r) * stride + x * 3;
+        ycbcr_to_rgb_row(
+            &y0[r * 8..],
+            &cb0[r * 8..],
+            &cr0[r * 8..],
+            &mut dst[d..],
+            cols0,
+        );
+        if let Some((y1, cb1, cr1)) = right {
+            if cols1 > 0 {
+                let d1 = d + cols0 * 3;
+                ycbcr_to_rgb_row(
+                    &y1[r * 8..],
+                    &cb1[r * 8..],
+                    &cr1[r * 8..],
+                    &mut dst[d1..],
+                    cols1,
+                );
+            }
+        }
+    }
+}
+
+/// Q14 butterfly on 8 i16 lanes → packed u8. Shared by the row and MCU-block
+/// NEON writers so 8-wide and 16-wide stores stay bit-identical.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[inline]
+unsafe fn ycbcr_half_neon(
+    yv: core::arch::aarch64::int16x8_t,
+    cbv: core::arch::aarch64::int16x8_t,
+    crv: core::arch::aarch64::int16x8_t,
+) -> (
+    core::arch::aarch64::uint8x8_t,
+    core::arch::aarch64::uint8x8_t,
+    core::arch::aarch64::uint8x8_t,
+) {
+    use core::arch::aarch64::*;
+    let c128 = vdupq_n_s16(128);
+    let cb2 = vshlq_n_s16::<1>(vsubq_s16(cbv, c128));
+    let cr2 = vshlq_n_s16::<1>(vsubq_s16(crv, c128));
+    let r = vaddq_s16(yv, vqrdmulhq_n_s16(cr2, CR_R));
+    let g = vsubq_s16(
+        vsubq_s16(yv, vqrdmulhq_n_s16(cb2, CB_G)),
+        vqrdmulhq_n_s16(cr2, CR_G),
+    );
+    let b = vaddq_s16(yv, vqrdmulhq_n_s16(cb2, CB_B));
+    (vqmovun_s16(r), vqmovun_s16(g), vqmovun_s16(b))
+}
+
 /// 16 pixels per iteration: two 8-lane s16 halves through the Q14 butterfly,
 /// then one `vst3q_u8` interleaved store.
 #[cfg(target_arch = "aarch64")]
@@ -91,36 +202,18 @@ fn ycbcr_to_rgb_row_scalar(y: &[u8], cb: &[u8], cr: &[u8], dst: &mut [u8], start
 unsafe fn ycbcr_to_rgb_row_neon(y: &[u8], cb: &[u8], cr: &[u8], dst: &mut [u8], n: usize) {
     use core::arch::aarch64::*;
 
-    #[inline(always)]
-    unsafe fn half(
-        yv: int16x8_t,
-        cbv: int16x8_t,
-        crv: int16x8_t,
-    ) -> (uint8x8_t, uint8x8_t, uint8x8_t) {
-        let c128 = vdupq_n_s16(128);
-        let cb2 = vshlq_n_s16::<1>(vsubq_s16(cbv, c128));
-        let cr2 = vshlq_n_s16::<1>(vsubq_s16(crv, c128));
-        let r = vaddq_s16(yv, vqrdmulhq_n_s16(cr2, CR_R));
-        let g = vsubq_s16(
-            vsubq_s16(yv, vqrdmulhq_n_s16(cb2, CB_G)),
-            vqrdmulhq_n_s16(cr2, CR_G),
-        );
-        let b = vaddq_s16(yv, vqrdmulhq_n_s16(cb2, CB_B));
-        (vqmovun_s16(r), vqmovun_s16(g), vqmovun_s16(b))
-    }
-
     let mut i = 0usize;
     while i + 16 <= n {
         let yq = vld1q_u8(y.as_ptr().add(i));
         let cbq = vld1q_u8(cb.as_ptr().add(i));
         let crq = vld1q_u8(cr.as_ptr().add(i));
 
-        let (r_lo, g_lo, b_lo) = half(
+        let (r_lo, g_lo, b_lo) = ycbcr_half_neon(
             vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(yq))),
             vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(cbq))),
             vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(crq))),
         );
-        let (r_hi, g_hi, b_hi) = half(
+        let (r_hi, g_hi, b_hi) = ycbcr_half_neon(
             vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(yq))),
             vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(cbq))),
             vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(crq))),
@@ -135,7 +228,7 @@ unsafe fn ycbcr_to_rgb_row_neon(y: &[u8], cb: &[u8], cr: &[u8], dst: &mut [u8], 
         i += 16;
     }
     while i + 8 <= n {
-        let (r, g, b) = half(
+        let (r, g, b) = ycbcr_half_neon(
             vreinterpretq_s16_u16(vmovl_u8(vld1_u8(y.as_ptr().add(i)))),
             vreinterpretq_s16_u16(vmovl_u8(vld1_u8(cb.as_ptr().add(i)))),
             vreinterpretq_s16_u16(vmovl_u8(vld1_u8(cr.as_ptr().add(i)))),
@@ -144,6 +237,80 @@ unsafe fn ycbcr_to_rgb_row_neon(y: &[u8], cb: &[u8], cr: &[u8], dst: &mut [u8], 
         i += 8;
     }
     ycbcr_to_rgb_row_scalar(y, cb, cr, dst, i, n);
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn ycbcr_to_rgb_block8_neon(
+    y: &[u8; 64],
+    cb: &[u8; 64],
+    cr: &[u8; 64],
+    dst: &mut [u8],
+    stride: usize,
+    x: usize,
+    y0: usize,
+    rows: usize,
+) {
+    use core::arch::aarch64::*;
+    for r in 0..rows {
+        let src = r * 8;
+        let (rv, gv, bv) = ycbcr_half_neon(
+            vreinterpretq_s16_u16(vmovl_u8(vld1_u8(y.as_ptr().add(src)))),
+            vreinterpretq_s16_u16(vmovl_u8(vld1_u8(cb.as_ptr().add(src)))),
+            vreinterpretq_s16_u16(vmovl_u8(vld1_u8(cr.as_ptr().add(src)))),
+        );
+        let d = (y0 + r) * stride + x * 3;
+        vst3_u8(dst.as_mut_ptr().add(d), uint8x8x3_t(rv, gv, bv));
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn ycbcr_to_rgb_block16_neon(
+    y0: &[u8; 64],
+    cb0: &[u8; 64],
+    cr0: &[u8; 64],
+    y1: &[u8; 64],
+    cb1: &[u8; 64],
+    cr1: &[u8; 64],
+    dst: &mut [u8],
+    stride: usize,
+    x: usize,
+    y: usize,
+    rows: usize,
+) {
+    use core::arch::aarch64::*;
+    for r in 0..rows {
+        let src = r * 8;
+        let yq = vcombine_u8(vld1_u8(y0.as_ptr().add(src)), vld1_u8(y1.as_ptr().add(src)));
+        let cbq = vcombine_u8(
+            vld1_u8(cb0.as_ptr().add(src)),
+            vld1_u8(cb1.as_ptr().add(src)),
+        );
+        let crq = vcombine_u8(
+            vld1_u8(cr0.as_ptr().add(src)),
+            vld1_u8(cr1.as_ptr().add(src)),
+        );
+        let (r_lo, g_lo, b_lo) = ycbcr_half_neon(
+            vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(yq))),
+            vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(cbq))),
+            vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(crq))),
+        );
+        let (r_hi, g_hi, b_hi) = ycbcr_half_neon(
+            vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(yq))),
+            vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(cbq))),
+            vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(crq))),
+        );
+        let rgb = uint8x16x3_t(
+            vcombine_u8(r_lo, r_hi),
+            vcombine_u8(g_lo, g_hi),
+            vcombine_u8(b_lo, b_hi),
+        );
+        let d = (y + r) * stride + x * 3;
+        vst3q_u8(dst.as_mut_ptr().add(d), rgb);
+    }
 }
 
 /// `pshufb` selector byte meaning "write zero".
@@ -203,24 +370,96 @@ use core::arch::x86_64::__m128i;
 ///
 /// `pmulhrsw` computes `(a·b + 0x4000) >> 15`, which is exactly the scalar
 /// `qrdmulh` and NEON's `SQRDMULH`, so all three paths are bit-identical.
+/// One 8-pixel half: Q14 butterfly on i16 lanes. Shared by the row and
+/// MCU-block SSE4.1 writers so both stay bit-identical (`pmulhrsw` matches
+/// scalar `qrdmulh` and NEON `SQRDMULH` exactly).
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "sse4.1")]
+#[inline]
+unsafe fn ycbcr_half_sse41(
+    yv: core::arch::x86_64::__m128i,
+    cbv: core::arch::x86_64::__m128i,
+    crv: core::arch::x86_64::__m128i,
+) -> (
+    core::arch::x86_64::__m128i,
+    core::arch::x86_64::__m128i,
+    core::arch::x86_64::__m128i,
+) {
+    use core::arch::x86_64::*;
+    let c128 = _mm_set1_epi16(128);
+    let cb2 = _mm_slli_epi16::<1>(_mm_sub_epi16(cbv, c128));
+    let cr2 = _mm_slli_epi16::<1>(_mm_sub_epi16(crv, c128));
+    let r = _mm_add_epi16(yv, _mm_mulhrs_epi16(cr2, _mm_set1_epi16(CR_R)));
+    let g = _mm_sub_epi16(
+        _mm_sub_epi16(yv, _mm_mulhrs_epi16(cb2, _mm_set1_epi16(CB_G))),
+        _mm_mulhrs_epi16(cr2, _mm_set1_epi16(CR_G)),
+    );
+    let b = _mm_add_epi16(yv, _mm_mulhrs_epi16(cb2, _mm_set1_epi16(CB_B)));
+    (r, g, b)
+}
+
+/// Paired 8×8 blocks → 16 RGB pixels per row (SSE4.1). x86 mirror of
+/// `ycbcr_to_rgb_block16_neon`: without it the fused-RGB write fell to the
+/// scalar row tail on x86 (the 16-wide row kernel never engages at 8-pixel
+/// block width), which cost ~70% on the RGB arm of Rocket Lake after the
+/// per-MCU write path landed.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "sse4.1")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn ycbcr_to_rgb_block16_sse41(
+    y0: &[u8; 64],
+    cb0: &[u8; 64],
+    cr0: &[u8; 64],
+    y1: &[u8; 64],
+    cb1: &[u8; 64],
+    cr1: &[u8; 64],
+    dst: &mut [u8],
+    stride: usize,
+    x: usize,
+    y: usize,
+    rows: usize,
+) {
+    use core::arch::x86_64::*;
+    let zero = _mm_setzero_si128();
+    for r in 0..rows {
+        let src = r * 8;
+        let pair = |a: &[u8; 64], b: &[u8; 64]| -> __m128i {
+            _mm_unpacklo_epi64(
+                _mm_loadl_epi64(a.as_ptr().add(src) as *const __m128i),
+                _mm_loadl_epi64(b.as_ptr().add(src) as *const __m128i),
+            )
+        };
+        let yq = pair(y0, y1);
+        let cbq = pair(cb0, cb1);
+        let crq = pair(cr0, cr1);
+        let (r_lo, g_lo, b_lo) = ycbcr_half_sse41(
+            _mm_unpacklo_epi8(yq, zero),
+            _mm_unpacklo_epi8(cbq, zero),
+            _mm_unpacklo_epi8(crq, zero),
+        );
+        let (r_hi, g_hi, b_hi) = ycbcr_half_sse41(
+            _mm_unpackhi_epi8(yq, zero),
+            _mm_unpackhi_epi8(cbq, zero),
+            _mm_unpackhi_epi8(crq, zero),
+        );
+        let d = (y + r) * stride + x * 3;
+        store_rgb16(
+            _mm_packus_epi16(r_lo, r_hi),
+            _mm_packus_epi16(g_lo, g_hi),
+            _mm_packus_epi16(b_lo, b_hi),
+            dst.as_mut_ptr().add(d),
+        );
+    }
+}
+
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "sse4.1")]
 unsafe fn ycbcr_to_rgb_row_sse41(y: &[u8], cb: &[u8], cr: &[u8], dst: &mut [u8], n: usize) {
     use core::arch::x86_64::*;
 
-    /// One 8-pixel half: Q14 butterfly on i16 lanes.
     #[inline(always)]
     unsafe fn half(yv: __m128i, cbv: __m128i, crv: __m128i) -> (__m128i, __m128i, __m128i) {
-        let c128 = _mm_set1_epi16(128);
-        let cb2 = _mm_slli_epi16::<1>(_mm_sub_epi16(cbv, c128));
-        let cr2 = _mm_slli_epi16::<1>(_mm_sub_epi16(crv, c128));
-        let r = _mm_add_epi16(yv, _mm_mulhrs_epi16(cr2, _mm_set1_epi16(CR_R)));
-        let g = _mm_sub_epi16(
-            _mm_sub_epi16(yv, _mm_mulhrs_epi16(cb2, _mm_set1_epi16(CB_G))),
-            _mm_mulhrs_epi16(cr2, _mm_set1_epi16(CR_G)),
-        );
-        let b = _mm_add_epi16(yv, _mm_mulhrs_epi16(cb2, _mm_set1_epi16(CB_B)));
-        (r, g, b)
+        ycbcr_half_sse41(yv, cbv, crv)
     }
 
     let mut i = 0usize;
@@ -351,6 +590,60 @@ mod tests {
         let mut exp = vec![0u8; n * 3];
         ycbcr_to_rgb_row(&y, &cb, &cr, &mut got, n);
         ycbcr_to_rgb_row_scalar(&y, &cb, &cr, &mut exp, 0, n);
+        assert_eq!(got, exp);
+    }
+
+    #[test]
+    fn mcu_blocks_match_row_kernel() {
+        let mut y0 = [0u8; 64];
+        let mut cb0 = [0u8; 64];
+        let mut cr0 = [0u8; 64];
+        let mut y1 = [0u8; 64];
+        let mut cb1 = [0u8; 64];
+        let mut cr1 = [0u8; 64];
+        let a = lcg_bytes(3, 64);
+        let b = lcg_bytes(5, 64);
+        let c = lcg_bytes(7, 64);
+        let d = lcg_bytes(11, 64);
+        let e = lcg_bytes(13, 64);
+        let f = lcg_bytes(17, 64);
+        y0.copy_from_slice(&a);
+        cb0.copy_from_slice(&b);
+        cr0.copy_from_slice(&c);
+        y1.copy_from_slice(&d);
+        cb1.copy_from_slice(&e);
+        cr1.copy_from_slice(&f);
+
+        let stride = 16 * 3;
+        let mut got = vec![0u8; 8 * stride];
+        ycbcr_to_rgb_blocks(
+            &y0,
+            &cb0,
+            &cr0,
+            Some((&y1, &cb1, &cr1)),
+            &mut got,
+            stride,
+            0,
+            0,
+            8,
+            8,
+            8,
+        );
+
+        let mut exp = vec![0u8; 8 * stride];
+        for r in 0..8 {
+            let mut yrow = [0u8; 16];
+            let mut cbrow = [0u8; 16];
+            let mut crrow = [0u8; 16];
+            yrow[..8].copy_from_slice(&y0[r * 8..r * 8 + 8]);
+            yrow[8..].copy_from_slice(&y1[r * 8..r * 8 + 8]);
+            cbrow[..8].copy_from_slice(&cb0[r * 8..r * 8 + 8]);
+            cbrow[8..].copy_from_slice(&cb1[r * 8..r * 8 + 8]);
+            crrow[..8].copy_from_slice(&cr0[r * 8..r * 8 + 8]);
+            crrow[8..].copy_from_slice(&cr1[r * 8..r * 8 + 8]);
+            let d = r * stride;
+            ycbcr_to_rgb_row_scalar(&yrow, &cbrow, &crrow, &mut exp[d..], 0, 16);
+        }
         assert_eq!(got, exp);
     }
 

--- a/crates/codec/src/jpeg/cpu.rs
+++ b/crates/codec/src/jpeg/cpu.rs
@@ -70,6 +70,18 @@ impl NeonTier {
         }
     }
 
+    /// Whether the block decoder should use the paired-coefficient probe
+    /// (`HuffmanTable::pair_ac`). Out-of-order cores win from halving the
+    /// serial probe chain (~2.7% on A76); in-order A53/A55 lose ~1-3% — the
+    /// phantom-single path retires more instructions per coefficient and a
+    /// 2-wide in-order pipe pays for all of them (measured on imx8mp/imx95,
+    /// COCO decode-only, 2026-08).
+    #[inline]
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+    pub fn entropy_pair_decode(self) -> bool {
+        matches!(self, Self::High)
+    }
+
     /// Prefetch distance (bytes ahead in the entropy stream).
     /// A53 dual-issues `prfm` for free; keep distances modest to avoid pollution.
     #[inline]
@@ -165,6 +177,20 @@ pub fn entropy_huffman_fast_bits() -> u8 {
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     {
         10
+    }
+}
+
+/// Whether the active arch tier uses the paired-coefficient entropy probe.
+/// x86 is unmeasured and stays on the single-coefficient path for now.
+#[inline]
+pub fn entropy_pair_decode() -> bool {
+    #[cfg(target_arch = "aarch64")]
+    {
+        neon_tier().entropy_pair_decode()
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        false
     }
 }
 

--- a/crates/codec/src/jpeg/huffman.rs
+++ b/crates/codec/src/jpeg/huffman.rs
@@ -9,7 +9,7 @@
 //! Entries are packed `u16 = (symbol << 8) | len` (libjpeg-turbo style).
 
 use crate::error::CodecError;
-use crate::jpeg::bitstream::BitStream;
+use crate::jpeg::bitstream::{BitCursor, BitStream};
 use crate::jpeg::cpu;
 
 /// Maximum Huffman code length in JPEG.
@@ -28,10 +28,45 @@ pub struct HuffmanTable {
     /// `(sign-extended value as u16) << 16 | run << 8 | total_bits`
     ///
     /// where `total_bits = code_len + magnitude_bits` is the single `consume`
-    /// amount. `0` means miss (EOB/ZRL, size-0 symbols, or codes that spill
-    /// past the window) — fall back to the two-step path. For DC tables the
-    /// symbol *is* the size, so `run == 0` on every valid hit.
+    /// amount. `0` means miss (size-0 symbols other than the baked ones below,
+    /// or codes that spill past the window) — fall back to the two-step path.
+    ///
+    /// Three size-0 symbols are baked in rather than treated as misses:
+    ///
+    /// - **DC size 0** (`is_ac == false`, symbol 0x00): predictor unchanged —
+    ///   a plain hit with `value = 0, run = 0`. Very common in flat regions.
+    /// - **EOB** (`is_ac == true`, symbol 0x00): encoded with the sentinel
+    ///   `run = 0xFF`, which forces `k += run` past 63 so the block decoder's
+    ///   *existing* bounds branch resolves end-of-block — no extra hot-path
+    ///   compare, and the two-step fallback disappears from the common exit.
+    /// - **ZRL** (`is_ac == true`, symbol 0xF0): `value = 0, run = 15` writes
+    ///   a zero into a slot the clear discipline already guarantees is zero —
+    ///   sixteen positions are skipped, matching the two-step path.
+    ///
+    /// For DC tables the symbol *is* the size, so `run == 0` on every valid
+    /// hit and the sentinels never appear.
     fast_ac: Vec<u32>,
+    /// Paired-coefficient lookup (AC tables only; empty for DC). Decodes up to
+    /// **two** coefficients per probe when both fit the lookahead window —
+    /// on COCO val2017 ~54% of AC coefficients pair at 10 bits, and the serial
+    /// peek → load → consume chain is the in-order bottleneck, so halving the
+    /// probes on paired coefficients attacks it directly.
+    ///
+    /// Entry: `val2:i8 << 24 | val1:i8 << 16 | run2:u4 << 12 | run1:u4 << 8 |
+    /// total_bits:u8`. `0` = miss (EOB/ZRL windows, codes past the window,
+    /// magnitudes over 7 bits).
+    ///
+    /// Single coefficients are baked as **phantom pairs** (`val2 = 0,
+    /// run2 = 0`) so the probe branch keeps the ~94% hit rate of the single
+    /// table instead of introducing a ~50/50 pair-vs-single branch that an
+    /// in-order branch predictor would keep missing. The block decoder
+    /// discriminates real-vs-phantom *branchlessly*: it always stores `val2`
+    /// at the second position — a phantom writes `0` into the next undecoded
+    /// slot, which the clear discipline already guarantees is zero — and
+    /// advances `k` by `(val2 != 0)`. Sound because a real second value is
+    /// never zero: JPEG magnitude coding cannot encode 0 (`size ≥ 1 ⇒
+    /// |value| ≥ 1`), and `size ≤ 7 ⇒ |value| ≤ 127` fits the i8 lane.
+    pair_ac: Vec<u32>,
     /// Lookahead width used to index `fast`.
     fast_bits: u8,
     /// Code values indexed by increasing code length. Used for slow decode.
@@ -44,8 +79,11 @@ pub struct HuffmanTable {
 
 impl HuffmanTable {
     /// Build a Huffman table using the process-wide NEON tier's fast-bit width.
-    pub fn build(counts: &[u8; 16], values: &[u8]) -> crate::Result<Self> {
-        Self::build_with_fast_bits(counts, values, cpu::entropy_huffman_fast_bits())
+    ///
+    /// `is_ac` selects the run/size interpretation of size-0 symbols when
+    /// baking the combined table — see [`Self::fast_ac`].
+    pub fn build(counts: &[u8; 16], values: &[u8], is_ac: bool) -> crate::Result<Self> {
+        Self::build_with_fast_bits(counts, values, cpu::entropy_huffman_fast_bits(), is_ac)
     }
 
     /// Build with an explicit fast-lookup width (8..=12).
@@ -53,6 +91,7 @@ impl HuffmanTable {
         counts: &[u8; 16],
         values: &[u8],
         fast_bits: u8,
+        is_ac: bool,
     ) -> crate::Result<Self> {
         let fast_bits = fast_bits.clamp(8, 12);
         let fast_size = 1usize << fast_bits;
@@ -130,17 +169,75 @@ impl HuffmanTable {
             let symbol = (packed >> 8) as u8;
             let run = (symbol >> 4) as u32;
             let size = symbol & 0x0F;
-            if size == 0 || len + size > fast_bits {
-                continue; // EOB/ZRL or magnitude spills past the window
+            if size == 0 {
+                // Size-0 symbols: bake the three meaningful ones (see the
+                // `fast_ac` field docs); everything else stays a miss so the
+                // two-step path can reject it.
+                fast_ac[idx] = match (is_ac, symbol) {
+                    (false, 0x00) => len as u32,              // DC diff 0
+                    (true, 0x00) => (0xFF << 8) | len as u32, // EOB sentinel
+                    (true, 0xF0) => (15 << 8) | len as u32,   // ZRL
+                    _ => 0,
+                };
+                continue;
+            }
+            if len + size > fast_bits {
+                continue; // magnitude spills past the window
             }
             let mag = ((idx >> (fast_bits - len - size)) as u32) & ((1u32 << size) - 1);
             let val = BitStream::extend(mag, size) as i16;
             fast_ac[idx] = ((val as u16 as u32) << 16) | (run << 8) | (len + size) as u32;
         }
 
+        // Paired-coefficient table (see the `pair_ac` field docs). Decodes a
+        // window as coefficient-1 [+ coefficient-2] entirely at build time.
+        let mut pair_ac = Vec::new();
+        if is_ac {
+            pair_ac = vec![0u32; fast_size];
+            // First code+magnitude of a window, when it is a pairable
+            // coefficient: size 1..=7 (value fits i8) fully inside the window.
+            let coeff_at = |idx: usize, offset: u8| -> Option<(u8, u8, i8)> {
+                let sub = (idx << offset) & (fast_size - 1);
+                let packed = fast[sub];
+                let len = (packed & 0xFF) as u8;
+                if len == 0 {
+                    return None;
+                }
+                let symbol = (packed >> 8) as u8;
+                let run = symbol >> 4;
+                let size = symbol & 0x0F;
+                if size == 0 || size > 7 || offset + len + size > fast_bits {
+                    return None; // EOB/ZRL, wide magnitude, or spills the window
+                }
+                // `sub` already carries the window shifted up by `offset`, so
+                // the magnitude sits `len` bits below its top.
+                let shift = fast_bits - len - size;
+                let mag = ((sub >> shift) as u32) & ((1u32 << size) - 1);
+                let val = BitStream::extend(mag, size) as i8;
+                Some((len + size, run, val))
+            };
+            for (idx, entry) in pair_ac.iter_mut().enumerate() {
+                let Some((used1, run1, val1)) = coeff_at(idx, 0) else {
+                    continue;
+                };
+                // Second coefficient from the remaining window bits, else a
+                // phantom (val2 = 0, run2 = 0) single.
+                let (total, run2, val2) = match coeff_at(idx, used1) {
+                    Some((used2, run2, val2)) => (used1 + used2, run2, val2),
+                    None => (used1, 0, 0),
+                };
+                *entry = ((val2 as u8 as u32) << 24)
+                    | ((val1 as u8 as u32) << 16)
+                    | ((run2 as u32) << 12)
+                    | ((run1 as u32) << 8)
+                    | total as u32;
+            }
+        }
+
         Ok(Self {
             fast,
             fast_ac,
+            pair_ac,
             fast_bits,
             symbols: values[..total].to_vec(),
             max_code,
@@ -148,54 +245,66 @@ impl HuffmanTable {
         })
     }
 
+    /// Probe the paired-coefficient table (AC tables only — the table is empty
+    /// for DC tables and this must not be called on them). Non-zero hit ⇒ one
+    /// or two fully decoded coefficients; see [`Self::pair_ac`] for the layout.
+    #[inline(always)]
+    pub fn probe_pair_ac(&self, cur: &BitCursor<'_>) -> u32 {
+        debug_assert!(!self.pair_ac.is_empty(), "pair probe on a DC table");
+        let window = cur.peek(self.fast_bits) as usize;
+        // SAFETY: peek returns fast_bits bits, so window < 1 << fast_bits,
+        // the length pair_ac was allocated with for every AC table.
+        unsafe { *self.pair_ac.get_unchecked(window) }
+    }
+
     /// Probe the combined code+magnitude table with a `fast_bits`-wide window.
     /// Non-zero hit ⇒ `(value << 16) | (run << 8) | total_bits`.
     ///
-    /// Takes the stream rather than a caller-computed index: the window is
+    /// Takes the cursor rather than a caller-computed index: the window is
     /// `peek(self.fast_bits)`, so reading it here makes "index is in range" a
     /// property of this function instead of an invariant every call site has to
     /// re-establish for the unchecked load to stay sound.
     #[inline(always)]
-    pub fn probe_fast_ac(&self, bs: &BitStream<'_>) -> u32 {
-        let window = bs.peek(self.fast_bits) as usize;
+    pub fn probe_fast_ac(&self, cur: &BitCursor<'_>) -> u32 {
+        let window = cur.peek(self.fast_bits) as usize;
         // SAFETY: peek returns fast_bits bits, so window < 1 << fast_bits,
         // which is exactly the length fast_ac was allocated with.
         unsafe { *self.fast_ac.get_unchecked(window) }
     }
 
-    /// Decode one Huffman symbol from the bit stream.
+    /// Decode one Huffman symbol from the bit cursor.
     ///
-    /// Contract: the caller refilled the buffer to ≥ 32 bits ([`BitStream::refill`]),
+    /// Contract: the caller refilled the buffer to ≥ 32 bits ([`BitCursor::refill`]),
     /// covering the longest code (16) plus its magnitude bits without another
     /// memory touch. Pure register ops on the fast path: peek → LUT → consume.
     #[inline(always)]
-    pub fn decode_symbol(&self, bs: &mut BitStream<'_>) -> crate::Result<u8> {
-        let peek = bs.peek(self.fast_bits) as usize;
+    pub fn decode_symbol(&self, cur: &mut BitCursor<'_>) -> crate::Result<u8> {
+        let peek = cur.peek(self.fast_bits) as usize;
         // peek is always < 2^fast_bits; table was sized to match.
         let packed = unsafe { *self.fast.get_unchecked(peek) };
         let len = (packed & 0xFF) as u8;
         if len > 0 {
-            bs.consume(len);
+            cur.consume(len);
             return Ok((packed >> 8) as u8);
         }
-        self.decode_slow(bs)
+        self.decode_slow(cur)
     }
 
     /// Slow Huffman decode for codes longer than `fast_bits` (rare: <1% of
     /// symbols at 10-bit lookahead). Consumes at most 16 buffered bits, within
     /// the caller's refill guarantee.
     ///
-    /// Inlined for the same reason as [`BitStream::refill_slow`]: taking
-    /// `&mut BitStream` out of line escapes the pointer and pushes the bit
+    /// Inlined for the same reason as [`BitCursor::refill_slow`]: taking
+    /// the cursor out of line escapes the pointer and pushes the bit
     /// buffer out of registers for the whole coefficient loop.
     #[inline(always)]
-    fn decode_slow(&self, bs: &mut BitStream<'_>) -> crate::Result<u8> {
+    fn decode_slow(&self, cur: &mut BitCursor<'_>) -> crate::Result<u8> {
         let fb = self.fast_bits;
-        let mut code = bs.peek(fb) as i32;
-        bs.consume(fb);
+        let mut code = cur.peek(fb) as i32;
+        cur.consume(fb);
 
         for i in (fb as usize)..MAX_CODE_LEN {
-            code = (code << 1) | bs.get_bits(1) as i32;
+            code = (code << 1) | cur.get_bits(1) as i32;
 
             if code <= self.max_code[i] {
                 let idx = (code + self.val_offset[i]) as usize;
@@ -209,53 +318,161 @@ impl HuffmanTable {
     }
 }
 
+/// Per-slot DHT fingerprint plus the built LUT, reused across frames.
+///
+/// Camera streams keep the same DHT for every frame; rebuilding the lookahead
+/// tables is then pure overhead. The LUTs are **moved** into the parse result
+/// for the decode (no `clone` of the `Vec` tables) and [`Self::restore`]d
+/// afterwards so the hot loop stays allocation-free on a cache hit.
+#[derive(Debug, Default)]
+pub(crate) struct HuffmanCache {
+    dc: [CachedDht; 4],
+    ac: [CachedDht; 4],
+}
+
+#[derive(Debug, Default)]
+struct CachedDht {
+    counts: [u8; 16],
+    values: Vec<u8>,
+    table: Option<HuffmanTable>,
+}
+
+impl HuffmanCache {
+    /// Return a built table for this DHT payload, taking a cached LUT when the
+    /// counts and symbols match the previous frame.
+    pub(crate) fn intern(
+        &mut self,
+        class: u8,
+        id: usize,
+        counts: &[u8; 16],
+        values: &[u8],
+    ) -> crate::Result<HuffmanTable> {
+        let slot = if class == 0 {
+            &mut self.dc[id]
+        } else {
+            &mut self.ac[id]
+        };
+        if slot.counts == *counts && slot.values.as_slice() == values {
+            if let Some(table) = slot.table.take() {
+                return Ok(table);
+            }
+        }
+        let table = HuffmanTable::build(counts, values, class != 0)?;
+        slot.counts = *counts;
+        slot.values.clear();
+        slot.values.extend_from_slice(values);
+        Ok(table)
+    }
+
+    /// Move tables from a finished parse/decode back into the cache.
+    pub(crate) fn restore(
+        &mut self,
+        dc_tables: &mut [Option<HuffmanTable>; 4],
+        ac_tables: &mut [Option<HuffmanTable>; 4],
+    ) {
+        for i in 0..4 {
+            if let Some(t) = dc_tables[i].take() {
+                self.dc[i].table = Some(t);
+            }
+            if let Some(t) = ac_tables[i].take() {
+                self.ac[i].table = Some(t);
+            }
+        }
+    }
+}
+
+/// Entropy-decode result for one block: whether any AC coefficient was
+/// written, and the highest zigzag index that was written (`last_k`, 0 for a
+/// DC-only block). `last_k` is a free by-product of the scan order — zigzag
+/// indices only grow — and bounds the block's occupied zigzag prefix, which
+/// the NEON IDCT uses to pick a sparse tier without re-deriving sparsity from
+/// the coefficient vectors.
+#[derive(Debug, Clone, Copy)]
+pub struct BlockInfo {
+    /// Any non-zero AC coefficient decoded (DC-only shortcut gate).
+    pub has_ac: bool,
+    /// Highest zigzag index written (upper bound; a baked ZRL writes a zero).
+    pub last_k: u8,
+}
+
 /// Decode one 8×8 block of **quantised** DCT coefficients from the
 /// entropy-coded data. Dequantisation happens inside the IDCT kernels
 /// (libjpeg-turbo `JCOEF` model): the entropy loop stays multiply-free and the
 /// coefficient block is a 128-byte `i16` array instead of 256-byte `i32`.
-///
-/// Returns `true` when any non-zero AC coefficient was decoded.
 ///
 /// `prev_has_ac` tracks whether the shared `coeffs` scratch still holds stale AC
 /// values from the previous block. When the previous block was DC-only only
 /// `coeffs[0]` needs clearing — avoids a 128-byte memset on every MCU block
 /// (COCO 4:4:4 does ~3× more blocks than 4:2:0).
 ///
-/// Refill discipline (turbo `decode_mcu_fast` shape): one [`BitStream::refill`]
+/// Refill discipline (turbo `decode_mcu_fast` shape): one [`BitCursor::refill`]
 /// per coefficient covers the Huffman code (≤ 16 bits) plus its magnitude bits
 /// (≤ 11), so everything between refills is register arithmetic. The combined
 /// `fast_ac` probe additionally resolves code + run + sign-extended value with
-/// a single table load and a single `consume` when both fit the lookahead.
-#[inline]
-pub fn decode_block(
+/// a single table load and a single `consume` when both fit the lookahead;
+/// EOB arrives through the same probe as a `run = 0xFF` sentinel that the
+/// existing `k >= 64` bounds branch resolves (see [`HuffmanTable::fast_ac`]).
+///
+/// The whole block runs on a [`BitCursor`] so the bit buffer lives in
+/// registers; state is committed back to the stream on every exit, error
+/// exits included.
+///
+/// `#[inline(never)]` is load-bearing. With the cursor pattern LLVM finds
+/// inlining this into the MCU loop attractive (it can then eliminate the
+/// cursor copies against the caller's `BitStream`), but `decode_image`'s
+/// frame already spills, and merging the two register-allocation problems
+/// costs ~20% of decode time on Cortex-A53 (measured: 7.68 ms → 9.23 ms
+/// p50 on imx8mp COCO when this inlines). Outlined, the cursor is this
+/// function's own non-escaping local and lives entirely in registers.
+#[inline(never)]
+pub fn decode_block<const PAIR: bool>(
     bs: &mut BitStream<'_>,
     dc_table: &HuffmanTable,
     ac_table: &HuffmanTable,
     coeffs: &mut [i16; 64],
     dc_pred: &mut i32,
     prev_has_ac: &mut bool,
-) -> crate::Result<bool> {
+) -> crate::Result<BlockInfo> {
+    let mut cur = bs.cursor();
+    let res = decode_block_cur::<PAIR>(&mut cur, dc_table, ac_table, coeffs, dc_pred, prev_has_ac);
+    bs.commit(cur);
+    res
+}
+
+/// Cursor-side body of [`decode_block`]. `#[inline(always)]` so the cursor
+/// stays a provably non-escaping local of the caller and its fields live in
+/// registers for the whole coefficient loop.
+#[inline(always)]
+fn decode_block_cur<const PAIR: bool>(
+    cur: &mut BitCursor<'_>,
+    dc_table: &HuffmanTable,
+    ac_table: &HuffmanTable,
+    coeffs: &mut [i16; 64],
+    dc_pred: &mut i32,
+    prev_has_ac: &mut bool,
+) -> crate::Result<BlockInfo> {
     if *prev_has_ac {
         *coeffs = [0i16; 64];
     } else {
         coeffs[0] = 0;
     }
 
-    bs.refill(); // ≥ 32 bits: DC code (≤16) + DC magnitude (≤11)
-                 // Combined fast path: one lookup yields the sign-extended DC diff and the
-                 // total bits to consume. `run != 0` never occurs in a valid DC hit (the
-                 // symbol is the size, ≤ 11), so any non-zero-run entry falls through.
-    let dc_fa = dc_table.probe_fast_ac(bs);
+    cur.refill(); // ≥ 32 bits: DC code (≤16) + DC magnitude (≤11)
+                  // Combined fast path: one lookup yields the sign-extended DC diff and the
+                  // total bits to consume. `run != 0` never occurs in a valid DC hit (the
+                  // symbol is the size, ≤ 11, and size 0 is baked with run 0), so any
+                  // non-zero-run entry falls through.
+    let dc_fa = dc_table.probe_fast_ac(cur);
     if dc_fa != 0 && dc_fa & 0xFF00 == 0 {
-        bs.consume((dc_fa & 0xFF) as u8);
+        cur.consume((dc_fa & 0xFF) as u8);
         *dc_pred += (dc_fa >> 16) as u16 as i16 as i32;
     } else {
-        let dc_size = dc_table.decode_symbol(bs)?;
+        let dc_size = dc_table.decode_symbol(cur)?;
         if dc_size > 0 {
             if dc_size > 11 {
                 return Err(CodecError::InvalidData("JPEG: DC size > 11".into()));
             }
-            let dc_val = bs.get_bits(dc_size);
+            let dc_val = cur.get_bits(dc_size);
             let dc_diff = BitStream::extend(dc_val, dc_size);
             *dc_pred += dc_diff;
         }
@@ -263,35 +480,108 @@ pub fn decode_block(
     coeffs[0] = *dc_pred as i16;
 
     let mut has_ac = false;
+    let mut last_k = 0usize;
     let mut k = 1;
     while k < 64 {
-        bs.refill(); // ≥ 32 bits: AC code (≤16) + AC magnitude (≤10)
+        cur.refill(); // ≥ 32 bits: covers every probe below (pair total ≤ 12)
 
-        // Combined fast path: code + run + sign-extended value in one probe,
-        // one consume. Covers the overwhelming majority of AC coefficients
-        // (small magnitudes with short codes).
-        let fa = ac_table.probe_fast_ac(bs);
-        if fa != 0 {
-            bs.consume((fa & 0xFF) as u8);
-            k += ((fa >> 8) & 0xFF) as usize;
-            if k >= 64 {
+        // Paired fast path: up to two coefficients in one probe and one
+        // consume (~54% of COCO AC coefficients pair at 10 bits; singles hit
+        // as phantom pairs, so this branch keeps the single table's ~94% hit
+        // rate). The second store is branchless: a phantom writes value 0
+        // into the next undecoded slot — already zero by the clear
+        // discipline — and `k` advances by `(val2 != 0)`.
+        let pa = if PAIR { ac_table.probe_pair_ac(cur) } else { 0 };
+        if pa != 0 {
+            let run1 = ((pa >> 8) & 0xF) as usize;
+            let k1 = k + run1;
+            // SAFETY: k1 ≤ 63 + 15 < ZIGZAG_EXT length (320). Issued before
+            // the bounds branch to hide the L1 hit from the store below.
+            let zz1 = unsafe { *crate::jpeg::types::ZIGZAG_EXT.get_unchecked(k1) } as usize;
+            if k1 >= 64 {
                 return Err(CodecError::InvalidData(
                     "JPEG: AC coefficient past end".into(),
                 ));
             }
-            // SAFETY: k < 64 (checked above); ZIGZAG values are all < 64.
+            let val2 = ((pa >> 24) as u8 as i8) as i16;
+            let pos2 = k1 + 1 + ((pa >> 12) & 0xF) as usize;
+            if pos2 < 64 {
+                cur.consume((pa & 0xFF) as u8);
+                // SAFETY: k1 < 64 and pos2 < 64 (checked above) — both
+                // indices come from the real zigzag prefix. A phantom's
+                // second store writes 0 at the next undecoded position
+                // (pos2 == k1 + 1), which is already zero.
+                unsafe {
+                    *coeffs.get_unchecked_mut(zz1) = ((pa >> 16) as u8 as i8) as i16;
+                    *coeffs.get_unchecked_mut(
+                        *crate::jpeg::types::ZIGZAG_EXT.get_unchecked(pos2) as usize,
+                    ) = val2;
+                }
+                k = pos2 + (val2 != 0) as usize;
+                has_ac = true;
+                last_k = k - 1;
+                continue;
+            }
+            if val2 == 0 || k1 == 63 {
+                // The block ends exactly at coefficient 1 — the entry's
+                // "second symbol" was decoded from the next block's bits at
+                // build time and must not be consumed. The single-coefficient
+                // probe is a guaranteed hit here (the pair conditions are a
+                // strict subset of its own) and carries coefficient 1's true
+                // bit count.
+                let fa = ac_table.probe_fast_ac(cur);
+                debug_assert!(fa != 0);
+                debug_assert_eq!((fa >> 8) & 0xFF, run1 as u32);
+                cur.consume((fa & 0xFF) as u8);
+                // SAFETY: k1 < 64 (checked above).
+                unsafe {
+                    *coeffs.get_unchecked_mut(zz1) = ((pa >> 16) as u8 as i8) as i16;
+                }
+                k = k1 + 1;
+                has_ac = true;
+                last_k = k1;
+                continue;
+            }
+            return Err(CodecError::InvalidData(
+                "JPEG: AC coefficient past end".into(),
+            ));
+        }
+
+        // Combined fast path: code + run + sign-extended value in one probe,
+        // one consume. Still first choice for what the pair table skips:
+        // EOB (run-0xFF sentinel), ZRL (run 15, value 0), and single
+        // coefficients with magnitudes wider than 7 bits.
+        let fa = ac_table.probe_fast_ac(cur);
+        if fa != 0 {
+            cur.consume((fa & 0xFF) as u8);
+            let run = ((fa >> 8) & 0xFF) as usize;
+            k += run;
+            // Issued before the bounds branch so the L1 hit is underway by the
+            // time the coefficient store needs the address.
+            // SAFETY: k <= 63 + 255 < ZIGZAG_EXT length (320).
+            let natural_idx = unsafe { *crate::jpeg::types::ZIGZAG_EXT.get_unchecked(k) } as usize;
+            if k >= 64 {
+                if run == 0xFF {
+                    break; // EOB, baked into the probe table
+                }
+                return Err(CodecError::InvalidData(
+                    "JPEG: AC coefficient past end".into(),
+                ));
+            }
+            // SAFETY: k < 64 (checked above), so natural_idx came from the
+            // real zigzag prefix and is < 64.
             unsafe {
-                let natural_idx = *crate::jpeg::types::ZIGZAG.get_unchecked(k) as usize;
                 *coeffs.get_unchecked_mut(natural_idx) = (fa >> 16) as u16 as i16;
             }
             has_ac = true;
+            last_k = k;
             k += 1;
             continue;
         }
 
-        let symbol = ac_table.decode_symbol(bs)?;
+        let symbol = ac_table.decode_symbol(cur)?;
         if symbol == 0x00 {
-            break; // EOB
+            break; // EOB (code longer than the fast window)
         }
 
         let run = (symbol >> 4) as usize;
@@ -322,7 +612,7 @@ pub fn decode_block(
                 "JPEG: AC coefficient size {size} exceeds spec maximum (10)"
             )));
         }
-        let val = bs.get_bits(size);
+        let val = cur.get_bits(size);
         let coeff = BitStream::extend(val, size);
         // SAFETY: k < 64 (checked above); ZIGZAG values are all < 64.
         unsafe {
@@ -330,11 +620,15 @@ pub fn decode_block(
             *coeffs.get_unchecked_mut(natural_idx) = coeff as i16;
         }
         has_ac = true;
+        last_k = k;
         k += 1;
     }
 
     *prev_has_ac = has_ac;
-    Ok(has_ac)
+    Ok(BlockInfo {
+        has_ac,
+        last_k: last_k as u8,
+    })
 }
 
 #[cfg(test)]
@@ -346,11 +640,32 @@ mod tests {
         let mut counts = [0u8; 16];
         counts[0] = 2;
         let values = [0x00, 0x01];
-        let table = HuffmanTable::build(&counts, &values).unwrap();
+        let table = HuffmanTable::build(&counts, &values, true).unwrap();
 
         let data = [0b1000_0000];
-        let mut bs = BitStream::new(&data, 0);
-        assert_eq!(table.decode_symbol(&mut bs).unwrap(), 1);
+        let bs = BitStream::new(&data, 0);
+        let mut cur = bs.cursor();
+        assert_eq!(table.decode_symbol(&mut cur).unwrap(), 1);
+    }
+
+    /// DC size-0 (predictor unchanged) must be a `fast_ac` hit with value 0;
+    /// the same symbol in an AC table is EOB and must carry the 0xFF run
+    /// sentinel; ZRL must decode as run 15 / value 0.
+    #[test]
+    fn fast_ac_bakes_size_zero_symbols() {
+        let mut counts = [0u8; 16];
+        counts[0] = 2;
+        let values = [0x00, 0xF0];
+
+        let dc = HuffmanTable::build(&counts, &values, false).unwrap();
+        // Window of all-zero bits selects the first (size-0) code.
+        assert_eq!(dc.fast_ac[0], 1, "DC size-0: value 0, run 0, 1 bit");
+
+        let ac = HuffmanTable::build(&counts, &values, true).unwrap();
+        assert_eq!(ac.fast_ac[0], (0xFF << 8) | 1, "EOB: run sentinel 0xFF");
+        // Second 1-bit code (window with the top bit set) is ZRL.
+        let zrl = ac.fast_ac[1 << (ac.fast_bits - 1)];
+        assert_eq!(zrl, (15 << 8) | 1, "ZRL: value 0, run 15, 1 bit");
     }
 
     #[test]
@@ -366,7 +681,7 @@ mod tests {
         counts[7] = 1;
         counts[8] = 1;
         let values = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-        let table = HuffmanTable::build(&counts, &values).unwrap();
+        let table = HuffmanTable::build(&counts, &values, false).unwrap();
         assert!(!table.fast.is_empty());
     }
 
@@ -375,7 +690,7 @@ mod tests {
         let mut counts = [0u8; 16];
         counts[0] = 2;
         let values = [0u8];
-        let result = HuffmanTable::build(&counts, &values);
+        let result = HuffmanTable::build(&counts, &values, true);
         assert!(result.is_err());
     }
 
@@ -388,19 +703,279 @@ mod tests {
         let mut counts = [0u8; 16];
         counts[0] = 3; // only two 1-bit codes can exist
         let values = [0u8, 1, 2];
-        assert!(HuffmanTable::build(&counts, &values).is_err());
+        assert!(HuffmanTable::build(&counts, &values, true).is_err());
 
         // Oversubscription deeper in the tree, past the fast-table width.
         let mut counts = [0u8; 16];
         counts[0] = 1;
         counts[1] = 3; // one 1-bit code leaves room for only two 2-bit codes
         let values = [0u8, 1, 2, 3];
-        assert!(HuffmanTable::build(&counts, &values).is_err());
+        assert!(HuffmanTable::build(&counts, &values, true).is_err());
 
         // A full canonical code must still build: 2 one-bit codes is the limit.
         let mut counts = [0u8; 16];
         counts[0] = 2;
         let values = [0u8, 1];
-        assert!(HuffmanTable::build(&counts, &values).is_ok());
+        assert!(HuffmanTable::build(&counts, &values, true).is_ok());
+    }
+
+    /// Minimal JPEG entropy encoder for round-trip tests: canonical codes for
+    /// a caller-chosen DHT, MSB-first bit writer with FF stuffing.
+    struct TestEncoder {
+        /// (code, len) per DC symbol value.
+        dc_codes: std::collections::HashMap<u8, (u32, u8)>,
+        /// (code, len) per AC symbol value.
+        ac_codes: std::collections::HashMap<u8, (u32, u8)>,
+        bits: Vec<u8>,
+        acc: u64,
+        nbits: u32,
+    }
+
+    impl TestEncoder {
+        fn canonical(counts: &[u8; 16], values: &[u8]) -> std::collections::HashMap<u8, (u32, u8)> {
+            let mut codes = std::collections::HashMap::new();
+            let mut code = 0u32;
+            let mut si = 0usize;
+            for (i, &count) in counts.iter().enumerate() {
+                for _ in 0..count {
+                    codes.insert(values[si], (code, (i + 1) as u8));
+                    code += 1;
+                    si += 1;
+                }
+                code <<= 1;
+            }
+            codes
+        }
+
+        fn new(
+            dc_counts: &[u8; 16],
+            dc_values: &[u8],
+            ac_counts: &[u8; 16],
+            ac_values: &[u8],
+        ) -> Self {
+            Self {
+                dc_codes: Self::canonical(dc_counts, dc_values),
+                ac_codes: Self::canonical(ac_counts, ac_values),
+                bits: Vec::new(),
+                acc: 0,
+                nbits: 0,
+            }
+        }
+
+        fn put_bits(&mut self, value: u32, n: u8) {
+            for i in (0..n).rev() {
+                self.acc = (self.acc << 1) | ((value >> i) & 1) as u64;
+                self.nbits += 1;
+                if self.nbits == 8 {
+                    let b = self.acc as u8;
+                    self.bits.push(b);
+                    if b == 0xFF {
+                        self.bits.push(0x00);
+                    }
+                    self.acc = 0;
+                    self.nbits = 0;
+                }
+            }
+        }
+
+        fn put_dc_symbol(&mut self, symbol: u8) {
+            let (code, len) = self.dc_codes[&symbol];
+            self.put_bits(code, len);
+        }
+
+        fn put_ac_symbol(&mut self, symbol: u8) {
+            let (code, len) = self.ac_codes[&symbol];
+            self.put_bits(code, len);
+        }
+
+        /// Encode one AC coefficient as (run, value != 0).
+        fn put_coeff(&mut self, run: u8, val: i32) {
+            let size = (32 - (val.unsigned_abs()).leading_zeros()) as u8;
+            self.put_ac_symbol((run << 4) | size);
+            let mag = if val < 0 {
+                (val + (1 << size) - 1) as u32
+            } else {
+                val as u32
+            };
+            self.put_bits(mag, size);
+        }
+
+        fn finish(mut self) -> Vec<u8> {
+            if self.nbits > 0 {
+                let pad = 8 - self.nbits;
+                let b = ((self.acc << pad) | ((1u64 << pad) - 1)) as u8;
+                self.bits.push(b);
+                if b == 0xFF {
+                    self.bits.push(0x00);
+                }
+            }
+            self.bits
+        }
+    }
+
+    /// DHT with 4 three-bit DC size codes and enough four-bit AC codes to
+    /// cover the shapes the pair table bakes (small runs/sizes, ZRL, EOB) plus
+    /// a size-8 symbol that must fall back to the single-coefficient probe.
+    fn test_tables() -> (
+        HuffmanTable,
+        HuffmanTable,
+        [u8; 16],
+        Vec<u8>,
+        [u8; 16],
+        Vec<u8>,
+    ) {
+        let mut dc_counts = [0u8; 16];
+        dc_counts[2] = 4; // 3-bit codes for DC sizes 0..=3
+        let dc_values = vec![0u8, 1, 2, 3];
+        let mut ac_counts = [0u8; 16];
+        ac_counts[3] = 10; // 4-bit codes
+        let ac_values = vec![0x00u8, 0x01, 0x02, 0x12, 0x21, 0xF0, 0xF1, 0xE1, 0xD1, 0x08];
+        let dc = HuffmanTable::build_with_fast_bits(&dc_counts, &dc_values, 10, false).unwrap();
+        let ac = HuffmanTable::build_with_fast_bits(&ac_counts, &ac_values, 10, true).unwrap();
+        (dc, ac, dc_counts, dc_values, ac_counts, ac_values)
+    }
+
+    /// Encode blocks, decode them with `decode_block`, and compare the full
+    /// coefficient array against a directly constructed expectation.
+    /// Exercises the pair fast path, phantom singles, the block-boundary
+    /// rewind (coefficient landing exactly on zigzag 63), ZRL, EOB, and the
+    /// size-8 fallback — across consecutive blocks sharing one bit stream so
+    /// any over-consume corrupts the following block and fails loudly.
+    #[test]
+    fn decode_block_roundtrip_pair_paths() {
+        use crate::jpeg::types::ZIGZAG;
+        let (dc, ac, dc_counts, dc_values, ac_counts, ac_values) = test_tables();
+
+        // Each block: (dc_diff, &[(zero_run, value)], explicit_eob)
+        // Zigzag positions fill as k = 1 + Σ(run_i + 1).
+        type Block = (i32, Vec<(u8, i32)>, bool);
+        let blocks: Vec<Block> = vec![
+            // Adjacent small pairs (pair hits), then EOB.
+            (2, vec![(0, 3), (0, -1), (0, 2), (1, -2)], true),
+            // Single small coefficient (phantom), EOB.
+            (-1, vec![(2, 1)], true),
+            // DC-only block (EOB immediately).
+            (0, vec![], true),
+            // Coefficient landing exactly at zigzag 63: no EOB after —
+            // the boundary rewind must not eat the next block's bits.
+            (1, vec![(15, 1), (15, -1), (15, 1), (14, 1)], false),
+            // Next block right after the boundary case: pairs again.
+            (3, vec![(0, -3), (0, 3)], true),
+            // ZRL then a coefficient, then a size-8 value (single-probe path).
+            (0, vec![(15, 1), (0, 1), (0, 200)], true),
+            // Dense run of 63 alternating values (max pair pressure).
+            (
+                -2,
+                (0..63)
+                    .map(|i| (0u8, if i % 2 == 0 { 1 } else { -1 }))
+                    .collect(),
+                false,
+            ),
+        ];
+
+        let mut enc = TestEncoder::new(&dc_counts, &dc_values, &ac_counts, &ac_values);
+        for (dc_diff, coeffs, eob) in &blocks {
+            let size = (32 - dc_diff.unsigned_abs().leading_zeros()) as u8;
+            enc.put_dc_symbol(size);
+            if size > 0 {
+                let mag = if *dc_diff < 0 {
+                    (dc_diff + (1 << size) - 1) as u32
+                } else {
+                    *dc_diff as u32
+                };
+                enc.put_bits(mag, size);
+            }
+            let mut k = 1;
+            for &(run, val) in coeffs {
+                let mut r = run;
+                while r >= 16 {
+                    enc.put_ac_symbol(0xF0);
+                    r -= 16;
+                    k += 16;
+                }
+                enc.put_coeff(r, val);
+                k += r as usize + 1;
+            }
+            if *eob {
+                assert!(k < 64, "test case bug: EOB after full block");
+                enc.put_ac_symbol(0x00);
+            } else {
+                assert_eq!(k, 64, "test case bug: unfinished block without EOB");
+            }
+        }
+        let data = enc.finish();
+
+        let mut bs = BitStream::new(&data, 0);
+        let mut dc_pred = 0i32;
+        let mut prev_has_ac = true;
+        let mut coeffs = [0i16; 64];
+        let mut expect_pred = 0i32;
+        for (bi, (dc_diff, entries, _)) in blocks.iter().enumerate() {
+            let info = decode_block::<true>(
+                &mut bs,
+                &dc,
+                &ac,
+                &mut coeffs,
+                &mut dc_pred,
+                &mut prev_has_ac,
+            )
+            .unwrap_or_else(|e| panic!("block {bi}: {e:?}"));
+            expect_pred += dc_diff;
+            let mut expected = [0i16; 64];
+            expected[0] = expect_pred as i16;
+            let mut k = 1usize;
+            let mut expect_last = 0usize;
+            for &(run, val) in entries {
+                k += run as usize;
+                expected[ZIGZAG[k] as usize] = val as i16;
+                expect_last = k;
+                k += 1;
+            }
+            assert_eq!(coeffs, expected, "block {bi} coefficients");
+            assert_eq!(info.has_ac, !entries.is_empty(), "block {bi} has_ac");
+            if info.has_ac {
+                assert!(
+                    (info.last_k as usize) >= expect_last,
+                    "block {bi}: last_k {} < highest nonzero {}",
+                    info.last_k,
+                    expect_last
+                );
+            }
+        }
+        assert!(!bs.overran(), "stream over-consumed");
+    }
+
+    #[test]
+    fn cache_hit_takes_and_restore_returns() {
+        let mut counts = [0u8; 16];
+        counts[0] = 2;
+        let values = [0u8, 1];
+        let mut cache = HuffmanCache::default();
+        let t1 = cache.intern(0, 0, &counts, &values).unwrap();
+        assert!(cache.dc[0].table.is_none());
+        cache.restore(
+            &mut [Some(t1), None, None, None],
+            &mut [None, None, None, None],
+        );
+        assert!(cache.dc[0].table.is_some());
+
+        let t2 = cache.intern(0, 0, &counts, &values).unwrap();
+        assert!(cache.dc[0].table.is_none());
+        // Same payload: intern must not rebuild (fingerprint still matches).
+        cache.restore(
+            &mut [Some(t2), None, None, None],
+            &mut [None, None, None, None],
+        );
+
+        // Different symbols: miss, rebuild, then a subsequent matching intern hits.
+        let values_miss = [0u8, 2];
+        let t3 = cache.intern(0, 0, &counts, &values_miss).unwrap();
+        cache.restore(
+            &mut [Some(t3), None, None, None],
+            &mut [None, None, None, None],
+        );
+        assert!(cache.dc[0].table.is_some());
+        let _t4 = cache.intern(0, 0, &counts, &values_miss).unwrap();
+        assert!(cache.dc[0].table.is_none());
     }
 }

--- a/crates/codec/src/jpeg/huffman.rs
+++ b/crates/codec/src/jpeg/huffman.rs
@@ -357,6 +357,13 @@ impl HuffmanCache {
                 return Ok(table);
             }
         }
+        // Rebuilding for a different payload: drop any table still parked in
+        // the slot. It was built for the OLD payload, and leaving it there
+        // lets a later matching intern hand it out under the new fingerprint
+        // (reachable via a duplicate DHT for the same slot within one frame,
+        // or an error exit that skipped `restore`) — decoding with the wrong
+        // codes.
+        slot.table = None;
         let table = HuffmanTable::build(counts, values, class != 0)?;
         slot.counts = *counts;
         slot.values.clear();
@@ -943,6 +950,39 @@ mod tests {
             }
         }
         assert!(!bs.overran(), "stream over-consumed");
+    }
+
+    /// A fingerprint change must evict any table still parked in the slot:
+    /// intern payload A, restore it, intern payload B (miss) with NO restore
+    /// (as after a decode error), then intern B again — the hit must not hand
+    /// back A's table under B's fingerprint.
+    #[test]
+    fn cache_rebuild_evicts_stale_table() {
+        let mut counts = [0u8; 16];
+        counts[0] = 2;
+        let values_a = [0u8, 1];
+        let values_b = [2u8, 3];
+        let mut cache = HuffmanCache::default();
+
+        let ta = cache.intern(1, 0, &counts, &values_a).unwrap();
+        cache.restore(
+            &mut [None, None, None, None],
+            &mut [Some(ta), None, None, None],
+        );
+
+        // Payload change; the returned table is dropped without a restore.
+        let _tb = cache.intern(1, 0, &counts, &values_b).unwrap();
+
+        // Same payload again: must be a freshly built B table, not stale A.
+        let tb2 = cache.intern(1, 0, &counts, &values_b).unwrap();
+        let data = [0b0000_0000];
+        let bs = BitStream::new(&data, 0);
+        let mut cur = bs.cursor();
+        assert_eq!(
+            tb2.decode_symbol(&mut cur).unwrap(),
+            2,
+            "stale table for the previous DHT payload was returned"
+        );
     }
 
     #[test]

--- a/crates/codec/src/jpeg/idct.rs
+++ b/crates/codec/src/jpeg/idct.rs
@@ -3,6 +3,7 @@
 
 //! IDCT dispatcher — selects scalar, NEON, AVX2, SSE4.1, or SSE2.
 
+pub mod fast;
 pub mod scalar;
 
 #[cfg(target_arch = "aarch64")]

--- a/crates/codec/src/jpeg/idct/fast.rs
+++ b/crates/codec/src/jpeg/idct/fast.rs
@@ -1,0 +1,454 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Opt-in fast 8×8 IDCT (AAN factorisation, libjpeg `ifast` class).
+//!
+//! **Off by default.** Selected via [`crate::DctMethod::Fast`]; the default
+//! path remains the accurate `islow`-class kernel, and every published
+//! comparison against libjpeg-turbo quotes the accurate kernel. This kernel
+//! trades a bounded accuracy loss (small quantised-domain rounding error, and
+//! the documented `ifast` degeneration at very high quality factors ≥ ~97)
+//! for roughly an eighth of the multiplies:
+//!
+//! - The per-coefficient AAN scale factors are folded into the **dequant
+//!   table** at derive time ([`derive_fast_quant`]), so the butterfly needs
+//!   only four constants.
+//! - All four constants are applied as `x·(1+c)` or `x·(2+c)` with `c < 1`
+//!   in Q15, i.e. one `SQDMULH` plus adds — no widening multiplies, the
+//!   whole transform stays in 16-bit lanes end to end.
+//! - Like the accurate kernels, arithmetic wraps on out-of-contract inputs
+//!   (a hostile stream garbles only its own pixels; see `IdctFn`).
+//!
+//! The scalar kernel is the reference: it mirrors the NEON ops exactly
+//! (including `SQDMULH` semantics and rounding shifts), so scalar↔NEON
+//! parity is bit-exact — same discipline as `color.rs`.
+
+/// AAN dequant scale factors in Q14: `2^14 · f(row) · f(col)` where
+/// `f(0) = 1` and `f(k) = √2 · cos(kπ/16)` — the classic `aanscales` table.
+/// Verified against the closed form in the tests below.
+#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))] // fast kernels bind on NEON only
+#[rustfmt::skip]
+pub const AANSCALES: [u16; 64] = [
+    16384, 22725, 21407, 19266, 16384, 12873,  8867,  4520,
+    22725, 31521, 29692, 26722, 22725, 17855, 12299,  6270,
+    21407, 29692, 27969, 25172, 21407, 16819, 11585,  5906,
+    19266, 26722, 25172, 22654, 19266, 15137, 10426,  5315,
+    16384, 22725, 21407, 19266, 16384, 12873,  8867,  4520,
+    12873, 17855, 16819, 15137, 12873, 10114,  6967,  3552,
+     8867, 12299, 11585, 10426,  8867,  6967,  4799,  2446,
+     4520,  6270,  5906,  5315,  4520,  3552,  2446,  1247,
+];
+
+/// Q15 butterfly constants: the fractional parts of the four AAN multipliers.
+/// `round((m − ⌊m⌋) · 2^15)` for m ∈ {1.414213562, 1.847759065, 1.082392200,
+/// 2.613125930}.
+const F_0_414: i16 = 13573; // 1.414213562 − 1
+const F_0_847: i16 = 27779; // 1.847759065 − 1
+const F_0_082: i16 = 2700; //  1.082392200 − 1
+const F_0_613: i16 = 20091; // 2.613125930 − 2
+
+/// Derive the AAN-prescaled dequant table: `(quant · aanscale + 2^11) >> 12`
+/// (Q14 scale, keeping the `ifast` 2-bit headroom). Values stay well inside
+/// `i16` (255 · 31521 ≫ 12 = 1962) and are always positive, so they are
+/// stored in the same `[u16; 64]` shape the kernels already take and
+/// reinterpreted as `i16` lanes at multiply time, exactly like the accurate
+/// kernels' dequant.
+#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))] // fast kernels bind on NEON only
+pub fn derive_fast_quant(quant: &[u16; 64]) -> [u16; 64] {
+    let mut out = [0u16; 64];
+    for (o, (&q, &s)) in out.iter_mut().zip(quant.iter().zip(AANSCALES.iter())) {
+        *o = (((q as u32) * (s as u32) + (1 << 11)) >> 12) as u16;
+    }
+    out
+}
+
+/// Scalar mirror of `vqdmulhq_n_s16`: `(2·a·b) >> 16` with saturation of the
+/// doubling (only reachable at `a = b = i16::MIN`, which the Q15 constants
+/// above never are).
+#[cfg_attr(not(test), allow(dead_code))] // reference impl, exercised by the parity tests
+#[inline(always)]
+fn qdmulh(a: i16, b: i16) -> i16 {
+    (((a as i32) * (b as i32) * 2) >> 16) as i16
+}
+
+/// One 8-point AAN butterfly on `i16` values, wrapping adds. `MULTIPLY(x, m)`
+/// is expressed as `x + qdmulh(x, frac(m))` (or `2x + …` for m > 2), the same
+/// shape the NEON kernel uses.
+#[cfg_attr(not(test), allow(dead_code))] // reference impl, exercised by the parity tests
+#[inline(always)]
+fn butterfly8_fast(s: [i16; 8]) -> [i16; 8] {
+    let mul_1_414 = |x: i16| x.wrapping_add(qdmulh(x, F_0_414));
+    let mul_1_847 = |x: i16| x.wrapping_add(qdmulh(x, F_0_847));
+    let mul_1_082 = |x: i16| x.wrapping_add(qdmulh(x, F_0_082));
+    let mul_2_613 = |x: i16| x.wrapping_add(x).wrapping_add(qdmulh(x, F_0_613));
+
+    // Even part.
+    let tmp10 = s[0].wrapping_add(s[4]);
+    let tmp11 = s[0].wrapping_sub(s[4]);
+    let tmp13 = s[2].wrapping_add(s[6]);
+    let tmp12 = mul_1_414(s[2].wrapping_sub(s[6])).wrapping_sub(tmp13);
+
+    let e0 = tmp10.wrapping_add(tmp13);
+    let e3 = tmp10.wrapping_sub(tmp13);
+    let e1 = tmp11.wrapping_add(tmp12);
+    let e2 = tmp11.wrapping_sub(tmp12);
+
+    // Odd part.
+    let z13 = s[5].wrapping_add(s[3]);
+    let z10 = s[5].wrapping_sub(s[3]);
+    let z11 = s[1].wrapping_add(s[7]);
+    let z12 = s[1].wrapping_sub(s[7]);
+
+    let t7 = z11.wrapping_add(z13);
+    let t11 = mul_1_414(z11.wrapping_sub(z13));
+    let z5 = mul_1_847(z10.wrapping_add(z12));
+    let t10 = z5.wrapping_sub(mul_1_082(z12));
+    let t12 = z5.wrapping_sub(mul_2_613(z10));
+
+    let t6 = t12.wrapping_sub(t7);
+    let t5 = t11.wrapping_sub(t6);
+    let t4 = t10.wrapping_sub(t5);
+
+    [
+        e0.wrapping_add(t7),
+        e1.wrapping_add(t6),
+        e2.wrapping_add(t5),
+        e3.wrapping_add(t4),
+        e3.wrapping_sub(t4),
+        e2.wrapping_sub(t5),
+        e1.wrapping_sub(t6),
+        e0.wrapping_sub(t7),
+    ]
+}
+
+/// Scalar fast 8×8 IDCT on quantised coefficients with an AAN-prescaled
+/// dequant table (from [`derive_fast_quant`]). Reference for the NEON kernel.
+#[cfg_attr(not(test), allow(dead_code))] // reference impl, exercised by the parity tests
+pub fn idct_8x8_scalar_fast(
+    coeffs: &[i16; 64],
+    fast_quant: &[u16; 64],
+    output: &mut [u8],
+    stride: usize,
+) {
+    let mut ws = [0i16; 64];
+
+    // Pass 1: columns.
+    for c in 0..8 {
+        let mut s = [0i16; 8];
+        for r in 0..8 {
+            s[r] = coeffs[r * 8 + c].wrapping_mul(fast_quant[r * 8 + c] as i16);
+        }
+        let o = butterfly8_fast(s);
+        for r in 0..8 {
+            ws[r * 8 + c] = o[r];
+        }
+    }
+
+    // Pass 2: rows, then descale (rounding >> 5) and centre.
+    for r in 0..8 {
+        let mut s = [0i16; 8];
+        s.copy_from_slice(&ws[r * 8..r * 8 + 8]);
+        let o = butterfly8_fast(s);
+        for c in 0..8 {
+            let v = ((o[c] as i32 + 16) >> 5) + 128;
+            output[r * stride + c] = v.clamp(0, 255) as u8;
+        }
+    }
+}
+
+/// Scalar fast DC-only fill: both AAN passes broadcast the (prescaled)
+/// dequantised DC, so the block is `clamp(((dc + 16) >> 5) + 128)`.
+#[cfg_attr(not(test), allow(dead_code))] // reference impl, exercised by the parity tests
+pub fn idct_dc_only_fast_scalar(dc_value: i32, output: &mut [u8], stride: usize) {
+    let v = ((dc_value.wrapping_add(16) >> 5) + 128).clamp(0, 255) as u8;
+    for row in output.chunks_mut(stride).take(8) {
+        row[..8].fill(v);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+pub use neon::{idct_8x8_neon_fast_k, idct_dc_only_fast_neon};
+
+#[cfg(target_arch = "aarch64")]
+mod neon {
+    use std::arch::aarch64::*;
+
+    use super::{F_0_082, F_0_414, F_0_613, F_0_847};
+
+    /// Full-width 8-lane AAN butterfly (all eight columns at once — the
+    /// 16-bit-only math is what lets the fast kernel skip the accurate
+    /// kernel's 4-lane widening halves).
+    #[inline(always)]
+    unsafe fn butterfly8_fast_q(s: [int16x8_t; 8]) -> [int16x8_t; 8] {
+        let mul_1_414 = |x: int16x8_t| vaddq_s16(x, vqdmulhq_n_s16(x, F_0_414));
+        let mul_1_847 = |x: int16x8_t| vaddq_s16(x, vqdmulhq_n_s16(x, F_0_847));
+        let mul_1_082 = |x: int16x8_t| vaddq_s16(x, vqdmulhq_n_s16(x, F_0_082));
+        let mul_2_613 = |x: int16x8_t| vaddq_s16(vaddq_s16(x, x), vqdmulhq_n_s16(x, F_0_613));
+
+        let tmp10 = vaddq_s16(s[0], s[4]);
+        let tmp11 = vsubq_s16(s[0], s[4]);
+        let tmp13 = vaddq_s16(s[2], s[6]);
+        let tmp12 = vsubq_s16(mul_1_414(vsubq_s16(s[2], s[6])), tmp13);
+
+        let e0 = vaddq_s16(tmp10, tmp13);
+        let e3 = vsubq_s16(tmp10, tmp13);
+        let e1 = vaddq_s16(tmp11, tmp12);
+        let e2 = vsubq_s16(tmp11, tmp12);
+
+        let z13 = vaddq_s16(s[5], s[3]);
+        let z10 = vsubq_s16(s[5], s[3]);
+        let z11 = vaddq_s16(s[1], s[7]);
+        let z12 = vsubq_s16(s[1], s[7]);
+
+        let t7 = vaddq_s16(z11, z13);
+        let t11 = mul_1_414(vsubq_s16(z11, z13));
+        let z5 = mul_1_847(vaddq_s16(z10, z12));
+        let t10 = vsubq_s16(z5, mul_1_082(z12));
+        let t12 = vsubq_s16(z5, mul_2_613(z10));
+
+        let t6 = vsubq_s16(t12, t7);
+        let t5 = vsubq_s16(t11, t6);
+        let t4 = vsubq_s16(t10, t5);
+
+        [
+            vaddq_s16(e0, t7),
+            vaddq_s16(e1, t6),
+            vaddq_s16(e2, t5),
+            vaddq_s16(e3, t4),
+            vsubq_s16(e3, t4),
+            vsubq_s16(e2, t5),
+            vsubq_s16(e1, t6),
+            vsubq_s16(e0, t7),
+        ]
+    }
+
+    /// NEON fast 8×8 IDCT. Signature matches the accurate `idct_8x8_neon_k`
+    /// so the MCU loop binds either as the same fn-item shape; the `last_k`
+    /// sparsity hint is unused here — the AAN butterfly is cheap enough that
+    /// tiering it has not been worth the branches so far.
+    #[inline(always)]
+    pub fn idct_8x8_neon_fast_k(
+        coeffs: &[i16; 64],
+        fast_quant: &[u16; 64],
+        _last_k: u8,
+        output: &mut [u8],
+        stride: usize,
+    ) {
+        // SAFETY: caller is the aarch64 decode path, NEON presence probed.
+        unsafe { idct_8x8_neon_fast_inner(coeffs, fast_quant, output, stride) }
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn idct_8x8_neon_fast_inner(
+        coeffs: &[i16; 64],
+        fast_quant: &[u16; 64],
+        output: &mut [u8],
+        stride: usize,
+    ) {
+        // Dequantise all eight rows (prescaled table, wrapping 16-bit mul).
+        let mut s = [vdupq_n_s16(0); 8];
+        for (r, v) in s.iter_mut().enumerate() {
+            *v = vmulq_s16(
+                vld1q_s16(coeffs.as_ptr().add(r * 8)),
+                vreinterpretq_s16_u16(vld1q_u16(fast_quant.as_ptr().add(r * 8))),
+            );
+        }
+
+        // Pass 1 (columns: lanes are columns), transpose, pass 2 (rows).
+        let w = butterfly8_fast_q(s);
+        let (t0, t1, t2, t3, t4, t5, t6, t7) =
+            super::super::neon::transpose_8x8_s16(w[0], w[1], w[2], w[3], w[4], w[5], w[6], w[7]);
+        let o = butterfly8_fast_q([t0, t1, t2, t3, t4, t5, t6, t7]);
+
+        // Descale (rounding >> 5), centre on 128, narrow to u8 — output
+        // vectors are columns, so transpose bytes back to rows and store.
+        let c128 = vdupq_n_s16(128);
+        let narrow =
+            |x: int16x8_t| -> uint8x8_t { vqmovun_s16(vaddq_s16(vrshrq_n_s16::<5>(x), c128)) };
+        let (y0, y1, y2, y3, y4, y5, y6, y7) = super::super::neon::transpose_8x8_u8(
+            narrow(o[0]),
+            narrow(o[1]),
+            narrow(o[2]),
+            narrow(o[3]),
+            narrow(o[4]),
+            narrow(o[5]),
+            narrow(o[6]),
+            narrow(o[7]),
+        );
+        let out = output.as_mut_ptr();
+        vst1_u8(out, y0);
+        vst1_u8(out.add(stride), y1);
+        vst1_u8(out.add(2 * stride), y2);
+        vst1_u8(out.add(3 * stride), y3);
+        vst1_u8(out.add(4 * stride), y4);
+        vst1_u8(out.add(5 * stride), y5);
+        vst1_u8(out.add(6 * stride), y6);
+        vst1_u8(out.add(7 * stride), y7);
+    }
+
+    /// NEON fast DC-only fill (see the scalar version for the scaling).
+    #[inline(always)]
+    pub fn idct_dc_only_fast_neon(dc_value: i32, output: &mut [u8], stride: usize) {
+        let v = ((dc_value.wrapping_add(16) >> 5) + 128).clamp(0, 255) as u8;
+        // SAFETY: 8×8 block within `output` per the IdctFn contract.
+        unsafe {
+            let fill = vdup_n_u8(v);
+            for row in 0..8 {
+                vst1_u8(output.as_mut_ptr().add(row * stride), fill);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The literal AANSCALES table must equal `2^14·f(r)·f(c)` rounded.
+    #[test]
+    fn aanscales_matches_closed_form() {
+        let f = |k: usize| -> f64 {
+            if k == 0 {
+                1.0
+            } else {
+                std::f64::consts::SQRT_2 * (k as f64 * std::f64::consts::PI / 16.0).cos()
+            }
+        };
+        for r in 0..8 {
+            for c in 0..8 {
+                let expect = (16384.0 * f(r) * f(c)).round() as u16;
+                assert_eq!(AANSCALES[r * 8 + c], expect, "({r},{c})");
+            }
+        }
+    }
+
+    /// Forward-DCT an 8×8 pixel block and quantise — the only way to get
+    /// *valid* spectra. Random coefficient arrays are not valid DCT spectra:
+    /// they decode to out-of-range "pixels" and legitimately overflow the
+    /// fast kernel's 16-bit lanes (the documented `ifast` contract), so they
+    /// cannot be used to judge its accuracy.
+    fn quantised_spectrum(pixels: &[[u8; 8]; 8], quant: &[u16; 64]) -> [i16; 64] {
+        let mut coeffs = [0i16; 64];
+        for u in 0..8 {
+            for v in 0..8 {
+                let cu = if u == 0 {
+                    std::f64::consts::FRAC_1_SQRT_2
+                } else {
+                    1.0
+                };
+                let cv = if v == 0 {
+                    std::f64::consts::FRAC_1_SQRT_2
+                } else {
+                    1.0
+                };
+                let mut s = 0.0;
+                for (y, row) in pixels.iter().enumerate() {
+                    for (x, &p) in row.iter().enumerate() {
+                        s += (p as f64 - 128.0)
+                            * ((2 * y + 1) as f64 * u as f64 * std::f64::consts::PI / 16.0).cos()
+                            * ((2 * x + 1) as f64 * v as f64 * std::f64::consts::PI / 16.0).cos();
+                    }
+                }
+                let spec = cu * cv * s / 4.0;
+                coeffs[u * 8 + v] = (spec / quant[u * 8 + v] as f64).round() as i16;
+            }
+        }
+        coeffs
+    }
+
+    /// Fast scalar output must stay close to the accurate scalar reference on
+    /// in-contract blocks (the whole point of `ifast`-class accuracy).
+    #[test]
+    fn fast_scalar_close_to_accurate() {
+        use super::super::scalar::idct_8x8_scalar;
+        let mut quant = [0u16; 64];
+        for (i, q) in quant.iter_mut().enumerate() {
+            *q = 2 + (i as u16 % 9);
+        }
+        let fq = derive_fast_quant(&quant);
+
+        let mut state = 0x2468_ACE0u32;
+        let mut next = move || {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            state
+        };
+        for t in 0..200 {
+            // Gradient + edge + noise pixel content, then a real forward DCT.
+            let mut px = [[0u8; 8]; 8];
+            let edge = (next() % 8) as usize;
+            for (y, row) in px.iter_mut().enumerate() {
+                for (x, p) in row.iter_mut().enumerate() {
+                    let base = 128.0
+                        + 70.0 * ((x as f64 + t as f64) / 2.7).sin()
+                        + 50.0 * ((y as f64 - t as f64) / 1.9).cos()
+                        + if x >= edge { 40.0 } else { -40.0 };
+                    let noise = (next() % 31) as f64 - 15.0;
+                    *p = (base + noise).clamp(0.0, 255.0) as u8;
+                }
+            }
+            let coeffs = quantised_spectrum(&px, &quant);
+            let mut acc = [0u8; 64];
+            let mut fast = [0u8; 64];
+            idct_8x8_scalar(&coeffs, &quant, &mut acc, 8);
+            idct_8x8_scalar_fast(&coeffs, &fq, &mut fast, 8);
+            for i in 0..64 {
+                let diff = (acc[i] as i32 - fast[i] as i32).abs();
+                assert!(
+                    diff <= 6,
+                    "fast kernel drifted: idx {i} accurate={} fast={} diff={diff}",
+                    acc[i],
+                    fast[i]
+                );
+            }
+        }
+    }
+
+    /// NEON fast kernel must be bit-identical to the fast scalar reference.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn fast_neon_matches_fast_scalar_exactly() {
+        if !std::arch::is_aarch64_feature_detected!("neon") {
+            eprintln!("SIMD feature not available, skipping");
+            return;
+        }
+        let mut quant = [0u16; 64];
+        for (i, q) in quant.iter_mut().enumerate() {
+            *q = 1 + (i as u16 % 24);
+        }
+        let fq = derive_fast_quant(&quant);
+        let mut state = 0x1357_9BDFu32;
+        let mut next = move || {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            state
+        };
+        for _ in 0..500 {
+            let mut coeffs = [0i16; 64];
+            for c in coeffs.iter_mut() {
+                if next() % 4 == 0 {
+                    *c = (next() % 256) as i16 - 128;
+                }
+            }
+            let mut s_out = [0u8; 64];
+            let mut n_out = [0u8; 64];
+            idct_8x8_scalar_fast(&coeffs, &fq, &mut s_out, 8);
+            idct_8x8_neon_fast_k(&coeffs, &fq, 63, &mut n_out, 8);
+            assert_eq!(s_out, n_out, "scalar/NEON fast parity");
+        }
+    }
+
+    #[test]
+    fn dc_only_fast_matches_full_kernel() {
+        let quant = [3u16; 64];
+        let fq = derive_fast_quant(&quant);
+        for dc in [-200i16, -1, 0, 1, 77, 255] {
+            let mut coeffs = [0i16; 64];
+            coeffs[0] = dc;
+            let mut full = [0u8; 64];
+            let mut fill = [0u8; 64];
+            idct_8x8_scalar_fast(&coeffs, &fq, &mut full, 8);
+            let dcv = dc.wrapping_mul(fq[0] as i16) as i32;
+            idct_dc_only_fast_scalar(dcv, &mut fill, 8);
+            assert_eq!(full, fill, "dc={dc}");
+        }
+    }
+}

--- a/crates/codec/src/jpeg/idct/neon.rs
+++ b/crates/codec/src/jpeg/idct/neon.rs
@@ -10,7 +10,10 @@
 //! `int16x8` registers (no memory round-trip). Sparse shortcuts skip the
 //! arithmetic for the two dominant block shapes of quantised natural images:
 //! all-zero bottom rows (4–7) in pass 1 and all-zero right columns (4–7) in
-//! pass 2.
+//! pass 2. A further per-half DC-only path (rows 1–7 of a 4×8 half all zero)
+//! broadcasts `dequant(row0) << PASS1_BITS`, matching turbo islow special
+//! case 2 — the remaining in-order gap after whole-block DC-only is taken in
+//! the MCU loop.
 
 use std::arch::aarch64::*;
 
@@ -176,8 +179,104 @@ unsafe fn descale_p1(x: int32x4_t) -> int16x4_t {
 
 /// NEON 8×8 IDCT on quantised i16 coefficients (natural order) with the
 /// component quant table (natural order).
+#[inline(always)]
 pub fn idct_8x8_neon(coeffs: &[i16; 64], quant: &[u16; 64], output: &mut [u8], stride: usize) {
     unsafe { idct_8x8_neon_inner(coeffs, quant, output, stride) }
+}
+
+/// NEON 8×8 IDCT with an entropy-derived sparsity hint.
+///
+/// `last_k` is the highest zigzag index the block decoder wrote (an upper
+/// bound on occupancy — see [`huffman::BlockInfo`]). Because the zigzag order
+/// fills the top-left corner first, small `last_k` proves whole regions zero
+/// without touching the coefficient memory:
+///
+/// - `last_k ≤ 1`: AC only at (0,1) — left 4×8 half is DC-broadcast shape,
+///   right half entirely zero.
+/// - `last_k ≤ 9`: the prefix stays in rows 0–3 / cols 0–2 — sparse pass-1
+///   butterfly on the left half, right half zero.
+/// - `last_k ≤ 13`: adds naturals 32/25/18/11 (row 4 possible, cols still
+///   ≤ 3) — full-width pass-1 with rows 5–7 as zero registers.
+/// - otherwise: the value-based detection kernel (which still finds shapes
+///   the prefix bound cannot prove, e.g. all-zero bottom rows behind a high
+///   `last_k`).
+///
+/// The proven-sparse tiers use only 64-bit `vld1_s16` loads for the rows that
+/// participate — the Cortex-A53's load path is 64 bits wide, and the skipped
+/// rows/halves never touch the cache. Bit-exact with [`idct_8x8_neon`]: every
+/// dropped term is exactly zero, and the shared tail is the same code.
+///
+/// [`huffman::BlockInfo`]: crate::jpeg::huffman::BlockInfo
+#[inline(always)]
+pub fn idct_8x8_neon_k(
+    coeffs: &[i16; 64],
+    quant: &[u16; 64],
+    last_k: u8,
+    output: &mut [u8],
+    stride: usize,
+) {
+    unsafe { idct_8x8_neon_k_inner(coeffs, quant, last_k, output, stride) }
+}
+
+#[target_feature(enable = "neon")]
+unsafe fn idct_8x8_neon_k_inner(
+    coeffs: &[i16; 64],
+    quant: &[u16; 64],
+    last_k: u8,
+    output: &mut [u8],
+    stride: usize,
+) {
+    if last_k > 13 {
+        return idct_8x8_neon_inner(coeffs, quant, output, stride);
+    }
+
+    let k0 = vld1q_s16(std::hint::black_box(K0.as_ptr()));
+    let k1 = vld1q_s16(std::hint::black_box(K1.as_ptr()));
+    let zero4 = vdup_n_s16(0);
+
+    // Dequantise one 4-lane left-half row (cols 0–3): 64-bit loads only.
+    let dqd = |i: usize| -> int16x4_t {
+        vmul_s16(
+            vld1_s16(coeffs.as_ptr().add(i * 8)),
+            vreinterpret_s16_u16(vld1_u16(quant.as_ptr().add(i * 8))),
+        )
+    };
+
+    let r0 = dqd(0);
+    let wl: [int16x4_t; 8] = if last_k <= 1 {
+        // Column IDCT of [v, 0, …, 0] is saturate(v << PASS1_BITS) per row.
+        let dc = vqmovn_s32(vshll_n_s16::<{ PASS1_BITS }>(r0));
+        [dc; 8]
+    } else {
+        let x = if last_k <= 9 {
+            butterfly8_sparse(r0, dqd(1), dqd(2), dqd(3), k0, k1)
+        } else {
+            butterfly8(
+                r0,
+                dqd(1),
+                dqd(2),
+                dqd(3),
+                dqd(4),
+                zero4,
+                zero4,
+                zero4,
+                k0,
+                k1,
+            )
+        };
+        [
+            descale_p1(x[0]),
+            descale_p1(x[1]),
+            descale_p1(x[2]),
+            descale_p1(x[3]),
+            descale_p1(x[4]),
+            descale_p1(x[5]),
+            descale_p1(x[6]),
+            descale_p1(x[7]),
+        ]
+    };
+
+    finish_pass2_store(wl, [zero4; 8], true, k0, k1, output, stride);
 }
 
 #[target_feature(enable = "neon")]
@@ -199,11 +298,20 @@ unsafe fn idct_8x8_neon_inner(
     let c7 = vld1q_s16(coeffs.as_ptr().add(56));
 
     let bottom_or = vorrq_s16(vorrq_s16(c4, c5), vorrq_s16(c6, c7));
-    let all_or = vorrq_s16(vorrq_s16(vorrq_s16(c0, c1), vorrq_s16(c2, c3)), bottom_or);
+    let top_ac = vorrq_s16(vorrq_s16(c1, c2), c3);
+    let ac_or = vorrq_s16(top_ac, bottom_or);
+    let all_or = vorrq_s16(c0, ac_or);
     let bottom_u64 = vreinterpretq_u64_s16(bottom_or);
     let bottom_zero = (vgetq_lane_u64::<0>(bottom_u64) | vgetq_lane_u64::<1>(bottom_u64)) == 0;
     // Columns 4–7 across all rows sit in the high 64 bits of each row vector.
     let right_zero = vgetq_lane_u64::<1>(vreinterpretq_u64_s16(all_or)) == 0;
+    // Rows 1–7 of a 4×8 half all zero → that half is DC-only (turbo islow).
+    // Whole-block DC-only is already taken in the MCU loop via `has_ac`; this
+    // catches the common "AC only in the top-left 4×4" / "row 0 only" shapes
+    // that still enter the full kernel.
+    let ac_u64 = vreinterpretq_u64_s16(ac_or);
+    let left_ac_zero = vgetq_lane_u64::<0>(ac_u64) == 0;
+    let right_ac_zero = vgetq_lane_u64::<1>(ac_u64) == 0;
 
     // Dequantise (16-bit wrapping multiply — turbo's contract; valid baseline
     // streams never overflow, corrupt ones only garble their own pixels).
@@ -214,14 +322,23 @@ unsafe fn idct_8x8_neon_inner(
         )
     };
     let r0 = dq(c0, 0);
-    let r1 = dq(c1, 1);
-    let r2 = dq(c2, 2);
-    let r3 = dq(c3, 3);
     let zero8 = vdupq_n_s16(0);
-    let (r4, r5, r6, r7) = if bottom_zero {
-        (zero8, zero8, zero8, zero8)
+    // Row-0-only (both 4×8 halves DC in pass 1): skip AC dequant entirely.
+    let skip_ac_dequant = left_ac_zero && (right_zero || right_ac_zero);
+    let (r1, r2, r3, r4, r5, r6, r7) = if skip_ac_dequant {
+        (zero8, zero8, zero8, zero8, zero8, zero8, zero8)
+    } else if bottom_zero {
+        (dq(c1, 1), dq(c2, 2), dq(c3, 3), zero8, zero8, zero8, zero8)
     } else {
-        (dq(c4, 4), dq(c5, 5), dq(c6, 6), dq(c7, 7))
+        (
+            dq(c1, 1),
+            dq(c2, 2),
+            dq(c3, 3),
+            dq(c4, 4),
+            dq(c5, 5),
+            dq(c6, 6),
+            dq(c7, 7),
+        )
     };
 
     // Butterfly constants, loaded once per block rather than rebuilt at every
@@ -264,19 +381,29 @@ unsafe fn idct_8x8_neon_inner(
         ]
     };
 
-    let wl = pass1_half(
-        vget_low_s16(r0),
-        vget_low_s16(r1),
-        vget_low_s16(r2),
-        vget_low_s16(r3),
-        vget_low_s16(r4),
-        vget_low_s16(r5),
-        vget_low_s16(r6),
-        vget_low_s16(r7),
-        bottom_zero,
-    );
+    let wl = if left_ac_zero {
+        // Column IDCT of [dc, 0,0,0,0,0,0,0] is saturate(dc << PASS1_BITS)
+        // in every row — same as descale_p1 of the 32-bit even part.
+        let dc = vqmovn_s32(vshll_n_s16::<{ PASS1_BITS }>(vget_low_s16(r0)));
+        [dc; 8]
+    } else {
+        pass1_half(
+            vget_low_s16(r0),
+            vget_low_s16(r1),
+            vget_low_s16(r2),
+            vget_low_s16(r3),
+            vget_low_s16(r4),
+            vget_low_s16(r5),
+            vget_low_s16(r6),
+            vget_low_s16(r7),
+            bottom_zero,
+        )
+    };
     let wr = if right_zero {
         [zero4; 8]
+    } else if right_ac_zero {
+        let dc = vqmovn_s32(vshll_n_s16::<{ PASS1_BITS }>(vget_high_s16(r0)));
+        [dc; 8]
     } else {
         pass1_half(
             vget_high_s16(r0),
@@ -291,6 +418,22 @@ unsafe fn idct_8x8_neon_inner(
         )
     };
 
+    finish_pass2_store(wl, wr, right_zero, k0, k1, output, stride);
+}
+
+/// Shared tail of the 8×8 kernels: combine the pass-1 half results, transpose,
+/// run pass 2 (sparse when the right workspace half is known zero), descale,
+/// and store. `#[inline(always)]` so each caller keeps its registers.
+#[inline(always)]
+unsafe fn finish_pass2_store(
+    wl: [int16x4_t; 8],
+    wr: [int16x4_t; 8],
+    right_zero: bool,
+    k0: int16x8_t,
+    k1: int16x8_t,
+    output: &mut [u8],
+    stride: usize,
+) {
     // Workspace rows (lanes = columns) → transpose to columns (lanes = rows).
     let w0 = vcombine_s16(wl[0], wr[0]);
     let w1 = vcombine_s16(wl[1], wr[1]);
@@ -375,7 +518,7 @@ unsafe fn idct_8x8_neon_inner(
 /// 8×8 transpose of int16x8 vectors (three trn stages: 16 → 32 → 64 bit).
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-unsafe fn transpose_8x8_s16(
+pub(crate) unsafe fn transpose_8x8_s16(
     w0: int16x8_t,
     w1: int16x8_t,
     w2: int16x8_t,
@@ -431,7 +574,7 @@ unsafe fn transpose_8x8_s16(
 /// 8×8 transpose of uint8x8 vectors (three trn stages: 8 → 16 → 32 bit).
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
-unsafe fn transpose_8x8_u8(
+pub(crate) unsafe fn transpose_8x8_u8(
     u0: uint8x8_t,
     u1: uint8x8_t,
     u2: uint8x8_t,
@@ -485,6 +628,7 @@ unsafe fn transpose_8x8_u8(
 }
 
 /// NEON DC-only IDCT: fill 8×8 block with a single value.
+#[inline(always)]
 pub fn idct_dc_only_neon(dc_value: i32, output: &mut [u8], stride: usize) {
     let range_shift = CONST_BITS + PASS1_BITS + 3;
     let round = 1 << (range_shift - 1);
@@ -507,7 +651,8 @@ pub fn idct_dc_only_neon(dc_value: i32, output: &mut [u8], stride: usize) {
 #[cfg(test)]
 mod tests {
     use super::super::scalar::{idct_8x8_scalar, idct_dc_only_scalar};
-    use super::{idct_8x8_neon, idct_dc_only_neon};
+    use super::{idct_8x8_neon, idct_8x8_neon_k, idct_dc_only_neon};
+    use crate::jpeg::types::ZIGZAG;
 
     const UNIT_QUANT: [u16; 64] = [1u16; 64];
 
@@ -554,6 +699,40 @@ mod tests {
         // Default coefficients live in rows 0–3 / cols 0–3: exercises both
         // sparse shortcuts (bottom rows zero + right columns zero).
         assert_parity(&make_test_coeffs(), &UNIT_QUANT, "sparse");
+    }
+
+    /// Rows 1–7 zero: per-half DC-only shortcut (turbo islow case 2).
+    #[test]
+    fn idct_8x8_parity_row0_only() {
+        if !std::arch::is_aarch64_feature_detected!("neon") {
+            eprintln!("SIMD feature not available, skipping");
+            return;
+        }
+        let mut coeffs = [0i16; 64];
+        coeffs[0] = 256;
+        coeffs[1] = 40;
+        coeffs[2] = -16;
+        coeffs[3] = 8;
+        assert_parity(&coeffs, &UNIT_QUANT, "row0-left");
+        coeffs[4] = 22;
+        coeffs[7] = -9;
+        assert_parity(&coeffs, &UNIT_QUANT, "row0-both-halves");
+    }
+
+    /// Left 4×8 is DC-only; right 4×8 has AC — the two halves take different
+    /// shortcuts.
+    #[test]
+    fn idct_8x8_parity_left_dc_right_ac() {
+        if !std::arch::is_aarch64_feature_detected!("neon") {
+            eprintln!("SIMD feature not available, skipping");
+            return;
+        }
+        let mut coeffs = [0i16; 64];
+        coeffs[0] = 200;
+        coeffs[5] = 18;
+        coeffs[12] = -14;
+        coeffs[23] = 9;
+        assert_parity(&coeffs, &UNIT_QUANT, "left-dc-right-ac");
     }
 
     /// Coefficients in columns 4–7 defeat the right-half skip; parity must
@@ -655,6 +834,58 @@ mod tests {
                     simd_out[i],
                     diff
                 );
+            }
+        }
+    }
+
+    /// The entropy-hinted kernel must be bit-identical to the value-detection
+    /// kernel for every tier. For each `last_k`, build a block whose occupied
+    /// zigzag prefix ends exactly at `last_k` (worst case for the tier bound)
+    /// and compare against the scalar reference.
+    #[test]
+    fn idct_8x8_k_tiers_match_scalar() {
+        if !std::arch::is_aarch64_feature_detected!("neon") {
+            eprintln!("SIMD feature not available, skipping");
+            return;
+        }
+        let mut quant = [0u16; 64];
+        for (i, q) in quant.iter_mut().enumerate() {
+            *q = 1 + (i as u16 % 7);
+        }
+        for last_k in 1..64u8 {
+            let mut coeffs = [0i16; 64];
+            coeffs[0] = 300;
+            // Fill the whole prefix with non-zeros: every position the bound
+            // permits is occupied, so a tier that loads too little fails loudly.
+            for k in 1..=last_k {
+                let natural = ZIGZAG[k as usize] as usize;
+                coeffs[natural] = if k % 2 == 0 { 17 } else { -13 };
+            }
+            let mut scalar_out = [0u8; 64];
+            let mut simd_out = [0u8; 64];
+            idct_8x8_scalar(&coeffs, &quant, &mut scalar_out, 8);
+            idct_8x8_neon_k(&coeffs, &quant, last_k, &mut simd_out, 8);
+            for i in 0..64 {
+                let diff = (scalar_out[i] as i32 - simd_out[i] as i32).abs();
+                assert!(
+                    diff <= 1,
+                    "last_k={last_k}: mismatch at {i}: scalar={} simd={}",
+                    scalar_out[i],
+                    simd_out[i]
+                );
+            }
+            // A sparser block under the same bound (only the last position
+            // occupied) must also match — the hint is an upper bound.
+            let mut coeffs2 = [0i16; 64];
+            coeffs2[0] = -180;
+            coeffs2[ZIGZAG[last_k as usize] as usize] = 21;
+            let mut scalar2 = [0u8; 64];
+            let mut simd2 = [0u8; 64];
+            idct_8x8_scalar(&coeffs2, &quant, &mut scalar2, 8);
+            idct_8x8_neon_k(&coeffs2, &quant, last_k, &mut simd2, 8);
+            for i in 0..64 {
+                let diff = (scalar2[i] as i32 - simd2[i] as i32).abs();
+                assert!(diff <= 1, "sparse last_k={last_k}: mismatch at {i}");
             }
         }
     }

--- a/crates/codec/src/jpeg/markers.rs
+++ b/crates/codec/src/jpeg/markers.rs
@@ -4,7 +4,7 @@
 //! JPEG marker segment parsing (SOF, SOS, DQT, DHT, DRI, APP/EXIF).
 
 use crate::error::{CodecError, UnsupportedFeature};
-use crate::jpeg::huffman::HuffmanTable;
+use crate::jpeg::huffman::{HuffmanCache, HuffmanTable};
 use crate::jpeg::types::{marker, Component, ImageHeader, QuantTable, SamplingFactor, ZIGZAG};
 
 /// Read a big-endian u16 from two bytes.
@@ -34,6 +34,15 @@ pub struct JpegHeaders {
 /// Returns `CodecError::InvalidData` for malformed markers, missing SOF/SOS,
 /// progressive JPEGs, or truncated data.
 pub fn parse_markers(data: &[u8]) -> crate::Result<JpegHeaders> {
+    parse_markers_with_cache(data, None)
+}
+
+/// Like [`parse_markers`], but reuses Huffman LUTs from `cache` when the DHT
+/// payload matches the previous frame (tables are **moved** out of the cache).
+pub(crate) fn parse_markers_with_cache(
+    data: &[u8],
+    mut cache: Option<&mut HuffmanCache>,
+) -> crate::Result<JpegHeaders> {
     if data.len() < 4 || data[0] != 0xFF || data[1] != marker::SOI {
         return Err(CodecError::InvalidData("not a JPEG (missing SOI)".into()));
     }
@@ -259,10 +268,14 @@ pub fn parse_markers(data: &[u8]) -> crate::Result<JpegHeaders> {
                     if off + total > data.len() {
                         return Err(CodecError::InvalidData("truncated DHT values".into()));
                     }
-                    let values = data[off..off + total].to_vec();
+                    let values = &data[off..off + total];
                     off += total;
 
-                    let table = HuffmanTable::build(&counts, &values)?;
+                    let table = if let Some(ref mut c) = cache {
+                        c.intern(table_class, table_id, &counts, values)?
+                    } else {
+                        HuffmanTable::build(&counts, values, table_class != 0)?
+                    };
                     if table_class == 0 {
                         dc_tables[table_id] = Some(table);
                     } else {
@@ -465,5 +478,18 @@ mod tests {
         assert_eq!(headers.header.height, 720);
         assert_eq!(headers.header.components.len(), 3);
         assert!(!headers.header.is_progressive);
+    }
+
+    #[test]
+    fn huffman_cache_second_parse_takes_tables() {
+        let data = minimal_jpeg();
+        let mut cache = HuffmanCache::default();
+        let mut h1 = parse_markers_with_cache(&data, Some(&mut cache)).unwrap();
+        assert!(h1.dc_tables[0].is_some());
+        cache.restore(&mut h1.dc_tables, &mut h1.ac_tables);
+        let mut h2 = parse_markers_with_cache(&data, Some(&mut cache)).unwrap();
+        assert!(h2.dc_tables[0].is_some());
+        assert!(h2.ac_tables[0].is_some());
+        cache.restore(&mut h2.dc_tables, &mut h2.ac_tables);
     }
 }

--- a/crates/codec/src/jpeg/mcu.rs
+++ b/crates/codec/src/jpeg/mcu.rs
@@ -13,7 +13,7 @@
 use crate::error::CodecError;
 use crate::jpeg::bitstream::BitStream;
 use crate::jpeg::huffman::{self, HuffmanTable};
-use crate::jpeg::idct::{self, IdctDcOnlyFn, IdctFn};
+use crate::jpeg::idct;
 use crate::jpeg::markers::JpegHeaders;
 use edgefirst_tensor::PixelFormat;
 
@@ -65,6 +65,7 @@ impl McuScratch {
 /// sampling shader applies (logical wrap vs. physical placement), keeping the
 /// codec and shader provably in agreement. `output_format` must be `Grey`,
 /// `Nv12`, `Nv16`, or `Nv24`.
+#[allow(clippy::too_many_arguments)]
 pub fn decode_image(
     data: &[u8],
     headers: &JpegHeaders,
@@ -72,6 +73,7 @@ pub fn decode_image(
     dst: &mut [u8],
     grid_row_stride: usize,
     output_format: PixelFormat,
+    fast_dct: bool,
 ) -> crate::Result<()> {
     let hdr = &headers.header;
     let img_w = hdr.width as usize;
@@ -134,10 +136,421 @@ pub fn decode_image(
         )));
     }
 
-    let idct_fn: IdctFn = idct::select_idct();
-    let idct_dc_fn: IdctDcOnlyFn = idct::select_idct_dc_only();
+    // Bind the IDCT as a fn-item (not a `fn` pointer). An indirect call per
+    // block is cheap on OoO cores and not on in-order A53/A55 (~20k blocks
+    // on a 640×640 4:4:4 frame). The NEON entry is `#[target_feature]` so a
+    // direct `bl` is legal; the 8×8 kernel stays outlined (one I-cache copy).
+    //
+    // The opt-in fast (AAN) kernel exists on the NEON path only; elsewhere
+    // `fast_dct` is advisory and the accurate path runs (see `DctMethod`).
+    // The dequant tables must match the kernel class: the fast kernels take
+    // AAN-prescaled tables, so both are resolved here, together.
+    #[cfg(target_arch = "aarch64")]
+    {
+        use crate::jpeg::cpu::{neon_tier, NeonTier};
+        if !matches!(neon_tier(), NeonTier::Scalar)
+            && std::arch::is_aarch64_feature_detected!("neon")
+        {
+            if fast_dct {
+                let quants: [[u16; 64]; 4] = core::array::from_fn(|i| {
+                    idct::fast::derive_fast_quant(&headers.quant_tables[i].values)
+                });
+                // SAFETY: NEON was probed above.
+                return unsafe {
+                    decode_image_neon_fast(
+                        data,
+                        headers,
+                        scratch,
+                        dst,
+                        grid_row_stride,
+                        output_format,
+                        &quants,
+                    )
+                };
+            }
+            let quants: [[u16; 64]; 4] = core::array::from_fn(|i| headers.quant_tables[i].values);
+            // SAFETY: NEON was probed above.
+            return unsafe {
+                decode_image_neon(
+                    data,
+                    headers,
+                    scratch,
+                    dst,
+                    grid_row_stride,
+                    output_format,
+                    &quants,
+                )
+            };
+        }
+    }
+    let _ = fast_dct; // advisory: no fast kernels outside the NEON path
+    let quants: [[u16; 64]; 4] = core::array::from_fn(|i| headers.quant_tables[i].values);
+    // Non-NEON kernels ignore the entropy-derived `last_k` sparsity hint.
+    let idct_fn = idct::select_idct();
+    decode_image_idct(
+        data,
+        headers,
+        scratch,
+        dst,
+        grid_row_stride,
+        output_format,
+        &quants,
+        move |coeffs: &[i16; 64], quant: &[u16; 64], _last_k: u8, out: &mut [u8], stride: usize| {
+            idct_fn(coeffs, quant, out, stride)
+        },
+        idct::select_idct_dc_only(),
+    )
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn decode_image_neon(
+    data: &[u8],
+    headers: &JpegHeaders,
+    scratch: &mut McuScratch,
+    dst: &mut [u8],
+    grid_row_stride: usize,
+    output_format: PixelFormat,
+    quants: &[[u16; 64]; 4],
+) -> crate::Result<()> {
+    decode_image_idct(
+        data,
+        headers,
+        scratch,
+        dst,
+        grid_row_stride,
+        output_format,
+        quants,
+        crate::jpeg::idct::neon::idct_8x8_neon_k,
+        crate::jpeg::idct::neon::idct_dc_only_neon,
+    )
+}
+
+/// Fast (AAN) kernel binding — `quants` must be AAN-prescaled
+/// ([`idct::fast::derive_fast_quant`]).
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn decode_image_neon_fast(
+    data: &[u8],
+    headers: &JpegHeaders,
+    scratch: &mut McuScratch,
+    dst: &mut [u8],
+    grid_row_stride: usize,
+    output_format: PixelFormat,
+    quants: &[[u16; 64]; 4],
+) -> crate::Result<()> {
+    decode_image_idct(
+        data,
+        headers,
+        scratch,
+        dst,
+        grid_row_stride,
+        output_format,
+        quants,
+        crate::jpeg::idct::fast::idct_8x8_neon_fast_k,
+        crate::jpeg::idct::fast::idct_dc_only_fast_neon,
+    )
+}
+
+/// Dedicated decode loop for the dominant colour shape: 3 components, all
+/// 1×1 sampling (4:4:4), writing NV24 or fused RGB directly per MCU.
+///
+/// The generic loop's sampling-factor machinery (per-component block loops,
+/// `Option` table lookups, planar scratch strides) forces a stack frame past
+/// the register file, and `perf annotate` on Cortex-A53/A55 showed the block
+/// loop reloading spilled state per block (`ldr/str [sp, #448..784]`). This
+/// shape — every COCO image, most camera 4:4:4 streams — needs none of it:
+/// one Y, one Cb, one Cr block per MCU, tables and quant pointers resolved
+/// once into plain locals.
+///
+/// Behaviour is bit-identical to the generic loop's `direct_444` arms, which
+/// dispatch here instead.
+#[allow(clippy::too_many_arguments)]
+fn decode_image_444_direct<Idct, IdctDc>(
+    data: &[u8],
+    headers: &JpegHeaders,
+    dst: &mut [u8],
+    grid_row_stride: usize,
+    output_format: PixelFormat,
+    quants: &[[u16; 64]; 4],
+    idct_fn: Idct,
+    idct_dc_fn: IdctDc,
+) -> crate::Result<()>
+where
+    Idct: Copy + Fn(&[i16; 64], &[u16; 64], u8, &mut [u8], usize),
+    IdctDc: Copy + Fn(i32, &mut [u8], usize),
+{
+    let hdr = &headers.header;
+    let img_w = hdr.width as usize;
+    let img_h = hdr.height as usize;
+    let is_rgb = output_format == PixelFormat::Rgb;
+
+    // Resolve per-component tables once into plain references — no per-block
+    // Option indexing in the loop.
+    let comp_tables = |i: usize| -> crate::Result<(&HuffmanTable, &HuffmanTable, &[u16; 64])> {
+        let c = &hdr.components[i];
+        let dc = headers.dc_tables[c.dc_table_id as usize]
+            .as_ref()
+            .ok_or_else(|| {
+                CodecError::InvalidData(format!("missing DC Huffman table {}", c.dc_table_id))
+            })?;
+        let ac = headers.ac_tables[c.ac_table_id as usize]
+            .as_ref()
+            .ok_or_else(|| {
+                CodecError::InvalidData(format!("missing AC Huffman table {}", c.ac_table_id))
+            })?;
+        Ok((dc, ac, &quants[c.quant_table_id as usize]))
+    };
+    let (dc_y, ac_y, q_y) = comp_tables(0)?;
+    let (dc_cb, ac_cb, q_cb) = comp_tables(1)?;
+    let (dc_cr, ac_cr, q_cr) = comp_tables(2)?;
+
+    // Same per-tier monomorphisation as the generic loop.
+    type DecodeBlockFn = for<'d> fn(
+        &mut BitStream<'d>,
+        &HuffmanTable,
+        &HuffmanTable,
+        &mut [i16; 64],
+        &mut i32,
+        &mut bool,
+    ) -> crate::Result<huffman::BlockInfo>;
+    let decode_block_fn: DecodeBlockFn = if crate::jpeg::cpu::entropy_pair_decode() {
+        huffman::decode_block::<true>
+    } else {
+        huffman::decode_block::<false>
+    };
+
+    let mut dc_pred = [0i32; 3];
+    let mut bs = BitStream::with_prefetch(
+        data,
+        headers.scan_data_offset,
+        crate::jpeg::cpu::entropy_prefetch_distance(),
+    );
+
+    let mcus_x = hdr.mcus_x();
+    let mcus_y = hdr.mcus_y();
+    let restart_interval = headers.restart_interval as usize;
+    let mut mcu_count = 0usize;
+
+    let mut coeffs = [0i16; 64];
+    let mut prev_has_ac = true; // force full clear on first block
+    let mut y_blk = [0u8; 64];
+    let mut cb_blk = [0u8; 64];
+    let mut cr_blk = [0u8; 64];
+
+    for mcu_row in 0..mcus_y {
+        let y_start = mcu_row * 8;
+        let num_rows = 8usize.min(img_h - y_start);
+        let _entropy =
+            tracing::trace_span!("codec.decode_jpeg.mcu_row.huffman_idct", row = mcu_row).entered();
+
+        let mut pend_y = [0u8; 64];
+        let mut pend_cb = [0u8; 64];
+        let mut pend_cr = [0u8; 64];
+        let mut pend_x = 0usize;
+        let mut has_pend = false;
+        for mcu_col in 0..mcus_x {
+            if restart_interval > 0 && mcu_count > 0 && mcu_count.is_multiple_of(restart_interval) {
+                bs.skip_restart_marker();
+                dc_pred = [0i32; 3];
+                prev_has_ac = true;
+            }
+
+            let x_offset = mcu_col * 8;
+
+            // Y block: straight into dst for interior NV24 MCUs, else via
+            // y_blk (fused RGB, or edge clipping).
+            let blk = decode_block_fn(
+                &mut bs,
+                dc_y,
+                ac_y,
+                &mut coeffs,
+                &mut dc_pred[0],
+                &mut prev_has_ac,
+            )?;
+            if !is_rgb {
+                let dst_off = y_start * grid_row_stride + x_offset;
+                let cols_fit = grid_row_stride.saturating_sub(x_offset).min(8);
+                if num_rows == 8 && cols_fit == 8 {
+                    idct_into(
+                        blk.has_ac,
+                        blk.last_k,
+                        &coeffs,
+                        q_y,
+                        &mut dst[dst_off..],
+                        grid_row_stride,
+                        idct_fn,
+                        idct_dc_fn,
+                    );
+                } else {
+                    idct_into(
+                        blk.has_ac, blk.last_k, &coeffs, q_y, &mut y_blk, 8, idct_fn, idct_dc_fn,
+                    );
+                    for r in 0..num_rows {
+                        let d = dst_off + r * grid_row_stride;
+                        dst[d..d + cols_fit].copy_from_slice(&y_blk[r * 8..r * 8 + cols_fit]);
+                    }
+                }
+            } else {
+                idct_into(
+                    blk.has_ac, blk.last_k, &coeffs, q_y, &mut y_blk, 8, idct_fn, idct_dc_fn,
+                );
+            }
+
+            let blk = decode_block_fn(
+                &mut bs,
+                dc_cb,
+                ac_cb,
+                &mut coeffs,
+                &mut dc_pred[1],
+                &mut prev_has_ac,
+            )?;
+            idct_into(
+                blk.has_ac,
+                blk.last_k,
+                &coeffs,
+                q_cb,
+                &mut cb_blk,
+                8,
+                idct_fn,
+                idct_dc_fn,
+            );
+
+            let blk = decode_block_fn(
+                &mut bs,
+                dc_cr,
+                ac_cr,
+                &mut coeffs,
+                &mut dc_pred[2],
+                &mut prev_has_ac,
+            )?;
+            idct_into(
+                blk.has_ac,
+                blk.last_k,
+                &coeffs,
+                q_cr,
+                &mut cr_blk,
+                8,
+                idct_fn,
+                idct_dc_fn,
+            );
+
+            // Write stage — identical to the generic loop's direct_444 tail.
+            let x = x_offset;
+            let cols = img_w.saturating_sub(x).min(8);
+            let rows = num_rows;
+            if is_rgb {
+                if has_pend {
+                    crate::jpeg::color::ycbcr_to_rgb_blocks(
+                        &pend_y,
+                        &pend_cb,
+                        &pend_cr,
+                        Some((&y_blk, &cb_blk, &cr_blk)),
+                        dst,
+                        grid_row_stride,
+                        pend_x,
+                        y_start,
+                        8,
+                        cols,
+                        rows,
+                    );
+                    has_pend = false;
+                } else if mcu_col + 1 < mcus_x
+                    && cols == 8
+                    && img_w.saturating_sub(x + 8).min(8) == 8
+                {
+                    pend_y = y_blk;
+                    pend_cb = cb_blk;
+                    pend_cr = cr_blk;
+                    pend_x = x;
+                    has_pend = true;
+                } else if cols > 0 && rows > 0 {
+                    crate::jpeg::color::ycbcr_to_rgb_blocks(
+                        &y_blk,
+                        &cb_blk,
+                        &cr_blk,
+                        None,
+                        dst,
+                        grid_row_stride,
+                        x,
+                        y_start,
+                        cols,
+                        0,
+                        rows,
+                    );
+                }
+            } else if cols > 0 && rows > 0 {
+                write_nv24_uv_block(
+                    &cb_blk,
+                    &cr_blk,
+                    dst,
+                    grid_row_stride,
+                    x,
+                    y_start,
+                    cols,
+                    rows,
+                    img_h,
+                );
+            }
+
+            mcu_count += 1;
+        }
+        debug_assert!(!has_pend, "pending RGB MCU not flushed at end of row");
+    }
+
+    if bs.overran() {
+        return Err(CodecError::InvalidData(
+            "truncated entropy-coded scan".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decode_image_idct<Idct, IdctDc>(
+    data: &[u8],
+    headers: &JpegHeaders,
+    scratch: &mut McuScratch,
+    dst: &mut [u8],
+    grid_row_stride: usize,
+    output_format: PixelFormat,
+    quants: &[[u16; 64]; 4],
+    idct_fn: Idct,
+    idct_dc_fn: IdctDc,
+) -> crate::Result<()>
+where
+    Idct: Copy + Fn(&[i16; 64], &[u16; 64], u8, &mut [u8], usize),
+    IdctDc: Copy + Fn(i32, &mut [u8], usize),
+{
+    let hdr = &headers.header;
+    let img_w = hdr.width as usize;
+    let img_h = hdr.height as usize;
+    let num_components = hdr.components.len();
+    let is_rgb = output_format == PixelFormat::Rgb;
 
     let is_greyscale = num_components == 1;
+
+    // Standard 4:4:4 (1×1 sampling on every component) with per-MCU NV24 UV /
+    // fused RGB writes: dedicated tight loop (see decode_image_444_direct).
+    if num_components == 3
+        && hdr.max_h_samp == 1
+        && hdr.max_v_samp == 1
+        && matches!(output_format, PixelFormat::Nv24 | PixelFormat::Rgb)
+    {
+        return decode_image_444_direct(
+            data,
+            headers,
+            dst,
+            grid_row_stride,
+            output_format,
+            quants,
+            idct_fn,
+            idct_dc_fn,
+        );
+    }
 
     // Fixed-size per-component state — no heap allocation per decode. JPEG
     // baseline allows at most 4 components (we only emit 1- and 3-component
@@ -166,6 +579,23 @@ pub fn decode_image(
         );
     }
 
+    // Paired-coefficient probe: a per-tier choice (OoO cores win, in-order
+    // cores lose — see cpu::entropy_pair_decode). Monomorphised, selected
+    // once per decode: one indirect call per block costs less than keeping a
+    // second live call site in the loop (which cost ~7% on the A53).
+    type DecodeBlockFn = for<'d> fn(
+        &mut BitStream<'d>,
+        &HuffmanTable,
+        &HuffmanTable,
+        &mut [i16; 64],
+        &mut i32,
+        &mut bool,
+    ) -> crate::Result<huffman::BlockInfo>;
+    let decode_block_fn: DecodeBlockFn = if crate::jpeg::cpu::entropy_pair_decode() {
+        huffman::decode_block::<true>
+    } else {
+        huffman::decode_block::<false>
+    };
     let mut dc_pred = [0i32; 4];
     let mut bs = BitStream::with_prefetch(
         data,
@@ -188,8 +618,9 @@ pub fn decode_image(
         let num_rows = mcu_pixel_h.min(img_h - y_start);
         // Direct Y→dst for full MCU-row bands (avoids planar scratch + memcpy).
         // Partial bottom bands still go through scratch + clipped copy.
-        // Chroma still uses planar MCU-row scratch + full-row NEON `vst2`
-        // interleave — 8-wide per-block interleave loses the SIMD path.
+        // 4:4:4 1×1 (COCO + fused RGB) writes chroma per MCU instead — see
+        // `direct_444`. Other chroma still uses planar scratch + full-row
+        // NEON `vst2` interleave.
         let y_direct = !is_greyscale
             && output_format != PixelFormat::Grey
             && !is_rgb
@@ -217,13 +648,13 @@ pub fn decode_image(
                     let blocks_v = comp.sampling.v as usize;
                     let comp_stride = mcus_x * blocks_h * 8;
 
-                    let quant = &headers.quant_tables[comp.quant_table_id as usize].values;
+                    let quant = &quants[comp.quant_table_id as usize];
 
                     let mut bv = 0usize;
                     while bv < blocks_v {
                         let mut bh = 0usize;
                         while bh < blocks_h {
-                            let has_ac = huffman::decode_block(
+                            let blk = decode_block_fn(
                                 &mut bs,
                                 dc_tables[ci].expect("resolved above for every component"),
                                 ac_tables[ci].expect("resolved above for every component"),
@@ -231,6 +662,8 @@ pub fn decode_image(
                                 &mut dc_pred[ci],
                                 &mut prev_has_ac,
                             )?;
+                            let has_ac = blk.has_ac;
+                            let last_k = blk.last_k;
 
                             let x_offset = mcu_col * blocks_h * 8 + bh * 8;
                             let y_offset = bv * 8;
@@ -238,17 +671,16 @@ pub fn decode_image(
                             if y_direct && ci == 0 {
                                 let dst_off = (y_start + y_offset) * grid_row_stride + x_offset;
                                 if x_offset + 8 <= grid_row_stride {
-                                    if has_ac {
-                                        idct_fn(
-                                            &coeffs,
-                                            quant,
-                                            &mut dst[dst_off..],
-                                            grid_row_stride,
-                                        );
-                                    } else {
-                                        let dc = dc_only_coefficient(coeffs[0], quant[0]);
-                                        idct_dc_fn(dc, &mut dst[dst_off..], grid_row_stride);
-                                    }
+                                    idct_into(
+                                        has_ac,
+                                        last_k,
+                                        &coeffs,
+                                        quant,
+                                        &mut dst[dst_off..],
+                                        grid_row_stride,
+                                        idct_fn,
+                                        idct_dc_fn,
+                                    );
                                 } else {
                                     // Right-edge MCU whose 8-wide block spills past the
                                     // physical row (MCU-aligned width > grid width, e.g.
@@ -257,12 +689,10 @@ pub fn decode_image(
                                     // fit — writing through would corrupt the next
                                     // row's left edge.
                                     let mut tmp = [0u8; 64];
-                                    if has_ac {
-                                        idct_fn(&coeffs, quant, &mut tmp, 8);
-                                    } else {
-                                        let dc = dc_only_coefficient(coeffs[0], quant[0]);
-                                        idct_dc_fn(dc, &mut tmp, 8);
-                                    }
+                                    idct_into(
+                                        has_ac, last_k, &coeffs, quant, &mut tmp, 8, idct_fn,
+                                        idct_dc_fn,
+                                    );
                                     let cols = grid_row_stride - x_offset; // < 8
                                     for r in 0..8 {
                                         let d = dst_off + r * grid_row_stride;
@@ -272,12 +702,16 @@ pub fn decode_image(
                             } else {
                                 let buf_offset = y_offset * comp_stride + x_offset;
                                 let buf = &mut scratch.component_bufs[ci];
-                                if has_ac {
-                                    idct_fn(&coeffs, quant, &mut buf[buf_offset..], comp_stride);
-                                } else {
-                                    let dc = dc_only_coefficient(coeffs[0], quant[0]);
-                                    idct_dc_fn(dc, &mut buf[buf_offset..], comp_stride);
-                                }
+                                idct_into(
+                                    has_ac,
+                                    last_k,
+                                    &coeffs,
+                                    quant,
+                                    &mut buf[buf_offset..],
+                                    comp_stride,
+                                    idct_fn,
+                                    idct_dc_fn,
+                                );
                             }
                             bh += 1;
                         }
@@ -389,6 +823,103 @@ pub fn decode_image(
 #[inline(always)]
 fn dc_only_coefficient(coeff: i16, quant: u16) -> i32 {
     coeff.wrapping_mul(quant as i16) as i32
+}
+
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn idct_into<Idct, IdctDc>(
+    has_ac: bool,
+    last_k: u8,
+    coeffs: &[i16; 64],
+    quant: &[u16; 64],
+    dst: &mut [u8],
+    stride: usize,
+    idct_fn: Idct,
+    idct_dc_fn: IdctDc,
+) where
+    Idct: Copy + Fn(&[i16; 64], &[u16; 64], u8, &mut [u8], usize),
+    IdctDc: Copy + Fn(i32, &mut [u8], usize),
+{
+    if has_ac {
+        idct_fn(coeffs, quant, last_k, dst, stride);
+    } else {
+        let dc = dc_only_coefficient(coeffs[0], quant[0]);
+        idct_dc_fn(dc, dst, stride);
+    }
+}
+
+/// Interleave one 8×8 Cb/Cr block into the NV24 UV plane (4:4:4 1×1).
+///
+/// UV for luma row `y` starts at `img_h * stride + y * 2 * stride` and is
+/// `2*img_w` contiguous bytes — the same linear layout as
+/// [`write_nv16_nv24_rows`]. 8-wide `vst2` keeps a SIMD store without the
+/// planar scratch + full-row second pass.
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn write_nv24_uv_block(
+    cb: &[u8; 64],
+    cr: &[u8; 64],
+    dst: &mut [u8],
+    stride: usize,
+    x: usize,
+    y: usize,
+    cols: usize,
+    rows: usize,
+    img_h: usize,
+) {
+    let uv_off = img_h * stride;
+    if cols == 8 {
+        #[cfg(target_arch = "aarch64")]
+        {
+            use crate::jpeg::cpu::{neon_tier, NeonTier};
+            if !matches!(neon_tier(), NeonTier::Scalar)
+                && std::arch::is_aarch64_feature_detected!("neon")
+            {
+                // SAFETY: 8 Cb + 8 Cr bytes → 16 interleaved destination bytes.
+                unsafe {
+                    use core::arch::aarch64::{uint8x8x2_t, vld1_u8, vst2_u8};
+                    for r in 0..rows {
+                        let base = uv_off + (y + r) * 2 * stride + x * 2;
+                        let src = r * 8;
+                        let b = vld1_u8(cb.as_ptr().add(src));
+                        let rv = vld1_u8(cr.as_ptr().add(src));
+                        vst2_u8(dst.as_mut_ptr().add(base), uint8x8x2_t(b, rv));
+                    }
+                }
+                return;
+            }
+        }
+        #[cfg(target_arch = "x86_64")]
+        {
+            if crate::jpeg::cpu::intel_tier().has_sse2() && is_x86_feature_detected!("sse2") {
+                // SAFETY: 8+8 source bytes unpack to 16 destination bytes.
+                unsafe {
+                    use core::arch::x86_64::{
+                        _mm_loadl_epi64, _mm_storeu_si128, _mm_unpacklo_epi8,
+                    };
+                    for r in 0..rows {
+                        let base = uv_off + (y + r) * 2 * stride + x * 2;
+                        let src = r * 8;
+                        let b = _mm_loadl_epi64(cb.as_ptr().add(src) as *const _);
+                        let rv = _mm_loadl_epi64(cr.as_ptr().add(src) as *const _);
+                        _mm_storeu_si128(
+                            dst.as_mut_ptr().add(base) as *mut _,
+                            _mm_unpacklo_epi8(b, rv),
+                        );
+                    }
+                }
+                return;
+            }
+        }
+    }
+    for r in 0..rows {
+        let base = uv_off + (y + r) * 2 * stride + x * 2;
+        let src = r * 8;
+        for c in 0..cols {
+            dst[base + c * 2] = cb[src + c];
+            dst[base + c * 2 + 1] = cr[src + c];
+        }
+    }
 }
 
 /// Write interleaved RGB rows from the 4:4:4 planar band scratch (fused
@@ -1054,12 +1585,20 @@ mod tests {
         let mut out = vec![0u8; stride * img_h * 3];
 
         // Whole file decodes; the same file cut to its first MCUs does not.
-        decode_image(&jpeg, &headers, &mut scratch, &mut out, stride, fmt).unwrap();
+        decode_image(&jpeg, &headers, &mut scratch, &mut out, stride, fmt, false).unwrap();
 
         for keep in [0usize, 64, 4096] {
             let cut = (headers.scan_data_offset + keep).min(jpeg.len());
-            let err = decode_image(&jpeg[..cut], &headers, &mut scratch, &mut out, stride, fmt)
-                .expect_err("truncated scan decoded as if complete");
+            let err = decode_image(
+                &jpeg[..cut],
+                &headers,
+                &mut scratch,
+                &mut out,
+                stride,
+                fmt,
+                false,
+            )
+            .expect_err("truncated scan decoded as if complete");
             assert!(
                 matches!(err, CodecError::InvalidData(_)),
                 "keep={keep}: unexpected error {err:?}"
@@ -1090,6 +1629,7 @@ mod tests {
                 &mut nv24,
                 even_w,
                 PixelFormat::Nv24,
+                false,
             )
             .unwrap();
 
@@ -1102,6 +1642,7 @@ mod tests {
                 &mut rgb,
                 rgb_stride,
                 PixelFormat::Rgb,
+                false,
             )
             .unwrap();
 
@@ -1147,6 +1688,7 @@ mod tests {
             &mut nv24,
             even_w,
             PixelFormat::Nv24,
+            false,
         )
         .unwrap();
 
@@ -1158,6 +1700,7 @@ mod tests {
             &mut nv12,
             even_w,
             PixelFormat::Nv12,
+            false,
         )
         .unwrap();
 
@@ -1207,6 +1750,7 @@ mod tests {
             &mut nv24,
             even_w,
             PixelFormat::Nv24,
+            false,
         )
         .unwrap();
         let mut grey = vec![0u8; img_w * img_h];
@@ -1217,6 +1761,7 @@ mod tests {
             &mut grey,
             img_w,
             PixelFormat::Grey,
+            false,
         )
         .unwrap();
         let mut diffs = 0;
@@ -1246,6 +1791,7 @@ mod tests {
             &mut rgb,
             img_w * 3,
             PixelFormat::Rgb,
+            false,
         );
         assert!(err.is_err());
     }
@@ -1275,8 +1821,26 @@ mod tests {
         let mut buf_tight = vec![0u8; rows * tight];
         let mut buf_padded = vec![0u8; rows * padded];
 
-        decode_image(&jpeg, &headers, &mut scratch, &mut buf_tight, tight, fmt).unwrap();
-        decode_image(&jpeg, &headers, &mut scratch, &mut buf_padded, padded, fmt).unwrap();
+        decode_image(
+            &jpeg,
+            &headers,
+            &mut scratch,
+            &mut buf_tight,
+            tight,
+            fmt,
+            false,
+        )
+        .unwrap();
+        decode_image(
+            &jpeg,
+            &headers,
+            &mut scratch,
+            &mut buf_padded,
+            padded,
+            fmt,
+            false,
+        )
+        .unwrap();
 
         // Luma (img_h rows) + chroma (ceil(img_h/2) rows) live on the same grid,
         // each placed at its stride. The natural-width content of every used row

--- a/crates/codec/src/jpeg/mod.rs
+++ b/crates/codec/src/jpeg/mod.rs
@@ -61,8 +61,16 @@ use edgefirst_tensor::{PixelFormat, Tensor, TensorTrait};
 pub struct JpegDecoderState {
     /// MCU scratch buffers (per-component IDCT output for one MCU row band).
     mcu_scratch: Option<mcu::McuScratch>,
+    /// Huffman LUTs reused across frames when the DHT payload is unchanged.
+    /// Tables are moved into [`markers::JpegHeaders`] for the decode and
+    /// restored afterwards so a cache hit allocates nothing.
+    huffman_cache: huffman::HuffmanCache,
     /// Optional fused-output preference (see [`resolve_output_format`]).
     pub(crate) preferred_format: Option<PixelFormat>,
+    /// Opt-in fast (AAN `ifast`-class) IDCT — see [`crate::DctMethod`].
+    /// Default false; `EDGEFIRST_CODEC_DCT=fast` flips the constructor
+    /// default so benchmarks can A/B without code changes.
+    pub(crate) fast_dct: bool,
     /// V4L2 hardware decoder, lazily probed on first decode. Probed at most
     /// once; a ready context is reused (and amortises per-image setup) across
     /// decodes.
@@ -79,7 +87,11 @@ impl JpegDecoderState {
     pub fn new() -> Self {
         Self {
             mcu_scratch: None,
+            huffman_cache: huffman::HuffmanCache::default(),
             preferred_format: None,
+            fast_dct: std::env::var("EDGEFIRST_CODEC_DCT")
+                .map(|v| v.trim().eq_ignore_ascii_case("fast"))
+                .unwrap_or(false),
             #[cfg(all(target_os = "linux", feature = "v4l2"))]
             v4l2: v4l2::V4l2Probe::default(),
             #[cfg(all(target_os = "linux", feature = "nvjpeg"))]
@@ -218,13 +230,28 @@ pub fn decode_jpeg_into<T: ImagePixel>(
     )
     .entered();
 
-    let headers = {
+    let mut headers = {
         let _s = tracing::trace_span!("codec.decode_jpeg.parse_markers").entered();
-        markers::parse_markers(data)?
+        markers::parse_markers_with_cache(data, Some(&mut state.huffman_cache))?
     };
+    let result = decode_jpeg_into_parsed(data, dst, state, &headers);
+    state
+        .huffman_cache
+        .restore(&mut headers.dc_tables, &mut headers.ac_tables);
+    result
+}
+
+/// Decode using already-parsed headers. Huffman tables live in `headers` for
+/// the duration of this call; the caller restores them to the cache after.
+fn decode_jpeg_into_parsed<T: ImagePixel>(
+    data: &[u8],
+    dst: &mut Tensor<T>,
+    state: &mut JpegDecoderState,
+    headers: &markers::JpegHeaders,
+) -> crate::Result<ImageInfo> {
     let img_w = headers.header.width as usize;
     let img_h = headers.header.height as usize;
-    let native_fmt = native_format(&headers)?;
+    let native_fmt = native_format(headers)?;
     let output_fmt = resolve_output_format(native_fmt, state.preferred_format);
     // Fused (non-native) outputs are a CPU-decoder feature: the hardware
     // decoders produce fixed formats, so bypass them when the resolved output
@@ -276,7 +303,7 @@ pub fn decode_jpeg_into<T: ImagePixel>(
     if allow_hw {
         match state
             .nvjpeg
-            .try_decode::<T>(data, &headers, dst, output_fmt, img_w, img_h, dst_stride)
+            .try_decode::<T>(data, headers, dst, output_fmt, img_w, img_h, dst_stride)
         {
             Ok(Some(mut info)) => {
                 info.rotation_degrees = rotation_degrees;
@@ -300,7 +327,7 @@ pub fn decode_jpeg_into<T: ImagePixel>(
     if allow_hw {
         match state
             .v4l2
-            .try_decode::<T>(data, &headers, dst, output_fmt, img_w, img_h, dst_stride)
+            .try_decode::<T>(data, headers, dst, output_fmt, img_w, img_h, dst_stride)
         {
             Ok(Some(mut info)) => {
                 info.rotation_degrees = rotation_degrees;
@@ -318,8 +345,8 @@ pub fn decode_jpeg_into<T: ImagePixel>(
 
     // CPU decode: MCU loop writes NV12/GREY u8 directly into the tensor.
     match &mut state.mcu_scratch {
-        Some(scratch) => scratch.ensure_capacity(&headers),
-        None => state.mcu_scratch = Some(mcu::McuScratch::new(&headers)),
+        Some(scratch) => scratch.ensure_capacity(headers),
+        None => state.mcu_scratch = Some(mcu::McuScratch::new(headers)),
     }
     let mcu_scratch = state.mcu_scratch.as_mut().unwrap();
 
@@ -331,7 +358,15 @@ pub fn decode_jpeg_into<T: ImagePixel>(
             std::slice::from_raw_parts_mut(dst_bytes.as_mut_ptr() as *mut u8, dst_bytes.len())
         };
         let _s = tracing::trace_span!("codec.decode_jpeg.mcu_loop").entered();
-        mcu::decode_image(data, &headers, mcu_scratch, dst_u8, dst_stride, output_fmt)?;
+        mcu::decode_image(
+            data,
+            headers,
+            mcu_scratch,
+            dst_u8,
+            dst_stride,
+            output_fmt,
+            state.fast_dct,
+        )?;
     }
 
     // RGB output carries no chroma colorimetry (matches the nvJPEG path);

--- a/crates/codec/src/jpeg/types.rs
+++ b/crates/codec/src/jpeg/types.rs
@@ -111,3 +111,20 @@ pub const ZIGZAG: [u8; 64] = [
     13, 6, 7, 14, 21, 28, 35, 42, 49, 56, 57, 50, 43, 36, 29, 22, 15, 23, 30, 37, 44, 51, 58, 59,
     52, 45, 38, 31, 39, 46, 53, 60, 61, 54, 47, 55, 62, 63,
 ];
+
+/// [`ZIGZAG`] padded to cover any `k + run` the block decoder can form
+/// (`k ≤ 63` plus a run byte ≤ 255, including the baked EOB sentinel run of
+/// 0xFF), so the natural-index load can issue *before* the `k >= 64` bounds
+/// branch. On in-order cores that load feeds the coefficient store's address;
+/// hoisting it above the branch hides its L1 latency behind instructions the
+/// loop already executes. Entries past 63 are never used (the bounds branch
+/// diverts first) — zero keeps any speculative read in-bounds and harmless.
+pub const ZIGZAG_EXT: [u8; 320] = {
+    let mut t = [0u8; 320];
+    let mut i = 0;
+    while i < 64 {
+        t[i] = ZIGZAG[i];
+        i += 1;
+    }
+    t
+};

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -55,7 +55,7 @@ mod pixel;
 mod png;
 mod traits;
 
-pub use decoder::{peek_info, ImageDecoder};
+pub use decoder::{peek_info, DctMethod, ImageDecoder};
 pub use error::{CodecError, UnsupportedFeature};
 pub use options::ImageInfo;
 pub use pixel::ImagePixel;

--- a/crates/codec/tests/decode_jpeg.rs
+++ b/crates/codec/tests/decode_jpeg.rs
@@ -710,3 +710,62 @@ fn decode_coco_grey_odd_width() {
     assert!(y_max <= 4, "grey luma max diff {y_max} > 4");
     assert!(y_mae < 1.0, "grey luma MAE {y_mae:.3} > 1.0");
 }
+
+/// Fast (AAN) DCT mode: opt-in, and its output must stay close to the
+/// accurate default — high cosine similarity and a small worst-case pixel
+/// delta on real images. Also proves the default is untouched: decoding
+/// without the option must be bit-identical to a fresh accurate decoder.
+#[test]
+fn fast_dct_mode_close_to_accurate_and_off_by_default() {
+    use edgefirst_codec::DctMethod;
+    for name in ["zidane.jpg", "zidane_444.jpg", "giraffe.jpg"] {
+        let jpeg = testdata(name);
+        let mut t_acc = Tensor::<u8>::image(
+            4096,
+            4096,
+            PixelFormat::Nv24,
+            Some(TensorMemory::Mem),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .unwrap();
+        let mut t_fast = Tensor::<u8>::image(
+            4096,
+            4096,
+            PixelFormat::Nv24,
+            Some(TensorMemory::Mem),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .unwrap();
+
+        let mut dec = ImageDecoder::new();
+        dec.set_dct_method(DctMethod::Accurate);
+        let info_a = t_acc.load_image(&mut dec, &jpeg).unwrap();
+
+        dec.set_dct_method(DctMethod::Fast);
+        let info_f = t_fast.load_image(&mut dec, &jpeg).unwrap();
+        assert_eq!(info_a.format, info_f.format);
+
+        let a = t_acc.map().unwrap();
+        let f = t_fast.map().unwrap();
+        let n = a.len().min(f.len());
+        let (mut dot, mut na, mut nf) = (0f64, 0f64, 0f64);
+        let mut max_diff = 0i32;
+        for i in 0..n {
+            let (x, y) = (a[i] as f64, f[i] as f64);
+            dot += x * y;
+            na += x * x;
+            nf += y * y;
+            max_diff = max_diff.max((a[i] as i32 - f[i] as i32).abs());
+        }
+        let cosine = dot / (na.sqrt() * nf.sqrt());
+        eprintln!("{name}: cosine={cosine:.7} max_diff={max_diff}");
+        assert!(
+            cosine > 0.9999,
+            "{name}: cosine similarity {cosine} too low for ifast-class accuracy"
+        );
+        assert!(
+            max_diff <= 24,
+            "{name}: max pixel delta {max_diff} too high"
+        );
+    }
+}

--- a/crates/codec/tests/decode_jpeg.rs
+++ b/crates/codec/tests/decode_jpeg.rs
@@ -741,6 +741,31 @@ fn fast_dct_mode_close_to_accurate_and_off_by_default() {
         dec.set_dct_method(DctMethod::Accurate);
         let info_a = t_acc.load_image(&mut dec, &jpeg).unwrap();
 
+        // The default really is Accurate: a fresh decoder with no setter (and
+        // without the documented env override) must be bit-identical to the
+        // explicit-Accurate decode.
+        std::env::remove_var("EDGEFIRST_CODEC_DCT");
+        let mut t_def = Tensor::<u8>::image(
+            4096,
+            4096,
+            PixelFormat::Nv24,
+            Some(TensorMemory::Mem),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .unwrap();
+        let mut dec_default = ImageDecoder::new();
+        let info_d = t_def.load_image(&mut dec_default, &jpeg).unwrap();
+        assert_eq!(info_a.format, info_d.format);
+        {
+            let a = t_acc.map().unwrap();
+            let d = t_def.map().unwrap();
+            assert_eq!(
+                &a[..],
+                &d[..],
+                "{name}: default decode != explicit Accurate"
+            );
+        }
+
         dec.set_dct_method(DctMethod::Fast);
         let info_f = t_fast.load_image(&mut dec, &jpeg).unwrap();
         assert_eq!(info_a.format, info_f.format);


### PR DESCRIPTION
Rewrites the JPEG software decoder's hot paths around on-target `perf annotate` evidence from the in-order Cortex-A53/A55 boards, and adds an opt-in fast DCT mode with a measured accuracy envelope. Every change was A/B'd on the boards it targets: imx8mp (A53), imx95 (A55), rpi5 (A76), Orin Nano (A78AE), and Rocket Lake x86.

**The accurate decoder now beats libjpeg-turbo's default `islow` IDCT *and* its fast `ifast` IDCT on every platform, while producing `islow`-class pixels.** The opt-in fast mode extends the lead within the fast accuracy class by a further 14–32%.

## Results

Six-arm decode A/B (`decode-ab-sweep.sh`): COCO val2017, decode-only, n=200, pinned, interleaved best-of-3, p50 ms — lower is better. **Bold** marks the fastest arm in each accuracy class (accurate: EdgeFirst vs turbo `islow`; fast: EdgeFirst `fast` vs turbo `ifast`).

| Board | Core | Arm | EdgeFirst | EF `fast` | Turbo `islow` | Turbo `ifast` | zune-jpeg | image |
|-------|------|-----|-----------|-----------|---------------|---------------|-----------|-------|
| rpi5-hailo | A76 | YUV | **2.392** | **2.100** | 3.156 | 2.889 | 3.973 | — |
| | | RGB | **2.604** | **2.298** | 3.361 | 3.110 | 4.237 | 4.709 |
| orin-nano | A78AE | YUV | **3.664** | **3.130** | 5.137 | 4.612 | 6.131 | — |
| | | RGB | **3.991** | **3.437** | 5.481 | 4.960 | 6.554 | 8.050 |
| x86-desktop | Rocket Lake i9-11900K | YUV | **1.207** | 1.212 | 1.437 | 1.358 | 1.810 | — |
| | | RGB | **1.300** | 1.294 | 1.490 | 1.418 | 1.822 | 1.919 |
| imx95-pro | A55 | YUV | **6.067** | **5.310** | 7.031 | 6.562 | 11.150 | — |
| | | RGB | **6.385** | **5.669** | 7.507 | 7.044 | 11.656 | 12.129 |
| imx8mp-frdm | A53 | YUV | **6.729** | **5.963** | 7.620 | 6.927 | 12.378 | — |
| | | RGB | **7.079** | **6.340** | 7.945 | 7.332 | 12.980 | 13.722 |

- Accurate vs turbo `islow`: +11.7%/+10.9% (A53), +13.7%/+14.9% (A55), +24.2%/+22.5% (A76), +28.7%/+27.2% (A78AE), +16.0%/+12.8% (x86) — and accurate also beats turbo `ifast` everywhere (+2.9% A53 … +20.6% A78AE).
- `fast` vs turbo `ifast`: +13.9%/+13.5% (A53), +19.1%/+19.5% (A55), +27.3%/+26.1% (A76), +32.1%/+30.7% (A78AE). x86 has no fast kernel yet (the option is advisory there and runs the accurate path).
- vs the Rust ecosystem: 1.5× faster than zune-jpeg on x86, 1.7× on A76/A78AE, 1.8–1.9× on in-order A53/A55; the image crate trails further. zune's YUV arm skips COCO's few greyscale images (Luma→YCbCr unimplemented in zune).
- Cumulative on the accurate default vs this branch's starting point: A53 −12%, A55 −12%, A76 −11%.

## Entropy decode

- **`BitCursor` register cache** — `decode_block` runs on a register-resident copy of the bit-stream state, committed back at every exit (turbo's `BITREAD_LOAD_STATE`/`SAVE_STATE` discipline). `perf annotate` on the A53 showed `avail` stored to the struct on every decoded coefficient. `decode_block` is `#[inline(never)]`: letting LLVM inline it into the MCU loop's frame cost ~20% on the A53 — documented in the code as load-bearing.
- **Terminators baked into the fast-AC LUT** — DC size-0 (predictor unchanged) becomes a plain hit; **EOB is encoded with a run=0xFF sentinel that the existing `k ≥ 64` bounds branch resolves**, so the common block exit adds no hot-path compare and never touches the two-step fallback; ZRL writes a harmless zero.
- **`ZIGZAG_EXT[320]`** — padded de-zigzag table so the natural-index load issues ahead of the bounds branch instead of address-stalling the coefficient store.
- **Paired-coefficient probe** (`NeonTier::High` only) — up to two coefficients per table hit (~54% of COCO AC coefficients pair at 10 bits). Singles bake as *phantom pairs* so the probe branch keeps its ~94% hit rate, and real-vs-phantom is discriminated branchlessly (sound because JPEG magnitude coding cannot encode zero). In-order A53/A55 lose 1–3% to the phantom overhead, so the instantiation is tier-selected once per decode as a fn pointer.

## MCU loop and IDCT

- **Entropy-derived sparsity tiers** — `decode_block` returns `last_k` (highest zigzag index written, free from the scan order); the NEON IDCT proves whole regions zero from it and uses 64-bit `vld1_s16` loads on the sparse tiers, instead of loading all eight coefficient vectors and OR-reducing them.
- **Dedicated 4:4:4 1×1 loop** (`decode_image_444_direct`) — the dominant shape (every COCO image, most camera 4:4:4 streams) gets a loop with tables resolved to plain locals, no sampling-factor loops, and no planar scratch. The generic loop's spilled frame (`ldr/str [sp,#448..784]` per block) was costing 4–8% on every core.
- **SSE4.1 paired-block kernel for the fused RGB write** — the per-MCU RGB write path had been falling to scalar colour conversion on x86 (the 16-wide row kernel never engages at 8-pixel block width); the paired case is exactly 16 pixels wide. Rocket Lake RGB decode: 2.295 → 1.291 ms.

## Opt-in fast DCT (`DctMethod::Fast`, off by default)

- AAN `ifast`-class NEON kernel: scale factors folded into the dequant table at derive time, four Q15 `SQDMULH` constants, 16-bit lanes end to end. The scalar reference mirrors the NEON ops bit-exactly. Advisory outside the NEON path (non-NEON tiers and hardware V4L2/nvJPEG decode stay accurate). `EDGEFIRST_CODEC_DCT=fast` flips a new decoder's default for benchmark A/B.
- **Measured accuracy envelope** (new `dct_compare` harness, 1000 COCO images, fast vs accurate): cosine similarity mean 0.9999807 / worst 0.9998482, PSNR mean 51.4 dB / worst 42.1 dB, max pixel delta 24. mAP impact is a planned follow-up; `fast` stays opt-in and every published comparison quotes the accurate kernel.

## Tests and tooling

- Encoder-driven round-trip unit tests for the pair/phantom/block-boundary entropy paths (including the "coefficient lands on zigzag 63 — don't consume the next block's bits" rewind), forward-DCT-driven accuracy tests for the fast kernel (random coefficient arrays are not valid spectra and legitimately overflow `ifast`'s 16-bit contract), scalar↔NEON bit-parity for all new kernels, and a fast-vs-accurate similarity gate on real fixtures. 134 codec tests pass on aarch64 and x86_64 (x86 suite run on the Rocket Lake host).
- New benchmark tooling: `decode-ab-sweep.sh` (six arms, aarch64 boards + x86_64 hosts), `rust_jpeg` (zune-jpeg / image-crate reference arms), `dct_compare` (pixel-similarity harness). BENCHMARKS.md carries the refreshed matrix and methodology, including the accuracy-class framing.

## Measured and rejected (so they aren't re-tried blind)

`-C target-cpu=cortex-a53` builds (wash in-order, −3.7% on A76); dropping the entropy `PRFM` on in-order tiers (−1.9% on A53 — the hardware prefetcher needs the hint despite the A55 SWOG's advice); naive entropy↔IDCT fusion via `inline(always)` (A76 −2.9%; the real interleave needs a hand-scheduled fused block loop and is future work). COCO val2017 was audited for restart-interval files (zero in 1000): turbo's fast Huffman path ran for the entire corpus, so the comparison is not inflated by its documented DRI fallback.
