### PR TITLE
JPEG decode benchmark publication suite (8 arms, 6 corpora, cloud + hardware tables)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,12 @@
 # compiles the TurboJPEG arm itself, and a host-built binary would be linked
 # against the wrong glibc.
 benchmarks/modules/turbojpeg/build/
+
+# Cargo build trees, results, fetched single-file deps, and git history are
+# gigabytes the image build never reads (all binaries build in-container).
+target/
+benchmarks/target/
+benchmarks/results/
+benchmarks/modules/stb/build/
+benchmarks/modules/wuffs/build/
+.git/

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -857,6 +857,13 @@ See [README.md § Benchmarking](../README.md#benchmarking) for full instructions
 | `decoder_benchmark` | `edgefirst-decoder` | YOLO post-processing, NMS, dequantization |
 | `opencv_benchmark` | `edgefirst-image` | Cross-library comparison (requires `--features opencv`) |
 
+The standalone `benchmarks/` workspace (excluded from the root workspace and CI
+triggers) carries the JPEG decoder A/B harness: `hal_cpu`, `rust_jpeg`
+(zune/image), `turbojpeg_bench`, `stb_bench`, `wuffs_bench`, plus the hardware
+arms `hal_v4l2_gl`, `hal_v4l2_cpu`, `hal_nvjpeg` and the `hal_gl`/`hal_g2d`
+pipeline arms — see `benchmarks/README.md` for the module map, protocol rules,
+and corpus tooling.
+
 **Key env vars:** `EDGEFIRST_FORCE_BACKEND={cpu,opengl,g2d}`, `EDGEFIRST_FORCE_TRANSFER=pbo`
 
 **JSON convention:** `benchmarks/<platform>/<name>.json` (platforms: `imx8mp-frdm`, `imx95-frdm`, `rpi5-hailo`, `x86-desktop`)

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ env.sh
 !/benchmarks/results/.gitkeep
 /benchmarks/**/target/
 /benchmarks/modules/turbojpeg/build/
+/benchmarks/modules/stb/build/
+/benchmarks/modules/wuffs/build/
 /benchmarks/imx*/
 /benchmarks/rpi*/
 /benchmarks/x86*/

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,7 +1,7 @@
 # EdgeFirst HAL - Benchmarks
 
-**Version:** 3.10
-**Last Updated:** June 16, 2026
+**Version:** 3.11
+**Last Updated:** August 13, 2026
 **Status:** 0.25.0 release refresh. The full bench matrix was re-collected on the 0.25.0
 converged-GL-engine code across imx8mp-frdm (Vivante GC7000UL + G2D), imx95-frdm
 (Mali-G310 + DPU-G2D), rpi5-hailo (V3D 7.1), and jetson-orin-nano (NVIDIA Tegra Orin,
@@ -367,7 +367,7 @@ JSON files are collected in `benchmarks/<platform>/` and processed by `.github/s
 
 **Scope:** JPEG bytes → decoded raster in memory. Letterbox / model-input
 preprocessing (`ImageProcessor::convert()`) is a separate measurement and is not
-included here. Six arms:
+included here. Eight arms:
 
 | Arm | Command |
 |-----|---------|
@@ -375,22 +375,44 @@ included here. Six arms:
 | **EdgeFirst `fast`** | same, `EDGEFIRST_CODEC_DCT=fast` — opt-in AAN `ifast`-class IDCT (`DctMethod::Fast`) |
 | **Turbo `islow`** | `turbojpeg_bench --dct accurate` — libjpeg-turbo's default IDCT |
 | **Turbo `ifast`** | `turbojpeg_bench --dct fast` |
-| **zune-jpeg** | `rust_jpeg --engine zune` — YCbCr out on the YUV arm, RGB on the RGB arm |
-| **image crate** | `rust_jpeg --engine image` — `load_from_memory` + `to_rgb8` (allocates per call; RGB only, its API exposes no raw-YUV output) |
+| **zune-jpeg** | `rust_jpeg --engine zune` — YCbCr out on the YUV arm, RGB on the RGB arm; built with its `x86` **and `neon`** SIMD features (both default-on in zune-jpeg 0.5.15, pinned explicitly in the harness), so its NEON IDCT / colour-convert / upsampling kernels are active on the ARM boards |
+| **image crate** | `rust_jpeg --engine image` — **zune-jpeg behind the `image` 0.25 wrapper**, not an independent decoder: `load_from_memory` + `to_rgb8` (allocates per call; RGB only, its API exposes no raw-YUV output). Its row measures the wrapper's per-call allocation and colour handling on top of zune |
+| **stb_image** | `stb_bench` — v2.30 single-header baseline (public domain/MIT); fixed accurate-class IDCT with SSE2 (auto) / NEON (enabled) SIMD; RGB only, allocates per call (its API has no decode-into). Pixel parity vs djpeg accurate: max abs diff 3, mean ≤0.07 |
+| **Wuffs** | `wuffs_bench` — Google's memory-safe decoder, v0.4.0-alpha.10 transpiled C (Apache-2.0); single fixed IDCT, **bit-exact** vs djpeg accurate (max abs diff 0 on every parity sample); RGB only (3-byte, via its swizzler), high-water buffer reuse |
 
 The YUV arm stops after decode into a YUV layout with no RGB colour step
 (EdgeFirst `--decode-fmt native` NV12/16/24, turbo `tjDecompressToYUV2`
 planar, zune interleaved YCbCr); the RGB arm decodes to interleaved RGB
-(EdgeFirst's fused MCU write, `TJPF_RGB`, zune/image RGB). COCO `val2017`
+(EdgeFirst's fused MCU write, `TJPF_RGB`, zune/image RGB). The YUV output
+layouts are the right conceptual comparison — every arm stops in YCbCr —
+but they are not byte-identical: turbo writes fully-planar, row-padded
+Y/Cb/Cr planes while EdgeFirst writes semi-planar NV formats, so the write
+patterns differ even though neither pays a colour conversion. COCO `val2017`
 is 4:4:4, so the fused RGB write engages. zune's YUV arm skips COCO's few
 greyscale images (its Luma→YCbCr mapping is unimplemented); the other arms
 decode them.
 
-All arms are native binaries — `hal_cpu` / `rust_jpeg` (Rust) and
-`modules/turbojpeg/bench.c` (C) — measured by harnesses that agree on image
-selection, preload before timing, `CLOCK_MONOTONIC` around decode alone,
-percentile index and MP/s. A Python driver on one side only would put
-interpreter dispatch and FFI marshalling inside the timed region.
+All arms are native binaries — `hal_cpu` / `rust_jpeg` (Rust) and the C
+arms `modules/turbojpeg/bench.c`, `stb_bench`, and `wuffs_bench` (the
+latter two built on the shared `modules/cbench/cbench.h` harness header) —
+measured by harnesses that agree on image selection, preload before timing,
+`CLOCK_MONOTONIC` around decode alone, percentile index, median-CI ranks,
+and MP/s. A Python driver on one side only would put interpreter dispatch
+and FFI marshalling inside the timed region.
+
+Buffer policy is matched wherever each API allows it: EdgeFirst decodes into
+a reused tensor pool, turbo into a reused high-water output buffer, and zune
+via `decode_into` into a reused buffer — no arm pays a steady-state
+allocation per frame. The `image` arm allocates per call by design; that is
+the wrapper overhead its row exists to show. Every arm decodes
+single-threaded on one pinned core (zune-jpeg itself is single-threaded —
+the multi-core post-processing zune-image advertises is not in play),
+matching libjpeg-turbo's one-thread-per-image model, and timing stops at the
+decoded raster, the same decode-only convention `tjbench` uses. mozjpeg has
+no row because its decoder *is* libjpeg-turbo's (it is an encoder-focused
+fork); Intel IPP has no row because Intel discontinued its JPEG codec sample
+(UIC), leaving no supported IPP JPEG decoder to benchmark short of
+hand-assembling one from primitives.
 
 **On the IDCT accuracy classes.** libjpeg-turbo decompresses with either the
 accurate `islow` IDCT or the faster, lower-accuracy `ifast` one; **`islow` is
@@ -398,57 +420,275 @@ its default**, and it is the kernel EdgeFirst's default implements, so
 EdgeFirst↔`islow` is the like-for-like comparison and the one claims should
 quote. EdgeFirst's opt-in `fast` mode is the same trade turbo's `ifast`
 makes, so `fast`↔`ifast` is the like-for-like comparison within the fast
-class. Measured on 1000 COCO images (`dct_compare`), EdgeFirst `fast` vs the
-default kernel: cosine similarity mean 0.99998 / worst 0.99985, PSNR mean
-51.4 dB / worst 42.1 dB, max pixel delta 24. mAP impact is not yet measured;
-`fast` stays opt-in.
+class. The measured `islow`↔`ifast` gaps (5–11%) sit inside libjpeg-turbo's
+own documented range — its `doc/libjpeg.txt` puts `ifast` "generally about
+5-15% faster" than `islow` on non-AVX2 CPUs and "similar" on AVX2, and its
+3.0 ChangeLog calls the fast algorithms "a legacy feature" — so a reader
+remembering a larger historical `ifast` advantage is remembering older
+hardware. Measured on 1000 COCO images (`dct_compare`), EdgeFirst `fast` vs
+the default kernel: cosine similarity mean 0.99998 / worst 0.99985, PSNR
+mean 51.4 dB / worst 42.1 dB, max pixel delta 24. mAP impact is not yet
+measured; `fast` stays opt-in.
 
-Interleaved best-of-3 in a single session per host with all arms alternating,
-pinned to one core, n=200 (`decode-ab-sweep.sh`, `CARGO_PROFILE=release`, no
-perf/trace). Captured 2026-08-13: register-cached bit cursor, fast-AC
-terminator baking, entropy-derived IDCT tiers, paired-coefficient probe (High
-tier), dedicated 4:4:4 MCU loop, SSE4.1 fused-RGB block kernel. The orin-nano
-row was captured on the fallback unit (`adis-uav1`, Orin Nano Super devkit) —
-its turbo baseline matches the prior orin-nano capture within 0.1%, so the
-rows are comparable. x86-desktop is `sebstation` (same i9-11900K host as the
-prior x86 captures).
+Re-captured 2026-08-13 under the updated protocol (`decode-ab-sweep.sh`,
+`CARGO_PROFILE=release`, no perf/trace): three interleaved rounds per host
+with all arms alternating inside each round, pinned to one core, n=200 drawn
+evenly spaced across the corpus by **every** arm; the quoted number is the
+**median across rounds' p50s**, with each round's p50, the min–max spread,
+the mean, and a nonparametric 95% CI on the median recorded in the run
+outputs, and per-host build/run `provenance.txt` (toolchains, comparator
+library path/version, governor, clocks) written next to them. Decoder state:
+register-cached bit cursor, fast-AC terminator baking, entropy-derived IDCT
+tiers, paired-coefficient probe (High tier), dedicated 4:4:4 MCU loop,
+SSE4.1 fused-RGB block kernel. The orin-nano row was captured on the
+fallback unit (`adis-uav1`, Orin Nano Super devkit; the prior capture
+established its turbo baseline matches orin-nano within 0.1%). x86-desktop
+is `sebstation` (same i9-11900K host as prior x86 captures). Round spreads
+were below 1% for nearly every cell; no run failed.
 
 All numbers are p50 ms; lower is better. **Bold** marks the fastest arm in
 each accuracy class (accurate: EdgeFirst vs turbo `islow`; fast: EdgeFirst
 `fast` vs turbo `ifast`).
 
-| Board | Core | Arm | EdgeFirst | EF `fast` | Turbo `islow` | Turbo `ifast` | zune-jpeg | image |
-|-------|------|-----|-----------|-----------|---------------|---------------|-----------|-------|
-| rpi5-hailo | A76 | YUV | **2.392** | **2.100** | 3.156 | 2.889 | 3.973 | — |
-| | | RGB | **2.604** | **2.298** | 3.361 | 3.110 | 4.237 | 4.709 |
-| orin-nano | A78AE | YUV | **3.664** | **3.130** | 5.137 | 4.612 | 6.131 | — |
-| | | RGB | **3.991** | **3.437** | 5.481 | 4.960 | 6.554 | 8.050 |
-| x86-desktop | Rocket Lake i9-11900K | YUV | **1.207** | 1.212 | 1.437 | 1.358 | 1.810 | — |
-| | | RGB | **1.300** | 1.294 | 1.490 | 1.418 | 1.822 | 1.919 |
-| imx95-pro | A55 | YUV | **6.067** | **5.310** | 7.031 | 6.562 | 11.150 | — |
-| | | RGB | **6.385** | **5.669** | 7.507 | 7.044 | 11.656 | 12.129 |
-| imx8mp-frdm | A53 | YUV | **6.729** | **5.963** | 7.620 | 6.927 | 12.378 | — |
-| | | RGB | **7.079** | **6.340** | 7.945 | 7.332 | 12.980 | 13.722 |
+| Board | Core | Arm | EdgeFirst | EF `fast` | Turbo `islow` | Turbo `ifast` | zune-jpeg | image | stb | Wuffs |
+|-------|------|-----|-----------|-----------|---------------|---------------|-----------|-------|-----|-------|
+| rpi5-hailo | A76 | YUV | **2.372** | **2.072** | 3.173 | 2.900 | 4.115 | — | — | — |
+| | | RGB | **2.574** | **2.263** | 3.356 | 3.110 | 4.411 | 4.939 | 5.423 | 7.312 |
+| orin-nano | A78AE | YUV | **3.719** | **3.178** | 5.144 | 4.627 | 6.404 | — | — | — |
+| | | RGB | **4.012** | **3.461** | 5.491 | 4.984 | 6.834 | 8.385 | 7.859 | 9.884 |
+| x86-desktop | Rocket Lake i9-11900K | YUV | **1.222** | 1.221 | 1.433 | 1.364 | 1.911 | — | — | — |
+| | | RGB | **1.323** | 1.321 | 1.504 | 1.432 | 1.932 | 2.041 | 2.511 | 2.726 |
+| imx95-pro | A55 | YUV | **6.032** | **5.270** | 7.044 | 6.576 | 11.457 | — | — | — |
+| | | RGB | **6.340** | **5.601** | 7.558 | 7.057 | 12.006 | 12.986 | 13.206 | 21.389 |
+| imx8mp-frdm | A53 | YUV | **6.745** | **5.941** | 7.747 | 6.954 | 13.504 | — | — | — |
+| | | RGB | **7.073** | **6.359** | 7.934 | 7.305 | 13.878 | 14.607 | 14.890 | 23.266 |
 
-- **EdgeFirst's accurate default beats turbo's `islow` everywhere** — +11.7%
-  / +10.9% on the A53, +13.7% / +14.9% on the A55, +24.2% / +22.5% on the
-  A76, +28.7% / +27.2% on the A78AE, +16.0% / +12.8% on Rocket Lake — and it
-  also beats turbo's **`ifast`** on every platform (+2.9% A53 … +20.6%
+- **EdgeFirst's accurate default beats turbo's `islow` everywhere** — +12.9%
+  / +10.9% on the A53, +14.4% / +16.1% on the A55, +25.2% / +23.3% on the
+  A76, +27.7% / +26.9% on the A78AE, +14.7% / +12.0% on Rocket Lake — and it
+  also beats turbo's **`ifast`** on every platform (+3.0% A53 … +19.6%
   A78AE) while producing `islow`-class pixels.
-- **The opt-in `fast` mode extends the lead within the fast class**: +13.9%
-  / +13.5% over `ifast` on the A53, +19.1% / +19.5% on the A55, +27.3% /
-  +26.1% on the A76, +32.1% / +30.7% on the A78AE. On x86 there is no fast
+- **The opt-in `fast` mode extends the lead within the fast class**: +14.6%
+  / +12.9% over `ifast` on the A53, +19.9% / +20.6% on the A55, +28.6% /
+  +27.2% on the A76, +31.3% / +30.6% on the A78AE. On x86 there is no fast
   kernel yet — the option is advisory and runs the accurate path (the
   `fast` and default rows measure the same code there).
-- **Against the Rust ecosystem**, EdgeFirst is 1.5× faster than zune-jpeg
-  on Rocket Lake, 1.7× on the A76/A78AE, and 1.8–1.9× on the in-order
-  A53/A55 (zune has no strong in-order tuning); the image crate (zune-jpeg
-  internally, plus a per-call allocation and RGB conversion) trails
-  further.
-- COCO val2017 contains no restart-interval (DRI) files (1000 checked), so
-  turbo's fast Huffman path — which its own ChangeLog documents as disabled
-  for DRI streams at a ~20% cost — ran for the whole corpus. On DRI camera
-  streams EdgeFirst's lead grows: its fast entropy path handles restarts.
+- **Against the Rust ecosystem**, EdgeFirst is 1.6× faster than zune-jpeg
+  on Rocket Lake, 1.7× on the A76/A78AE, and 1.9–2.0× on the in-order
+  A55/A53 — and the ARM rows are measured against zune's **NEON build**
+  (its `neon` feature, default-on in 0.5.15, gates real NEON IDCT,
+  colour-convert, and upsampling kernels), so the widening in-order gap is
+  scheduling and tuning, not a scalar-vs-SIMD artifact. The image crate
+  (zune-jpeg internally, plus a per-call allocation and RGB conversion)
+  trails further.
+- **stb_image and Wuffs are the floor, as expected**: stb runs 1.9–2.1×
+  behind EdgeFirst's RGB arm across hosts, and Wuffs 2.1× (x86) to 3.4×
+  (A55), its memory-safety cost growing with core simplicity and image
+  size. Both decode correctly — Wuffs bit-exactly matches the accurate
+  reference and stb sits within ±3 LSB (see the arm table) — so their rows
+  are like-for-like within the accurate class.
+- **The DRI (restart-marker) claim is now measured, not asserted.** COCO
+  val2017 itself has zero DRI files (all 5000 checked with
+  `corpus_stats.py`: 4990 baseline 4:4:4, 10 greyscale, none progressive),
+  so `make-dri-corpus.sh` re-serialised it **losslessly** (`jpegtran
+  -restart 1` — identical DCT coefficients, only restart markers added).
+  On that corpus turbo `islow` pays +5.4% (x86), +10.4% (A76), +11.7%
+  (A78AE), +15.6% (A55), +15.7% (A53) — approaching the ≤20% its own README
+  documents for the disabled fast-Huffman path — while EdgeFirst pays
+  ≤1.1% on every host. EdgeFirst's accurate-class lead therefore grows on
+  restart-carrying camera streams: to +18.2% on x86, +31.6% on the A76,
+  +34.8% on the A78AE, +25.6% on the A55, +24.8% on the A53.
+
+### Control corpora
+
+The same eight-arm sweep ran over five control corpora (see
+`benchmarks/README.md` § Corpora for recipes and licensing; per-run
+summaries, CIs, and provenance live under
+`benchmarks/results/<board>/decode-ab-sweep/<corpus>/` from the capture):
+`val2017-yuv420` (the same 5000 images transcoded to 4:2:0), `val2017-dri`
+(lossless restart-marker isolate, discussed above), and the CLIC 2025
+large-image set (62 files, 1.8–4.2 MP, p50 2.8 MP) encoded at 4:2:0 and
+4:4:4 from identical pixels plus a 4:2:0 DRI variant.
+
+**The headline gap is not corpus-driven.** The specific objection these
+controls answer: zune-jpeg's deficit against turbo on x86 could be an
+artifact of COCO being 4:4:4 and ~0.27 MP. Measured on the i9-11900K (YUV
+arm, p50 ms):
+
+| Corpus | Turbo `islow` | zune-jpeg | zune deficit |
+|--------|---------------|-----------|--------------|
+| val2017 (4:4:4, 0.27 MP) | 1.433 | 1.911 | 1.33× |
+| val2017-yuv420 (same images, 4:2:0) | 0.748 | 1.137 | **1.52×** |
+| CLIC 4:2:0 (2.8 MP) | 5.555 | 8.697 | **1.57×** |
+| CLIC 4:4:4 (2.8 MP) | 8.824 | 11.709 | 1.33× |
+
+zune never closes to within 10% of turbo on any control; moving to 4:2:0 —
+the subsampling where turbo's SIMD upsampling engages — *widens* its
+deficit. The COCO-measured gap generalises.
+
+EdgeFirst's accurate-class lead across every corpus (turbo `islow` p50 ÷
+EdgeFirst p50, YUV arm):
+
+| Board | val2017 | val2017-yuv420 | val2017-dri | CLIC 4:2:0 | CLIC 4:4:4 | CLIC 4:2:0-dri |
+|-------|---------|----------------|-------------|-----------|-----------|----------------|
+| x86-desktop | 1.17× | 1.12× | 1.22× | 1.09× | 1.22× | 1.11× |
+| rpi5-hailo (A76) | 1.34× | 1.26× | 1.46× | 1.20× | 1.31× | 1.31× |
+| orin-nano (A78AE) | 1.38× | 1.32× | 1.53× | 1.29× | 1.51× | 1.41× |
+| imx95-pro (A55) | 1.17× | 1.05× | 1.34× | 1.01× | 1.27× | 1.13× |
+| imx8mp-frdm (A53) | 1.15× | 1.00× | 1.33× | 1.00× | 1.31× | 1.15× |
+
+EdgeFirst leads or ties every cell. The two 1.00× cells — both on the
+in-order A53, on the 4:2:0 corpora where turbo is strongest — are the
+honest edge: the accurate class is a dead heat there (3.78 vs 3.80 ms on
+the small set, 30.40 vs 30.42 ms on CLIC), and at large 4:2:0 turbo
+`ifast` edges `hal_fast` by 1.4% (27.20 vs 27.59 ms) — the only fast-class
+cell EdgeFirst does not win across five hosts and six corpora. DRI widens
+the lead everywhere, most on the cores cameras actually ship.
+
+One footnote for readers of the raw summaries: on the 4:2:0 corpora the
+EdgeFirst *RGB* rows decode to native NV12, not RGB — the fused
+YCbCr→RGB write engages only for 4:4:4 sources, so an `rgb` request on
+4:2:0 resolves to the native layout (timings match the YUV row). Those
+cells are not comparable to the other arms' true-RGB rows and are excluded
+from RGB comparisons on 4:2:0 corpora; a fused 4:2:0→RGB path is a noted
+future optimization.
+
+### AWS cloud baselines
+
+The same decode-only matrix ran on AWS Batch (2026-08-13) across the five
+reproducible instance classes reviewers publish against — one job per
+corpus per queue, each on an exclusively-owned on-demand instance (the job
+requests the full 8 vCPUs), ECS AL2023 AMIs, the multi-arch
+`edgefirst-hal-jpeg-bench` container built from this tree, three
+interleaved rounds inside one session per instance, arms pinned to core 0,
+n=200. The container matrix carries six arms (EdgeFirst accurate, turbo
+`islow`, zune, image, stb, Wuffs — no fast-class arms). COCO val2017,
+YUV/RGB p50 ms, median of rounds; **bold** = fastest:
+
+| Queue | CPU | Arm | EdgeFirst | Turbo `islow` | zune-jpeg | image | stb | Wuffs |
+|-------|-----|-----|-----------|---------------|-----------|-------|-----|-------|
+| aws-m8g | Graviton4 (Neoverse-V2) | YUV | **1.376** | 2.117 | 2.547 | — | — | — |
+| | | RGB | **1.457** | 2.200 | 2.663 | 3.379 | 3.794 | 3.793 |
+| aws-c7g | Graviton3 (Neoverse-V1) | YUV | **1.665** | 2.529 | 2.984 | — | — | — |
+| | | RGB | **1.781** | 2.642 | 3.126 | 3.850 | 4.353 | 4.753 |
+| aws-m6g | Graviton2 (Neoverse-N1) | YUV | **2.292** | 3.271 | 3.968 | — | — | — |
+| | | RGB | **2.489** | 3.460 | 4.201 | 4.823 | 6.043 | 6.927 |
+| aws-m7i | Sapphire Rapids | YUV | **1.760** | 2.070 | 2.637 | — | — | — |
+| | | RGB | **1.882** | 2.184 | 2.667 | 2.826 | 3.417 | 3.272 |
+| aws-c7a | Genoa (Zen 4) | YUV | **1.455** | 1.667 | 2.131 | — | — | — |
+| | | RGB | **1.556** | 1.735 | 2.084 | 2.283 | 3.192 | 2.756 |
+
+- **EdgeFirst's largest leads anywhere are on the Graviton parts** — the
+  Arm baselines other published codec numbers use: 1.54× over turbo
+  `islow` on Graviton4, 1.52× on Graviton3, 1.43× on Graviton2 (COCO,
+  YUV), holding 1.32–1.63× across every control corpus. On the modern x86
+  servers the lead is 1.15–1.18× (1.07–1.24× across corpora) — EdgeFirst
+  is fastest in **every cloud cell**.
+- **The zune verdict replicates on the exact instances others benchmark
+  on**: zune trails turbo by 1.18–1.28× on COCO and the gap *widens* to
+  1.32–1.56× on the 4:2:0 corpora, on every queue — same shape as the
+  workstation and SBC results.
+- **Cross-corpus caveat**: unlike the board sweeps, each corpus ran on its
+  own freshly-launched instance, so within-corpus arm ratios are
+  same-silicon and tight (round spreads <1%) but cross-corpus deltas
+  carry instance-to-instance variance — the m7i pair shows it (its
+  val2017 and val2017-dri jobs landed on different-turbo-bin instances,
+  producing a nonphysical negative DRI delta). DRI penalties are therefore
+  quoted from the board captures, where the corpus pairs shared one
+  session; the cloud runs agree in direction on the other four queues
+  (turbo +8.8–10.0%, EdgeFirst +0.9–2.8%).
+
+### Hardware decoders
+
+The arms above are deliberately CPU-only. SoC hardware decode paths are
+measured separately — same corpora, same harness, published as their own
+table rather than mixed into the CPU comparison, because the resource being
+spent differs:
+
+- **i.MX 95 (V4L2 mxc-jpeg)** performs no colour-space conversion. Verified
+  on-target via `VIDIOC_ENUM_FMT`: the decode node's RGB capture formats
+  exist only for RGB-*encoded* JPEGs (the mirror of the encoder node's RGB
+  inputs); standard YCbCr streams decode to their native sampling —
+  4:2:0→NV12, 4:2:2→YUYV, 4:4:4→YUV3, greyscale→GREY. The table therefore
+  carries **two rows**: `hal_v4l2_* --decode-only` (JPEG → NV* in DMA — the
+  stopping point for consumers that take NV12 directly, e.g. GL-sampled
+  model preprocessing) and `--full-res-convert` (adds the full-resolution
+  NV*→RGB second pass, via GPU (`hal_v4l2_gl`) or CPU (`hal_v4l2_cpu`) — the
+  full cost for RGB consumers), with the per-frame decode/convert split
+  reported so both audiences can read their number from one run. Both passes
+  follow the pool-reuse discipline: `ImageProcessor::create_image()`
+  allocates the decode source and the RGB destination once, sized to the
+  dataset's largest frame, before the timed loop (warmup then absorbs
+  first-touch faults, EGL import, and V4L2 queue setup); per-frame work only
+  reconfigures logical dimensions. Buffer creation is never inside the timed
+  region, and the harness verifies the pools actually held — a
+  `BufferIdentity` change during the hot loop counts as `identity_churn` and
+  warns loudly (0 on the captured runs).
+- **Jetson Orin (nvJPEG)** is **not** a dedicated JPEG engine on this SoC:
+  only the GPU_HYBRID backend exists (Huffman on CPU, IDCT/postprocess on
+  the **shared CUDA cores** — the NVJPG ASIC is unreachable through CUDA
+  nvJPEG). Decoding therefore competes with anything else on the GPU, most
+  importantly AI inference; that contention is real, is the reason the
+  backend is opt-in (`EDGEFIRST_ENABLE_NVJPEG`), and is **out of scope for
+  these benchmarks** — concurrent decode-plus-inference impact will be
+  measured separately. Its fixed output is interleaved RGB (no NV12 in
+  CUDA 12.3.3), so it has no NV-native row.
+
+Captured 2026-08-13 with the same protocol as the CPU sweep (median of 3
+interleaved rounds, n=200 / all 62 CLIC files, pinned harness core; raw
+logs under `benchmarks/results/<board>/hw-decode/<corpus>/`). The EdgeFirst
+CPU column repeats the same board's CPU decode (YUV arm) for reference.
+
+**i.MX 95 V4L2 (mxc-jpeg), p50 ms.** decode-only stops at native NV*-in-DMA
+with near-zero CPU; the full-res rows add the NV*→RGB second pass
+(decode + convert split in parentheses):
+
+| Corpus | decode-only | + RGB, CPU convert | + RGB, GL convert | EdgeFirst CPU |
+|--------|-------------|--------------------|-------------------|---------------|
+| val2017 | 4.54 | 6.77 (4.47 + 2.35) | 9.11 (5.87 + 2.97) | 6.03 |
+| val2017-yuv420 | 2.53 | 4.44 (2.38 + 2.05) | 7.00 (3.78 + 2.98) | 3.37 |
+| val2017-dri | 4.39 | 6.65 (4.33 + 2.34) | 8.98 (5.77 + 2.99) | 6.05 |
+| CLIC 4:2:0 | 21.12 | 44.0 (21.6 + 23.2) | 47.6 (28.6 + 18.7) | 27.68 |
+| CLIC 4:4:4 | 42.15 | 62.7 (42.3 + 19.2) | 71.6 (51.2 + 18.0) | 40.70 |
+| CLIC 4:2:0-dri | 21.24 | 44.6 (21.8 + 23.5) | 47.5 (28.9 + 18.7) | 27.95 |
+
+What the splits show: the hardware block is **~25% faster than CPU decode
+on 4:2:0 and COCO** while freeing the core, and — unlike every CPU decoder
+— is **indifferent to restart markers** (val2017-dri matches val2017 within
+noise); at large 4:4:4 the tuned CPU decoder edges it. The two converters
+cross over exactly where predicted: at ~0.27 MP the CPU convert wins (GL's
+per-frame import/sync overhead dominates small frames) while at 2.8 MP the
+GL convert leg is cheaper (18.7 vs 23.2 ms) — though GL work visibly
+contends with the V4L2 decode leg (28.6 vs 21.6 ms decode under GL), so at
+these sizes the CPU-convert total still wins. One cost the full-res GL leg
+carries by design: reconfiguring the pooled RGB destination to each frame's
+dimensions requires a fresh EGLImage import per *distinct* geometry
+(imports are cached per size; reusing a stale-geometry image would sample
+at the wrong pitch), so varying-size corpora pay real import cost inside
+the convert leg that the fixed-size letterbox path does not — a genuine
+cost of GL output at native sizes, not harness overhead. NV12-native consumers should
+read the decode-only column; RGB consumers the full-cost columns.
+
+**Jetson Orin nvJPEG (GPU_HYBRID, RGB out), p50 ms** — captured on the
+orin-nano stand-in (`adis-uav1`), per-frame engagement verified via
+`codec.decode_jpeg.nvjpeg_*` tracing spans:
+
+| Corpus | nvJPEG | EdgeFirst CPU |
+|--------|--------|---------------|
+| val2017 | 4.72 | 3.72 |
+| val2017-yuv420 | 2.47 | 2.03 |
+| val2017-dri | 4.40 | 3.75 |
+| CLIC 4:2:0 | 16.46 | 15.73 |
+| CLIC 4:4:4 | 22.95 | 22.78 |
+| CLIC 4:2:0-dri | 16.69 | 15.69 |
+
+nvJPEG's GPU_HYBRID never beats the tuned CPU decoder outright at any size
+here, and its throughput tracks bitstream entropy — the Huffman leg stays
+on the CPU, so the large high-entropy CLIC files bottleneck exactly where a
+CPU decoder does. Its value on this SoC is GPU-resident RGB output and
+partial CPU offload (it is, however, restart-marker-indifferent like the
+i.MX block), not latency — which is why it stays opt-in and why the
+decode-plus-inference contention measurement is scoped separately.
 
 ### SIMD tier value (x86-desktop)
 
@@ -471,13 +711,44 @@ Per-block IDCT cost (in-tree microbenchmark `idct_kernel_cost`): **21.5 ns**
 on Rocket Lake, **81.1 ns** on the A76, **212.6 ns** on the A55, **220.8 ns** on
 the A53.
 
+### Build & run provenance
+
+Every sweep writes `results/<board>/decode-ab-*/provenance.txt` recording
+what a reader needs to reproduce (or falsify) that host's numbers: rustc and
+cargo-zigbuild versions, build profile and run parameters, the zune-jpeg /
+image crate versions from `Cargo.lock` (with zune's `x86`+`neon` SIMD
+features pinned explicitly in the harness manifest), the host kernel and CPU
+model, the pinned core's cpufreq governor and current/max clocks, and the
+loader-resolved libturbojpeg path with its owning package. The C arm
+additionally resolves the library it actually loaded via `dladdr` and embeds
+that path in its console output and CSV notes. The turbo provenance matters
+doubly on ARM: libjpeg-turbo 3.2 removed its GNU-assembler NEON
+implementation, so ARM builds need GCC 12+ or Clang for full performance —
+the recorded library version is what makes the ARM baselines checkable.
+Harness compilers are mixed by construction and recorded as such: the
+turbojpeg harness is compiled remotely with the host gcc on x86 targets
+(its timed region runs inside the dlopened system libturbojpeg either
+way), while the stb/wuffs arms — whose decoders compile into the binary —
+are cross-built with zig cc (clang) for both architectures; the provenance
+records both compilers.
+
 ### Reproduce
 
 ```bash
-# Full six-arm decoder sweep, aarch64 boards + x86_64 hosts over SSH
-# (release profile, interleaved best-of-3; EdgeFirst accurate/fast, turbo
-# islow/ifast, zune-jpeg, image crate)
+# Full eight-arm decoder sweep, aarch64 boards + x86_64 hosts over SSH
+# (release profile, interleaved rounds, median-of-3 reported with per-round
+# p50s and spread; EdgeFirst accurate/fast, turbo islow/ifast, zune-jpeg,
+# image crate, stb_image, Wuffs; provenance.txt written per host; results
+# land under results/<host>/decode-ab-sweep/<corpus>/)
 ./benchmarks/scripts/decode-ab-sweep.sh imx8mp-frdm imx95-pro rpi5-hailo adis-uav1 sebstation
+
+# Same sweep against a control corpus (staged by scripts/sync-corpus.sh)
+EDGEFIRST_BENCH_COCO_REMOTE=/data/corpora/val2017-yuv420 \
+  ./benchmarks/scripts/decode-ab-sweep.sh rpi5-hailo
+
+# Hardware-decode rows (i.MX 95 V4L2 / Jetson nvJPEG; see the hardware table)
+# hal_v4l2_gl --decode-only | hal_v4l2_cpu --full-res-convert |
+# hal_v4l2_gl --full-res-convert | hal_nvjpeg --decode-only --decode-fmt native
 
 # Three-arm publish subset (EdgeFirst accurate vs turbo islow/ifast only)
 CARGO_PROFILE=release EDGEFIRST_BENCH_ORIN_FALLBACK=adis-uav1 \
@@ -1437,6 +1708,7 @@ allocation.
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 3.11 | 2026-08-13 | JPEG decode section re-captured and expanded for publication: eight arms (stb_image and Wuffs added, both pixel-parity-verified against djpeg accurate — Wuffs bit-exact, stb ±3 LSB), median-of-3-interleaved-rounds protocol with per-round spread, mean, and nonparametric 95% median CIs, identical strided image selection for every arm, and per-host build/run provenance. New sections: control corpora (val2017-yuv420 / lossless val2017-dri / CLIC 2025 4:2:0+4:4:4+DRI — the zune-vs-turbo gap is shown to be general, not corpus-driven, and the DRI claim is measured), AWS cloud baselines (Graviton2/3/4, Sapphire Rapids, Genoa — EdgeFirst fastest in every cell, largest leads on Graviton), hardware decoders (i.MX 95 V4L2 decode-only + full-res NV*→RGB second pass via CPU/GL with decode/convert split; Orin nvJPEG scoped as shared-CUDA-core GPU_HYBRID), and build & run provenance. Headline: accurate beats turbo `islow` everywhere (+12.9% A53 … +27.7% A78AE; 1.43–1.54× on Graviton). |
 | 3.10 | 2026-08-13 | JPEG decode section rebuilt as the six-arm sweep (`decode-ab-sweep.sh`): EdgeFirst accurate + opt-in `fast` (`DctMethod::Fast`) vs turbo `islow`/`ifast`, zune-jpeg, and the image crate, across A53/A55/A76/A78AE/Rocket Lake. Accurate beats both turbo kernels everywhere (+11.7% A53 … +28.7% A78AE vs `islow`); `fast` beats `ifast` by 14–32% with its accuracy envelope stated (cosine ≥ 0.99985, PSNR ≥ 42 dB, max Δ 24 over 1000 COCO images). x86 re-captured after the SSE4.1 fused-RGB block-kernel fix. orin-nano row captured on the `adis-uav1` fallback (turbo baseline within 0.1% of the prior capture). |
 | 3.9 | 2026-06-16 | 0.25.0 release refresh: full bench matrix re-collected on the converged-GL-engine code across imx8mp-frdm, imx95-frdm, rpi5-hailo, and jetson-orin-nano, plus the existing mbp-m2-max rows. Confirms the GL-convergence captures within measurement noise (imx95 GL 1080p YUYV→RGBA letterbox 1.2 ms → 957 µs, NV12→RGBA 1.2 ms → 830 µs); no GPU regressions. Allocation table updated for the imx8mp DMA-alloc improvement (38 ms → 1.8 ms at 720p). macOS GL rows remain the pre-convergence capture (Known Gap #17). |
 | 3.8 | 2026-05-24 | macOS GL backend lands via ANGLE + IOSurface. `TensorMemory::Dma` extended to back IOSurface on macOS, with `is_gpu_buffer_available()` as the portable probe. Capture buffer-infrastructure numbers on mbp-m2-max for Mem/Shm/Dma (alloc 16 µs constant for IOSurface, memcpy 2–2.7× faster than SHM at every resolution). YUYV→RGBA same-size convert: 1.3× at 1080p, 4.8× at 4K vs CPU. Add mbp-m2-max **CPU-only** rows to letterbox / decoder / mask-decode / codec tables; add mbp-m2-max **GL** rows (YUYV→RGBA only) to the same-size format-conversion and 4K-convert tables. Letterbox GL rows pending Gap #17 closure. |

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -837,12 +837,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hal_nvjpeg"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "edgefirst-bench-common",
+ "edgefirst-codec",
+]
+
+[[package]]
+name = "hal_v4l2_cpu"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "edgefirst-bench-common",
+ "edgefirst-codec",
+]
+
+[[package]]
 name = "hal_v4l2_gl"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
  "edgefirst-bench-common",
+ "edgefirst-codec",
 ]
 
 [[package]]
