### PR TITLE
test(tensor): stop the fd-leak tests racing every other test

### DIFF
--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -4701,7 +4701,9 @@ mod dtype_tests {
 
 #[cfg(test)]
 mod image_tests {
+    // fd-lock discipline lives with FD_LOCK in the sibling `tests` module.
     use super::*;
+    use crate::tests::fd_lock_shared;
 
     #[test]
     fn image_shape_per_layout() {
@@ -4790,6 +4792,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn image_tensor_dma_non_aligned_packed_width_pads_zero_copy() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // RGBA u8 at width=4 → 4*4 = 16 bytes/row, not 64-byte aligned. RGBA has
         // a real IOSurface FourCC, so an explicit `Some(TensorMemory::Dma)`
         // request now allocates a padded image IOSurface (64-aligned
@@ -4827,6 +4831,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn image_tensor_dma_rejects_indivisible_pixel_pitch_without_pad_hint() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // Width=10 RGB f32 → 120 B/row, not 64-byte aligned, and (Rgb,
         // F32) has no IOSurface mapping so the padded-stride tolerance
         // does not apply. The next 64-multiple (128 B) isn't an integer
@@ -4865,6 +4871,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn image_tensor_dma_packed_rgb_u8_contract() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // Packed RGB u8 @Dma is a designed RGBA8888 mapping at
         // (W*3/4, H) — the INT8 NPU input layout, shared with Android.
         // width%4 != 0 cannot form whole texels → loud InvalidArgument…
@@ -4923,6 +4931,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn image_tensor_dma_planar_f16_alignment() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // PlanarRgb F16 uses single-channel row pitch (width * 2 bytes).
         // Width=16 → 32 bytes/row (not aligned); width=32 → 64 bytes/row (aligned).
         let err = Tensor::<half::f16>::image(
@@ -4967,6 +4977,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_preserves_logical_width() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // Skip if DMA not available (e.g. sandboxed CI lacking dma_heap access).
         if !is_dma_available() {
             eprintln!("SKIPPED: DMA heap not available");
@@ -5035,6 +5047,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_rejects_foreign_strided_map() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // A FOREIGN (imported via from_fd) DMA tensor with row_stride set
         // should still refuse CPU mapping — external allocator owns the
         // layout. This protects the V4L2 / GStreamer use case.
@@ -5065,6 +5079,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_map_rejects_tampered_stride() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // Round-3 PR feedback (C1): `set_row_stride` is public and only
         // validates `stride >= min_stride`, not that the new stride × height
         // fits the underlying buffer. A caller that tampers with the stride
@@ -5122,6 +5138,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_rejects_too_small_stride() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // 640×480 RGBA8 natural pitch = 2560, request 2400 → should error.
         let err = Tensor::<u8>::image_with_stride(
             640,
@@ -5137,6 +5155,8 @@ mod image_tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_rejects_non_packed() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // NV12 is SemiPlanar → not supported. (Linux-only because
         // `TensorMemory::Dma` itself is a Linux-only enum variant.)
         let err = Tensor::<u8>::image_with_stride(
@@ -5395,6 +5415,8 @@ mod cpu_access_tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn iosurface_read_only_lock_roundtrip() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         let Ok(t) = Tensor::<u8>::new(&[64], Some(TensorMemory::Dma), None) else {
             eprintln!("SKIPPED: IOSurface unavailable");
             return;
@@ -5425,7 +5447,7 @@ mod tests {
     use nix::unistd::{access, AccessFlags};
     #[cfg(target_os = "linux")]
     use std::io::Write as _;
-    use std::sync::RwLock;
+    use std::sync::{PoisonError, RwLock};
 
     use super::*;
 
@@ -5455,7 +5477,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_tensor() {
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         let shape = vec![1];
         let tensor = DmaTensor::<f32>::new(&shape, Some("dma_tensor"));
         let dma_enabled = tensor.is_ok();
@@ -5507,7 +5529,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_dma_tensor() {
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         match access(
             "/dev/dma_heap/linux,cma",
             AccessFlags::R_OK | AccessFlags::W_OK,
@@ -5605,7 +5627,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_shm_tensor() {
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         let shape = vec![2, 3, 4];
         let tensor =
             ShmTensor::<f32>::new(&shape, Some("test_tensor")).expect("Failed to create tensor");
@@ -5834,6 +5856,8 @@ mod tests {
     /// image-crate GL tests rather than here.
     #[test]
     fn subview_shares_buffer_identity_all_backends() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // u8 has align 1, so every byte offset is valid for the alignment check;
         // this isolates the identity-sharing contract from alignment concerns.
         let assert_shares = |memory: TensorMemory, label: &str| {
@@ -5951,6 +5975,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn shm_subview_partitions_parent_buffer() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // Mirrors `mem_subview_partitions_parent_buffer` for Shm: one [2,4] u8
         // parent shared segment (8 bytes); two [1,4] sub-views at byte offsets 0
         // and 4 must share the segment (zero-copy, via cloned fd) and be
@@ -5989,6 +6015,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn shm_subview_rejects_unaligned_and_oob() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         if !crate::is_shm_available() {
             eprintln!("SKIPPED: shm not available");
             return;
@@ -6007,7 +6035,7 @@ mod tests {
     fn dma_subview_matches_mem_subview() {
         // Serialize against the fd-leak tests: this test opens DMA fds (alloc +
         // clone_fd), which would otherwise perturb their fd counts.
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         // Identical sub-view semantics across Dma (shared fd) and Mem (shared
         // Arc): same offsets → same logical windows → same partition.
         let dma = match Tensor::<u8>::new(&[8], Some(TensorMemory::Dma), None) {
@@ -6042,7 +6070,7 @@ mod tests {
         // `row_stride × rows` window zero-copy at the view's offset (the GPU
         // batched-render-to-DMA case). Mirrors
         // `mem_strided_subview_maps_offset_and_byte_size` on a Dma parent.
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         let parent = match Tensor::<u8>::new(&[2048], Some(TensorMemory::Dma), None) {
             Ok(t) => t,
             Err(_) => {
@@ -6080,7 +6108,7 @@ mod tests {
         // keys its EGLImage import/pitch on that snapshot (not the view's tight
         // stride), so single-row and multi-row sibling views collapse onto the
         // same parent import.
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         // 8x4 RGBA with a padded 64-byte row stride (tight row = 8*4 = 32).
         let parent = match Tensor::<u8>::image_with_stride(
             8,
@@ -6160,7 +6188,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_dma_no_fd_leaks() {
-        let _lock = FD_LOCK.write().unwrap();
+        let _lock = fd_lock_exclusive();
         if !is_dma_available() {
             log::warn!(
                 "SKIPPED: {} - DMA memory allocation not available (permission denied or no DMA-BUF support)",
@@ -6169,12 +6197,19 @@ mod tests {
             return;
         }
 
-        let proc = procfs::process::Process::myself()
-            .expect("Failed to get current process using /proc/self");
+        let baseline = open_fd_count(DMA_FD_TARGETS);
 
-        let start_open_fds = proc
-            .fd_count()
-            .expect("Failed to get open file descriptor count");
+        // Self-check — see `test_shm_no_fd_leaks`.
+        {
+            let probe = Tensor::<u8>::new(&[100, 100], Some(TensorMemory::Dma), None)
+                .expect("Failed to create tensor");
+            assert!(
+                open_fd_count(DMA_FD_TARGETS) > baseline,
+                "a live DMA-BUF tensor must be visible to the dmabuf fd counter, \
+                 otherwise this test cannot detect a leak"
+            );
+            drop(probe);
+        }
 
         for _ in 0..100 {
             let tensor = Tensor::<u8>::new(&[100, 100], Some(TensorMemory::Dma), None)
@@ -6183,21 +6218,17 @@ mod tests {
             map.as_mut_slice().fill(233);
         }
 
-        let end_open_fds = proc
-            .fd_count()
-            .expect("Failed to get open file descriptor count");
-
+        let after = open_fd_count(DMA_FD_TARGETS);
         assert_eq!(
-            start_open_fds, end_open_fds,
-            "File descriptor leak detected: {} -> {}",
-            start_open_fds, end_open_fds
+            baseline, after,
+            "DMA-BUF file descriptor leak detected: {baseline} -> {after}"
         );
     }
 
     #[test]
     #[cfg(target_os = "linux")]
     fn test_dma_from_fd_no_fd_leaks() {
-        let _lock = FD_LOCK.write().unwrap();
+        let _lock = fd_lock_exclusive();
         if !is_dma_available() {
             log::warn!(
                 "SKIPPED: {} - DMA memory allocation not available (permission denied or no DMA-BUF support)",
@@ -6206,14 +6237,16 @@ mod tests {
             return;
         }
 
-        let proc = procfs::process::Process::myself()
-            .expect("Failed to get current process using /proc/self");
-
-        let start_open_fds = proc
-            .fd_count()
-            .expect("Failed to get open file descriptor count");
-
+        let baseline = open_fd_count(DMA_FD_TARGETS);
         let orig = Tensor::<u8>::new(&[100, 100], Some(TensorMemory::Dma), None).unwrap();
+
+        // Self-check — see `test_shm_no_fd_leaks`.
+        let held = open_fd_count(DMA_FD_TARGETS);
+        assert!(
+            held > baseline,
+            "a live DMA-BUF tensor must be visible to the dmabuf fd counter, \
+             otherwise this test cannot detect a leak"
+        );
 
         for _ in 0..100 {
             let tensor =
@@ -6226,14 +6259,19 @@ mod tests {
             let mut map = tensor.map().unwrap();
             map.as_mut_slice().fill(233);
         }
-        drop(orig);
 
-        let end_open_fds = proc.fd_count().unwrap();
-
+        let after_loop = open_fd_count(DMA_FD_TARGETS);
         assert_eq!(
-            start_open_fds, end_open_fds,
-            "File descriptor leak detected: {} -> {}",
-            start_open_fds, end_open_fds
+            held, after_loop,
+            "DMA-BUF file descriptor leak detected: {held} -> {after_loop}"
+        );
+
+        // And the source tensor's own fd goes back on drop.
+        drop(orig);
+        let after_drop = open_fd_count(DMA_FD_TARGETS);
+        assert_eq!(
+            baseline, after_drop,
+            "dropping the source tensor must release its fd: {baseline} -> {after_drop}"
         );
     }
 
@@ -6254,6 +6292,8 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_fs_magic_normalizes_sign_extended_values() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // Magics whose bit 31 is set. HUGETLBFS is the one that matters
         // most in practice: a MFD_HUGETLB memfd is the likeliest fd to land
         // in the UnknownBufferType arm.
@@ -6298,7 +6338,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_from_fd_dma_imports_as_dma() {
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         if !is_dma_available() {
             log::warn!("SKIPPED: {} - DMA memory not available", function!());
             return;
@@ -6324,7 +6364,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_from_fd_shm_imports_as_shm() {
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         if !is_shm_available() {
             log::warn!("SKIPPED: {} - SHM memory not available", function!());
             return;
@@ -6352,7 +6392,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_from_fd_rejects_unknown_filesystem() {
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
 
         let (read_end, _write_end) = nix::unistd::pipe().unwrap();
 
@@ -6370,7 +6410,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_shm_no_fd_leaks() {
-        let _lock = FD_LOCK.write().unwrap();
+        let _lock = fd_lock_exclusive();
         if !is_shm_available() {
             log::warn!(
                 "SKIPPED: {} - SHM memory allocation not available (permission denied or no SHM support)",
@@ -6379,12 +6419,22 @@ mod tests {
             return;
         }
 
-        let proc = procfs::process::Process::myself()
-            .expect("Failed to get current process using /proc/self");
+        let baseline = open_fd_count(SHM_FD_TARGETS);
 
-        let start_open_fds = proc
-            .fd_count()
-            .expect("Failed to get open file descriptor count");
+        // Self-check: the counter must actually see a live shm tensor. If
+        // it does not — a changed backing object, a different `/proc`
+        // rendering — the leak assertion below would hold no matter how
+        // much leaked, so fail loudly here instead.
+        {
+            let probe = Tensor::<u8>::new(&[100, 100], Some(TensorMemory::Shm), None)
+                .expect("Failed to create tensor");
+            assert!(
+                open_fd_count(SHM_FD_TARGETS) > baseline,
+                "a live shm tensor must be visible to the shm fd counter, \
+                 otherwise this test cannot detect a leak"
+            );
+            drop(probe);
+        }
 
         for _ in 0..100 {
             let tensor = Tensor::<u8>::new(&[100, 100], Some(TensorMemory::Shm), None)
@@ -6393,21 +6443,17 @@ mod tests {
             map.as_mut_slice().fill(233);
         }
 
-        let end_open_fds = proc
-            .fd_count()
-            .expect("Failed to get open file descriptor count");
-
+        let after = open_fd_count(SHM_FD_TARGETS);
         assert_eq!(
-            start_open_fds, end_open_fds,
-            "File descriptor leak detected: {} -> {}",
-            start_open_fds, end_open_fds
+            baseline, after,
+            "shm file descriptor leak detected: {baseline} -> {after}"
         );
     }
 
     #[test]
     #[cfg(target_os = "linux")]
     fn test_shm_from_fd_no_fd_leaks() {
-        let _lock = FD_LOCK.write().unwrap();
+        let _lock = fd_lock_exclusive();
         if !is_shm_available() {
             log::warn!(
                 "SKIPPED: {} - SHM memory allocation not available (permission denied or no SHM support)",
@@ -6416,14 +6462,16 @@ mod tests {
             return;
         }
 
-        let proc = procfs::process::Process::myself()
-            .expect("Failed to get current process using /proc/self");
-
-        let start_open_fds = proc
-            .fd_count()
-            .expect("Failed to get open file descriptor count");
-
+        let baseline = open_fd_count(SHM_FD_TARGETS);
         let orig = Tensor::<u8>::new(&[100, 100], Some(TensorMemory::Shm), None).unwrap();
+
+        // Self-check — see `test_shm_no_fd_leaks`.
+        let held = open_fd_count(SHM_FD_TARGETS);
+        assert!(
+            held > baseline,
+            "a live shm tensor must be visible to the shm fd counter, \
+             otherwise this test cannot detect a leak"
+        );
 
         for _ in 0..100 {
             let tensor =
@@ -6431,21 +6479,26 @@ mod tests {
             let mut map = tensor.map().unwrap();
             map.as_mut_slice().fill(233);
         }
-        drop(orig);
 
-        let end_open_fds = proc.fd_count().unwrap();
-
+        let after_loop = open_fd_count(SHM_FD_TARGETS);
         assert_eq!(
-            start_open_fds, end_open_fds,
-            "File descriptor leak detected: {} -> {}",
-            start_open_fds, end_open_fds
+            held, after_loop,
+            "shm file descriptor leak detected: {held} -> {after_loop}"
+        );
+
+        // And the source tensor's own fd goes back on drop.
+        drop(orig);
+        let after_drop = open_fd_count(SHM_FD_TARGETS);
+        assert_eq!(
+            baseline, after_drop,
+            "dropping the source tensor must release its fd: {baseline} -> {after_drop}"
         );
     }
 
     #[cfg(feature = "ndarray")]
     #[test]
     fn test_ndarray() {
-        let _lock = FD_LOCK.read().unwrap();
+        let _lock = fd_lock_shared();
         let shape = vec![2, 3, 4];
         let tensor = Tensor::<f32>::new(&shape, None, None).expect("Failed to create tensor");
 
@@ -6672,6 +6725,66 @@ mod tests {
     // shared.
     pub static FD_LOCK: RwLock<()> = RwLock::new(());
 
+    /// Take [`FD_LOCK`] shared, tolerating poisoning.
+    ///
+    /// A test that panics while holding the lock poisons it, and every later
+    /// `.unwrap()` on it panics too — one real failure turns into a handful
+    /// of unrelated ones that bury it. The guarded data is `()`, so a panic
+    /// cannot have left an invariant broken and there is nothing to protect
+    /// against by refusing the lock.
+    pub fn fd_lock_shared() -> std::sync::RwLockReadGuard<'static, ()> {
+        FD_LOCK.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Take [`FD_LOCK`] exclusively. Poison-tolerant, see [`fd_lock_shared`].
+    pub fn fd_lock_exclusive() -> std::sync::RwLockWriteGuard<'static, ()> {
+        FD_LOCK.write().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// `/proc` fd-target fragments identifying a POSIX shared memory
+    /// segment. `shm_open` then `shm_unlink` leaves the target rendered as
+    /// `/dev/shm/<name> (deleted)`.
+    #[cfg(target_os = "linux")]
+    const SHM_FD_TARGETS: &[&str] = &["/dev/shm/"];
+
+    /// `/proc` fd-target fragments identifying the fds a DMA tensor owns.
+    ///
+    /// Both the exported buffer and the heap it came from are listed, so a
+    /// leak of either is still caught — narrowing this to the buffer alone
+    /// would silently stop covering leaked heap handles.
+    #[cfg(target_os = "linux")]
+    const DMA_FD_TARGETS: &[&str] = &["dmabuf", "dma_heap"];
+
+    /// How many of this process's open fds point at an object whose `/proc`
+    /// target contains `needle`.
+    ///
+    /// The fd-leak tests deliberately do NOT compare total fd counts. Under
+    /// `cargo test` every test in this crate runs as a thread in one
+    /// process, and roughly twenty of them create shm or DMA tensors —
+    /// while anything else may open a file, a socket, or a pipe — so an
+    /// unrelated test opening or closing an fd inside the measurement
+    /// window moved the total and failed the assertion. Worse, the panic
+    /// poisoned [`FD_LOCK`] and took four more tests down with it, so the
+    /// visible failure had little to do with the cause.
+    ///
+    /// Counting only fds that name the object under test makes the
+    /// measurement immune to every unrelated fd, while still catching the
+    /// leak each test exists to catch. (CI runs nextest, one process per
+    /// test, which is why this only ever flaked when run locally.)
+    #[cfg(target_os = "linux")]
+    fn open_fd_count(needles: &[&str]) -> usize {
+        let proc = procfs::process::Process::myself()
+            .expect("Failed to get current process using /proc/self");
+        proc.fd()
+            .expect("Failed to list open file descriptors")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                let target = format!("{:?}", entry.target);
+                needles.iter().any(|needle| target.contains(needle))
+            })
+            .count()
+    }
+
     /// Test that DMA is NOT available on non-Linux platforms.
     /// This verifies the cross-platform behavior of is_dma_available().
     #[test]
@@ -6744,6 +6857,8 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn configure_image_preserves_iosurface_physical_stride() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         // Pool: GREY/R8 IOSurface 100 wide → bytesPerRow padded to 128.
         let mut pool = Tensor::<u8>::image(
             100,
@@ -6838,6 +6953,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_shm_available_and_usable() {
+        // Declares this test as an fd-opener; see FD_LOCK.
+        let _lock = fd_lock_shared();
         assert!(
             is_shm_available(),
             "SHM memory allocation should be available on Unix systems"

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -6735,6 +6735,13 @@ mod tests {
     }
 
     /// Take [`FD_LOCK`] exclusively. Poison-tolerant, see [`fd_lock_shared`].
+    ///
+    /// Linux-only, like all four of its callers: the fd-leak tests read fd
+    /// state out of `/proc`, which no other platform provides. Ungated, it
+    /// is dead code on macOS and the lint denies that.
+    /// [`fd_lock_shared`] stays available everywhere — macOS tests declare
+    /// fd activity too.
+    #[cfg(target_os = "linux")]
     pub fn fd_lock_exclusive() -> std::sync::RwLockWriteGuard<'static, ()> {
         FD_LOCK.write().unwrap_or_else(PoisonError::into_inner)
     }

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -4701,9 +4701,7 @@ mod dtype_tests {
 
 #[cfg(test)]
 mod image_tests {
-    // fd-lock discipline lives with FD_LOCK in the sibling `tests` module.
     use super::*;
-    use crate::tests::fd_lock_shared;
 
     #[test]
     fn image_shape_per_layout() {
@@ -4793,7 +4791,7 @@ mod image_tests {
     #[cfg(target_os = "macos")]
     fn image_tensor_dma_non_aligned_packed_width_pads_zero_copy() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // RGBA u8 at width=4 → 4*4 = 16 bytes/row, not 64-byte aligned. RGBA has
         // a real IOSurface FourCC, so an explicit `Some(TensorMemory::Dma)`
         // request now allocates a padded image IOSurface (64-aligned
@@ -4832,7 +4830,7 @@ mod image_tests {
     #[cfg(target_os = "macos")]
     fn image_tensor_dma_rejects_indivisible_pixel_pitch_without_pad_hint() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // Width=10 RGB f32 → 120 B/row, not 64-byte aligned, and (Rgb,
         // F32) has no IOSurface mapping so the padded-stride tolerance
         // does not apply. The next 64-multiple (128 B) isn't an integer
@@ -4872,7 +4870,7 @@ mod image_tests {
     #[cfg(target_os = "macos")]
     fn image_tensor_dma_packed_rgb_u8_contract() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // Packed RGB u8 @Dma is a designed RGBA8888 mapping at
         // (W*3/4, H) — the INT8 NPU input layout, shared with Android.
         // width%4 != 0 cannot form whole texels → loud InvalidArgument…
@@ -4932,7 +4930,7 @@ mod image_tests {
     #[cfg(target_os = "macos")]
     fn image_tensor_dma_planar_f16_alignment() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // PlanarRgb F16 uses single-channel row pitch (width * 2 bytes).
         // Width=16 → 32 bytes/row (not aligned); width=32 → 64 bytes/row (aligned).
         let err = Tensor::<half::f16>::image(
@@ -4978,7 +4976,7 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_preserves_logical_width() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // Skip if DMA not available (e.g. sandboxed CI lacking dma_heap access).
         if !is_dma_available() {
             eprintln!("SKIPPED: DMA heap not available");
@@ -5048,7 +5046,7 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_rejects_foreign_strided_map() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // A FOREIGN (imported via from_fd) DMA tensor with row_stride set
         // should still refuse CPU mapping — external allocator owns the
         // layout. This protects the V4L2 / GStreamer use case.
@@ -5080,7 +5078,7 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_map_rejects_tampered_stride() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // Round-3 PR feedback (C1): `set_row_stride` is public and only
         // validates `stride >= min_stride`, not that the new stride × height
         // fits the underlying buffer. A caller that tampers with the stride
@@ -5139,7 +5137,7 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_rejects_too_small_stride() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // 640×480 RGBA8 natural pitch = 2560, request 2400 → should error.
         let err = Tensor::<u8>::image_with_stride(
             640,
@@ -5156,7 +5154,7 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn image_tensor_with_stride_rejects_non_packed() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // NV12 is SemiPlanar → not supported. (Linux-only because
         // `TensorMemory::Dma` itself is a Linux-only enum variant.)
         let err = Tensor::<u8>::image_with_stride(
@@ -5416,7 +5414,7 @@ mod cpu_access_tests {
     #[cfg(target_os = "macos")]
     fn iosurface_read_only_lock_roundtrip() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         let Ok(t) = Tensor::<u8>::new(&[64], Some(TensorMemory::Dma), None) else {
             eprintln!("SKIPPED: IOSurface unavailable");
             return;
@@ -5477,7 +5475,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_tensor() {
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         let shape = vec![1];
         let tensor = DmaTensor::<f32>::new(&shape, Some("dma_tensor"));
         let dma_enabled = tensor.is_ok();
@@ -5529,7 +5527,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_dma_tensor() {
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         match access(
             "/dev/dma_heap/linux,cma",
             AccessFlags::R_OK | AccessFlags::W_OK,
@@ -5627,7 +5625,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn test_shm_tensor() {
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         let shape = vec![2, 3, 4];
         let tensor =
             ShmTensor::<f32>::new(&shape, Some("test_tensor")).expect("Failed to create tensor");
@@ -5857,7 +5855,7 @@ mod tests {
     #[test]
     fn subview_shares_buffer_identity_all_backends() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // u8 has align 1, so every byte offset is valid for the alignment check;
         // this isolates the identity-sharing contract from alignment concerns.
         let assert_shares = |memory: TensorMemory, label: &str| {
@@ -5976,7 +5974,7 @@ mod tests {
     #[cfg(unix)]
     fn shm_subview_partitions_parent_buffer() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // Mirrors `mem_subview_partitions_parent_buffer` for Shm: one [2,4] u8
         // parent shared segment (8 bytes); two [1,4] sub-views at byte offsets 0
         // and 4 must share the segment (zero-copy, via cloned fd) and be
@@ -6016,7 +6014,7 @@ mod tests {
     #[cfg(unix)]
     fn shm_subview_rejects_unaligned_and_oob() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         if !crate::is_shm_available() {
             eprintln!("SKIPPED: shm not available");
             return;
@@ -6035,7 +6033,7 @@ mod tests {
     fn dma_subview_matches_mem_subview() {
         // Serialize against the fd-leak tests: this test opens DMA fds (alloc +
         // clone_fd), which would otherwise perturb their fd counts.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // Identical sub-view semantics across Dma (shared fd) and Mem (shared
         // Arc): same offsets → same logical windows → same partition.
         let dma = match Tensor::<u8>::new(&[8], Some(TensorMemory::Dma), None) {
@@ -6070,7 +6068,7 @@ mod tests {
         // `row_stride × rows` window zero-copy at the view's offset (the GPU
         // batched-render-to-DMA case). Mirrors
         // `mem_strided_subview_maps_offset_and_byte_size` on a Dma parent.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         let parent = match Tensor::<u8>::new(&[2048], Some(TensorMemory::Dma), None) {
             Ok(t) => t,
             Err(_) => {
@@ -6108,7 +6106,7 @@ mod tests {
         // keys its EGLImage import/pitch on that snapshot (not the view's tight
         // stride), so single-row and multi-row sibling views collapse onto the
         // same parent import.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // 8x4 RGBA with a padded 64-byte row stride (tight row = 8*4 = 32).
         let parent = match Tensor::<u8>::image_with_stride(
             8,
@@ -6293,7 +6291,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn test_fs_magic_normalizes_sign_extended_values() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // Magics whose bit 31 is set. HUGETLBFS is the one that matters
         // most in practice: a MFD_HUGETLB memfd is the likeliest fd to land
         // in the UnknownBufferType arm.
@@ -6338,7 +6336,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_from_fd_dma_imports_as_dma() {
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         if !is_dma_available() {
             log::warn!("SKIPPED: {} - DMA memory not available", function!());
             return;
@@ -6364,7 +6362,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_from_fd_shm_imports_as_shm() {
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         if !is_shm_available() {
             log::warn!("SKIPPED: {} - SHM memory not available", function!());
             return;
@@ -6392,7 +6390,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_from_fd_rejects_unknown_filesystem() {
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
 
         let (read_end, _write_end) = nix::unistd::pipe().unwrap();
 
@@ -6498,7 +6496,7 @@ mod tests {
     #[cfg(feature = "ndarray")]
     #[test]
     fn test_ndarray() {
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         let shape = vec![2, 3, 4];
         let tensor = Tensor::<f32>::new(&shape, None, None).expect("Failed to create tensor");
 
@@ -6858,7 +6856,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     fn configure_image_preserves_iosurface_physical_stride() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         // Pool: GREY/R8 IOSurface 100 wide → bytesPerRow padded to 128.
         let mut pool = Tensor::<u8>::image(
             100,
@@ -6954,7 +6952,7 @@ mod tests {
     #[cfg(unix)]
     fn test_shm_available_and_usable() {
         // Declares this test as an fd-opener; see FD_LOCK.
-        let _lock = fd_lock_shared();
+        let _lock = crate::tests::fd_lock_shared();
         assert!(
             is_shm_available(),
             "SHM memory allocation should be available on Unix systems"


### PR DESCRIPTION
`cargo test -p edgefirst-tensor` fails about half the time on `main`. Measured on this machine, 15 consecutive runs each:

| | clean | failed |
|---|---|---|
| `main` | 7 | **8** |
| this branch | **15** | 0 |

## What was wrong

The four fd-leak tests compared the process's **total** open fd count before and after their loop. Under `cargo test` every test in this crate runs as a thread in one process, so any other test opening or closing an fd inside that window moved the total and failed the assertion — typically as a *decrease*:

```
File descriptor leak detected: 8 -> 7
```

which is not even the failure the test is named for. The window was wide open: twenty-odd tests create shm or DMA tensors, and only ten declared it by taking `FD_LOCK` shared.

The panic then poisoned `FD_LOCK`, so every later `.unwrap()` on it panicked too — one real failure became five, and the four collateral ones (`test_shm_tensor`, `test_tensor`, `test_shm_no_fd_leaks`, `view_single_row_snapshots_parent_stride`) buried the one that mattered.

**CI never saw this**, because CI runs nextest with one process per test. It only bites locally, which is exactly where it wastes someone's afternoon.

## What changed

**Count only the fds the test is about.** Each test now counts fds whose `/proc` target names the backend under test (`/dev/shm/` for shm; `dmabuf` or `dma_heap` for DMA) rather than the process total. Unrelated fds can come and go freely during the measurement. The DMA counter deliberately covers the heap fd as well as the exported buffer, so it does not quietly stop covering leaked heap handles.

**Each test self-checks that its counter can see a live tensor**, before relying on it. A counter that stops matching — a changed backing object, a different `/proc` rendering — now fails loudly instead of silently making the leak assertion vacuous. This is the failure mode I was most worried about introducing, so it is asserted rather than assumed.

**The shm/DMA-creating tests now take the shared `FD_LOCK`** that the discipline at its definition already called for. Sixteen of them never did.

**Lock acquisition is poison-tolerant.** The guarded data is `()`, so a panic cannot have left a broken invariant; refusing the lock only hides the failure that caused it.

## Verification

Beyond the 15/15 above, I checked the tests still do their job rather than just going quiet:

- **Injected a real leak** (`std::mem::forget(tensor.clone_fd())` in the loop) → caught, with a clearer message than before: `shm file descriptor leak detected: 0 -> 100`.
- **Broke the counter's match string** → the self-check fires: *"a live shm tensor must be visible to the shm fd counter, otherwise this test cannot detect a leak"*.
- **No cascade**: in that run the two shm leak tests failed while `test_shm_tensor` and `test_shm_available_and_usable` still passed, where previously they would have been dragged down by lock poisoning.

`cargo clippy -p edgefirst-tensor --all-targets` and `cargo fmt --check` are clean.

## Note

The DMA tests skip on this host (no DMA heap access), so the DMA half is verified by construction rather than execution — the `imx8mp` hardware lane is the real check. If the `dmabuf`/`dma_heap` target strings are wrong for that kernel, the self-check fails loudly there rather than passing vacuously, which is the failure mode I wanted.

No CHANGELOG entry: this changes no user-visible behaviour.
