### PR TITLE
Fix aarch64 wheel build: install lld on ubuntu-22.04-arm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,20 @@ jobs:
       - name: Install maturin
         run: pip install ${{ matrix.maturin-deps }}
 
+      - name: Install lld (aarch64 runner)
+        # ubuntu-22.04-arm does not ship lld by default, unlike ubuntu-latest
+        # (x86_64) -- recent stable rustc defaults to -fuse-ld=lld on Linux.
+        # tensor/codec/image/decoder's build.rs nested-builds the
+        # workspace-excluded edgefirst-tensor-capi via a plain `cargo build`
+        # (not routed through maturin's --zig cross-compiler), so it links
+        # natively and hits the same "collect2: fatal error: cannot find
+        # 'ld'" the build-capi job's aarch64 runner hit -- see that job's
+        # identically-named step, and test.yml's aarch64 lane.
+        if: matrix.name == 'aarch64-linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lld
+
       - name: Fetch ANGLE (Windows x64)
         # The Windows edgefirst-image wheel bundles ANGLE's libEGL.dll +
         # libGLESv2.dll next to _image.pyd (python-image/build.rs reads


### PR DESCRIPTION
## Summary

The `v0.29.1` tag push failed release.yml the same way `v0.29.0` did. PR #151/#154 fixed the missing-`lld` link failure on the `build-capi` job's `aarch64-linux` runner (`ubuntu-22.04-arm`), but missed that the `build-wheels` job's `aarch64-linux` entry runs on the *same* runner type and hits the identical `collect2: fatal error: cannot find 'ld'` failure — it goes through `python-tensor`'s `build.rs`, which nested-builds the workspace-excluded `edgefirst-tensor-capi` crate via a plain `cargo build` (not routed through maturin's `--zig` cross-compiler), so it links natively against the host and needs `lld` just like the other job did.

Nothing published under the `v0.29.1` tag: the other three `build-wheels` matrix entries were cancelled when `aarch64-linux` failed, and every publish job downstream was skipped. Safe to fix and retry under a new tag.

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Confirmed via the failed run log that this is the same root cause as the already-fixed `build-capi` job, and that `build-wheels`'s `aarch64-linux` entry (`runner: ubuntu-22.04-arm`) was the only aarch64 runner in the file left unpatched
- [ ] CI on this PR (can't reproduce the native aarch64 linking issue on x86_64 locally)
- [ ] Tag a new release once merged and confirm release.yml completes end-to-end