@@ -1643,6 +1664,7 @@ dependencies = [
  "anyhow",
  "clap",
  "image",
+ "libc",
  "zune-core",
  "zune-jpeg",
 ]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -14,6 +14,8 @@ members = [
     "modules/hal_gl",
     "modules/hal_g2d",
     "modules/hal_v4l2_gl",
+    "modules/hal_nvjpeg",
+    "modules/hal_v4l2_cpu",
 ]
 
 [workspace.package]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,16 +17,32 @@ benchmarks/
 ├── common/           # Shared Rust helpers (COCO walk, timing, CSV)
 ├── docker/           # Multi-processor container image (Dockerfile + entrypoint)
 ├── probe/            # Capability probe script
-├── scripts/          # sync-coco, deploy-and-run, decode-ab-matrix,
-│                     # perf-compare-decode, fixture-decode-matrix
+├── scripts/          # sync-coco, sync-corpus, deploy-and-run, decode-ab-*,
+│                     # make-coco-yuv420, make-dri-corpus, fetch-clic2025,
+│                     # corpus_stats.py, perf-compare-decode, fixture-decode-matrix
 ├── modules/
 │   ├── hal_cpu/      # HAL decode + HAL CPU convert          (Rust)
 │   ├── turbojpeg/    # libjpeg-turbo decode, reference arm    (C)
+│   ├── rust_jpeg/    # zune-jpeg + image-crate arms           (Rust)
+│   ├── stb/          # stb_image arm (single header, RGB)     (C)
+│   ├── wuffs/        # Wuffs v0.4 JPEG arm (Google, RGB)      (C)
+│   ├── cbench/       # shared C harness header (stb, wuffs)
+│   ├── dct_compare/  # fast-vs-accurate DCT pixel similarity  (Rust)
 │   ├── hal_gl/       # HAL decode → NV12 + HAL GL convert     (Rust)
 │   ├── hal_g2d/      # HAL decode → NV12 + HAL G2D (i.MX)     (Rust)
-│   └── hal_v4l2_gl/  # HAL V4L2 JPEG + HAL GL (i.MX 95)       (Rust)
-└── results/<board>/  # CSV outputs (gitignored)
+│   ├── hal_v4l2_gl/  # HAL V4L2 JPEG + HAL GL (i.MX 95)       (Rust)
+│   ├── hal_v4l2_cpu/ # HAL V4L2 JPEG + HAL CPU convert         (Rust)
+│   └── hal_nvjpeg/   # HAL nvJPEG GPU decode (Jetson Orin)     (Rust)
+└── results/<board>/  # CSV outputs + provenance.txt (gitignored)
 ```
+
+The `stb` and `wuffs` modules do not vendor their upstream sources: `make`
+fetches `stb_image.h` (pinned commit) and `wuffs-v0.4.c` (pinned release tag)
+with sha256 verification into their gitignored `build/` directories. Both are
+RGB-only arms — neither library exposes a raw-YUV output — and both compile
+their harness from `modules/cbench/cbench.h`, whose timing/stats/selection
+definitions are copies of `turbojpeg/bench.c`'s (which mirror
+`benchmarks/common`); a change to any of the three must be applied to all.
 
 ## Constants
 
@@ -36,6 +52,34 @@ benchmarks/
 | Output | 640×640 centered letterbox, pad **114**, RGB |
 | Smoke | `--limit 50` (default), 10 warmup |
 | Full | omit `--limit` (all 5000 JPEGs); latency only, no mAP |
+
+## Corpora
+
+COCO val2017 is the primary corpus. Measured with `scripts/corpus_stats.py`
+(full 5000): 4990 baseline 4:4:4 + 10 greyscale, none progressive, zero
+restart-interval (DRI) files, p50 0.273 MP. The control corpora below answer
+the specific objections a published comparison meets; each output directory
+carries a `MANIFEST.txt` recording its exact recipe and tool versions.
+
+| Corpus | Script | Isolates |
+|--------|--------|----------|
+| `val2017-yuv420` | `make-coco-yuv420.sh` (djpeg\|cjpeg `-quality 90 -sample 2x2`) | 4:2:0 vs the 4:4:4 corpus (add `--with-444-twin` for the same-quality 4:4:4 pair — the pure subsampling isolate) |
+| `val2017-dri` | `make-dri-corpus.sh` (`jpegtran -restart 1`, **lossless**) | restart-marker handling alone — identical DCT coefficients, only DRI added |
+| `CLIC2025/jpeg-yuv420` + `jpeg-yuv444` | `fetch-clic2025.sh` (pinned downloads + sha256; cjpeg q90 both subsamplings from identical pixels) | large images (62 files, ~1.8–4.2 MP, p50 2.8 MP) vs COCO's ~0.27 MP |
+| `CLIC2025/jpeg-yuv420-dri` | `make-dri-corpus.sh` on the above | restarts at large-image scale |
+
+CLIC 2025 images are Unsplash-licensed (commercial use OK, no attribution).
+COCO images carry individual Flickr CC licenses (some NC): never publish or
+redistribute COCO-derived JPEGs — generate locally, sync to private storage
+only.
+
+Sync any corpus to boards with `scripts/sync-corpus.sh --src DIR [host...]`
+(lands at `/data/corpora/<basename>`), then point a sweep at it:
+
+```bash
+EDGEFIRST_BENCH_COCO_REMOTE=/data/corpora/val2017-yuv420 \
+  ./benchmarks/scripts/decode-ab-sweep.sh rpi5-hailo
+```
 
 ## Build profile
 
@@ -67,13 +111,25 @@ cargo run --profile profiling --manifest-path benchmarks/modules/hal_cpu/Cargo.t
 make -C benchmarks/modules/turbojpeg
 ./benchmarks/modules/turbojpeg/build/turbojpeg_bench --limit 50 --board x86-desktop \
   --decode-only --format yuv --csv benchmarks/results/x86-desktop/turbojpeg.csv
+
+# stb_image / Wuffs arms (single-file deps fetched + sha256-checked by make)
+make -C benchmarks/modules/stb && make -C benchmarks/modules/wuffs
+./benchmarks/modules/stb/build/stb_bench --limit 50 --board x86-desktop \
+  --decode-only --format rgb --csv benchmarks/results/x86-desktop/stb.csv
+./benchmarks/modules/wuffs/build/wuffs_bench --limit 50 --board x86-desktop \
+  --decode-only --format rgb --csv benchmarks/results/x86-desktop/wuffs.csv
 ```
 
 ## Docker / multi-processor
 
-The `benchmarks/docker/` image packages `hal_cpu` so the same binary can be run
-on varied Intel (and other) CPUs to collect per-processor numbers and guide
-ISA-tier opts (`IntelTier` / `NeonTier`).
+The `benchmarks/docker/` image packages every CPU arm — `hal_cpu`,
+`turbojpeg_bench`, `rust_jpeg` (zune + image), `stb_bench`, `wuffs_bench` — so
+the same binaries run on varied Intel/AMD/Graviton CPUs (multi-arch bases;
+build arm64 with `docker buildx build --platform linux/arm64`) to collect
+per-processor numbers and guide ISA-tier opts (`IntelTier` / `NeonTier`). For
+AWS Batch, `DATASET_S3=s3://…/corpus.tar.gz` (job-role credentials) or
+`DATASET_URL=https://…` fetches the corpus before the run; `MODULES` selects
+arms (default all six; image/stb/wuffs are rgb-only and skip the yuv pass).
 
 Default container work is a **decode-only** YUV + RGB matrix (no letterbox /
 `ImageProcessor::convert`):
@@ -137,7 +193,7 @@ docker run --rm \
 | `LIMIT` / `WARMUP` | Smoke knobs (`LIMIT=0` = full set) |
 | `EDGEFIRST_CODEC_FORCE_INTEL` | `scalar\|sse2\|sse41\|avx2` A/B |
 | `EDGEFIRST_CODEC_FORCE_NEON` | `scalar\|baseline\|plus\|high` A/B (aarch64 images) |
-| `MODULES` | Comma list: `hal_cpu`, `turbojpeg` (default both) |
+| `MODULES` | Comma list: `hal_cpu`, `turbojpeg`, `zune`, `image`, `stb`, `wuffs` (default all six; `image`/`stb`/`wuffs` are rgb-only) |
 | `FORMATS` | Comma list: `yuv`, `rgb` (default both) |
 | `TENSOR_MEM` | `mem\|dma\|auto` (default `mem`) |
 | `EXTRA_ARGS` | Extra argv appended to `hal_cpu` |
@@ -157,7 +213,7 @@ The image is the portable OSS contract. How you schedule it on cloud CPUs
 # Decode-only HAL vs TurboJPEG (YUV + RGB) — smoke / investigation
 ./benchmarks/scripts/decode-ab-matrix.sh imx8mp-frdm imx95-pro rpi5-hailo orin-nano
 
-# Published decoder A/B (release, interleaved best-of-3, n=200)
+# Published decoder A/B (release, interleaved rounds, median-of-3 + spread, n=200)
 CARGO_PROFILE=release EDGEFIRST_BENCH_ORIN_FALLBACK=adis-uav1 \
   ./benchmarks/scripts/decode-ab-publish.sh imx8mp-frdm imx95-pro rpi5-hailo orin-nano
 
@@ -319,8 +375,10 @@ Each of these was measured and rejected; the reasons generalise.
 
 - **Interleave the arms.** This host is shared with a `powersave` governor and
   turbo enabled; single runs of the same binary drift by up to 40%, and one
-  briefly showed a faster kernel as a regression. Every published number is
-  best-of-N with the arms alternating inside one loop.
+  briefly showed a faster kernel as a regression. Every published number comes
+  from N interleaved rounds with the arms alternating inside one loop, reported
+  as the median across rounds with each round's p50 and the min-max spread
+  (best-of-N favours the low tail and is no longer the claim number).
 - **`libturbojpeg` ships stripped.** Group its samples by mapping each IP to the
   nearest preceding `endbr64`/call target on x86, or every `bl` target in the
   disassembly on aarch64. The hot functions then identify as `decode_mcu` and

--- a/benchmarks/common/src/cpu.rs
+++ b/benchmarks/common/src/cpu.rs
@@ -144,7 +144,13 @@ fn read_per_core_busy_idle() -> Vec<(u64, u64)> {
         }
         let mut parts = line.split_whitespace();
         let Some(name) = parts.next() else { continue };
-        if name == "cpu" || !name.bytes().nth(3).is_some_and(|c| c.is_ascii_digit()) {
+        if name == "cpu"
+            || !name
+                .as_bytes()
+                .get(3)
+                .copied()
+                .is_some_and(|c| c.is_ascii_digit())
+        {
             continue;
         }
         // user nice system idle iowait irq softirq steal guest guest_nice

--- a/benchmarks/common/src/lib.rs
+++ b/benchmarks/common/src/lib.rs
@@ -11,8 +11,8 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, ValueEnum};
 use edgefirst_codec::{peek_info, ImageDecoder, ImageLoad};
 use edgefirst_image::{
-    ComputeBackend, Crop, Flip, ImageProcessor, ImageProcessorConfig, ImageProcessorTrait,
-    Region, Rotation,
+    ComputeBackend, Crop, Flip, ImageProcessor, ImageProcessorConfig, ImageProcessorTrait, Region,
+    Rotation,
 };
 use edgefirst_tensor::{CpuAccess, DType, PixelFormat, TensorDyn, TensorMemory};
 use std::fs::{self, File};
