### PR TITLE
Fix release.yml and differential.yml pipeline breaks

### DIFF
--- a/.github/scripts/verify_version.py
+++ b/.github/scripts/verify_version.py
@@ -66,7 +66,7 @@ STANDALONE_LEAF_CRATES = [
 
 
 def read_file(path: str) -> str:
-    return Path(path).read_text()
+    return Path(path).read_text(encoding="utf-8")
 
 
 def extract_workspace_version(cargo_toml: str) -> str | None:
@@ -175,7 +175,7 @@ def check_pyproject_toml(version: str) -> list[str]:
             errors.append(f"{pyproject}: file not found")
             continue
 
-        content = pyproject.read_text()
+        content = pyproject.read_text(encoding="utf-8")
 
         if 'dynamic = ["version"]' not in content:
             errors.append(
@@ -205,7 +205,7 @@ def check_changelog(version: str) -> list[str]:
         errors.append("CHANGELOG.md: file not found")
         return errors
 
-    content = changelog.read_text()
+    content = changelog.read_text(encoding="utf-8")
 
     # Look for ## [X.Y.Z] heading
     pattern = rf"## \[{re.escape(version)}\]"
@@ -234,7 +234,7 @@ def check_notice(version: str) -> list[str]:
         errors.append("NOTICE: file not found")
         return errors
 
-    content = notice.read_text()
+    content = notice.read_text(encoding="utf-8")
     lines = content.splitlines()
 
     # Check internal crate versions
@@ -306,7 +306,7 @@ def check_crate_cargo_tomls(version: str) -> list[str]:
         if not cargo_toml.exists():
             continue
 
-        content = cargo_toml.read_text()
+        content = cargo_toml.read_text(encoding="utf-8")
         crate_name = None
         for line in content.splitlines():
             m = re.match(r'^name\s*=\s*"([^"]+)"', line)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,9 +166,22 @@ jobs:
         run: |
           # Four self-contained distributions since 0.29. Order is irrelevant to
           # the build (no shared object); it matters only at publish time.
+          #
+          # --sdist only for tracker. tensor/codec/image/decoder's build.rs
+          # nested-builds the workspace-excluded edgefirst-tensor-capi via a
+          # `../tensor-capi` relative path (dynamic backend); maturin builds
+          # the wheel FROM the generated sdist whenever --sdist is passed,
+          # and its sdist can never include a sibling outside the crate
+          # directory (`include`/`exclude` patterns reject any `..`), so
+          # `--sdist` against those four always fails with "manifest path
+          # .../tensor-capi/Cargo.toml does not exist". tracker has no such
+          # nested build and is the only one of the five safe to sdist.
+          ARGS="${{ matrix.maturin-args }}"
           for pkg in tensor codec image decoder tracker; do
+            pkg_args="$ARGS"
+            [ "$pkg" != "tracker" ] && pkg_args="${pkg_args//--sdist/}"
             maturin build --release --auditwheel skip -m "crates/python-$pkg/Cargo.toml" \
-              --features abi3-py311 ${{ matrix.maturin-args }}
+              --features abi3-py311 $pkg_args
           done
 
       - name: Build wheels (Python 3.8+ — compatible fallback)
@@ -290,6 +303,17 @@ jobs:
       - name: Add cross-compile target
         if: matrix.rust_target != ''
         run: rustup target add ${{ matrix.rust_target }}
+
+      - name: Install lld (aarch64 runner)
+        # ubuntu-22.04-arm does not ship lld by default, unlike ubuntu-latest
+        # (x86_64) -- recent stable rustc defaults to -fuse-ld=lld on Linux,
+        # so a bare build here fails at link time with "collect2: fatal
+        # error: cannot find 'ld'". test.yml's aarch64 runners already
+        # install it for the same reason (`Install build dependencies`).
+        if: matrix.target == 'aarch64-linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lld
 
       - name: Build the five modular C API libraries
         shell: bash

--- a/crates/python-tracker/Cargo.toml
+++ b/crates/python-tracker/Cargo.toml
@@ -18,6 +18,18 @@ crate-type = ["cdylib"]
 default = []
 abi3-py38 = ["pyo3/abi3-py38", "edgefirst-python-common/abi3-py38"]
 abi3-py311 = ["pyo3/abi3-py311", "edgefirst-python-common/abi3-py311"]
+# No-op stubs, unlike the real forwards on edgefirst-tracker/-image/-decoder/
+# -codec and python-common: this crate's `tracker` feature on
+# edgefirst-python-common never enables edgefirst-tensor (tracker consumes
+# plain boxes, so `_tracker.so` carries no DT_NEEDED on libedgefirst_tensor),
+# so there is no static/dynamic backend or tensor tracing to forward to.
+# Declared anyway so the Makefile's `venv-static`/`venv-dynamic` (G13, the
+# differential gate) and `wheel`/`build-python` loops, which pass the same
+# `--features` uniformly across every crate in PYTHON_CRATES, don't hard-error
+# with "does not contain these features" on this one.
+tracing = []
+static = []
+dynamic = []
 
 [dependencies]
 edgefirst-python-common = { path = "../python-common", default-features = false, features = ["tracker"] }

--- a/scripts/smoke-capi-archive.sh
+++ b/scripts/smoke-capi-archive.sh
@@ -16,6 +16,38 @@ set -euo pipefail
 ARCHIVE="${1:?usage: $0 <archive.tar.gz|archive.zip>}"
 CC="${CC:-cc}"
 
+# macos-latest is an Apple Silicon (arm64) runner, but this script also
+# smokes the x86_64-macos archive (cross-compiled via `--target
+# x86_64-apple-darwin`, a genuine x86_64 .dylib). Left to its host default,
+# `cc` compiles the smoke test itself for arm64, and linking an arm64 stub
+# against an x86_64 .dylib silently "ignores" it (a warning, not an error --
+# the trivial per-leaf stubs below call nothing, so nothing forces a real
+# link) right up until the INSTALL.txt example, which calls real functions
+# and fails hard with "Undefined symbols for architecture arm64". The
+# archive name carries the target triple, so pick the matching `-arch`
+# rather than trusting the host default.
+CC_ARCH_FLAGS=()
+CROSS_ARCH=0
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  host_arch="$(uname -m)"
+  case "${ARCHIVE}" in
+    *x86_64-macos*) CC_ARCH_FLAGS=(-arch x86_64); [[ "${host_arch}" != "x86_64" ]] && CROSS_ARCH=1 ;;
+    *aarch64-macos*) CC_ARCH_FLAGS=(-arch arm64); [[ "${host_arch}" != "arm64" ]] && CROSS_ARCH=1 ;;
+  esac
+fi
+# When cross-arch, only compile+link (still proves the header/.pc/SONAME
+# contract this script exists to check) -- do not assume Rosetta (or an
+# aarch64 emulator) is installed on the runner to actually EXECUTE a
+# foreign-arch binary; that risks trading this failure for an unrelated
+# "Bad CPU type in executable" one.
+run_bin() {
+  if [[ "${CROSS_ARCH}" -eq 1 ]]; then
+    echo "  (skipping execution: ${CC_ARCH_FLAGS[*]} binary, host is $(uname -m) -- compiled+linked only)"
+    return 0
+  fi
+  "$1"
+}
+
 if [[ ! -f "${ARCHIVE}" ]]; then
   echo "FAIL: ${ARCHIVE} not found" >&2
   exit 1