@@ -87,6 +87,19 @@ pub struct BenchArgs {
     /// Model-input preprocessing is out of scope for this mode.
     #[arg(long, env = "EDGEFIRST_BENCH_DECODE_ONLY", default_value_t = false)]
     pub decode_only: bool,
+
+    /// Convert to full-resolution RGB instead of the 640×640 letterbox:
+    /// decode → NV*/GREY → same-size RGB, a pure colour-conversion second
+    /// pass with no scaling.
+    ///
+    /// For the hardware-decode table's "full cost to RGB" rows: hardware
+    /// JPEG blocks that emit only their stream's native YUV layout (e.g.
+    /// i.MX mxc-jpeg) need this pass before an RGB consumer can use the
+    /// pixels, while NV12-native consumers stop at `--decode-only`. The
+    /// per-frame decode/convert split is reported so both costs publish
+    /// from one run. Ignored when `--decode-only` is set.
+    #[arg(long, default_value_t = false)]
+    pub full_res_convert: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
@@ -183,9 +196,7 @@ pub fn list_jpegs(dir: &Path, limit: Option<usize>) -> Result<Vec<PathBuf>> {
     if let Some(n) = limit {
         if n > 0 && n < paths.len() {
             let len = paths.len();
-            paths = (0..n)
-                .map(|i| paths[i * len / n].clone())
-                .collect();
+            paths = (0..n).map(|i| paths[i * len / n].clone()).collect();
         } else if n > 0 {
             paths.truncate(n);
         }
@@ -202,8 +213,27 @@ pub struct TimingStats {
     pub ms_p50: f64,
     pub ms_p95: f64,
     pub ms_p99: f64,
+    pub ms_mean: f64,
+    /// ~95% confidence interval for the median (nonparametric, order-statistic
+    /// ranks n/2 ∓ 1.96·√n/2 — no distribution assumption on the samples).
+    pub ms_p50_ci_lo: f64,
+    pub ms_p50_ci_hi: f64,
     pub mpix_per_s: f64,
     pub peak_rss_mb: f64,
+}
+
+/// 0-based sorted-sample indices bounding the ~95% CI for the median
+/// (normal approximation to the binomial: 1-based ranks
+/// ⌊n/2 − 1.96·√n/2⌋ and ⌈n/2 + 1 + 1.96·√n/2⌉, clamped to [1, n]).
+pub fn median_ci_indices(n: usize) -> (usize, usize) {
+    if n == 0 {
+        return (0, 0);
+    }
+    let nf = n as f64;
+    let half_width = 0.98 * nf.sqrt(); // 1.96·√n / 2
+    let lo_rank = (nf / 2.0 - half_width).floor().max(1.0);
+    let hi_rank = (nf / 2.0 + 1.0 + half_width).ceil().min(nf);
+    (lo_rank as usize - 1, hi_rank as usize - 1)
 }
 
 impl TimingStats {
@@ -223,11 +253,16 @@ impl TimingStats {
         } else {
             0.0
         };
+        let ms_mean = if n > 0 { sum_ms / n as f64 } else { 0.0 };
+        let (ci_lo, ci_hi) = median_ci_indices(n);
         Self {
             n,
             ms_p50: pct(0.50),
             ms_p95: pct(0.95),
             ms_p99: pct(0.99),
+            ms_mean,
+            ms_p50_ci_lo: if n > 0 { samples_ms[ci_lo] } else { 0.0 },
+            ms_p50_ci_hi: if n > 0 { samples_ms[ci_hi] } else { 0.0 },
             mpix_per_s,
             peak_rss_mb: peak_rss_mb(),
         }
@@ -276,15 +311,19 @@ pub fn write_summary_csv(
     let mut f = File::create(path).with_context(|| format!("create {}", path.display()))?;
     writeln!(
         f,
-        "board,class,module,ms_p50,ms_p95,ms_p99,mpix_per_s,peak_rss_mb,\
+        "board,class,module,ms_p50,ms_p95,ms_p99,ms_mean,ms_p50_ci_lo,ms_p50_ci_hi,\
+         mpix_per_s,peak_rss_mb,\
          cpu_pct_process,cpu_pct_system,cpu_pct_peak_core,n_images,notes"
     )?;
     writeln!(
         f,
-        "{board},{class},{module},{:.3},{:.3},{:.3},{:.3},{:.1},{:.1},{:.1},{:.1},{},{}",
+        "{board},{class},{module},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.3},{:.1},{:.1},{:.1},{:.1},{},{}",
         stats.ms_p50,
         stats.ms_p95,
         stats.ms_p99,
+        stats.ms_mean,
+        stats.ms_p50_ci_lo,
+        stats.ms_p50_ci_hi,
         stats.mpix_per_s,
         stats.peak_rss_mb,
         cpu.process_pct,
@@ -366,10 +405,12 @@ fn resolve_src_memory(cfg: &HalModuleConfig, args: &BenchArgs) -> Option<TensorM
     }
 }
 
-/// Letterbox crop; when the decoded image is smaller than the pooled tensor,
-/// pin `source` so the GPU samples only the live sub-rect (profiler pattern).
-fn letterbox_crop(info_w: usize, info_h: usize, tensor: &TensorDyn) -> Crop {
-    let mut crop = Crop::letterbox(LETTERBOX_PAD);
+/// Finish a per-frame crop: when the decoded image is smaller than the pooled
+/// tensor, pin `source` so the GPU samples only the live sub-rect (profiler
+/// pattern). `base` carries the fit — letterbox for the model-input pipeline,
+/// `Crop::no_crop()` for the full-resolution colour-conversion pass.
+fn frame_crop(base: Crop, info_w: usize, info_h: usize, tensor: &TensorDyn) -> Crop {
+    let mut crop = base;
     let shape = tensor.shape();
     let tensor_h = shape.first().copied().unwrap_or(0);
     let tensor_w = shape.get(1).copied().unwrap_or(0);
@@ -377,6 +418,37 @@ fn letterbox_crop(info_w: usize, info_h: usize, tensor: &TensorDyn) -> Crop {
         crop.source = Some(Region::new(0, 0, info_w, info_h));
     }
     crop
+}
+
+/// Per-frame convert setup: build the crop and, in full-res mode, reconfigure
+/// the pooled destination to this frame's dimensions so the convert is a pure
+/// NV*/GREY→RGB colour conversion (no scaling). The pool is sized for the
+/// largest frame, so `configure_image` only moves logical dims — a realloc
+/// would show up as `identity_churn`. Note the GL backend still re-imports an
+/// EGLImage per *distinct* configured geometry (cached per size; required for
+/// correct pitch), so on varying-size corpora the GL convert leg carries real
+/// per-new-size import cost that is measured convert work, not allocation
+/// churn — see BENCHMARKS.md § Hardware decoders.
+fn prepare_convert(
+    args: &BenchArgs,
+    info_w: usize,
+    info_h: usize,
+    input: &TensorDyn,
+    output: &mut TensorDyn,
+) -> Result<Crop> {
+    if args.full_res_convert {
+        output
+            .configure_image(info_w, info_h, PixelFormat::Rgb)
+            .context("configure full-res RGB dst")?;
+        Ok(frame_crop(Crop::no_crop(), info_w, info_h, input))
+    } else {
+        Ok(frame_crop(
+            Crop::letterbox(LETTERBOX_PAD),
+            info_w,
+            info_h,
+            input,
+        ))
+    }
 }
 
 /// HAL JPEG latency sweep: decode → optional letterbox convert.
@@ -398,8 +470,9 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        match edgefirst_hal::trace::start_tracing(path.to_str().unwrap_or("/tmp/hal-bench-trace.json"))
-        {
+        match edgefirst_hal::trace::start_tracing(
+            path.to_str().unwrap_or("/tmp/hal-bench-trace.json"),
+        ) {
             Ok(()) => {
                 tracing_active = true;
                 eprintln!("  chrome trace → {}", path.display());
@@ -412,6 +485,8 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
     let paths = list_jpegs(&coco, args.effective_limit())?;
     let scope = if args.decode_only {
         "decode-only"
+    } else if args.full_res_convert {
+        "decode+fullres-rgb"
     } else {
         "decode+letterbox"
     };
@@ -439,7 +514,10 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
             bytes,
         ));
     }
-    eprintln!("  max source: {max_w}×{max_h}  (preloaded {} JPEGs)", images.len());
+    eprintln!(
+        "  max source: {max_w}×{max_h}  (preloaded {} JPEGs)",
+        images.len()
+    );
 
     let src_memory = resolve_src_memory(&cfg, args);
     // Keep dst on the same policy for CPU modules; GPU modules keep auto (DMA).
@@ -454,10 +532,17 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
     let mut output = if args.decode_only {
         None
     } else {
+        // Full-res mode pools the dst at the largest source dims (reconfigured
+        // per frame); letterbox mode keeps the fixed model-input shape.
+        let (out_w, out_h) = if args.full_res_convert {
+            (max_w.next_multiple_of(2), max_h)
+        } else {
+            (MODEL_W, MODEL_H)
+        };
         Some(
             proc.create_image(
-                MODEL_W,
-                MODEL_H,
+                out_w,
+                out_h,
                 PixelFormat::Rgb,
                 DType::U8,
                 dst_memory,
@@ -477,7 +562,10 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
     let pool_h = max_h * 3;
     let src_cap = pool_w * pool_h; // Grey R8 bytes (= element count)
     let src_id0 = input.buffer_identity().id();
-    let dst_id0 = output.as_ref().map(|o| o.buffer_identity().id()).unwrap_or(0);
+    let dst_id0 = output
+        .as_ref()
+        .map(|o| o.buffer_identity().id())
+        .unwrap_or(0);
     eprintln!(
         "  pool: Grey R8  {pool_w}×{pool_h}  capacity≈{src_cap} B  src_mem={src_mem}  dst_mem={dst_mem}  src_id={src_id0}  dst_id={dst_id0}  tensor_mem={:?}",
         args.tensor_mem
@@ -537,7 +625,7 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
             .load_image(&mut decoder, first)
             .context("warmup decode")?;
         if let Some(output) = output.as_mut() {
-            let crop = letterbox_crop(info.width, info.height, &input);
+            let crop = prepare_convert(args, info.width, info.height, &input, output)?;
             convert_one(
                 &mut proc,
                 &mut cpu_fallback,
@@ -566,7 +654,7 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
             .with_context(|| format!("decode {name}"))?;
         let t1 = Instant::now();
         let t2 = if let Some(output) = output.as_mut() {
-            let crop = letterbox_crop(info.width, info.height, &input);
+            let crop = prepare_convert(args, info.width, info.height, &input, output)?;
             convert_one(
                 &mut proc,
                 &mut cpu_fallback,
@@ -627,18 +715,20 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
     let stats = TimingStats::from_samples(&mut samples_ms, total_mpix);
     decode_ms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     convert_ms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    let dec_p50 = decode_ms
-        .get(decode_ms.len() / 2)
-        .copied()
-        .unwrap_or(0.0);
-    let cvt_p50 = convert_ms
-        .get(convert_ms.len() / 2)
-        .copied()
-        .unwrap_or(0.0);
+    let dec_p50 = decode_ms.get(decode_ms.len() / 2).copied().unwrap_or(0.0);
+    let cvt_p50 = convert_ms.get(convert_ms.len() / 2).copied().unwrap_or(0.0);
 
     eprintln!(
-        "  p50={:.3} ms  (decode_p50={:.3} convert_p50={:.3})  p95={:.3}  p99={:.3}  {:.1} MP/s",
-        stats.ms_p50, dec_p50, cvt_p50, stats.ms_p95, stats.ms_p99, stats.mpix_per_s
+        "  p50={:.3} ms  ci95=[{:.3},{:.3}]  mean={:.3}  (decode_p50={:.3} convert_p50={:.3})  p95={:.3}  p99={:.3}  {:.1} MP/s",
+        stats.ms_p50,
+        stats.ms_p50_ci_lo,
+        stats.ms_p50_ci_hi,
+        stats.ms_mean,
+        dec_p50,
+        cvt_p50,
+        stats.ms_p95,
+        stats.ms_p99,
+        stats.mpix_per_s
     );
     eprintln!(
         "  cpu: process={:.1}%  system={:.1}%  peak_core={:.1}%  fallback_frames={cpu_fallback_frames}",
@@ -649,13 +739,15 @@ pub fn run_hal_module(cfg: HalModuleConfig, args: &BenchArgs) -> Result<TimingSt
         stats.n
     );
     if identity_churn > 0 {
-        eprintln!(
-            "  WARNING: BufferIdentity changed during the hot loop — pool reuse is broken"
-        );
+        eprintln!("  WARNING: BufferIdentity changed during the hot loop — pool reuse is broken");
     }
 
     let module_name = args.module.as_deref().unwrap_or(cfg.module);
-    let csv_class = if args.decode_only { "decode" } else { cfg.class };
+    let csv_class = if args.decode_only {
+        "decode"
+    } else {
+        cfg.class
+    };
     if let Some(csv) = &args.csv {
         write_summary_csv(
             csv,

--- a/benchmarks/docker/Dockerfile
+++ b/benchmarks/docker/Dockerfile
@@ -2,12 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Multi-stage image for per-processor JPEG decode benchmarks.
-# Builds both arms as native binaries: `hal_cpu` (Rust) and `turbojpeg_bench`
-# (C). Default entrypoint runs the decode-only YUV + RGB A/B (no letterbox).
+# Builds every CPU arm as a native binary: `hal_cpu` + `rust_jpeg` (Rust) and
+# `turbojpeg_bench` + `stb_bench` + `wuffs_bench` (C). Default entrypoint runs
+# the decode-only YUV + RGB A/B matrix (no letterbox).
 #
-# Build from the repository root (optionally after staging coco-smoke/):
+# Multi-arch: both stages use official multi-arch bases and everything builds
+# natively in-container, so the same file serves x86 and Graviton queues:
 #
 #   docker build -f benchmarks/docker/Dockerfile -t edgefirst-hal-jpeg-bench .
+#   docker buildx build --platform linux/arm64 -f benchmarks/docker/Dockerfile \
+#     -t edgefirst-hal-jpeg-bench:arm64 .
 #
 # See benchmarks/README.md § Docker / multi-processor.
 
@@ -19,28 +23,44 @@ COPY crates ./crates
 COPY benchmarks ./benchmarks
 
 WORKDIR /src/benchmarks
-RUN cargo build --profile profiling -p hal_cpu \
-    && cp target/profiling/hal_cpu /usr/local/bin/hal_cpu
+RUN cargo build --profile profiling -p hal_cpu -p rust_jpeg \
+    && cp target/profiling/hal_cpu /usr/local/bin/hal_cpu \
+    && cp target/profiling/rust_jpeg /usr/local/bin/rust_jpeg
 
-# The TurboJPEG arm is a native C binary for the same reason hal_cpu is a native
-# Rust one: this image measures two decoding libraries against each other, so
-# neither may carry an interpreter inside the timed region. `clean` first,
-# because a host build tree in the context would otherwise satisfy make and ship
-# a binary linked against the host's glibc.
+# The comparator arms are native C binaries for the same reason hal_cpu is a
+# native Rust one: this image measures decoding libraries against each other,
+# so no arm may carry an interpreter inside the timed region. `clean` first,
+# because a host build tree in the context would otherwise satisfy make and
+# ship binaries linked against the host's glibc (stb/wuffs then re-fetch their
+# pinned, sha256-checked single-file sources inside the container).
 RUN make -C modules/turbojpeg clean \
     && make -C modules/turbojpeg \
     && cp modules/turbojpeg/build/turbojpeg_bench /usr/local/bin/turbojpeg_bench
+RUN make -C modules/stb clean \
+    && make -C modules/stb \
+    && cp modules/stb/build/stb_bench /usr/local/bin/stb_bench
+RUN make -C modules/wuffs clean \
+    && make -C modules/wuffs \
+    && cp modules/wuffs/build/wuffs_bench /usr/local/bin/wuffs_bench
 
 FROM debian:bookworm-slim AS runtime
 
+# awscli: lets a Batch job pull the corpus with its job-role credentials
+# (DATASET_S3) with no secret handling; curl/unzip for DATASET_URL archives.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         libturbojpeg0 \
+        awscli \
+        curl \
+        unzip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /usr/local/bin/hal_cpu /usr/local/bin/hal_cpu
+COPY --from=build /usr/local/bin/rust_jpeg /usr/local/bin/rust_jpeg
 COPY --from=build /usr/local/bin/turbojpeg_bench /usr/local/bin/turbojpeg_bench
+COPY --from=build /usr/local/bin/stb_bench /usr/local/bin/stb_bench
+COPY --from=build /usr/local/bin/wuffs_bench /usr/local/bin/wuffs_bench
 COPY benchmarks/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 # Tiny always-present fixtures + optional 50-image COCO smoke set (gitignored
 # host staging under benchmarks/docker/coco-smoke/).
@@ -48,7 +68,8 @@ COPY testdata/zidane.jpg testdata/giraffe.jpg testdata/grey.jpg /opt/testdata/
 COPY benchmarks/docker/coco-smoke/ /opt/coco-smoke/
 
 RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/hal_cpu \
-    /usr/local/bin/turbojpeg_bench
+    /usr/local/bin/rust_jpeg /usr/local/bin/turbojpeg_bench \
+    /usr/local/bin/stb_bench /usr/local/bin/wuffs_bench
 
 ENV RESULTS_DIR=/results \
     EDGEFIRST_BENCH_COCO=/data/coco \
@@ -56,7 +77,7 @@ ENV RESULTS_DIR=/results \
     WARMUP=10 \
     BOARD=unknown \
     TENSOR_MEM=mem \
-    MODULES=hal_cpu,turbojpeg
+    MODULES=hal_cpu,turbojpeg,zune,image,stb,wuffs
 
 VOLUME ["/results", "/data/coco"]
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/benchmarks/docker/entrypoint.sh
+++ b/benchmarks/docker/entrypoint.sh
@@ -15,12 +15,24 @@
 # Env contract (documented in benchmarks/README.md):
 #   EDGEFIRST_BENCH_COCO   JPEG directory (falls back to /opt/coco-smoke then
 #                          /opt/testdata when empty)
+#   DATASET_S3             optional corpus source fetched into the JPEG dir
+#                          before the run, using the task's IAM role (AWS
+#                          Batch): s3://bucket/key.tar.gz|.tgz|.zip extracts
+#                          an archive; s3://bucket/prefix/ syncs a directory
+#   DATASET_URL            same, over plain https (e.g. a presigned URL)
 #   EDGEFIRST_CODEC_FORCE_INTEL / EDGEFIRST_CODEC_FORCE_NEON  optional tier A/B
 #   BOARD                  board / CPU label written into the CSV
 #   RESULTS_DIR            output directory (default /results)
 #   LIMIT / WARMUP         smoke knobs (default 50 / 10; LIMIT=0 = full set)
+#   ROUNDS                 interleaved rounds (default 1). With ROUNDS>1 the
+#                          whole module matrix repeats per round in one
+#                          session (the board-sweep protocol: report the
+#                          median across rounds); CSVs gain a _rN suffix
+#   PIN                    optional core to pin every arm to via taskset
 #   TENSOR_MEM             mem|dma|auto (default mem)
-#   MODULES                comma list: hal_cpu,turbojpeg (default both)
+#   MODULES                comma list: hal_cpu,turbojpeg,zune,image,stb,wuffs
+#                          (default all six; zune covers yuv+rgb, image/stb/
+#                          wuffs are rgb-only and skip the yuv pass)
 #   FORMATS                comma list: yuv,rgb (default both)
 #   DCT                    turbojpeg IDCT: accurate|fast (default accurate,
 #                          matching HAL's islow kernel and libjpeg-turbo's own
@@ -34,15 +46,79 @@ BOARD="${BOARD:-unknown}"
 LIMIT="${LIMIT:-50}"
 WARMUP="${WARMUP:-10}"
 TENSOR_MEM="${TENSOR_MEM:-mem}"
-MODULES="${MODULES:-hal_cpu,turbojpeg}"
+MODULES="${MODULES:-hal_cpu,turbojpeg,zune,image,stb,wuffs}"
 FORMATS="${FORMATS:-yuv,rgb}"
 DCT="${DCT:-accurate}"
+ROUNDS="${ROUNDS:-1}"
 mkdir -p "${RESULTS_DIR}"
+
+# Optional single-core pinning (matches the board sweeps' taskset -c).
+runner=()
+if [[ -n "${PIN:-}" ]]; then
+  if command -v taskset >/dev/null 2>&1; then
+    runner=(taskset -c "${PIN}")
+  else
+    echo "warn: PIN=${PIN} requested but taskset is unavailable; running unpinned" >&2
+  fi
+fi
+run_pinned() { "${runner[@]}" "$@"; }
 
 jpeg_count() {
   local d="$1"
   find "$d" -maxdepth 1 -type f \( -iname '*.jpg' -o -iname '*.jpeg' \) 2>/dev/null | wc -l
 }
+
+extract_archive() { # file dest
+  local f="$1" dest="$2"
+  case "$f" in
+    *.tar.gz | *.tgz) tar -xzf "$f" -C "$dest" ;;
+    *.tar) tar -xf "$f" -C "$dest" ;;
+    *.zip) unzip -qo "$f" -d "$dest" ;;
+    *)
+      echo "error: unsupported archive type: $f" >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Optional corpus fetch (AWS Batch: the job role authenticates DATASET_S3, no
+# secrets in the job definition). Skipped when the directory already has
+# JPEGs, so a mounted volume wins over a re-download.
+if [[ -n "${DATASET_S3:-}${DATASET_URL:-}" ]] && [[ "$(jpeg_count "${COCO}")" -eq 0 ]]; then
+  mkdir -p "${COCO}"
+  if [[ -n "${DATASET_S3:-}" ]]; then
+    case "${DATASET_S3}" in
+      *.tar.gz | *.tgz | *.tar | *.zip)
+        echo "==> fetching corpus archive ${DATASET_S3}" >&2
+        fname="/tmp/$(basename "${DATASET_S3}")"
+        aws s3 cp --no-progress "${DATASET_S3}" "${fname}"
+        extract_archive "${fname}" "${COCO}"
+        rm -f "${fname}"
+        ;;
+      *)
+        echo "==> syncing corpus prefix ${DATASET_S3}" >&2
+        aws s3 sync --no-progress "${DATASET_S3}" "${COCO}"
+        ;;
+    esac
+  else
+    echo "==> fetching corpus archive from URL" >&2
+    fname="/tmp/corpus-archive.$(basename "${DATASET_URL%%\?*}")"
+    curl -fSL -o "${fname}" "${DATASET_URL}"
+    extract_archive "${fname}" "${COCO}"
+    rm -f "${fname}"
+  fi
+  # macOS BSD tar can ship AppleDouble metadata (._*) unless the archive was
+  # created with COPYFILE_DISABLE=1; they match *.jpg globs and are not JPEGs.
+  find "${COCO}" -name '._*' -delete 2>/dev/null || true
+  # Archives may nest a single top-level directory; flatten one level.
+  if [[ "$(jpeg_count "${COCO}")" -eq 0 ]]; then
+    inner="$(find "${COCO}" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    if [[ -n "${inner}" ]] && [[ "$(jpeg_count "${inner}")" -gt 0 ]]; then
+      COCO="${inner}"
+    fi
+  fi
+  echo "==> corpus ready: ${COCO} ($(jpeg_count "${COCO}") JPEGs)" >&2
+fi
 
 if [[ ! -d "${COCO}" ]] || [[ "$(jpeg_count "${COCO}")" -eq 0 ]]; then
   if [[ -d /opt/coco-smoke ]] && [[ "$(jpeg_count /opt/coco-smoke)" -gt 0 ]]; then
@@ -66,10 +142,10 @@ elif [[ -n "${EDGEFIRST_CODEC_FORCE_NEON:-}" ]]; then
   tier_tag="neon-${EDGEFIRST_CODEC_FORCE_NEON}"
 fi
 
-limit_args=()
-if [[ "${LIMIT}" != "0" ]]; then
-  limit_args=(--limit "${LIMIT}")
-fi
+# Always pass --limit explicitly: every harness honours `--limit 0` as "full
+# set", whereas omitting the flag would fall back to per-arm defaults that
+# DISAGREE (50 for hal_cpu/turbojpeg/stb/wuffs, 200 for rust_jpeg).
+limit_args=(--limit "${LIMIT}")
 
 hal_decode_fmt() {
   case "$1" in
@@ -85,6 +161,12 @@ hal_decode_fmt() {
 IFS=',' read -r -a mods <<< "${MODULES}"
 IFS=',' read -r -a fmts <<< "${FORMATS}"
 
+for round in $(seq 1 "${ROUNDS}"); do
+rtag=""
+if [[ "${ROUNDS}" != "1" ]]; then
+  rtag="_r${round}"
+  echo "######## ROUND ${round}/${ROUNDS} ########" >&2
+fi
 for fmt in "${fmts[@]}"; do
   fmt="$(echo "${fmt}" | tr -d '[:space:]')"
   [[ -z "${fmt}" ]] && continue
@@ -94,10 +176,10 @@ for fmt in "${fmts[@]}"; do
     mod="$(echo "${mod}" | tr -d '[:space:]')"
     case "${mod}" in
       hal_cpu|hal)
-        csv="${RESULTS_DIR}/${BOARD}_hal_cpu_${fmt}_${tier_tag}.csv"
+        csv="${RESULTS_DIR}/${BOARD}_hal_cpu_${fmt}_${tier_tag}${rtag:-}.csv"
         echo "===== MODULE hal_cpu decode-only format=${fmt} (${BOARD}) =====" >&2
         # shellcheck disable=SC2086
-        /usr/local/bin/hal_cpu \
+        run_pinned /usr/local/bin/hal_cpu \
           --board "${BOARD}" \
           --tensor-mem "${TENSOR_MEM}" \
           --warmup "${WARMUP}" \
@@ -110,9 +192,9 @@ for fmt in "${fmts[@]}"; do
         cat "${csv}"
         ;;
       turbojpeg|turbo)
-        csv="${RESULTS_DIR}/${BOARD}_turbojpeg_${fmt}.csv"
+        csv="${RESULTS_DIR}/${BOARD}_turbojpeg_${fmt}${rtag:-}.csv"
         echo "===== MODULE turbojpeg decode-only format=${fmt} (${BOARD}) =====" >&2
-        /usr/local/bin/turbojpeg_bench \
+        run_pinned /usr/local/bin/turbojpeg_bench \
           --coco "${COCO}" \
           --board "${BOARD}" \
           --warmup "${WARMUP}" \
@@ -124,12 +206,69 @@ for fmt in "${fmts[@]}"; do
         echo "===== CSV ${csv} ====="
         cat "${csv}"
         ;;
+      zune)
+        csv="${RESULTS_DIR}/${BOARD}_zune_${fmt}${rtag:-}.csv"
+        echo "===== MODULE zune decode-only format=${fmt} (${BOARD}) =====" >&2
+        run_pinned /usr/local/bin/rust_jpeg \
+          --coco "${COCO}" \
+          --board "${BOARD}" \
+          --warmup "${WARMUP}" \
+          --engine zune \
+          --format "${fmt}" \
+          --csv "${csv}" \
+          "${limit_args[@]}"
+        echo "===== CSV ${csv} ====="
+        cat "${csv}"
+        ;;
+      image)
+        if [[ "${fmt}" != rgb ]]; then
+          echo "(skip image: rgb-only arm, format=${fmt})" >&2
+          continue
+        fi
+        csv="${RESULTS_DIR}/${BOARD}_image_rgb${rtag:-}.csv"
+        echo "===== MODULE image decode-only format=rgb (${BOARD}) =====" >&2
+        run_pinned /usr/local/bin/rust_jpeg \
+          --coco "${COCO}" \
+          --board "${BOARD}" \
+          --warmup "${WARMUP}" \
+          --engine image \
+          --format rgb \
+          --csv "${csv}" \
+          "${limit_args[@]}"
+        echo "===== CSV ${csv} ====="
+        cat "${csv}"
+        ;;
+      stb|wuffs)
+        if [[ "${fmt}" != rgb ]]; then
+          echo "(skip ${mod}: rgb-only arm, format=${fmt})" >&2
+          continue
+        fi
+        csv="${RESULTS_DIR}/${BOARD}_${mod}_rgb${rtag:-}.csv"
+        echo "===== MODULE ${mod} decode-only format=rgb (${BOARD}) =====" >&2
+        run_pinned "/usr/local/bin/${mod}_bench" \
+          --coco "${COCO}" \
+          --board "${BOARD}" \
+          --warmup "${WARMUP}" \
+          --decode-only \
+          --format rgb \
+          --csv "${csv}" \
+          "${limit_args[@]}"
+        echo "===== CSV ${csv} ====="
+        cat "${csv}"
+        ;;
       "")
         ;;
       *)
-        echo "error: unknown MODULE '${mod}' (expected hal_cpu|turbojpeg)" >&2
+        echo "error: unknown MODULE '${mod}' (expected hal_cpu|turbojpeg|zune|image|stb|wuffs)" >&2
         exit 1
         ;;
     esac
   done
 done
+done
+
+csv_count="$(find "${RESULTS_DIR}" -maxdepth 1 -name '*.csv' 2>/dev/null | wc -l | tr -d ' ')"
+if [[ "${csv_count}" -eq 0 ]]; then
+  echo "error: matrix produced no CSVs (MODULES=${MODULES}, FORMATS=${FORMATS} — rgb-only modules skip the yuv pass)" >&2
+  exit 1
+fi

--- a/benchmarks/modules/cbench/cbench.h
+++ b/benchmarks/modules/cbench/cbench.h
@@ -1,0 +1,273 @@
+/* SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Shared C harness for single-library decode arms (stb_image, Wuffs).
+ *
+ * Every definition that moves a number is copied verbatim from
+ * modules/turbojpeg/bench.c, which in turn mirrors benchmarks/common: the
+ * evenly-spaced image selection, preload-before-timing, CLOCK_MONOTONIC
+ * around decode alone, percentile index, median-CI ranks, MP/s definition,
+ * peak-RSS source, and CSV schema. A new arm built on this header therefore
+ * differs from the Rust and TurboJPEG arms only in the decoder it calls.
+ * If a definition changes here, change bench.c and benchmarks/common to
+ * match (and vice versa).
+ */
+
+#ifndef EDGEFIRST_CBENCH_H
+#define EDGEFIRST_CBENCH_H
+
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((noreturn, format(printf, 1, 2)))
+#endif
+static void
+cbench_die(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fputc('\n', stderr);
+    exit(1);
+}
+
+/* --- timing / stats: identical definitions to benchmarks/common ---------- */
+
+static double cbench_now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1e6;
+}
+
+static int cbench_cmp_double(const void *a, const void *b) {
+    double x = *(const double *)a, y = *(const double *)b;
+    return (x > y) - (x < y);
+}
+
+/* `idx = round(p * (n - 1))`, as TimingStats::from_samples does. */
+static double cbench_percentile(const double *sorted, size_t n, double p) {
+    if (n == 0) return 0.0;
+    double pos = p * ((double)n - 1.0);
+    size_t idx = (size_t)(pos + 0.5);
+    if (idx >= n) idx = n - 1;
+    return sorted[idx];
+}
+
+/* 0-based sorted-sample indices bounding the ~95% CI for the median, identical
+ * to benchmarks/common median_ci_indices(): 1-based ranks
+ * floor(n/2 - 1.96*sqrt(n)/2) and ceil(n/2 + 1 + 1.96*sqrt(n)/2), clamped. */
+static void cbench_median_ci_indices(size_t n, size_t *lo, size_t *hi) {
+    if (n == 0) {
+        *lo = *hi = 0;
+        return;
+    }
+    double nf = (double)n;
+    double half_width = 0.98 * sqrt(nf); /* 1.96*sqrt(n)/2 */
+    double lo_rank = floor(nf / 2.0 - half_width);
+    double hi_rank = ceil(nf / 2.0 + 1.0 + half_width);
+    if (lo_rank < 1.0) lo_rank = 1.0;
+    if (hi_rank > nf) hi_rank = nf;
+    *lo = (size_t)lo_rank - 1;
+    *hi = (size_t)hi_rank - 1;
+}
+
+/* Peak RSS, matching peak_rss_mb(). Linux VmHWM is kB; Darwin ru_maxrss is bytes. */
+static double cbench_peak_rss_mb(void) {
+#ifdef __APPLE__
+    struct rusage ru;
+    if (getrusage(RUSAGE_SELF, &ru) != 0) return 0.0;
+    return (double)ru.ru_maxrss / (1024.0 * 1024.0);
+#else
+    FILE *f = fopen("/proc/self/status", "r");
+    if (!f) return 0.0;
+    char line[256];
+    double mb = 0.0;
+    while (fgets(line, sizeof(line), f)) {
+        long kb;
+        if (sscanf(line, "VmHWM: %ld kB", &kb) == 1) {
+            mb = (double)kb / 1024.0;
+            break;
+        }
+    }
+    fclose(f);
+    return mb;
+#endif
+}
+
+/* Process CPU time; the decode loop is single-threaded, so this doubles as the
+ * busiest-core figure. From the CPU clock rather than /proc/self/stat (jiffy
+ * quantisation misreports short runs). */
+static double cbench_process_cpu_seconds(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) != 0) return 0.0;
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
+}
+
+/* --- image list: sorted, then evenly spaced, as list_jpegs() does -------- */
+
+typedef struct {
+    char *name;
+    unsigned char *bytes;
+    size_t len;
+} CbenchImage;
+
+static int cbench_cmp_str(const void *a, const void *b) {
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+static int cbench_is_jpeg(const char *name) {
+    const char *dot = strrchr(name, '.');
+    return dot && (strcasecmp(dot, ".jpg") == 0 || strcasecmp(dot, ".jpeg") == 0);
+}
+
+static char **cbench_list_jpegs(const char *dir, size_t *out_n) {
+    DIR *d = opendir(dir);
+    if (!d) cbench_die("COCO directory not found: %s", dir);
+    size_t cap = 1024, n = 0;
+    char **paths = (char **)malloc(cap * sizeof(*paths));
+    struct dirent *e;
+    while ((e = readdir(d))) {
+        if (!cbench_is_jpeg(e->d_name)) continue;
+        if (n == cap) {
+            cap *= 2;
+            paths = (char **)realloc(paths, cap * sizeof(*paths));
+        }
+        size_t len = strlen(dir) + strlen(e->d_name) + 2;
+        paths[n] = (char *)malloc(len);
+        snprintf(paths[n], len, "%s/%s", dir, e->d_name);
+        n++;
+    }
+    closedir(d);
+    if (n == 0) cbench_die("no JPEG files in %s", dir);
+    qsort(paths, n, sizeof(*paths), cbench_cmp_str);
+    *out_n = n;
+    return paths;
+}
+
+static CbenchImage *cbench_preload(char **paths, size_t total, size_t limit, size_t *out_n) {
+    size_t n = (limit > 0 && limit < total) ? limit : total;
+    CbenchImage *images = (CbenchImage *)calloc(n, sizeof(*images));
+    for (size_t i = 0; i < n; i++) {
+        /* paths[i * total / n] — the Rust harness's spacing, so every arm sees
+         * the same subset of val2017 for a given --limit. */
+        const char *path = (limit > 0 && limit < total) ? paths[i * total / n] : paths[i];
+        FILE *f = fopen(path, "rb");
+        if (!f) cbench_die("open %s", path);
+        fseek(f, 0, SEEK_END);
+        long len = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        if (len <= 0) cbench_die("empty %s", path);
+        images[i].bytes = (unsigned char *)malloc((size_t)len);
+        if (fread(images[i].bytes, 1, (size_t)len, f) != (size_t)len) cbench_die("read %s", path);
+        fclose(f);
+        images[i].len = (size_t)len;
+        const char *slash = strrchr(path, '/');
+        images[i].name = strdup(slash ? slash + 1 : path);
+    }
+    *out_n = n;
+    return images;
+}
+
+/* --- CLI + report -------------------------------------------------------- */
+
+typedef struct {
+    const char *coco;
+    const char *board;
+    const char *format; /* modules validate; stb/wuffs arms are rgb-only */
+    const char *csv_path;
+    size_t limit, warmup;
+    int verbose;
+} CbenchArgs;
+
+static void cbench_usage(const char *argv0) {
+    fprintf(stderr,
+            "usage: %s [--coco DIR] [--limit N] [--warmup N] [--board LABEL]\n"
+            "          [--format rgb] [--decode-only] [--csv PATH] [--verbose]\n",
+            argv0);
+    exit(2);
+}
+
+static CbenchArgs cbench_parse_args(int argc, char **argv) {
+    CbenchArgs a = {
+        .coco = getenv("EDGEFIRST_BENCH_COCO"),
+        .board = "unknown",
+        .format = "rgb",
+        .csv_path = NULL,
+        .limit = 50,
+        .warmup = 10,
+        .verbose = 0,
+    };
+    for (int i = 1; i < argc; i++) {
+        const char *arg = argv[i];
+#define CBENCH_NEXT(opt) \
+    (i + 1 < argc ? argv[++i] : (cbench_usage(argv[0]), (char *)NULL))
+        if (!strcmp(arg, "--coco")) a.coco = CBENCH_NEXT("--coco");
+        else if (!strcmp(arg, "--limit")) a.limit = strtoul(CBENCH_NEXT("--limit"), NULL, 10);
+        else if (!strcmp(arg, "--warmup")) a.warmup = strtoul(CBENCH_NEXT("--warmup"), NULL, 10);
+        else if (!strcmp(arg, "--board")) a.board = CBENCH_NEXT("--board");
+        else if (!strcmp(arg, "--format")) a.format = CBENCH_NEXT("--format");
+        else if (!strcmp(arg, "--csv")) a.csv_path = CBENCH_NEXT("--csv");
+        else if (!strcmp(arg, "--verbose")) a.verbose = 1;
+        /* Accepted and ignored: these arms only do decode-only, which is what
+         * the flag selects on the HAL side. */
+        else if (!strcmp(arg, "--decode-only")) continue;
+        else cbench_usage(argv[0]);
+#undef CBENCH_NEXT
+    }
+    if (!a.coco) cbench_die("set EDGEFIRST_BENCH_COCO or pass --coco");
+    return a;
+}
+
+/* Standard console line + CSV row (schema identical to benchmarks/common and
+ * bench.c). `samples` is sorted in place. `notes` must not contain commas. */
+static void cbench_report(const CbenchArgs *a, const char *module, const char *notes,
+                          double *samples, size_t n, double total_mpix, double cpu_pct) {
+    qsort(samples, n, sizeof(*samples), cbench_cmp_double);
+    double sum_ms = 0.0;
+    for (size_t i = 0; i < n; i++) sum_ms += samples[i];
+    double p50 = cbench_percentile(samples, n, 0.50);
+    double p95 = cbench_percentile(samples, n, 0.95);
+    double p99 = cbench_percentile(samples, n, 0.99);
+    double mean = n > 0 ? sum_ms / (double)n : 0.0;
+    size_t ci_lo_idx, ci_hi_idx;
+    cbench_median_ci_indices(n, &ci_lo_idx, &ci_hi_idx);
+    double ci_lo = n > 0 ? samples[ci_lo_idx] : 0.0;
+    double ci_hi = n > 0 ? samples[ci_hi_idx] : 0.0;
+    double mpix_per_s = sum_ms > 0.0 ? total_mpix / (sum_ms / 1000.0) : 0.0;
+    double rss = cbench_peak_rss_mb();
+
+    fprintf(stderr,
+            "  p50=%.3f ms  ci95=[%.3f,%.3f]  mean=%.3f  p95=%.3f ms  p99=%.3f ms  %.1f MP/s  "
+            "peak RSS=%.1f MB  n=%zu\n",
+            p50, ci_lo, ci_hi, mean, p95, p99, mpix_per_s, rss, n);
+    fprintf(stderr, "  cpu: process=%.1f%%\n", cpu_pct);
+
+    if (a->csv_path) {
+        FILE *f = fopen(a->csv_path, "w");
+        if (!f) cbench_die("create %s", a->csv_path);
+        fprintf(f,
+                "board,class,module,ms_p50,ms_p95,ms_p99,ms_mean,ms_p50_ci_lo,ms_p50_ci_hi,"
+                "mpix_per_s,peak_rss_mb,"
+                "cpu_pct_process,cpu_pct_system,cpu_pct_peak_core,n_images,notes\n");
+        fprintf(f,
+                "%s,decode,%s,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.1f,%.1f,%.1f,%.1f,%zu,%s\n",
+                a->board, module, p50, p95, p99, mean, ci_lo, ci_hi, mpix_per_s, rss, cpu_pct,
+                0.0, cpu_pct, n, notes);
+        fclose(f);
+    }
+}
+
+#endif /* EDGEFIRST_CBENCH_H */

--- a/benchmarks/modules/hal_nvjpeg/Cargo.toml
+++ b/benchmarks/modules/hal_nvjpeg/Cargo.toml
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "hal_v4l2_gl"
+name = "hal_nvjpeg"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "HAL V4L2 JPEG (mxc-jpeg) + HAL GL letterbox (plan W2, i.MX 95)"
+description = "HAL nvJPEG GPU decode arm (Jetson Orin; hardware-decode table)"
 
 [[bin]]
-name = "hal_v4l2_gl"
+name = "hal_nvjpeg"
 path = "src/main.rs"
 
 [dependencies]

--- a/benchmarks/modules/hal_nvjpeg/src/main.rs
+++ b/benchmarks/modules/hal_nvjpeg/src/main.rs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! HAL nvJPEG GPU JPEG decode (Jetson Orin) — the CUDA arm of the
+//! hardware-decode table (BENCHMARKS.md § JPEG Decode).
+//!
+//! **This is GPU decode, not dedicated JPEG hardware.** On Orin-class SoCs
+//! only nvJPEG's GPU_HYBRID backend exists: Huffman decode stays on the CPU
+//! and IDCT/postprocess run on the **shared CUDA cores** (the NVJPG ASIC is
+//! unreachable through CUDA nvJPEG). Anything else using the GPU — above
+//! all AI inference — will be impacted by concurrent decode, which is why
+//! the backend is opt-in (`EDGEFIRST_ENABLE_NVJPEG`, set here) and off by
+//! default in production. The decode-vs-inference contention is measured in
+//! separate benchmarks, out of scope for this arm. CUDA 12.3.3 has no NV12
+//! output, so nvJPEG's fixed decode surface is interleaved RGB (RGBI).
+//!
+//! **Run this arm with `--decode-fmt native` (the default), never `rgb`.**
+//! The codec routes hardware decoders only when no fused output is requested
+//! (`allow_hw = output_fmt == native_fmt` in `codec/src/jpeg/mod.rs`); a
+//! `rgb` preference selects the CPU fused-RGB path and silently bypasses
+//! nvJPEG. Under `native`, nvJPEG reconfigures the destination to RGB by
+//! itself — which doubles as a per-frame engagement check: a decoded format
+//! of `Rgb` means nvJPEG ran, `Nv12/16/24` means the CPU decoder handled
+//! that frame.
+//!
+//! Startup asserts `nvjpeg_available()` so a missing libnvjpeg/CUDA fails
+//! loudly instead of silently publishing CPU-decode numbers under a GPU
+//! label (on JetPack, libnvjpeg comes from the `libnvjpeg-12-6` package —
+//! NOT the same-named stub in `/usr/lib/aarch64-linux-gnu/nvidia/`).
+//! Per-frame engagement is verifiable on-target with `EDGEFIRST_TRACE=…`:
+//! the capture must show `codec.decode_jpeg.nvjpeg_*` spans for every frame.
+
+use clap::Parser;
+use edgefirst_bench_common::{run_hal_module, BenchArgs, HalModuleConfig};
+
+fn main() -> anyhow::Result<()> {
+    // Must be set before the first decode probes the backend.
+    std::env::set_var("EDGEFIRST_ENABLE_NVJPEG", "1");
+    let args = BenchArgs::parse();
+    anyhow::ensure!(
+        edgefirst_codec::nvjpeg_available(),
+        "nvJPEG unavailable (need Linux + CUDA device + loadable libnvjpeg.so.12); \
+         refusing to run the GPU arm on the CPU decoder"
+    );
+    run_hal_module(
+        HalModuleConfig {
+            class: "hw_gpu",
+            module: "hal_nvjpeg",
+            force_backend: "opengl",
+            disable_v4l2: true,
+            prefer_heap_src: false,
+        },
+        &args,
+    )?;
+    Ok(())
+}

--- a/benchmarks/modules/hal_v4l2_cpu/Cargo.toml
+++ b/benchmarks/modules/hal_v4l2_cpu/Cargo.toml
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [package]
-name = "hal_v4l2_gl"
+name = "hal_v4l2_cpu"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "HAL V4L2 JPEG (mxc-jpeg) + HAL GL letterbox (plan W2, i.MX 95)"
+description = "HAL V4L2 JPEG decode + HAL CPU convert (i.MX 95 hardware-decode table)"
 
 [[bin]]
-name = "hal_v4l2_gl"
+name = "hal_v4l2_cpu"
 path = "src/main.rs"
 
 [dependencies]

--- a/benchmarks/modules/hal_v4l2_cpu/src/main.rs
+++ b/benchmarks/modules/hal_v4l2_cpu/src/main.rs
@@ -1,23 +1,18 @@
 // SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
 // SPDX-License-Identifier: Apache-2.0
 
-//! HAL V4L2 mem2mem JPEG (e.g. mxc-jpeg) → NV12 + HAL OpenGL letterbox.
+//! HAL V4L2 mem2mem JPEG (e.g. mxc-jpeg) + HAL **CPU** convert — the
+//! CPU-second-pass variant of `hal_v4l2_gl` for the i.MX 95 hardware-decode
+//! table.
 //!
-//! Forces `EDGEFIRST_FORCE_BACKEND=opengl` and leaves V4L2 enabled. For the
-//! i.MX 95 hardware-decode table:
-//!
-//! - `--decode-only` — V4L2 JPEG → native NV*/GREY, no convert: the row for
-//!   consumers that take NV12 directly.
-//! - `--full-res-convert` — adds the full-resolution NV*→RGB GPU convert:
-//!   the full cost for RGB consumers. The mxc-jpeg block does no
-//!   colour-space conversion (its RGB capture formats serve only
-//!   RGB-encoded JPEGs), so this second pass is not optional for RGB.
-//!   `hal_v4l2_cpu` is the CPU-convert counterpart. The decode/convert
-//!   split is reported per run.
-//!
-//! Startup asserts a V4L2 JPEG device is actually present so the arm fails
-//! loudly off-target instead of silently publishing CPU-decode numbers under
-//! a hardware label.
+//! The mxc-jpeg block performs no colour-space conversion (verified on-target
+//! via `VIDIOC_ENUM_FMT`: its RGB capture formats serve only RGB-encoded
+//! JPEGs; YCbCr streams decode to NV12/YUYV/YUV3/GREY per their sampling),
+//! so an RGB consumer pays a second pass. Run this arm with
+//! `--full-res-convert` to measure hardware decode + full-resolution
+//! NV*→RGB on the CPU; `hal_v4l2_gl --full-res-convert` is the GPU-convert
+//! counterpart, and `--decode-only` is the stop-at-NV12 row. The per-frame
+//! decode/convert split is reported either way.
 
 use clap::Parser;
 use edgefirst_bench_common::{run_hal_module, BenchArgs, DecodeFmt, HalModuleConfig};
@@ -40,9 +35,9 @@ fn main() -> anyhow::Result<()> {
     );
     run_hal_module(
         HalModuleConfig {
-            class: "hw_gl",
-            module: "hal_v4l2_gl",
-            force_backend: "opengl",
+            class: "hw_cpu",
+            module: "hal_v4l2_cpu",
+            force_backend: "cpu",
             disable_v4l2: false,
             prefer_heap_src: false,
         },

--- a/benchmarks/modules/rust_jpeg/Cargo.toml
+++ b/benchmarks/modules/rust_jpeg/Cargo.toml
@@ -16,6 +16,12 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
-zune-jpeg = "0.5.15"
+# SIMD features listed explicitly, not left to defaults: zune-jpeg 0.5.15
+# defaults to ["x86", "neon", "std"], but the published A/B depends on the
+# comparator running its best SIMD path on every arch, so a future upstream
+# default change must not be able to silently drop `neon` (NEON IDCT,
+# color-convert, and upsampling kernels on aarch64) or `x86` (AVX2/SSE).
+zune-jpeg = { version = "0.5.15", features = ["x86", "neon", "std"] }
 zune-core = "0.5"
 image = { version = "0.25.10", default-features = false, features = ["jpeg"] }
+libc = "0.2"

--- a/benchmarks/modules/rust_jpeg/src/main.rs
+++ b/benchmarks/modules/rust_jpeg/src/main.rs
@@ -3,8 +3,11 @@
 
 //! Rust-ecosystem JPEG decode reference arms for the decoder A/B.
 //!
-//! Mirrors the `turbojpeg` bench protocol: sorted COCO subset, warmup on the
-//! same set, per-image wall time, p50/p95/p99. Two engines:
+//! Mirrors the `turbojpeg` bench protocol: sorted, **evenly spaced** COCO
+//! subset (the same `i * total / n` stride as `benchmarks/common` and
+//! `bench.c`, so every arm decodes the same images for a given `--limit`),
+//! warmup repeated on the first image, per-image wall time, p50 (with ~95%
+//! CI) / mean / p95 / p99. Two engines:
 //!
 //! - `--engine zune`: `zune-jpeg` directly, headers + `decode_into` a reused
 //!   buffer. `--format yuv` decodes to interleaved YCbCr (its closest
@@ -29,8 +32,38 @@ struct Args {
     engine: String,
     #[arg(long, default_value = "yuv")]
     format: String,
-    #[arg(long, default_value = "")]
+    #[arg(long, default_value = "unknown")]
     board: String,
+    /// Write summary CSV (same schema as benchmarks/common) to this path.
+    #[arg(long)]
+    csv: Option<std::path::PathBuf>,
+}
+
+/// Process CPU time, as the C harnesses measure it (CLOCK_PROCESS_CPUTIME_ID;
+/// the decode loop is single-threaded so this doubles as busiest-core).
+fn process_cpu_seconds() -> f64 {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    if unsafe { libc::clock_gettime(libc::CLOCK_PROCESS_CPUTIME_ID, &mut ts) } != 0 {
+        return 0.0;
+    }
+    ts.tv_sec as f64 + ts.tv_nsec as f64 / 1e9
+}
+
+/// Peak RSS in MB, matching peak_rss_mb() in benchmarks/common and the C
+/// harnesses. Linux ru_maxrss is kilobytes; Darwin reports bytes.
+fn peak_rss_mb() -> f64 {
+    let mut ru: libc::rusage = unsafe { std::mem::zeroed() };
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut ru) } != 0 {
+        return 0.0;
+    }
+    if cfg!(target_os = "macos") {
+        ru.ru_maxrss as f64 / (1024.0 * 1024.0)
+    } else {
+        ru.ru_maxrss as f64 / 1024.0
+    }
 }
 
 fn main() -> Result<()> {
@@ -45,7 +78,15 @@ fn main() -> Result<()> {
         })
         .collect();
     files.sort();
-    files.truncate(args.limit);
+    // Evenly spaced subset, exactly as benchmarks/common list_jpegs() and
+    // bench.c preload() select: COCO val2017's lexicographic prefix is biased
+    // (4:4:4-dominant), and every arm must see the same images.
+    if args.limit > 0 && args.limit < files.len() {
+        let len = files.len();
+        files = (0..args.limit)
+            .map(|i| files[i * len / args.limit].clone())
+            .collect();
+    }
     anyhow::ensure!(!files.is_empty(), "no JPEGs in {}", args.coco.display());
 
     let data: Vec<Vec<u8>> = files
@@ -63,7 +104,10 @@ fn main() -> Result<()> {
         "--engine image supports --format rgb only"
     );
 
-    let mut buf = vec![0u8; 64 << 20];
+    // High-water scratch, grown on demand by decode_one (the turbo/wuffs
+    // pattern): starting empty keeps the reported peak RSS an honest measure
+    // of the decoder's working set instead of a pre-allocated 64 MB floor.
+    let mut buf = Vec::new();
     let mut mp_total = 0f64;
     let mut decode_one = |jpeg: &[u8]| -> Result<(usize, usize)> {
         match args.engine.as_str() {
@@ -83,22 +127,31 @@ fn main() -> Result<()> {
             }
             "image" => {
                 let img =
-                    image::load_from_memory_with_format(jpeg, image::ImageFormat::Jpeg)?
-                        .to_rgb8();
+                    image::load_from_memory_with_format(jpeg, image::ImageFormat::Jpeg)?.to_rgb8();
                 Ok((img.width() as usize, img.height() as usize))
             }
             other => anyhow::bail!("unknown --engine {other}"),
         }
     };
 
-    for jpeg in data.iter().take(args.warmup) {
-        let _ = decode_one(jpeg);
+    // Warmup on the first *decodable* image, repeated as the hal_cpu and
+    // turbojpeg harnesses do; if the corpus leads with an image this engine
+    // rejects (e.g. greyscale under forced YCbCr), fall through to the next
+    // so warmup is never a silent no-op.
+    if let Some(first) = data.iter().find(|jpeg| decode_one(jpeg).is_ok()) {
+        for _ in 1..args.warmup {
+            let _ = decode_one(first);
+        }
+    } else {
+        eprintln!("  warn: no image in the corpus warms up under this engine/format");
     }
 
     // Per-image failures are skipped and counted, not fatal: e.g. zune-jpeg
     // rejects forced-YCbCr output for COCO's greyscale images.
     let mut skipped = 0usize;
     let mut times = Vec::with_capacity(data.len());
+    let cpu0 = process_cpu_seconds();
+    let wall0 = Instant::now();
     for jpeg in &data {
         let t0 = Instant::now();
         match decode_one(jpeg) {
@@ -114,16 +167,67 @@ fn main() -> Result<()> {
         eprintln!("  note: {skipped} images skipped (decode error)");
     }
     times.sort_by(|a, b| a.total_cmp(b));
-    let pct = |p: f64| times[(((times.len() - 1) as f64) * p) as usize];
+    let n = times.len();
+    // `round(p * (n - 1))`, the same index as benchmarks/common and bench.c.
+    let pct = |p: f64| times[((p * (n as f64 - 1.0)).round() as usize).min(n - 1)];
     let total_ms: f64 = times.iter().sum();
+    // ~95% CI for the median: 1-based ranks n/2 ∓ 1.96·√n/2, as in
+    // benchmarks/common median_ci_indices().
+    let half_width = 0.98 * (n as f64).sqrt();
+    let ci_lo = times[((n as f64) / 2.0 - half_width).floor().max(1.0) as usize - 1];
+    let ci_hi = times[((n as f64) / 2.0 + 1.0 + half_width).ceil().min(n as f64) as usize - 1];
+    let wall_s = wall0.elapsed().as_secs_f64();
+    let cpu_s = process_cpu_seconds() - cpu0;
+    let cpu_pct = if wall_s > 0.0 {
+        100.0 * cpu_s / wall_s
+    } else {
+        0.0
+    };
+    let mpix_per_s = mp_total / (total_ms / 1e3);
     println!(
-        "  p50={:.3} ms  p95={:.3} ms  p99={:.3} ms  {:.1} MP/s  n={}",
+        "  p50={:.3} ms  ci95=[{:.3},{:.3}]  mean={:.3}  p95={:.3} ms  p99={:.3} ms  {:.1} MP/s  n={}",
         pct(0.50),
+        ci_lo,
+        ci_hi,
+        total_ms / n as f64,
         pct(0.95),
         pct(0.99),
-        mp_total / (total_ms / 1e3),
-        times.len()
+        mpix_per_s,
+        n
     );
-    let _ = &args.board;
+    if let Some(csv) = &args.csv {
+        // Same schema as benchmarks/common write_summary_csv / bench.c.
+        if let Some(parent) = csv.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let notes = format!(
+            "backend={engine}-{format};scope=decode-only;harness=rust;skipped={skipped}",
+            engine = args.engine,
+            format = args.format
+        );
+        std::fs::write(
+            csv,
+            format!(
+                "board,class,module,ms_p50,ms_p95,ms_p99,ms_mean,ms_p50_ci_lo,ms_p50_ci_hi,\
+                 mpix_per_s,peak_rss_mb,cpu_pct_process,cpu_pct_system,cpu_pct_peak_core,\
+                 n_images,notes\n\
+                 {board},decode,{module},{p50:.3},{p95:.3},{p99:.3},{mean:.3},{ci_lo:.3},\
+                 {ci_hi:.3},{mpix:.3},{rss:.1},{cpu:.1},0.0,{cpu:.1},{n},{notes}\n",
+                board = args.board,
+                module = args.engine,
+                p50 = pct(0.50),
+                p95 = pct(0.95),
+                p99 = pct(0.99),
+                mean = total_ms / n as f64,
+                ci_lo = ci_lo,
+                ci_hi = ci_hi,
+                mpix = mpix_per_s,
+                rss = peak_rss_mb(),
+                cpu = cpu_pct,
+                n = n,
+                notes = notes
+            ),
+        )?;
+    }
     Ok(())
 }

--- a/benchmarks/modules/stb/Makefile
+++ b/benchmarks/modules/stb/Makefile
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+#
+# stb_image decode benchmark.
+#
+#   make                  host build             -> build/stb_bench
+#   make aarch64          cross build for boards -> build/stb_bench.aarch64
+#   make x86_64           cross build (zig)      -> build/stb_bench.x86_64
+#
+# stb_image.h is not vendored: `make deps` (run automatically) fetches it at a
+# pinned commit and verifies its sha256, keeping the 280 KB header out of git
+# while keeping the build reproducible. stb_image is public domain / MIT.
+
+CC      ?= cc
+CFLAGS  ?= -O2 -g -Wall -Wextra -std=c11
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+LDLIBS  :=
+else
+LDLIBS  := -lm
+endif
+BUILD   := build
+
+INCLUDES := -I../cbench -I$(BUILD)
+
+# stb_image v2.30, pinned to the last commit touching stb_image.h (2024-07).
+STB_URL    := https://raw.githubusercontent.com/nothings/stb/013ac3beddff3dbffafd5177e7972067cd2b5083/stb_image.h
+STB_SHA256 := 594c2fe35d49488b4382dbfaec8f98366defca819d916ac95becf3e75f4200b3
+
+SHA256_CHECK := $(shell command -v sha256sum >/dev/null 2>&1 && echo "sha256sum -c -" || echo "shasum -a 256 -c -")
+
+ifeq ($(shell command -v aarch64-linux-gnu-gcc 2>/dev/null),)
+AARCH64_CC ?= zig cc -target aarch64-linux-gnu
+AARCH64_LDLIBS := -lm
+else
+AARCH64_CC ?= aarch64-linux-gnu-gcc
+AARCH64_LDLIBS := -lm -static-libgcc
+endif
+X86_64_CC ?= zig cc -target x86_64-linux-gnu
+
+.PHONY: all aarch64 x86_64 deps clean
+all: $(BUILD)/stb_bench
+
+$(BUILD):
+	@mkdir -p $(BUILD)
+
+deps: $(BUILD)/stb_image.h
+
+$(BUILD)/stb_image.h: | $(BUILD)
+	curl -fsSL -o $@.tmp $(STB_URL)
+	echo "$(STB_SHA256)  $@.tmp" | $(SHA256_CHECK)
+	mv $@.tmp $@
+
+$(BUILD)/stb_bench: bench.c ../cbench/cbench.h $(BUILD)/stb_image.h | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ bench.c $(LDLIBS)
+
+aarch64: $(BUILD)/stb_bench.aarch64
+
+$(BUILD)/stb_bench.aarch64: bench.c ../cbench/cbench.h $(BUILD)/stb_image.h | $(BUILD)
+	$(AARCH64_CC) $(CFLAGS) $(INCLUDES) -o $@ bench.c $(AARCH64_LDLIBS)
+
+x86_64: $(BUILD)/stb_bench.x86_64
+
+$(BUILD)/stb_bench.x86_64: bench.c ../cbench/cbench.h $(BUILD)/stb_image.h | $(BUILD)
+	$(X86_64_CC) $(CFLAGS) $(INCLUDES) -o $@ bench.c -lm
+
+clean:
+	rm -rf $(BUILD)

--- a/benchmarks/modules/stb/bench.c
+++ b/benchmarks/modules/stb/bench.c
@@ -1,0 +1,108 @@
+/* SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * stb_image decode-only benchmark — the single-header baseline arm of the
+ * EdgeFirst decoder A/B (vs hal_cpu --decode-fmt rgb and the other RGB arms).
+ *
+ * stb_image is the recognizable floor: a single-file public-domain/MIT
+ * decoder with a fixed accurate-class integer IDCT (derived from jidctint)
+ * and SIMD IDCT/YCbCr paths (SSE2 auto-enabled on x86-64, NEON enabled here
+ * for aarch64 via STBI_NEON). Accuracy class measured against djpeg
+ * (libjpeg-turbo, accurate IDCT) over 4:4:4/4:2:0/DRI/greyscale/large
+ * samples: max abs diff 3, mean <=0.07 — accurate-class rounding, not a
+ * different accuracy trade (2026-08-13 parity check). RGB output only,
+ * forced to 3 channels. Its API
+ * has no decode-into-preallocated-buffer call, so this arm allocates the
+ * output per frame by design — that per-call allocation is part of what any
+ * stb_image user pays and is recorded in the CSV notes rather than hidden.
+ *
+ * Harness choices that move the number live in ../cbench/cbench.h and are
+ * identical across the C arms; see the three rules in benchmarks/README.md.
+ *
+ * stb_image.h is fetched (pinned commit + sha256) by `make deps`; see the
+ * Makefile. Build: make -C benchmarks/modules/stb
+ */
+
+#include "cbench.h"
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#define STBI_NEON
+#endif
+#define STBI_ONLY_JPEG
+#define STBI_NO_STDIO
+#define STB_IMAGE_IMPLEMENTATION
+/* Third-party header; its own warnings are not ours to fix. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include "stb_image.h"
+#pragma GCC diagnostic pop
+
+int main(int argc, char **argv) {
+    CbenchArgs args = cbench_parse_args(argc, argv);
+    if (strcmp(args.format, "rgb") != 0)
+        cbench_die("--format must be rgb (stb_image exposes no raw-YUV output)");
+
+    size_t total = 0, n = 0;
+    char **paths = cbench_list_jpegs(args.coco, &total);
+    CbenchImage *images = cbench_preload(paths, total, args.limit, &n);
+
+#if defined(STBI_NEON)
+    const char *simd = "neon";
+#elif defined(__x86_64__) || defined(_M_X64)
+    const char *simd = "sse2";
+#else
+    const char *simd = "scalar";
+#endif
+    fprintf(stderr, "=== stb_image (decode-only, format=rgb, simd=%s) — %zu images ===\n", simd,
+            n);
+
+    /* Warm up on the first image, as every other arm does. */
+    for (size_t i = 0; i < args.warmup; i++) {
+        int w, h, comp;
+        unsigned char *px = stbi_load_from_memory(images[0].bytes, (int)images[0].len, &w, &h,
+                                                  &comp, 3);
+        if (!px) cbench_die("warmup decode failed: %s", stbi_failure_reason());
+        stbi_image_free(px);
+    }
+
+    double *samples = (double *)malloc(n * sizeof(*samples));
+    double total_mpix = 0.0;
+    double cpu0 = cbench_process_cpu_seconds();
+    double wall0 = cbench_now_ms();
+
+    for (size_t i = 0; i < n; i++) {
+        int w, h, comp;
+        double t0 = cbench_now_ms();
+        unsigned char *px = stbi_load_from_memory(images[i].bytes, (int)images[i].len, &w, &h,
+                                                  &comp, 3);
+        if (!px)
+            cbench_die("decode failed on %s: %s", images[i].name, stbi_failure_reason());
+        /* The free stays inside the timed region: allocate-decode-free is the
+         * complete per-frame cost of stb_image's allocating API in a hot loop. */
+        stbi_image_free(px);
+        samples[i] = cbench_now_ms() - t0;
+        total_mpix += (double)w * (double)h / 1e6;
+        if (args.verbose)
+            fprintf(stderr, "  [%4zu/%zu] %.3f ms  %d×%d  %s\n", i + 1, n, samples[i], w, h,
+                    images[i].name);
+    }
+
+    double wall_s = (cbench_now_ms() - wall0) / 1000.0;
+    double cpu_s = cbench_process_cpu_seconds() - cpu0;
+    double cpu_pct = wall_s > 0.0 ? 100.0 * cpu_s / wall_s : 0.0;
+
+    char notes[160];
+    snprintf(notes, sizeof(notes),
+             "backend=stb_image-rgb;scope=decode-only;harness=c;simd=%s;alloc=per-call", simd);
+    cbench_report(&args, "stb", notes, samples, n, total_mpix, cpu_pct);
+
+    free(samples);
+    for (size_t i = 0; i < n; i++) {
+        free(images[i].bytes);
+        free(images[i].name);
+    }
+    free(images);
+    for (size_t i = 0; i < total; i++) free(paths[i]);
+    free(paths);
+    return 0;
+}

--- a/benchmarks/modules/turbojpeg/Makefile
+++ b/benchmarks/modules/turbojpeg/Makefile
@@ -11,11 +11,11 @@
 CC      ?= cc
 CFLAGS  ?= -O2 -g -Wall -Wextra -std=c11
 UNAME_S := $(shell uname -s)
-# libdl is a separate library on Linux; on Darwin dlopen lives in libSystem.
+# libdl/libm are separate libraries on Linux; on Darwin both live in libSystem.
 ifeq ($(UNAME_S),Darwin)
 LDLIBS  :=
 else
-LDLIBS  := -ldl
+LDLIBS  := -ldl -lm
 endif
 BUILD   := build
 
@@ -24,10 +24,10 @@ BUILD   := build
 # Linux even when this Makefile runs on Darwin.
 ifeq ($(shell command -v aarch64-linux-gnu-gcc 2>/dev/null),)
 AARCH64_CC ?= zig cc -target aarch64-linux-gnu
-AARCH64_LDLIBS := -ldl
+AARCH64_LDLIBS := -ldl -lm
 else
 AARCH64_CC ?= aarch64-linux-gnu-gcc
-AARCH64_LDLIBS := -ldl -static-libgcc
+AARCH64_LDLIBS := -ldl -lm -static-libgcc
 endif
 
 .PHONY: all aarch64 clean

--- a/benchmarks/modules/turbojpeg/bench.c
+++ b/benchmarks/modules/turbojpeg/bench.c
@@ -26,6 +26,7 @@
 #define _GNU_SOURCE
 #include <dirent.h>
 #include <dlfcn.h>
+#include <math.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -67,6 +68,9 @@ static struct {
     const char *path;
 } tj;
 
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((noreturn, format(printf, 1, 2)))
+#endif
 static void die(const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
@@ -117,6 +121,12 @@ static void tj_load(void) {
     tj.error = (tj_error_fn)dlsym(tj.handle, "tjGetErrorStr");
     if (!tj.init || !tj.destroy || !tj.header || !tj.to_yuv || !tj.decompress || !tj.bufsize_yuv)
         die("libturbojpeg at %s is missing required symbols", tj.path);
+
+    /* The candidate string may be relative ("libturbojpeg.so.0"); record the
+     * loader's resolved absolute path so the run's provenance names the exact
+     * library file measured. */
+    Dl_info info;
+    if (dladdr((void *)tj.init, &info) && info.dli_fname) tj.path = info.dli_fname;
 }
 
 /* --- timing / stats: identical definitions to benchmarks/common ---------- */
@@ -139,6 +149,24 @@ static double percentile(const double *sorted, size_t n, double p) {
     size_t idx = (size_t)(pos + 0.5);
     if (idx >= n) idx = n - 1;
     return sorted[idx];
+}
+
+/* 0-based sorted-sample indices bounding the ~95% CI for the median, identical
+ * to benchmarks/common median_ci_indices(): 1-based ranks
+ * floor(n/2 - 1.96*sqrt(n)/2) and ceil(n/2 + 1 + 1.96*sqrt(n)/2), clamped. */
+static void median_ci_indices(size_t n, size_t *lo, size_t *hi) {
+    if (n == 0) {
+        *lo = *hi = 0;
+        return;
+    }
+    double nf = (double)n;
+    double half_width = 0.98 * sqrt(nf); /* 1.96*sqrt(n)/2 */
+    double lo_rank = floor(nf / 2.0 - half_width);
+    double hi_rank = ceil(nf / 2.0 + 1.0 + half_width);
+    if (lo_rank < 1.0) lo_rank = 1.0;
+    if (hi_rank > nf) hi_rank = nf;
+    *lo = (size_t)lo_rank - 1;
+    *hi = (size_t)hi_rank - 1;
 }
 
 /* Peak RSS, matching peak_rss_mb(). Linux VmHWM is kB; Darwin ru_maxrss is bytes. */
@@ -385,25 +413,35 @@ int main(int argc, char **argv) {
     double p50 = percentile(samples, n, 0.50);
     double p95 = percentile(samples, n, 0.95);
     double p99 = percentile(samples, n, 0.99);
+    double mean = n > 0 ? sum_ms / (double)n : 0.0;
+    size_t ci_lo_idx, ci_hi_idx;
+    median_ci_indices(n, &ci_lo_idx, &ci_hi_idx);
+    double ci_lo = n > 0 ? samples[ci_lo_idx] : 0.0;
+    double ci_hi = n > 0 ? samples[ci_hi_idx] : 0.0;
     double mpix_per_s = sum_ms > 0.0 ? total_mpix / (sum_ms / 1000.0) : 0.0;
     double rss = peak_rss_mb();
 
-    fprintf(stderr, "  p50=%.3f ms  p95=%.3f ms  p99=%.3f ms  %.1f MP/s  peak RSS=%.1f MB  n=%zu\n",
-            p50, p95, p99, mpix_per_s, rss, n);
+    fprintf(stderr,
+            "  p50=%.3f ms  ci95=[%.3f,%.3f]  mean=%.3f  p95=%.3f ms  p99=%.3f ms  %.1f MP/s  "
+            "peak RSS=%.1f MB  n=%zu\n",
+            p50, ci_lo, ci_hi, mean, p95, p99, mpix_per_s, rss, n);
     fprintf(stderr, "  cpu: process=%.1f%%\n", cpu_pct);
 
     if (csv_path) {
-        char notes[160];
-        snprintf(notes, sizeof(notes), "backend=%s;scope=decode-only;harness=c;dct=%s", backend,
-                 dct);
+        char notes[288];
+        snprintf(notes, sizeof(notes), "backend=%s;scope=decode-only;harness=c;dct=%s;lib=%s",
+                 backend, dct, tj.path);
         FILE *f = fopen(csv_path, "w");
         if (!f) die("create %s", csv_path);
         fprintf(f,
-                "board,class,module,ms_p50,ms_p95,ms_p99,mpix_per_s,peak_rss_mb,"
+                "board,class,module,ms_p50,ms_p95,ms_p99,ms_mean,ms_p50_ci_lo,ms_p50_ci_hi,"
+                "mpix_per_s,peak_rss_mb,"
                 "cpu_pct_process,cpu_pct_system,cpu_pct_peak_core,n_images,notes\n");
-        fprintf(f, "%s,decode,turbojpeg,%.3f,%.3f,%.3f,%.3f,%.1f,%.1f,%.1f,%.1f,%zu,%s\n",
-                board, p50, p95, p99, mpix_per_s, rss, cpu_pct, 0.0, cpu_pct, n,
-                notes);
+        fprintf(f,
+                "%s,decode,turbojpeg,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.1f,%.1f,%.1f,%.1f,%zu,"
+                "%s\n",
+                board, p50, p95, p99, mean, ci_lo, ci_hi, mpix_per_s, rss, cpu_pct, 0.0, cpu_pct,
+                n, notes);
         fclose(f);
     }
 

--- a/benchmarks/modules/wuffs/Makefile
+++ b/benchmarks/modules/wuffs/Makefile
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+#
+# Wuffs JPEG decode benchmark.
+#
+#   make                  host build             -> build/wuffs_bench
+#   make aarch64          cross build for boards -> build/wuffs_bench.aarch64
+#   make x86_64           cross build (zig)      -> build/wuffs_bench.x86_64
+#
+# The 3.6 MB transpiled wuffs-v0.4.c is not vendored: `make deps` (run
+# automatically) fetches it at a pinned release tag and verifies its sha256,
+# keeping it out of git while keeping the build reproducible. Wuffs is
+# Apache-2.0.
+
+CC      ?= cc
+CFLAGS  ?= -O2 -g -Wall -Wextra -std=c11
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+LDLIBS  :=
+else
+LDLIBS  := -lm
+endif
+BUILD   := build
+
+INCLUDES := -I../cbench -I$(BUILD)
+
+# Wuffs v0.4.0-alpha.10 (the v0.4 line is the first with the JPEG decoder).
+WUFFS_URL    := https://raw.githubusercontent.com/google/wuffs/v0.4.0-alpha.10/release/c/wuffs-v0.4.c
+WUFFS_SHA256 := 1f8039ef82911604c063f6ac2ed57254bdb17d742aebdeae06356530d4a0fde7
+
+SHA256_CHECK := $(shell command -v sha256sum >/dev/null 2>&1 && echo "sha256sum -c -" || echo "shasum -a 256 -c -")
+
+ifeq ($(shell command -v aarch64-linux-gnu-gcc 2>/dev/null),)
+AARCH64_CC ?= zig cc -target aarch64-linux-gnu
+AARCH64_LDLIBS := -lm
+else
+AARCH64_CC ?= aarch64-linux-gnu-gcc
+AARCH64_LDLIBS := -lm -static-libgcc
+endif
+X86_64_CC ?= zig cc -target x86_64-linux-gnu
+
+.PHONY: all aarch64 x86_64 deps clean
+all: $(BUILD)/wuffs_bench
+
+$(BUILD):
+	@mkdir -p $(BUILD)
+
+deps: $(BUILD)/wuffs-v0.4.c
+
+$(BUILD)/wuffs-v0.4.c: | $(BUILD)
+	curl -fsSL -o $@.tmp $(WUFFS_URL)
+	echo "$(WUFFS_SHA256)  $@.tmp" | $(SHA256_CHECK)
+	mv $@.tmp $@
+
+$(BUILD)/wuffs_bench: bench.c ../cbench/cbench.h $(BUILD)/wuffs-v0.4.c | $(BUILD)
+	$(CC) $(CFLAGS) $(INCLUDES) -o $@ bench.c $(LDLIBS)
+
+aarch64: $(BUILD)/wuffs_bench.aarch64
+
+$(BUILD)/wuffs_bench.aarch64: bench.c ../cbench/cbench.h $(BUILD)/wuffs-v0.4.c | $(BUILD)
+	$(AARCH64_CC) $(CFLAGS) $(INCLUDES) -o $@ bench.c $(AARCH64_LDLIBS)
+
+x86_64: $(BUILD)/wuffs_bench.x86_64
+
+$(BUILD)/wuffs_bench.x86_64: bench.c ../cbench/cbench.h $(BUILD)/wuffs-v0.4.c | $(BUILD)
+	$(X86_64_CC) $(CFLAGS) $(INCLUDES) -o $@ bench.c -lm
+
+clean:
+	rm -rf $(BUILD)

--- a/benchmarks/modules/wuffs/bench.c
+++ b/benchmarks/modules/wuffs/bench.c
@@ -1,0 +1,184 @@
+/* SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Wuffs (Google) JPEG decode-only benchmark — the memory-safe C arm of the
+ * EdgeFirst decoder A/B (vs hal_cpu --decode-fmt rgb and the other RGB arms).
+ *
+ * Wuffs transpiles to a single C file (Apache-2.0), fetched at a pinned
+ * release tag by `make deps` (see the Makefile). Its JPEG decoder has a
+ * single fixed IDCT with no accurate/fast knob — measured **bit-exact**
+ * against djpeg (libjpeg-turbo, accurate IDCT) over 4:4:4/4:2:0/DRI/
+ * greyscale/large samples (max abs diff 0; 2026-08-13 parity check), so its
+ * row compares within the accurate class with zero accuracy caveat. Output goes through Wuffs'
+ * swizzler; this arm asks for 3-byte RGB and falls back through BGR and the
+ * 4-byte formats if the swizzler refuses, recording the format actually used
+ * in the CSV notes (a 4-byte destination writes 33% more bytes than the
+ * other RGB arms and must be read accordingly).
+ *
+ * Steady-state allocation: the destination and work buffers grow to their
+ * high-water mark and are reused, like the HAL and turbo arms. Wuffs decoder
+ * objects are single-use per image, so the per-image reset
+ * (wuffs_jpeg__decoder__initialize, which zeroes the decoder struct) is
+ * inside the timed region — it is a cost every Wuffs user pays per frame.
+ *
+ * Harness choices that move the number live in ../cbench/cbench.h and are
+ * identical across the C arms; see the three rules in benchmarks/README.md.
+ *
+ * Build: make -C benchmarks/modules/wuffs
+ */
+
+#include "cbench.h"
+
+#define WUFFS_IMPLEMENTATION
+#define WUFFS_CONFIG__MODULES
+#define WUFFS_CONFIG__MODULE__BASE
+#define WUFFS_CONFIG__MODULE__JPEG
+#include "wuffs-v0.4.c"
+
+typedef struct {
+    wuffs_jpeg__decoder *dec;
+    uint32_t pixfmt;
+    size_t bytes_per_pixel;
+    uint8_t *dst;
+    size_t dst_cap;
+    uint8_t *workbuf;
+    size_t workbuf_cap;
+    uint32_t width, height;
+} WuffsBench;
+
+/* Full per-image decode: reset, parse config, swizzle-decode the frame.
+ * Returns NULL on success or a status message on failure. */
+static const char *wuffs_decode_one(WuffsBench *b, const CbenchImage *img) {
+    wuffs_base__status st = wuffs_jpeg__decoder__initialize(
+        b->dec, sizeof__wuffs_jpeg__decoder(), WUFFS_VERSION, 0);
+    if (!wuffs_base__status__is_ok(&st)) return wuffs_base__status__message(&st);
+
+    wuffs_base__io_buffer src = wuffs_base__ptr_u8__reader(img->bytes, img->len, true);
+    wuffs_base__image_config ic = {0};
+    st = wuffs_jpeg__decoder__decode_image_config(b->dec, &ic, &src);
+    if (!wuffs_base__status__is_ok(&st)) return wuffs_base__status__message(&st);
+
+    uint32_t w = wuffs_base__pixel_config__width(&ic.pixcfg);
+    uint32_t h = wuffs_base__pixel_config__height(&ic.pixcfg);
+    wuffs_base__pixel_config__set(&ic.pixcfg, b->pixfmt, WUFFS_BASE__PIXEL_SUBSAMPLING__NONE, w,
+                                  h);
+
+    size_t need = (size_t)w * (size_t)h * b->bytes_per_pixel;
+    if (need > b->dst_cap) {
+        b->dst = (uint8_t *)realloc(b->dst, need);
+        if (!b->dst) cbench_die("out of memory for %zu byte output", need);
+        b->dst_cap = need;
+    }
+    wuffs_base__pixel_buffer pb = {0};
+    st = wuffs_base__pixel_buffer__set_from_slice(&pb, &ic.pixcfg,
+                                                  wuffs_base__make_slice_u8(b->dst, need));
+    if (!wuffs_base__status__is_ok(&st)) return wuffs_base__status__message(&st);
+
+    st = wuffs_jpeg__decoder__decode_frame_config(b->dec, NULL, &src);
+    if (!wuffs_base__status__is_ok(&st)) return wuffs_base__status__message(&st);
+
+    wuffs_base__range_ii_u64 wr = wuffs_jpeg__decoder__workbuf_len(b->dec);
+    if (wr.max_incl > b->workbuf_cap) {
+        b->workbuf = (uint8_t *)realloc(b->workbuf, wr.max_incl);
+        if (!b->workbuf) cbench_die("out of memory for %llu byte workbuf",
+                                    (unsigned long long)wr.max_incl);
+        b->workbuf_cap = wr.max_incl;
+    }
+    st = wuffs_jpeg__decoder__decode_frame(
+        b->dec, &pb, &src, WUFFS_BASE__PIXEL_BLEND__SRC,
+        wuffs_base__make_slice_u8(b->workbuf, b->workbuf_cap), NULL);
+    if (!wuffs_base__status__is_ok(&st)) return wuffs_base__status__message(&st);
+
+    b->width = w;
+    b->height = h;
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    CbenchArgs args = cbench_parse_args(argc, argv);
+    if (strcmp(args.format, "rgb") != 0)
+        cbench_die("--format must be rgb (this arm decodes via Wuffs' RGB-family swizzles)");
+
+    size_t total = 0, n = 0;
+    char **paths = cbench_list_jpegs(args.coco, &total);
+    CbenchImage *images = cbench_preload(paths, total, args.limit, &n);
+
+    WuffsBench b = {0};
+    b.dec = wuffs_jpeg__decoder__alloc();
+    if (!b.dec) cbench_die("wuffs_jpeg__decoder__alloc failed");
+
+    /* Pick the destination format once, before anything is timed: prefer the
+     * 3-byte formats that match the other RGB arms, fall back to 4-byte. */
+    static const struct {
+        uint32_t repr;
+        size_t bpp;
+        const char *name;
+    } candidates[] = {
+        {WUFFS_BASE__PIXEL_FORMAT__RGB, 3, "RGB"},
+        {WUFFS_BASE__PIXEL_FORMAT__BGR, 3, "BGR"},
+        {WUFFS_BASE__PIXEL_FORMAT__RGBA_NONPREMUL, 4, "RGBA_NONPREMUL"},
+        {WUFFS_BASE__PIXEL_FORMAT__BGRA_NONPREMUL, 4, "BGRA_NONPREMUL"},
+    };
+    const char *fmt_name = NULL;
+    const char *probe_err = "no candidate tried";
+    for (size_t i = 0; i < sizeof(candidates) / sizeof(*candidates); i++) {
+        b.pixfmt = candidates[i].repr;
+        b.bytes_per_pixel = candidates[i].bpp;
+        probe_err = wuffs_decode_one(&b, &images[0]);
+        if (!probe_err) {
+            fmt_name = candidates[i].name;
+            break;
+        }
+    }
+    if (!fmt_name) cbench_die("no supported destination format (last error: %s)", probe_err);
+
+    fprintf(stderr,
+            "=== wuffs (decode-only, format=rgb, dst=%s, decoder=%zu B/frame reset) — %zu images "
+            "===\n",
+            fmt_name, sizeof__wuffs_jpeg__decoder(), n);
+
+    /* Warm up on the first image, as every other arm does. */
+    for (size_t i = 0; i < args.warmup; i++) {
+        const char *err = wuffs_decode_one(&b, &images[0]);
+        if (err) cbench_die("warmup decode failed: %s", err);
+    }
+
+    double *samples = (double *)malloc(n * sizeof(*samples));
+    double total_mpix = 0.0;
+    double cpu0 = cbench_process_cpu_seconds();
+    double wall0 = cbench_now_ms();
+
+    for (size_t i = 0; i < n; i++) {
+        double t0 = cbench_now_ms();
+        const char *err = wuffs_decode_one(&b, &images[i]);
+        if (err) cbench_die("decode failed on %s: %s", images[i].name, err);
+        samples[i] = cbench_now_ms() - t0;
+        total_mpix += (double)b.width * (double)b.height / 1e6;
+        if (args.verbose)
+            fprintf(stderr, "  [%4zu/%zu] %.3f ms  %u×%u  %s\n", i + 1, n, samples[i], b.width,
+                    b.height, images[i].name);
+    }
+
+    double wall_s = (cbench_now_ms() - wall0) / 1000.0;
+    double cpu_s = cbench_process_cpu_seconds() - cpu0;
+    double cpu_pct = wall_s > 0.0 ? 100.0 * cpu_s / wall_s : 0.0;
+
+    char notes[192];
+    snprintf(notes, sizeof(notes),
+             "backend=wuffs-jpeg;scope=decode-only;harness=c;dst=%s;alloc=high-water-reuse",
+             fmt_name);
+    cbench_report(&args, "wuffs", notes, samples, n, total_mpix, cpu_pct);
+
+    free(b.dec);
+    free(b.dst);
+    free(b.workbuf);
+    free(samples);
+    for (size_t i = 0; i < n; i++) {
+        free(images[i].bytes);
+        free(images[i].name);
+    }
+    free(images);
+    for (size_t i = 0; i < total; i++) free(paths[i]);
+    free(paths);
+    return 0;
+}

--- a/benchmarks/scripts/corpus_stats.py
+++ b/benchmarks/scripts/corpus_stats.py
@@ -69,16 +69,23 @@ def parse_jpeg(path):
         if marker == 0xD9:  # EOI
             break
         seglen = struct.unpack(">H", data[i + 2 : i + 4])[0]
+        # A truncated/corrupt file can declare a segment running past EOF (or
+        # an impossible <2 length); stop parsing and let the caller count the
+        # file as unparsed rather than raising out of the whole run.
+        if seglen < 2 or i + 2 + seglen > n:
+            break
         seg = data[i + 4 : i + 2 + seglen]
         if marker == 0xDD:
             facts["dri"] = True
         elif marker in SOF_MARKERS:
+            if len(seg) < 6:  # truncated SOF payload
+                break
             facts["progressive"] = marker in PROGRESSIVE_SOFS
             _prec, h, w, ncomp = struct.unpack(">BHHB", seg[0:6])
             facts["height"], facts["width"], facts["ncomp"] = h, w, ncomp
             if ncomp == 1:
                 facts["subsampling"] = "grey"
-            elif ncomp >= 3:
+            elif ncomp >= 3 and len(seg) >= 8:
                 # Luma sampling factors relative to 1x1 chroma.
                 hv = seg[6 + 1]
                 lh, lv = hv >> 4, hv & 0xF

--- a/benchmarks/scripts/corpus_stats.py
+++ b/benchmarks/scripts/corpus_stats.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+"""JPEG corpus statistics for benchmark reporting (stdlib only).
+
+Walks a directory of JPEGs and reports the distribution facts a published
+benchmark must state about its corpus: image count, dimensions/megapixels,
+file sizes, chroma subsampling histogram, baseline-vs-progressive split,
+greyscale count, and restart-interval (DRI) presence.
+
+The DRI count is what turns "COCO has no restart-marker files" from an
+assumption into a measurement: libjpeg-turbo documents that its fast Huffman
+decoder is disabled for DRI streams (up to ~20% slower), so whether a corpus
+carries DRI markers changes which turbo code path a benchmark exercises.
+
+Markers are parsed structurally up to the first SOS (where cjpeg/jpegtran
+place DRI), not text-searched, so EXIF thumbnails cannot false-positive.
+
+Usage:
+    python3 corpus_stats.py DIR [DIR ...]
+"""
+
+import struct
+import sys
+from pathlib import Path
+
+SOF_MARKERS = {
+    0xC0,
+    0xC1,
+    0xC2,
+    0xC3,
+    0xC5,
+    0xC6,
+    0xC7,
+    0xC9,
+    0xCA,
+    0xCB,
+    0xCD,
+    0xCE,
+    0xCF,
+}
+PROGRESSIVE_SOFS = {0xC2, 0xC6, 0xCA, 0xCE}
+
+
+def parse_jpeg(path):
+    """Return dict of facts for one JPEG, or None if it does not parse."""
+    data = path.read_bytes()
+    if len(data) < 4 or data[0:2] != b"\xff\xd8":
+        return None
+    facts = {
+        "bytes": len(data),
+        "width": 0,
+        "height": 0,
+        "ncomp": 0,
+        "subsampling": "?",
+        "progressive": False,
+        "dri": False,
+    }
+    i = 2
+    n = len(data)
+    while i + 4 <= n:
+        if data[i] != 0xFF:
+            i += 1
+            continue
+        marker = data[i + 1]
+        if marker in (0xFF, 0x00) or 0xD0 <= marker <= 0xD8:
+            i += 2
+            continue
+        if marker == 0xD9:  # EOI
+            break
+        seglen = struct.unpack(">H", data[i + 2 : i + 4])[0]
+        seg = data[i + 4 : i + 2 + seglen]
+        if marker == 0xDD:
+            facts["dri"] = True
+        elif marker in SOF_MARKERS:
+            facts["progressive"] = marker in PROGRESSIVE_SOFS
+            _prec, h, w, ncomp = struct.unpack(">BHHB", seg[0:6])
+            facts["height"], facts["width"], facts["ncomp"] = h, w, ncomp
+            if ncomp == 1:
+                facts["subsampling"] = "grey"
+            elif ncomp >= 3:
+                # Luma sampling factors relative to 1x1 chroma.
+                hv = seg[6 + 1]
+                lh, lv = hv >> 4, hv & 0xF
+                facts["subsampling"] = {
+                    (1, 1): "4:4:4",
+                    (2, 1): "4:2:2",
+                    (1, 2): "4:4:0",
+                    (2, 2): "4:2:0",
+                    (4, 1): "4:1:1",
+                }.get((lh, lv), f"{lh}x{lv}")
+        elif marker == 0xDA:  # first SOS: tables (incl. DRI) precede this
+            break
+        i += 2 + seglen
+    return facts
+
+
+def pctl(sorted_vals, p):
+    if not sorted_vals:
+        return 0
+    idx = min(round(p * (len(sorted_vals) - 1)), len(sorted_vals) - 1)
+    return sorted_vals[idx]
+
+
+def report(directory):
+    d = Path(directory).expanduser()
+    files = sorted(
+        p for p in d.iterdir() if p.suffix.lower() in (".jpg", ".jpeg") and p.is_file()
+    )
+    if not files:
+        print(f"{d}: no JPEG files")
+        return 1
+    stats, unparsed = [], 0
+    for p in files:
+        f = parse_jpeg(p)
+        if f is None or f["width"] == 0:
+            unparsed += 1
+            continue
+        stats.append(f)
+    if not stats:
+        print(f"{d}: {unparsed} files, none parsed as JPEG")
+        return 1
+
+    mpix = sorted(f["width"] * f["height"] / 1e6 for f in stats)
+    sizes = sorted(f["bytes"] / 1024.0 for f in stats)
+    sub_hist = {}
+    for f in stats:
+        sub_hist[f["subsampling"]] = sub_hist.get(f["subsampling"], 0) + 1
+    n_dri = sum(f["dri"] for f in stats)
+    n_prog = sum(f["progressive"] for f in stats)
+
+    print(f"=== {d} ===")
+    print(
+        f"  files: {len(stats)} parsed" + (f", {unparsed} unparsed" if unparsed else "")
+    )
+    print(
+        f"  megapixels: min={mpix[0]:.3f}  p50={pctl(mpix, 0.5):.3f}  max={mpix[-1]:.3f}"
+    )
+    print(
+        f"  file KB:    min={sizes[0]:.0f}  p50={pctl(sizes, 0.5):.0f}  max={sizes[-1]:.0f}"
+    )
+    subs = "  ".join(
+        f"{k}={v}" for k, v in sorted(sub_hist.items(), key=lambda kv: -kv[1])
+    )
+    print(f"  subsampling: {subs}")
+    print(f"  progressive: {n_prog}    restart-interval (DRI): {n_dri}")
+    return 0
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    rc = 0
+    for d in sys.argv[1:]:
+        rc |= report(d)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/scripts/decode-ab-publish.sh
+++ b/benchmarks/scripts/decode-ab-publish.sh
@@ -6,7 +6,9 @@
 #
 # Release profile, no perf/trace instrumentation. Arms alternate inside one
 # session (HAL / turbo islow / turbo ifast × YUV / RGB), pinned to one core.
-# Best-of-N p50 is the claim number.
+# The claim number is the MEDIAN p50 across rounds, reported with every
+# round's p50 and the min–max spread (best-of-N favours the low tail).
+# Build/run provenance for each host is captured to provenance.txt.
 #
 # Usage:
 #   EDGEFIRST_BENCH_ORIN_FALLBACK=adis-uav1 \
@@ -68,6 +70,50 @@ EOS
 parse_p50() {
   # First "p50=N.NNN ms" in a log (HAL prints decode_p50 afterwards).
   grep -oE 'p50=[0-9.]+ ms' "$1" | head -1 | sed -E 's/p50=([0-9.]+) ms/\1/'
+}
+
+# "median min max" of the newline-separated numbers on stdin (even count
+# averages the two middle values).
+median_spread() {
+  sort -g | awk '
+    { a[NR] = $1 }
+    END {
+      if (NR == 0) exit 1
+      m = (NR % 2) ? a[(NR + 1) / 2] : (a[NR / 2] + a[NR / 2 + 1]) / 2
+      printf "%.3f %.3f %.3f\n", m, a[1], a[NR]
+    }'
+}
+
+# Toolchain on the build side; kernel / CPU / governor / clocks / libturbojpeg
+# resolution on the run side. What a reader needs to reproduce the numbers.
+capture_provenance() { # host out_dir
+  local host="$1" out="$2"
+  {
+    echo "captured: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "--- local build ---"
+    echo "rustc: $(rustc -V 2>/dev/null || echo unknown)"
+    echo "cargo-zigbuild: $(cargo zigbuild --version 2>/dev/null || echo unknown)"
+    echo "profile: ${PROFILE}  n=${LIMIT}  warmup=${WARMUP}  rounds=${ROUNDS}  pin=${PIN}"
+    echo "turbojpeg cross cc: zig $(zig version 2>/dev/null || echo unknown)"
+    echo "--- ${host} ---"
+    ssh "${host}" "bash -s" -- "${PIN}" <<'EOS'
+PIN="${1:-0}"
+uname -a
+grep -m1 -E 'model name|^Model' /proc/cpuinfo 2>/dev/null || true
+for f in scaling_governor scaling_cur_freq cpuinfo_max_freq; do
+  p="/sys/devices/system/cpu/cpu${PIN}/cpufreq/${f}"
+  [ -r "$p" ] && echo "cpu${PIN} ${f}: $(cat "$p")"
+done
+lib="$(ldconfig -p 2>/dev/null | awk '/libturbojpeg\.so/ { print $NF; exit }')"
+echo "libturbojpeg: ${lib:-not-in-ldconfig}"
+if [ -n "${lib:-}" ]; then
+  real="$(readlink -f "${lib}")"
+  echo "libturbojpeg resolved: ${real}"
+  command -v dpkg >/dev/null 2>&1 && dpkg -S "${real}" 2>/dev/null | head -1
+fi
+true
+EOS
+  } >"${out}/provenance.txt" 2>&1 || echo "  WARN: provenance capture incomplete (see ${out}/provenance.txt)"
 }
 
 echo "==> Building hal_cpu for ${TARGET_TRIPLE} (profile=${PROFILE})"
@@ -145,22 +191,32 @@ for target in "${TARGETS[@]}"; do
     done
   done
 
+  capture_provenance "${host}" "${out_dir}"
+
   {
-    echo "==== ${board_label} best-of-${ROUNDS} (n=${LIMIT}, pin=${PIN}, profile=${PROFILE})"
+    echo "==== ${board_label} median-of-${ROUNDS} (n=${LIMIT}, pin=${PIN}, profile=${PROFILE})"
     for arm in hal tj_islow tj_ifast; do
       for fmt in yuv rgb; do
-        best=""
+        vals=""
         rounds=""
         for round in $(seq 1 "${ROUNDS}"); do
           f="${out_dir}/r${round}_${arm}_${fmt}.log"
+          [[ -f "${f}" ]] || continue
           p="$(parse_p50 "${f}" || true)"
           [[ -z "${p}" ]] && continue
           rounds="${rounds}${rounds:+, }r${round}=${p}"
-          if [[ -z "${best}" ]] || awk "BEGIN{exit !(${p} < ${best})}"; then
-            best="${p}"
-          fi
+          vals="${vals}${vals:+ }${p}"
         done
-        printf "  %-10s %-4s  best=%s ms  (%s)\n" "${arm}" "${fmt}" "${best:-?}" "${rounds:-no p50}"
+        if [[ -n "${vals}" ]]; then
+          read -r med lo hi < <(printf '%s\n' ${vals} | median_spread)
+          n_rounds="$(printf '%s\n' ${vals} | wc -l | tr -d ' ')"
+          short=""
+          [[ "${n_rounds}" != "${ROUNDS}" ]] && short=" [only ${n_rounds}/${ROUNDS} rounds]"
+          printf "  %-10s %-4s  median=%s ms  spread=[%s,%s]  (%s)%s\n" \
+            "${arm}" "${fmt}" "${med}" "${lo}" "${hi}" "${rounds}" "${short}"
+        else
+          printf "  %-10s %-4s  median=?  (no p50)\n" "${arm}" "${fmt}"
+        fi
       done
     done
   } | tee "${out_dir}/summary.txt"

--- a/benchmarks/scripts/decode-ab-sweep.sh
+++ b/benchmarks/scripts/decode-ab-sweep.sh
@@ -189,7 +189,10 @@ for target in "${TARGETS[@]}"; do
   else
     echo "  WARN: stb/wuffs cross-build failed; their arms will FAIL on ${target}"
   fi
-  ssh "${target}" "chmod +x ${REMOTE_BIN_DIR}/hal_cpu ${REMOTE_BIN_DIR}/rust_jpeg ${REMOTE_BIN_DIR}/turbojpeg_bench ${REMOTE_BIN_DIR}/stb_bench ${REMOTE_BIN_DIR}/wuffs_bench"
+  ssh "${target}" "chmod +x ${REMOTE_BIN_DIR}/hal_cpu ${REMOTE_BIN_DIR}/rust_jpeg ${REMOTE_BIN_DIR}/turbojpeg_bench"
+  # Tolerant for the optional arms: absent binaries (failed cross-build/scp
+  # above) must not kill the sweep under set -e — their runs FAIL per-cell.
+  ssh "${target}" "chmod +x ${REMOTE_BIN_DIR}/stb_bench ${REMOTE_BIN_DIR}/wuffs_bench 2>/dev/null" || true
 
   pin_cmd="taskset -c ${PIN}"
   if ! ssh "${target}" "command -v taskset >/dev/null"; then

--- a/benchmarks/scripts/decode-ab-sweep.sh
+++ b/benchmarks/scripts/decode-ab-sweep.sh
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
 # SPDX-License-Identifier: Apache-2.0
 #
-# Full decoder A/B sweep (BENCHMARKS.md § JPEG Decode): six arms per host.
+# Full decoder A/B sweep (BENCHMARKS.md § JPEG Decode): eight arms per host.
 #
 #   hal        EdgeFirst accurate (islow-class, the default)
 #   hal_fast   EdgeFirst DctMethod::Fast (AAN, opt-in; EDGEFIRST_CODEC_DCT=fast)
@@ -10,11 +10,17 @@
 #   tj_ifast   libjpeg-turbo fast IDCT
 #   zune       zune-jpeg (Rust; YCbCr / RGB output)
 #   image      image crate (Rust; RGB only — its API has no raw-YUV output)
+#   stb        stb_image (C single-header; RGB only, allocates per call)
+#   wuffs      Wuffs v0.4 (Google, memory-safe C; RGB only)
 #
 # Release profile, no perf/trace. Arms alternate inside one session per round,
-# pinned to one core. Best-of-N p50 is the claim number. Supports aarch64
-# boards and x86_64 hosts (the turbojpeg C bench is compiled on the remote
-# host with its native gcc; Rust arms are cross-built with zigbuild).
+# pinned to one core. The claim number is the MEDIAN p50 across rounds, with
+# every round's p50 and the min–max spread reported next to it (best-of-N
+# systematically favours the low tail; the median of interleaved rounds does
+# not). Build/run provenance for each host is captured to provenance.txt.
+# Supports aarch64 boards and x86_64 hosts (the turbojpeg C bench is compiled
+# on the remote host with its native gcc; Rust arms are cross-built with
+# zigbuild).
 #
 # Usage:
 #   ./benchmarks/scripts/decode-ab-sweep.sh imx8mp-frdm imx95-pro rpi5-hailo sebstation
@@ -33,6 +39,11 @@ WARMUP="${WARMUP:-20}"
 ROUNDS="${ROUNDS:-3}"
 PIN="${PIN:-0}"
 REMOTE_COCO="${EDGEFIRST_BENCH_COCO_REMOTE:-/data/coco/val2017}"
+# Corpus identity (val2017, val2017-yuv420, jpeg-yuv420, …): names the
+# results subdirectory so control-corpus runs never overwrite the primary,
+# and extends the remote fallback search to ~/corpora/<name> (hosts where
+# /data is not writable, e.g. adis-uav1).
+CORPUS_NAME="$(basename "${REMOTE_COCO}")"
 # Home-relative: /tmp is quota-limited tmpfs on some hosts (sebstation).
 REMOTE_BIN_DIR="edgefirst-bench-decode-sweep"
 
@@ -46,7 +57,7 @@ remote_coco_path() {
   local host="$1"
   ssh "${host}" "bash -s" <<EOS
 set -euo pipefail
-for d in '${REMOTE_COCO}' "\$HOME/coco/val2017" /tmp/coco/val2017 /root/coco/val2017; do
+for d in '${REMOTE_COCO}' "\$HOME/corpora/${CORPUS_NAME}" "\$HOME/coco/val2017" /tmp/coco/val2017 /root/coco/val2017; do
   if [[ -d "\$d" ]] && compgen -G "\$d/*.[Jj][Pp][Gg]" >/dev/null; then
     echo "\$d"
     exit 0
@@ -60,6 +71,58 @@ parse_p50() {
   grep -oE 'p50=[0-9.]+ ms' "$1" | head -1 | sed -E 's/p50=([0-9.]+) ms/\1/'
 }
 
+# "median min max" of the newline-separated numbers on stdin (even count
+# averages the two middle values).
+median_spread() {
+  sort -g | awk '
+    { a[NR] = $1 }
+    END {
+      if (NR == 0) exit 1
+      m = (NR % 2) ? a[(NR + 1) / 2] : (a[NR / 2] + a[NR / 2 + 1]) / 2
+      printf "%.3f %.3f %.3f\n", m, a[1], a[NR]
+    }'
+}
+
+# Record everything a reader needs to reproduce this host's numbers:
+# toolchain + comparator versions on the build side, kernel / CPU / governor /
+# clocks / libturbojpeg resolution on the run side.
+capture_provenance() { # host out_dir
+  local host="$1" out="$2"
+  {
+    echo "captured: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "--- local build ---"
+    echo "rustc: $(rustc -V 2>/dev/null || echo unknown)"
+    echo "cargo-zigbuild: $(cargo zigbuild --version 2>/dev/null || echo unknown)"
+    echo "profile: ${PROFILE}  n=${LIMIT}  warmup=${WARMUP}  rounds=${ROUNDS}  pin=${PIN}"
+    for pkg in zune-jpeg image; do
+      v="$(awk -v p="$pkg" '$0 == "name = \"" p "\"" { getline; gsub(/version = |"/, ""); print; exit }' \
+        "${BENCH_WS}/Cargo.lock")"
+      echo "${pkg}: ${v:-unknown}"
+    done
+    echo "zune-jpeg features: x86,neon,std (explicit in modules/rust_jpeg/Cargo.toml)"
+    echo "stb/wuffs cross cc: zig $(zig version 2>/dev/null || echo unknown) (aarch64/x86_64 targets)"
+    echo "--- ${host} ---"
+    ssh "${host}" "bash -s" -- "${PIN}" <<'EOS'
+PIN="${1:-0}"
+uname -a
+grep -m1 -E 'model name|^Model' /proc/cpuinfo 2>/dev/null || true
+for f in scaling_governor scaling_cur_freq cpuinfo_max_freq; do
+  p="/sys/devices/system/cpu/cpu${PIN}/cpufreq/${f}"
+  [ -r "$p" ] && echo "cpu${PIN} ${f}: $(cat "$p")"
+done
+lib="$(ldconfig -p 2>/dev/null | awk '/libturbojpeg\.so/ { print $NF; exit }')"
+echo "libturbojpeg: ${lib:-not-in-ldconfig}"
+if [ -n "${lib:-}" ]; then
+  real="$(readlink -f "${lib}")"
+  echo "libturbojpeg resolved: ${real}"
+  command -v dpkg >/dev/null 2>&1 && dpkg -S "${real}" 2>/dev/null | head -1
+fi
+command -v gcc >/dev/null 2>&1 && gcc --version | head -1
+true
+EOS
+  } >"${out}/provenance.txt" 2>&1 || echo "  WARN: provenance capture incomplete (see ${out}/provenance.txt)"
+}
+
 build_for() {
   local triple="$1"
   (
@@ -70,7 +133,7 @@ build_for() {
 
 for target in "${TARGETS[@]}"; do
   echo "============================================"
-  echo "==> sweep ${target}  n=${LIMIT} rounds=${ROUNDS} pin=${PIN}"
+  echo "==> sweep ${target}  corpus=${CORPUS_NAME}  n=${LIMIT} rounds=${ROUNDS} pin=${PIN}"
   echo "============================================"
   if ! ssh -o BatchMode=yes -o ConnectTimeout=5 "${target}" 'true' 2>/dev/null; then
     echo "SKIP: ${target} unreachable"
@@ -83,11 +146,16 @@ for target in "${TARGETS[@]}"; do
     *) echo "SKIP: ${target} unsupported arch ${arch}"; continue ;;
   esac
 
-  out_dir="${RESULTS}/${target}/decode-ab-sweep"
+  out_dir="${RESULTS}/${target}/decode-ab-sweep/${CORPUS_NAME}"
   mkdir -p "${out_dir}"
 
   if ! coco="$(remote_coco_path "${target}")"; then
     echo "WARN: no COCO on ${target}; run sync-coco.sh first. Skipping."
+    continue
+  fi
+  if [[ "$(basename "${coco}")" != "${CORPUS_NAME}" ]]; then
+    echo "SKIP: ${target} resolved '${coco}' but this sweep is labelled corpus '${CORPUS_NAME}'" \
+      "— refusing to publish one corpus's numbers under another's name (sync it first)"
     continue
   fi
   echo "  arch=${arch}  COCO=${coco}"
@@ -106,9 +174,22 @@ for target in "${TARGETS[@]}"; do
       "${target}:${REMOTE_BIN_DIR}/turbojpeg_bench"
   else
     scp -q "${BENCH_WS}/modules/turbojpeg/bench.c" "${target}:${REMOTE_BIN_DIR}/bench.c"
-    ssh "${target}" "gcc -O2 -o '${REMOTE_BIN_DIR}/turbojpeg_bench' '${REMOTE_BIN_DIR}/bench.c' -ldl"
+    ssh "${target}" "gcc -O2 -o '${REMOTE_BIN_DIR}/turbojpeg_bench' '${REMOTE_BIN_DIR}/bench.c' -ldl -lm"
   fi
-  ssh "${target}" "chmod +x ${REMOTE_BIN_DIR}/hal_cpu ${REMOTE_BIN_DIR}/rust_jpeg ${REMOTE_BIN_DIR}/turbojpeg_bench"
+  # stb + wuffs benches: statically compiled cross-binaries for either arch
+  # (zig cc; their pinned single-file sources are fetched by `make deps`).
+  # Non-fatal: a missing zig / offline fetch loses the stb+wuffs arms for
+  # this target (their runs FAIL individually) without killing the sweep.
+  if make -C "${BENCH_WS}/modules/stb" "${arch}" \
+    && make -C "${BENCH_WS}/modules/wuffs" "${arch}"; then
+    scp -q "${BENCH_WS}/modules/stb/build/stb_bench.${arch}" \
+      "${target}:${REMOTE_BIN_DIR}/stb_bench" || true
+    scp -q "${BENCH_WS}/modules/wuffs/build/wuffs_bench.${arch}" \
+      "${target}:${REMOTE_BIN_DIR}/wuffs_bench" || true
+  else
+    echo "  WARN: stb/wuffs cross-build failed; their arms will FAIL on ${target}"
+  fi
+  ssh "${target}" "chmod +x ${REMOTE_BIN_DIR}/hal_cpu ${REMOTE_BIN_DIR}/rust_jpeg ${REMOTE_BIN_DIR}/turbojpeg_bench ${REMOTE_BIN_DIR}/stb_bench ${REMOTE_BIN_DIR}/wuffs_bench"
 
   pin_cmd="taskset -c ${PIN}"
   if ! ssh "${target}" "command -v taskset >/dev/null"; then
@@ -148,16 +229,26 @@ for target in "${TARGETS[@]}"; do
       if [[ "${fmt}" == rgb ]]; then
         run_arm image "${round}" "${fmt}" \
           "./rust_jpeg --limit ${LIMIT} --warmup ${WARMUP} --engine image --format rgb"
+        run_arm stb "${round}" "${fmt}" \
+          "./stb_bench --limit ${LIMIT} --warmup ${WARMUP} --board '${target}' \
+           --decode-only --format rgb"
+        run_arm wuffs "${round}" "${fmt}" \
+          "./wuffs_bench --limit ${LIMIT} --warmup ${WARMUP} --board '${target}' \
+           --decode-only --format rgb"
       fi
     done
   done
 
+  capture_provenance "${target}" "${out_dir}"
+
   {
-    echo "==== ${target} best-of-${ROUNDS} (n=${LIMIT}, pin=${PIN}, profile=${PROFILE})"
-    for arm in hal hal_fast tj_islow tj_ifast zune image; do
+    echo "==== ${target} ${CORPUS_NAME} median-of-${ROUNDS} (n=${LIMIT}, pin=${PIN}, profile=${PROFILE})"
+    for arm in hal hal_fast tj_islow tj_ifast zune image stb wuffs; do
       for fmt in yuv rgb; do
-        [[ "${arm}" == image && "${fmt}" == yuv ]] && continue
-        best=""
+        case "${arm}" in
+          image | stb | wuffs) [[ "${fmt}" == yuv ]] && continue ;;
+        esac
+        vals=""
         rounds=""
         for round in $(seq 1 "${ROUNDS}"); do
           f="${out_dir}/r${round}_${arm}_${fmt}.log"
@@ -165,11 +256,18 @@ for target in "${TARGETS[@]}"; do
           p="$(parse_p50 "${f}" || true)"
           [[ -z "${p}" ]] && continue
           rounds="${rounds}${rounds:+, }r${round}=${p}"
-          if [[ -z "${best}" ]] || awk "BEGIN{exit !(${p} < ${best})}"; then
-            best="${p}"
-          fi
+          vals="${vals}${vals:+ }${p}"
         done
-        printf "  %-10s %-4s  best=%s ms  (%s)\n" "${arm}" "${fmt}" "${best:-?}" "${rounds:-no p50}"
+        if [[ -n "${vals}" ]]; then
+          read -r med lo hi < <(printf '%s\n' ${vals} | median_spread)
+          n_rounds="$(printf '%s\n' ${vals} | wc -l | tr -d ' ')"
+          short=""
+          [[ "${n_rounds}" != "${ROUNDS}" ]] && short=" [only ${n_rounds}/${ROUNDS} rounds]"
+          printf "  %-10s %-4s  median=%s ms  spread=[%s,%s]  (%s)%s\n" \
+            "${arm}" "${fmt}" "${med}" "${lo}" "${hi}" "${rounds}" "${short}"
+        else
+          printf "  %-10s %-4s  median=?  (no p50)\n" "${arm}" "${fmt}"
+        fi
       done
     done
   } | tee "${out_dir}/summary.txt"

--- a/benchmarks/scripts/fetch-clic2025.sh
+++ b/benchmarks/scripts/fetch-clic2025.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+#
+# CLIC 2025 large-image corpus: fetch the challenge's image validation + test
+# sets (62 lossless PNGs, ~2048 px long edge) and encode the JPEG benchmark
+# corpora from them.
+#
+# Why CLIC 2025: the recognized, license-clean large-image set. The CLIC
+# tasks page states "The images are released using the Unsplash license"
+# (free including commercial use, no attribution required), and the download
+# URLs are live — unlike CLIC 2020, whose archive is gone. COCO val2017
+# stays the primary corpus (~0.27 MP); this one covers the ≥2 MP class.
+#
+# Every standard corpus ships lossless sources, so a JPEG decode benchmark on
+# it is always "sources + an encode recipe". The recipe here is pinned and
+# recorded in each output MANIFEST.txt: libjpeg-turbo cjpeg, fixed quality,
+# one directory per subsampling (4:2:0 and 4:4:4 from identical pixels, so
+# the pair isolates subsampling exactly). For the restart-marker control run
+# make-dri-corpus.sh on an output directory afterwards (lossless jpegtran).
+#
+# Usage:
+#   ./benchmarks/scripts/fetch-clic2025.sh [--dest DIR] [--quality N] [--jobs N]
+#
+# Defaults: --dest ~/Dataset/CLIC2025, --quality 90, --jobs = CPU count.
+# Requires: curl, unzip, cjpeg (libjpeg-turbo), and one PNG reader out of
+# ImageMagick `magick`, python3+Pillow, or macOS `sips`.
+
+set -euo pipefail
+
+DEST="${HOME}/Dataset/CLIC2025"
+QUALITY=90
+JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dest) DEST="$2"; shift 2 ;;
+    --quality) QUALITY="$2"; shift 2 ;;
+    --jobs) JOBS="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Pinned downloads (checked 2026-08-13, from https://clic2025.compression.cc/tasks/).
+VAL_URL="https://d152a8jkvz9wzs.cloudfront.net/data/clic2025_image_validation.zip"
+VAL_SHA256="735f8da90c860e872db6b9dc6fac88d42d0ba021a7a5898b89c062f0634b3149"
+TEST_URL="https://storage.googleapis.com/clic_datasets/clic2025_image_test.zip"
+TEST_SHA256="c479a92b7579f716826822fe892abbe583cfa7cd7f07730a14227a98c7870e92"
+
+command -v cjpeg >/dev/null || { echo "cjpeg not found (install libjpeg-turbo)" >&2; exit 1; }
+command -v unzip >/dev/null || { echo "unzip not found" >&2; exit 1; }
+if command -v sha256sum >/dev/null 2>&1; then SHA256() { sha256sum "$1" | cut -d' ' -f1; }
+else SHA256() { shasum -a 256 "$1" | cut -d' ' -f1; }; fi
+
+# PNG → PPM converter: ImageMagick, then python3+Pillow, then macOS sips.
+if command -v magick >/dev/null 2>&1; then
+  PNG2PPM=magick
+elif python3 -c "import PIL" >/dev/null 2>&1; then
+  PNG2PPM=pillow
+elif command -v sips >/dev/null 2>&1; then
+  PNG2PPM=sips
+else
+  echo "no PNG reader found (need ImageMagick, python3+Pillow, or sips)" >&2
+  exit 1
+fi
+
+fetch() { # url sha out
+  local url="$1" sha="$2" out="$3"
+  if [[ -f "${out}" && "$(SHA256 "${out}")" == "${sha}" ]]; then
+    echo "  cached: ${out}"
+    return
+  fi
+  echo "  fetching $(basename "${out}")"
+  curl -fSL -o "${out}.tmp" "${url}"
+  [[ "$(SHA256 "${out}.tmp")" == "${sha}" ]] || { echo "sha256 mismatch for ${url}" >&2; exit 1; }
+  mv "${out}.tmp" "${out}"
+}
+
+mkdir -p "${DEST}/zips" "${DEST}/png"
+echo "==> Fetching CLIC 2025 image sets to ${DEST}"
+fetch "${VAL_URL}" "${VAL_SHA256}" "${DEST}/zips/clic2025_image_validation.zip"
+fetch "${TEST_URL}" "${TEST_SHA256}" "${DEST}/zips/clic2025_image_test.zip"
+unzip -qo "${DEST}/zips/clic2025_image_validation.zip" -d "${DEST}/png" -x "__MACOSX/*"
+unzip -qo "${DEST}/zips/clic2025_image_test.zip" -d "${DEST}/png" -x "__MACOSX/*"
+n_png="$(find "${DEST}/png" -maxdepth 1 -iname '*.png' | wc -l | tr -d ' ')"
+echo "  ${n_png} PNGs (expect 62: 32 validation + 30 test)"
+
+encode_dir() { # sample_arg out_dir
+  local sample="$1" out="$2"
+  mkdir -p "${out}"
+  echo "==> Encoding ${out} (cjpeg -quality ${QUALITY} -sample ${sample}, png2ppm=${PNG2PPM}, ${JOBS} jobs)"
+  find "${DEST}/png" -maxdepth 1 -iname '*.png' -print0 |
+    PNG2PPM="${PNG2PPM}" xargs -0 -P "${JOBS}" -I{} sh -c '
+      src="$1"; out_dir="$2"; quality="$3"; sample="$4"
+      name="$(basename "${src}" .png)"
+      ppm="${out_dir}/${name}.ppm.tmp"
+      case "${PNG2PPM}" in
+        magick) magick "${src}" "ppm:${ppm}" ;;
+        pillow) python3 -c "import sys; from PIL import Image; \
+Image.open(sys.argv[1]).convert(\"RGB\").save(sys.argv[2], format=\"PPM\")" "${src}" "${ppm}" ;;
+        sips)   sips -s format bmp "${src}" --out "${ppm}" >/dev/null ;;
+      esac
+      cjpeg -quality "${quality}" -sample "${sample}" -outfile "${out_dir}/${name}.jpg" "${ppm}" \
+        || echo "FAIL ${name}" >&2
+      rm -f "${ppm}"
+    ' _ {} "${out}" "${QUALITY}" "${sample}"
+
+  local n_out
+  n_out="$(find "${out}" -maxdepth 1 -iname '*.jpg' | wc -l | tr -d ' ')"
+  echo "    ${n_out}/${n_png} files"
+  [[ "${n_out}" == "${n_png}" ]] || { echo "ERROR: incomplete encode in ${out}" >&2; exit 1; }
+
+  {
+    echo "source: CLIC 2025 image validation + test sets (Unsplash license)"
+    echo "  ${VAL_URL} sha256=${VAL_SHA256}"
+    echo "  ${TEST_URL} sha256=${TEST_SHA256}"
+    echo "recipe: png → ppm (${PNG2PPM}) → cjpeg -quality ${QUALITY} -sample ${sample}"
+    echo "cjpeg: $(command -v cjpeg)"
+    cjpeg -version 2>&1 | head -1
+    echo "generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  } > "${out}/MANIFEST.txt"
+}
+
+encode_dir 2x2 "${DEST}/jpeg-yuv420"
+encode_dir 1x1 "${DEST}/jpeg-yuv444"
+
+echo "OK. Next steps:"
+echo "  python3 benchmarks/scripts/corpus_stats.py ${DEST}/jpeg-yuv420 ${DEST}/jpeg-yuv444"
+echo "  ./benchmarks/scripts/make-dri-corpus.sh --src ${DEST}/jpeg-yuv420   # restart-marker control"

--- a/benchmarks/scripts/make-coco-yuv420.sh
+++ b/benchmarks/scripts/make-coco-yuv420.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+#
+# 4:2:0 control corpus: transcode COCO val2017 (4:4:4 as distributed) to
+# 4:2:0 with libjpeg-turbo cjpeg — same 5000 images, subsampling changed.
+# This is the control that answers "is the measured decoder gap driven by the
+# corpus being 4:4:4?": rerun the decoder A/B against this directory and
+# compare the relative gaps.
+#
+# The transcode re-encodes at a fixed --quality (default 90), so against the
+# ORIGINAL corpus two variables change (quality + subsampling). Pass
+# --with-444-twin to also emit a 4:4:4 re-encode at the same quality: the
+# twin pair differs ONLY in subsampling and is the airtight isolate.
+#
+# Greyscale sources (10 in val2017) pass through djpeg|cjpeg unchanged in
+# kind (no chroma to subsample) so every arm still sees all 5000 files.
+#
+# COCO images carry individual Flickr CC licenses (some NC): NEVER publish or
+# redistribute the transcoded JPEGs — generate locally, sync only to private
+# board/S3 storage.
+#
+# Usage:
+#   ./benchmarks/scripts/make-coco-yuv420.sh [--src DIR] [--quality N]
+#       [--jobs N] [--with-444-twin]
+#
+# Defaults: --src ~/Dataset/COCO/val2017, output alongside it as
+# val2017-yuv420 (and val2017-yuv444 for the twin), --quality 90,
+# --jobs = CPU count. Requires cjpeg/djpeg (libjpeg-turbo) on PATH.
+
+set -euo pipefail
+
+SRC="${HOME}/Dataset/COCO/val2017"
+QUALITY=90
+JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+WITH_TWIN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --src) SRC="$2"; shift 2 ;;
+    --quality) QUALITY="$2"; shift 2 ;;
+    --jobs) JOBS="$2"; shift 2 ;;
+    --with-444-twin) WITH_TWIN=1; shift ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v cjpeg >/dev/null || { echo "cjpeg not found (install libjpeg-turbo)" >&2; exit 1; }
+command -v djpeg >/dev/null || { echo "djpeg not found (install libjpeg-turbo)" >&2; exit 1; }
+[[ -d "${SRC}" ]] || { echo "source not found: ${SRC}" >&2; exit 1; }
+
+transcode_dir() { # sample_arg out_dir
+  local sample="$1" out="$2"
+  mkdir -p "${out}"
+  echo "==> ${SRC} → ${out}  (cjpeg -quality ${QUALITY} -sample ${sample}, ${JOBS} jobs)"
+  # djpeg → PPM/PGM → cjpeg. -sample applies to colour images; greyscale
+  # sources come out of djpeg as PGM and re-encode as single-component JPEG.
+  find "${SRC}" -maxdepth 1 \( -iname '*.jpg' -o -iname '*.jpeg' \) -print0 |
+    xargs -0 -P "${JOBS}" -I{} sh -c '
+      src="$1"; out_dir="$2"; quality="$3"; sample="$4"
+      name="$(basename "${src}")"
+      djpeg "${src}" | cjpeg -quality "${quality}" -sample "${sample}" \
+        -outfile "${out_dir}/${name}" || echo "FAIL ${name}" >&2
+    ' _ {} "${out}" "${QUALITY}" "${sample}"
+
+  local n_src n_out
+  n_src="$(find "${SRC}" -maxdepth 1 \( -iname '*.jpg' -o -iname '*.jpeg' \) | wc -l | tr -d ' ')"
+  n_out="$(find "${out}" -maxdepth 1 \( -iname '*.jpg' -o -iname '*.jpeg' \) | wc -l | tr -d ' ')"
+  echo "    ${n_out}/${n_src} files"
+  [[ "${n_out}" == "${n_src}" ]] || { echo "ERROR: incomplete transcode in ${out}" >&2; exit 1; }
+
+  # Record the exact recipe next to the corpus.
+  {
+    echo "source: ${SRC}"
+    echo "recipe: djpeg | cjpeg -quality ${QUALITY} -sample ${sample}"
+    echo "cjpeg: $(command -v cjpeg)"
+    cjpeg -version 2>&1 | head -1
+    echo "generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "note: COCO-derived; individual Flickr CC licenses — do not redistribute"
+  } > "${out}/MANIFEST.txt"
+}
+
+transcode_dir 2x2 "$(dirname "${SRC}")/$(basename "${SRC}")-yuv420"
+if [[ "${WITH_TWIN}" == 1 ]]; then
+  transcode_dir 1x1 "$(dirname "${SRC}")/$(basename "${SRC}")-yuv444"
+fi
+
+echo "OK. Verify with: python3 benchmarks/scripts/corpus_stats.py <out_dir>"

--- a/benchmarks/scripts/make-dri-corpus.sh
+++ b/benchmarks/scripts/make-dri-corpus.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+#
+# Restart-interval (DRI) control corpus: losslessly add restart markers to
+# every JPEG in a directory with `jpegtran -restart`.
+#
+# jpegtran re-serialises the SAME DCT coefficients — pixels and quality are
+# bit-identical to the source; the ONLY change is the restart-marker
+# structure. That makes this the exact isolate for the claim that
+# libjpeg-turbo's fast Huffman decoder is disabled on DRI streams (its README
+# documents up to ~20% slower): rerun the decoder A/B on the -dri directory
+# and any timing change is attributable to restart handling alone.
+#
+# `-restart 1` = one restart marker per MCU row, the camera-stream-like
+# density (hardware encoders emit restarts for error resilience).
+#
+# Usage:
+#   ./benchmarks/scripts/make-dri-corpus.sh --src DIR [--restart N] [--jobs N]
+#
+# Output: sibling directory <src>-dri. Requires jpegtran (libjpeg-turbo).
+
+set -euo pipefail
+
+SRC=""
+RESTART=1
+JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --src) SRC="$2"; shift 2 ;;
+    --restart) RESTART="$2"; shift 2 ;;
+    --jobs) JOBS="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v jpegtran >/dev/null || { echo "jpegtran not found (install libjpeg-turbo)" >&2; exit 1; }
+[[ -n "${SRC}" && -d "${SRC}" ]] || { echo "pass --src DIR (got: '${SRC}')" >&2; exit 1; }
+
+OUT="${SRC%/}-dri"
+mkdir -p "${OUT}"
+echo "==> ${SRC} → ${OUT}  (jpegtran -restart ${RESTART} -copy all, lossless, ${JOBS} jobs)"
+
+find "${SRC}" -maxdepth 1 \( -iname '*.jpg' -o -iname '*.jpeg' \) -print0 |
+  xargs -0 -P "${JOBS}" -I{} sh -c '
+    src="$1"; out_dir="$2"; restart="$3"
+    name="$(basename "${src}")"
+    jpegtran -restart "${restart}" -copy all -outfile "${out_dir}/${name}" "${src}" \
+      || echo "FAIL ${name}" >&2
+  ' _ {} "${OUT}" "${RESTART}"
+
+n_src="$(find "${SRC}" -maxdepth 1 \( -iname '*.jpg' -o -iname '*.jpeg' \) | wc -l | tr -d ' ')"
+n_out="$(find "${OUT}" -maxdepth 1 \( -iname '*.jpg' -o -iname '*.jpeg' \) | wc -l | tr -d ' ')"
+echo "    ${n_out}/${n_src} files"
+[[ "${n_out}" == "${n_src}" ]] || { echo "ERROR: incomplete DRI transcode" >&2; exit 1; }
+
+{
+  echo "source: ${SRC}"
+  echo "recipe: jpegtran -restart ${RESTART} -copy all (lossless; coefficients unchanged)"
+  echo "jpegtran: $(command -v jpegtran)"
+  jpegtran -version 2>&1 | head -1
+  echo "generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "${OUT}/MANIFEST.txt"
+
+echo "OK. Verify with: python3 benchmarks/scripts/corpus_stats.py ${OUT}"

--- a/benchmarks/scripts/sync-corpus.sh
+++ b/benchmarks/scripts/sync-corpus.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+# SPDX-License-Identifier: Apache-2.0
+#
+# Rsync any benchmark corpus directory to boards, mirroring sync-coco.sh's
+# host handling. Made for the control corpora (val2017-yuv420, val2017-dri,
+# CLIC2025 jpeg-yuv420/yuv444/-dri): each lands at /data/corpora/<basename>
+# (fallback ~/corpora/<basename>), and a sweep is pointed at it with
+#   EDGEFIRST_BENCH_COCO_REMOTE=/data/corpora/<basename> ./decode-ab-sweep.sh …
+#
+# Usage:
+#   ./benchmarks/scripts/sync-corpus.sh --src DIR [host...]
+#
+# Env:
+#   EDGEFIRST_BENCH_ORIN_FALLBACK   fallback host for orin-nano (as sync-coco.sh)
+
+set -euo pipefail
+
+SRC=""
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --src) SRC="$2"; shift 2 ;;
+    *) ARGS+=("$1"); shift ;;
+  esac
+done
+[[ -n "${SRC}" && -d "${SRC}" ]] || { echo "pass --src DIR (got: '${SRC}')" >&2; exit 1; }
+NAME="$(basename "${SRC%/}")"
+
+if [[ ${#ARGS[@]} -gt 0 ]]; then
+  TARGETS=("${ARGS[@]}")
+else
+  TARGETS=(imx8mp-frdm imx95-frdm imx95-pro rpi5-hailo orin-nano)
+fi
+
+resolve_target() {
+  local t="$1"
+  if ssh -o BatchMode=yes -o ConnectTimeout=5 "$t" 'true' 2>/dev/null; then
+    echo "$t"
+    return 0
+  fi
+  local fallback="${EDGEFIRST_BENCH_ORIN_FALLBACK:-}"
+  if [[ "$t" == "orin-nano" && -n "${fallback}" ]] \
+      && ssh -o BatchMode=yes -o ConnectTimeout=5 "${fallback}" 'true' 2>/dev/null; then
+    echo "${fallback}"
+    return 0
+  fi
+  return 1
+}
+
+for target in "${TARGETS[@]}"; do
+  echo "============================================"
+  echo "==> sync ${NAME} → ${target}"
+  echo "============================================"
+  if ! host="$(resolve_target "${target}")"; then
+    echo "SKIP: ${target} unreachable"
+    continue
+  fi
+  [[ "${host}" != "${target}" ]] && echo "(using fallback host ${host})"
+
+  remote_dir="$(ssh "${host}" "bash -s" <<EOS
+set -euo pipefail
+pref='/data/corpora/${NAME}'
+try_dir() {
+  local d="\$1"
+  mkdir -p "\$d" 2>/dev/null || sudo mkdir -p "\$d" 2>/dev/null || return 1
+  sudo chown "\$(id -un):\$(id -gn)" "\$d" 2>/dev/null || true
+  local probe="\$d/.edgefirst_bench_write_test"
+  if touch "\$probe" 2>/dev/null; then
+    rm -f "\$probe"
+    echo "\$d"
+    return 0
+  fi
+  return 1
+}
+if try_dir "\$pref"; then
+  exit 0
+fi
+mkdir -p "\$HOME/corpora/${NAME}"
+echo "\$HOME/corpora/${NAME}"
+EOS
+)"
+  echo "  remote: ${host}:${remote_dir}"
+  # Minimal Yocto images ship without rsync; stream a tar instead (corpora are
+  # immutable, so losing incremental transfer costs nothing on a re-sync of an
+  # already-complete directory — the JPEG count check below short-circuits it).
+  src_count="$(find "${SRC}" -maxdepth 1 \( -iname '*.jpg' -o -iname '*.jpeg' \) | wc -l | tr -d ' ')"
+  remote_count() {
+    ssh "${host}" "find '${remote_dir}' -maxdepth 1 \\( -iname '*.jpg' -o -iname '*.jpeg' \\) | wc -l" | tr -d ' '
+  }
+  if [[ "$(remote_count)" == "${src_count}" ]]; then
+    echo "OK: ${host} already has ${src_count} JPEGs at ${remote_dir}"
+    continue
+  fi
+  if ssh "${host}" 'command -v rsync >/dev/null'; then
+    rsync -a --info=progress2 "${SRC}/" "${host}:${remote_dir}/"
+  else
+    echo "  (no rsync on ${host}; streaming tar)"
+    tar -C "${SRC}" -cf - . | ssh "${host}" "tar -C '${remote_dir}' -xf -"
+  fi
+  count="$(remote_count)"
+  echo "OK: ${host} has ${count} JPEGs at ${remote_dir}"
+done

--- a/crates/codec/ARCHITECTURE.md
+++ b/crates/codec/ARCHITECTURE.md
@@ -79,6 +79,18 @@ dependency graph clean.
 | `v4l2/`          | Optional Linux hardware JPEG backend (see below)     |
 | `nvjpeg/`        | Optional nvJPEG GPU backend (Linux + CUDA, see below) |
 
+Both hardware backends expose crate-level runtime probes —
+`edgefirst_codec::v4l2_available()` (opens and drops the first working
+decoder device; honours `EDGEFIRST_DISABLE_V4L2`) and
+`edgefirst_codec::nvjpeg_available()` (honours the `EDGEFIRST_ENABLE_NVJPEG`
+opt-in) — for consumers that must fail fast rather than silently fall back
+to the CPU decoder (e.g. the hardware-decode benchmark arms). Routing note:
+hardware decoders are only attempted when no fused output is requested
+(`allow_hw = output_fmt == native_fmt`); a fused `Rgb`/`Nv12` preference
+selects the CPU decoder even when a hardware backend is available. nvJPEG,
+whose fixed output is interleaved RGB, engages under a `native` request and
+reconfigures the destination to `Rgb` itself.
+
 ### nvJPEG Backend Module Map (`jpeg/nvjpeg/`, Linux + `nvjpeg` feature)
 
 | Module        | Purpose                                                |

--- a/crates/codec/TESTING.md
+++ b/crates/codec/TESTING.md
@@ -23,6 +23,7 @@ Inline `#[cfg(test)]` modules in each source file:
 | `jpeg/idct.rs`        | Selected-tier dispatch; coefficients that overflow the 16-bit dequant neither panic under overflow checks nor write outside the block |
 | `jpeg/v4l2/format.rs` | `classify()` CAPTURE FourCC → `CapKind`             |
 | `jpeg/v4l2/mod.rs`    | Backend helpers (geometry/format negotiation logic) |
+| `tests/v4l2_jpeg.rs` (`v4l2_available_probe_honours_disable_env`) | Public `v4l2_available()` probe (Linux lanes; compile-time `false` elsewhere): answers without panicking, `EDGEFIRST_DISABLE_V4L2` forces `false` — the fail-fast guard for the `hal_v4l2_*` benchmark arms |
 | `jpeg/nvjpeg/mod.rs`  | Graceful degradation without a GPU: a non-CUDA destination falls through untouched, an unavailable or unprobed probe returns `None` without writing the tensor, circuit-breaker threshold sanity |
 
 ### Integration Tests

--- a/crates/codec/src/jpeg/mod.rs
+++ b/crates/codec/src/jpeg/mod.rs
@@ -36,6 +36,13 @@ mod nvjpeg;
 #[cfg(all(target_os = "linux", feature = "nvjpeg"))]
 pub(crate) use nvjpeg::is_nvjpeg_available as nvjpeg_available;
 
+/// Runtime probe: `true` when a V4L2 JPEG decoder device is present (and not
+/// opted out via `EDGEFIRST_DISABLE_V4L2`). Opens and drops the device once.
+#[cfg(all(target_os = "linux", feature = "v4l2"))]
+pub(crate) fn v4l2_available() -> bool {
+    v4l2::device_available()
+}
+
 /// Parse a boolean backend-gate environment variable: `true` only for
 /// `1`/`true`/`yes` (case-insensitive, trimmed); absent or anything else is
 /// `false`. Shared by the V4L2 opt-out (`EDGEFIRST_DISABLE_V4L2`) and the nvJPEG

--- a/crates/codec/src/jpeg/v4l2/mod.rs
+++ b/crates/codec/src/jpeg/v4l2/mod.rs
@@ -94,6 +94,13 @@ enum DecodeErr {
     Fatal(CodecError),
 }
 
+/// One-shot availability probe: opens and drops the first working decoder
+/// device. Backs the crate-level `v4l2_available()`; the decode path keeps its
+/// own lazy [`V4l2Probe`] and is unaffected (V4L2 nodes are multi-open).
+pub(crate) fn device_available() -> bool {
+    device::probe().is_some()
+}
+
 /// Lazily-probed V4L2 backend state, stored on the reusable decoder state so
 /// the device is probed at most once and the context is reused across decodes.
 //

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -79,5 +79,22 @@ pub fn nvjpeg_available() -> bool {
     }
 }
 
+/// Returns `true` when a V4L2 memory-to-memory JPEG decoder (e.g. the i.MX
+/// mxc-jpeg block) is present and not opted out via `EDGEFIRST_DISABLE_V4L2`.
+/// Opens and drops the device once; the decode path re-probes lazily and
+/// keeps its own context. Always `false` on other platforms or when the
+/// `v4l2` feature is disabled. Useful for benchmarks and consumers that must
+/// fail fast instead of silently falling back to the CPU decoder.
+pub fn v4l2_available() -> bool {
+    #[cfg(all(target_os = "linux", feature = "v4l2"))]
+    {
+        jpeg::v4l2_available()
+    }
+    #[cfg(not(all(target_os = "linux", feature = "v4l2")))]
+    {
+        false
+    }
+}
+
 /// Result type for codec operations.
 pub type Result<T> = std::result::Result<T, CodecError>;

--- a/crates/codec/tests/v4l2_jpeg.rs
+++ b/crates/codec/tests/v4l2_jpeg.rs
@@ -421,3 +421,18 @@ fn v4l2_zero_copy_dma_nv12() {
     let reference = decode(&jpeg, w, h, PixelFormat::Nv12, false);
     assert_close(&reference, &zc, "zero-copy-dma");
 }
+
+/// The public probe backing the hardware benchmark arms' fail-fast guards.
+/// Not device-gated: it must answer (not panic) with or without a decoder
+/// device, and the `EDGEFIRST_DISABLE_V4L2` opt-out must force `false` even
+/// when one is present. (This file is Linux-gated; off-Linux the function is
+/// compile-time `false`.)
+#[test]
+fn v4l2_available_probe_honours_disable_env() {
+    // Safety of env mutation: the workspace mandates --test-threads=1.
+    std::env::set_var("EDGEFIRST_DISABLE_V4L2", "1");
+    assert!(!edgefirst_codec::v4l2_available());
+    std::env::remove_var("EDGEFIRST_DISABLE_V4L2");
+    // Un-gated result is platform-dependent; just require it to answer.
+    let _present: bool = edgefirst_codec::v4l2_available();
+}

--- a/crates/python/README.md
+++ b/crates/python/README.md
@@ -122,9 +122,7 @@ processor.convert(src, dst)
 processor.convert(src, dst, letterbox=[114, 114, 114, 255])
 
 # With rotation and horizontal flip
-processor.convert(
-    src, dst, rotation=ef.Rotation.Clockwise90, flip=ef.Flip.Horizontal
-)
+processor.convert(src, dst, rotation=ef.Rotation.Clockwise90, flip=ef.Flip.Horizontal)
 
 # Crop a source region — Region(x, y, width, height) in source pixels
 processor.convert(src, dst, source=ef.Region(100, 100, 400, 400))
@@ -365,9 +363,9 @@ It assigns consistent track IDs across frames.
 import edgefirst_hal as ef
 
 tracker = ef.ByteTrack(
-    high_conf=0.7,         # High-confidence detection threshold
-    iou=0.25,              # IoU threshold for association
-    update=0.25,           # Update/low-confidence threshold
+    high_conf=0.7,  # High-confidence detection threshold
+    iou=0.25,  # IoU threshold for association
+    update=0.25,  # Update/low-confidence threshold
     lifespan_ns=500_000_000,  # Track lifespan without detection (nanoseconds)
 )
 
@@ -390,12 +388,12 @@ Draw pre-decoded masks onto a destination image:
 ```python
 processor.draw_decoded_masks(
     dst,
-    bbox,           # numpy array [N, 4]
-    scores,         # numpy array [N]
-    classes,        # numpy array [N]
-    seg=[],         # list of segmentation arrays (optional)
+    bbox,  # numpy array [N, 4]
+    scores,  # numpy array [N]
+    classes,  # numpy array [N]
+    seg=[],  # list of segmentation arrays (optional)
     background=None,  # optional background tensor to blit before drawing
-    opacity=1.0,    # mask alpha scale (0.0 – 1.0)
+    opacity=1.0,  # mask alpha scale (0.0 – 1.0)
 )
 ```
 
@@ -419,16 +417,21 @@ boxes, scores, classes = processor.draw_masks(decoder, outputs, dst)
 
 # With overlay parameters
 boxes, scores, classes = processor.draw_masks(
-    decoder, outputs, dst,
+    decoder,
+    outputs,
+    dst,
     background=bg_tensor,  # blit bg_tensor into dst before masks
-    opacity=0.7,           # semi-transparent masks
+    opacity=0.7,  # semi-transparent masks
 )
 
 # With tracking (requires tracker= and timestamp=)
 import time
+
 ts = time.monotonic_ns()
 boxes, scores, classes, tracks = processor.draw_masks(
-    decoder, outputs, dst,
+    decoder,
+    outputs,
+    dst,
     tracker=tracker,
     timestamp=ts,
 )


### PR DESCRIPTION
Prepares the JPEG decode benchmarks for publication: every objection catalogued in the third-party review of BENCHMARKS.md (arm coverage, corpus bias, methodology, hardware-decoder scoping, reproducibility) now has a measurement, a control, or an explicit caveat behind it. Data was fully re-collected on 5 boards/hosts, 5 AWS instance classes, and 6 corpora under a hardened protocol.

## Benchmark summary

**CPU decode, COCO val2017 (p50 ms, YUV arm, median of 3 interleaved rounds):**

| Platform | EdgeFirst | Turbo `islow` | Lead | zune-jpeg |
|---|---|---|---|---|
| i9-11900K | **1.222** | 1.433 | +14.7% | 1.911 |
| RPi5 (A76) | **2.372** | 3.173 | +25.2% | 4.115 |
| Orin Nano (A78AE) | **3.719** | 5.144 | +27.7% | 6.404 |
| i.MX 95 (A55) | **6.032** | 7.044 | +14.4% | 11.457 |
| i.MX 8MP (A53) | **6.745** | 7.747 | +12.9% | 13.504 |
| AWS Graviton4 | **1.376** | 2.117 | +35.0% | 2.547 |
| AWS Graviton3 | **1.665** | 2.529 | +34.2% | 2.984 |
| AWS Graviton2 | **2.292** | 3.271 | +29.9% | 3.968 |
| AWS Sapphire Rapids | **1.760** | 2.070 | +15.0% | 2.637 |
| AWS Genoa (Zen 4) | **1.455** | 1.667 | +12.7% | 2.131 |

EdgeFirst's accurate (`islow`-class) decoder is the fastest arm in every cell across 10 platforms × 6 corpora, with two honest 1.00× ties on the A53 at 4:2:0 and a single 1.4% fast-class loss to turbo `ifast` (A53, large 4:2:0) — all published as-is. The largest leads are on the Graviton parts reviewers benchmark against.

**Key verdicts from the control corpora:**

- **The zune-jpeg gap is not corpus-driven** (the review's #1 predicted attack): zune never closes to within 10% of turbo on any control, and moving to 4:2:0 *widens* its deficit (x86: 1.33× → 1.52–1.57×). Replicated on the SBCs, workstation, and all five AWS classes — with zune's `neon` feature verified active on ARM.
- **The restart-marker (DRI) claim is now measured**: on a losslessly re-serialised COCO (`jpegtran -restart 1`, identical coefficients), turbo `islow` pays +5.4% (x86) to +15.7% (A53) while EdgeFirst pays ≤1.1%, growing its lead to +18–35% on camera-style streams.
- **Hardware decoders published in their own table**: i.MX 95 V4L2 decodes NV12 ~25% faster than CPU at COCO sizes while freeing the core (restart-indifferent), with the required NV*→RGB second pass measured via both CPU and GL converts (no colour-space conversion in the block — verified on-target via `VIDIOC_ENUM_FMT`); Orin nvJPEG (GPU_HYBRID on shared CUDA cores, not the NVJPG ASIC) never beats the tuned CPU decoder and is scoped accordingly, with decode-vs-inference contention explicitly out of scope.
- **New arms behave as billed**: stb_image (1.9–2.1× behind) and Wuffs (2.1–3.4×) are the recognizable floor; Wuffs decodes **bit-identically** to djpeg's accurate path (max abs diff 0) and stb within ±3 LSB, so their rows are like-for-like in the accurate class.

## What's in the change

- **Two new CPU arms** (`benchmarks/modules/stb`, `wuffs`) on a shared C harness header (`modules/cbench/cbench.h`) that copies the reference arm's timing definitions verbatim; pinned, sha256-verified single-file upstreams fetched by make (not vendored).
- **Two hardware arms**: new `hal_nvjpeg` (asserts nvJPEG availability; per-frame engagement verifiable via tracing spans) and `hal_v4l2_cpu`; `hal_v4l2_gl` gained a startup guard. New `--full-res-convert` harness mode measures the pure NV*→RGB second pass with pooled, `create_image`-allocated buffers (creation outside the timed region, verified by the `BufferIdentity` churn counter).
- **Codec crate**: public `v4l2_available()` probe (mirroring `nvjpeg_available()`) so hardware arms fail loudly instead of silently benchmarking the CPU fallback; ARCHITECTURE.md documents both probes and the `allow_hw` routing rule (hardware decoders engage only under native-format requests).
- **Methodology hardening**: mean + nonparametric 95% CI on the median in all harnesses (identical CSV schema), median-of-rounds reporting with per-round p50s and spread (best-of-N retired), per-host build/run provenance capture, `dladdr`-resolved comparator library paths, and a fixed subset-selection bug (the zune/image arms previously drew the corpus prefix rather than the strided sample the other arms use).
- **Corpus tooling** (`benchmarks/scripts/`): `corpus_stats.py` (marker-level stats; measured COCO val2017 in full: 4990× 4:4:4 + 10 grey, zero progressive, zero DRI), `make-coco-yuv420.sh`, `make-dri-corpus.sh` (lossless `jpegtran -restart`), `fetch-clic2025.sh` (pinned downloads + published encode recipe; Unsplash-licensed), `sync-corpus.sh` (rsync with tar-over-ssh fallback for rsync-less Yocto boards).
- **Cloud pipeline**: multi-arch bench container (all six arms, `ROUNDS`/`PIN`/`DATASET_URL` support, results via stdout→CloudWatch), run on AWS Batch across `profiler-{m8g,m7i,c7g,c7a,m6g}-2xlarge`.
- **BENCHMARKS.md § JPEG Decode** fully refreshed: 8-arm main table, control-corpora section, AWS cloud baselines, hardware-decode tables, and a build/run provenance section. zune relabeled/pinned (`neon` explicit), image-crate arm labeled as the zune wrapper it is, mozjpeg/IPP omissions justified.

## Verification

- All 232 numbers in the refreshed section (5 tables + lead/DRI percentages) machine-verified against the raw capture data (zero mismatches).
- 0 failed runs across the board sweep (5 hosts × 6 corpora × 8 arms × 3 rounds) and 30/30 AWS Batch jobs.
- Pixel parity: Wuffs bit-exact / stb ±3 LSB vs `djpeg` accurate across 4:4:4, 4:2:0, DRI, greyscale, and large samples.
- `make format lint` and `make sbom` clean; benchmarks tree remains excluded from the workspace and CI path triggers.
- Raw capture data (round logs, CIs, provenance) archived at `~/edgefirst-baselines/jpeg-recapture-2026-08-13{,-cloud}.tar.gz`.

## Review

An eight-angle multi-agent review ran over the full diff before this PR; every finding was adjudicated and the accepted ones fixed in-tree:

- **Fixed**: `LIMIT=0` in the container entrypoint now passes `--limit 0` explicitly (previously each arm silently fell back to *disagreeing* built-in defaults); the entrypoint's script-level MODULES default now matches the documented six arms; missing `taskset` under `PIN` warns instead of silently unpinning; an all-skipped matrix now exits non-zero; the sweep refuses to publish a fallback corpus under the requested corpus's label; sweep summaries flag cells with fewer rounds than requested; stb/wuffs cross-build failure no longer aborts the whole sweep; `rust_jpeg` warmup survives an undecodable first image and its 64 MB pre-allocated scratch was replaced with high-water growth (its `peak_rss_mb` column is now honest); the `hal_v4l2_*` arms reject non-native `--decode-fmt` (a fused preference silently routes to the CPU decoder); `corpus_stats.py` reports rather than crashes on an unparseable directory; the benchmarks README's corpora paragraph was moved out of a code fence; BENCHMARKS.md is now versioned 3.11 with a changelog row, discloses the full-res GL leg's per-geometry EGLImage import cost and the mixed harness toolchain (remote gcc vs zig for the C arms, both now recorded in provenance); `v4l2_available()` gained a unit test and TESTING.md/copilot-instructions entries.
- **Adjudicated, deliberate**: per-size EGLImage re-import is correctness-required (documented, not "fixed"); the image-crate arm keeps `to_rgb8` because the published row documents exactly that call (switching to `into_rgb8` would need a recapture — noted below).

Known follow-ups (tracked, out of scope here — several from the review's simplification/reuse angles):
- Deduplicate the three C stats copies (`bench.c` ↔ `cbench.h` ↔ `benchmarks/common`) by migrating `turbojpeg/bench.c` onto `cbench.h`, share a `cbench.mk` across the module Makefiles, extract a sourced `scripts/lib/common.sh`, and fold `sync-coco.sh` into `sync-corpus.sh` — deferred as a mechanical refactor PR so this one doesn't perturb the just-captured reference arm.
- Per-frame hardware-decode engagement counter in the codec (the startup guards + trace spans catch setup failures; a mid-run V4L2/nvJPEG fallback is only visible in traces today).
- `image` arm `to_rgb8`→`into_rgb8` (removes a per-frame clone; requires re-capturing that arm's rows), pre-existing Python lint debt (525 ruff findings in untouched files; no ruff pin in the repo), and script-efficiency niceties (shared PPM decode for twin encodes, bounded-prefix corpus_stats reads, parallel corpus sync). fused 4:2:0→RGB decode path, orin-nano primary-unit re-check (rows captured on the baseline-matched `adis-uav1` stand-in), decode-vs-inference GPU contention benchmarks, and whether an explicit RGB output preference should route to nvJPEG when enabled.