@@ -54,12 +86,12 @@ for leaf in tensor image codec decoder tracker; do
   bin="${WORKDIR}/${leaf}.bin"
   printf '#include <edgefirst/%s.h>\nint main(void){return 0;}\n' "${leaf}" > "${src}"
   # shellcheck disable=SC2046
-  if ! "${CC}" -std=c11 -Wall -Wextra -Werror -o "${bin}" "${src}" \
+  if ! "${CC}" -std=c11 -Wall -Wextra -Werror "${CC_ARCH_FLAGS[@]}" -o "${bin}" "${src}" \
       $(pkg-config --cflags --libs "edgefirst-${leaf}"); then
     echo "FAIL: compile ${leaf} via pkg-config" >&2
     exit 1
   fi
-  if ! "${bin}"; then
+  if ! run_bin "${bin}"; then
     echo "FAIL: run ${leaf} (compile succeeded, load/execute failed)" >&2
     exit 1
   fi
@@ -98,7 +130,7 @@ if ! grep -q 'ef_tensor_image_alloc' "${example_c}"; then
 fi
 example_bin="${WORKDIR}/install_example.bin"
 # shellcheck disable=SC2046
-if ! "${CC}" -std=c11 -Wall -Wextra -Werror -o "${example_bin}" "${example_c}" \
+if ! "${CC}" -std=c11 -Wall -Wextra -Werror "${CC_ARCH_FLAGS[@]}" -o "${example_bin}" "${example_c}" \
     $(pkg-config --cflags --libs edgefirst-codec); then
   echo "FAIL: INSTALL.txt example does not compile" >&2
   exit 1

--- a/tests/packaging/test_dependency_isolation.py
+++ b/tests/packaging/test_dependency_isolation.py
@@ -220,15 +220,37 @@ def _embedded_sibling_c_libs(so: Path) -> list[str]:
     return [lib for lib in SIBLING_C_LIBS if _library_named(text, lib)]
 
 
+def _tensor_backend_is_dynamic() -> bool:
+    """Whether the installed edgefirst-tensor wheel links libedgefirst_tensor
+    (the `dynamic` backend) rather than embedding the implementation
+    (`static`) -- measured off the actual installed wheel, not assumed.
+
+    Every real release ships `dynamic` (each python-* crate's own default),
+    but G13 (the differential gate, `make test-differential`) deliberately
+    installs a genuine `static` build in one of its two comparison venvs, so
+    this test cannot assume the backend it is running against.
+    """
+    return _links_libedgefirst_tensor(_wheel_extension("tensor"))
+
+
 @pytest.mark.parametrize("leaf", ["tensor", "codec", "image", "decoder"])
 def test_python_wheel_dt_needed_libedgefirst_tensor(leaf):
-    """Four wheels dynamically link libedgefirst_tensor; they must not
-    embed a sibling C library (G12).
+    """Under a `dynamic` tensor backend, these four wheels link
+    libedgefirst_tensor; under `static` none of them do (the implementation
+    is embedded instead). Either way they must not embed a sibling C
+    library (G12).
     """
     so = _wheel_extension(leaf)
-    assert _links_libedgefirst_tensor(so), (
-        f"{so} has no DT_NEEDED/otool entry for libedgefirst_tensor"
-    )
+    dynamic = _tensor_backend_is_dynamic()
+    if dynamic:
+        assert _links_libedgefirst_tensor(so), (
+            f"{so} has no DT_NEEDED/otool entry for libedgefirst_tensor"
+        )
+    else:
+        assert not _links_libedgefirst_tensor(so), (
+            f"{so} links libedgefirst_tensor under a static tensor backend; "
+            "a static build must embed the implementation, not DT_NEEDED it"
+        )
     siblings = _embedded_sibling_c_libs(so)
     assert not siblings, (
         f"{so} dynamically links sibling C libraries {siblings}; "


### PR DESCRIPTION
## Summary

The v0.29.0 tag push (first real end-to-end run of `release.yml` since the modular five-library split) failed in four places, plus `differential.yml` (G13, nightly) has been red since 2026-08-28. All five are fixed and verified here.

**release.yml:**
- `Build wheels (x86_64-linux)`: `--sdist` made maturin build the wheel FROM a generated sdist, which can never include `tensor-capi` (workspace-excluded, reached only via a `../tensor-capi` `build.rs` relative path — maturin's `include` patterns reject any `..`). Only `tracker` has no such nested build, so `--sdist` is now passed for `tracker` alone.
- `Build modular C API (aarch64-linux)`: `ubuntu-22.04-arm` has no `lld` by default and current stable rustc defaults to `-fuse-ld=lld` on Linux, failing with "cannot find 'ld'". `test.yml`'s aarch64 runners already install it for the same reason; `release.yml`'s `build-capi` job now does too.
- `Build modular C API (x86_64-windows)`: `verify_version.py`'s `read_text()` calls had no explicit encoding, defaulting to the Windows runner's cp1252 locale; CHANGELOG.md's non-ASCII bytes broke mid-decode.
- `Build modular C API (x86_64-macos)`: `macos-latest` is now an Apple Silicon runner. `smoke-capi-archive.sh` compiled its own test stubs for the host's default arm64 while smoking a cross-compiled x86_64-macos archive, so linking against the archive's real x86_64 dylib failed. The script now matches `-arch` to the archive's target triple, and skips executing a cross-arch binary rather than assume Rosetta is installed.

**differential.yml (G13):** `crates/python-tracker/Cargo.toml` never gained the `static`/`dynamic`/`tracing` forwarding features its four sibling Python crates have, so the Makefile's uniform `--features static,tracing` build across every `PYTHON_CRATES` entry hard-errored on it. Fixed with no-op stubs (tracker's Python binding never links tensor). That uncovered a second bug: `test_python_wheel_dt_needed_libedgefirst_tensor` unconditionally asserted DT_NEEDED on `libedgefirst_tensor`, true only for a dynamic backend; G13's static-backend venv is a genuine static build and would diverge on every future run. The assertion now branches on the actual installed backend.

## Test plan
- [x] `make format lint` clean
- [x] Reproduced and fixed the x86_64-linux wheel failure locally (`maturin build --sdist` against each of the five `python-*` crates)
- [x] Reproduced and fixed the Windows `verify_version.py` UnicodeDecodeError locally (forced non-UTF8 default)
- [x] `scripts/smoke-capi-archive.sh` re-tested end to end on the x86_64-linux archive (no regression on the non-Darwin path)
- [x] `make test-differential` (G13) passes 0/391 divergences after both tracker fixes
- [ ] CI on this PR

Not tied to the v0.29.0 tag — that tag stays as-is; the next release will pick these fixes up.