### PR TITLE
Restore the plane offset onto reconstructed IOSurface and D3D11 tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,12 +112,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   top-left — a *fresh* `view()` converted the parent's origin on Windows,
   not only a reconstructed one. The Windows leaf now refuses to attach a
   source carrying a plane offset and the engine uploads it through `map()`,
-  which honours the offset. Because a texture tensor's offset is measured in
-  a staging pitch the consumer's driver may not share, `apply_plane_offset`
-  re-expresses it row by row from the descriptor's stride to the local pitch.
-  Pinned by seven `d3d11` tests in `crates/tensor/tests/d3d11_tensor.rs` and
-  the Windows arm of `crates/image/tests/reconstructed_view_convert.rs`, on
-  the Windows CI lanes.
+  which honours the offset. A *destination* rebuilt from a descriptor has the
+  same problem from the other side: it carries the offset but not the
+  `view_origin` a `view()` would have given it, so the engine has no viewport
+  to place it by and the render would land at the texture's origin. The
+  engine now asks the platform whether a zero-copy destination import can
+  place the tensor (`GlPlatform::dst_import_places`), and lowers one it
+  cannot to the mapped texture path, whose readback writes through `map()`
+  at the offset. A single-row window keeps `view()`'s tight row stride when
+  a descriptor narrows it (`Tensor::set_logical_shape`), so it maps in the
+  texture's last row, and the offset is applied as the producer measured it:
+  the consumer opens the same texture on the same adapter, so its staging
+  pitch is the same, and the descriptor's stride is not a pitch to translate
+  it by. Pinned by eight `d3d11` tests in
+  `crates/tensor/tests/d3d11_tensor.rs` and the Windows arm of
+  `crates/image/tests/reconstructed_view_convert.rs`, on the Windows CI
+  lanes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,12 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   past the sub-region a second time. Both directions are covered by
   `test_view_converts_its_own_sub_region_not_the_parents_origin`.
 
-  **Fixed on Linux DMA-BUF and on IOSurface (macOS/iOS); D3D11 (Windows)
-  still needs the same treatment.** `Tensor::set_plane_offset` now syncs the
-  storage-internal offset for `Mem`, Linux `Dma` and Apple `Dma`, so a
-  reconstructed IOSurface view addresses its own sub-region rather than the
-  parent surface's origin. `MEM`/`SHM` were never affected (they take the
-  pinned-pointer path), Android fails the import outright rather than
+  **Fixed on Linux DMA-BUF, on IOSurface (macOS/iOS) and on D3D11
+  (Windows).** `Tensor::set_plane_offset` now syncs the storage-internal
+  offset for `Mem`, Linux `Dma`, Apple `Dma` and Windows `Dma`, so a
+  reconstructed IOSurface or D3D11 view addresses its own sub-region rather
+  than the parent buffer's origin. `MEM`/`SHM` were never affected (they take
+  the pinned-pointer path), Android fails the import outright rather than
   reconstructing, and a PBO image's `view()` comes back as host memory so it
   never reaches the PBO arm. See `interop::apply_plane_offset`'s doc comment
   for the per-backing accounting.
@@ -95,6 +95,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `set_format_clears_the_iosurface_map_window` for the clear — all on the
   macOS CI lane, which runs the Rust suite the Python interop tests cannot
   reach there.
+
+  The D3D11 half had a different shape, and needed three parts. A view's
+  descriptor was not reconstructed at the wrong origin, it was *refused*: the
+  `D3D11_TEXTURE` import checks the descriptor's shape against the texture's
+  own geometry, and a window is neither of the two spellings it accepted. The
+  import now takes a packed window as a third spelling, opens the whole
+  texture and narrows it to the window, with `Tensor::set_logical_shape`
+  keeping the texture's pitch as the row stride while it does. The storage
+  arms then follow the IOSurface pair — plus one at `reshape`'s clear site,
+  because `D3d11TextureTensor::reshape` does not zero its own offset — and
+  the pins refuse an offset past the backing rather than trusting a
+  descriptor's value. Last, and the part no `map()` test could see: the ANGLE
+  D3D11 import binds the whole texture from its origin and cannot express an
+  offset, so the GL engine sampled every offset *source* from the texture's
+  top-left — a *fresh* `view()` converted the parent's origin on Windows,
+  not only a reconstructed one. The Windows leaf now refuses to attach a
+  source carrying a plane offset and the engine uploads it through `map()`,
+  which honours the offset. Because a texture tensor's offset is measured in
+  a staging pitch the consumer's driver may not share, `apply_plane_offset`
+  re-expresses it row by row from the descriptor's stride to the local pitch.
+  Pinned by seven `d3d11` tests in `crates/tensor/tests/d3d11_tensor.rs` and
+  the Windows arm of `crates/image/tests/reconstructed_view_convert.rs`, on
+  the Windows CI lanes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,15 +64,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   past the sub-region a second time. Both directions are covered by
   `test_view_converts_its_own_sub_region_not_the_parents_origin`.
 
-  **Fixed on Linux DMA-BUF; IOSurface (macOS/iOS) and D3D11 (Windows) still
-  need the same treatment.** `Tensor::set_plane_offset` only syncs the
-  storage-internal offset for `Mem` and Linux `Dma`, so on those two a
-  reconstructed view still lands at the parent's origin. `MEM`/`SHM` were
-  never affected (they take the pinned-pointer path), Android fails the
-  import outright rather than reconstructing, and a PBO image's `view()`
-  comes back as host memory so it never reaches the PBO arm. See
-  `interop::apply_plane_offset`'s doc comment for the per-backing
-  accounting.
+  **Fixed on Linux DMA-BUF and on IOSurface (macOS/iOS); D3D11 (Windows)
+  still needs the same treatment.** `Tensor::set_plane_offset` now syncs the
+  storage-internal offset for `Mem`, Linux `Dma` and Apple `Dma`, so a
+  reconstructed IOSurface view addresses its own sub-region rather than the
+  parent surface's origin. `MEM`/`SHM` were never affected (they take the
+  pinned-pointer path), Android fails the import outright rather than
+  reconstructing, and a PBO image's `view()` comes back as host memory so it
+  never reaches the PBO arm. See `interop::apply_plane_offset`'s doc comment
+  for the per-backing accounting.
+
+  The IOSurface half was easy to miss because `IoSurfaceTensor::view` always
+  set its own `view_offset` correctly — a *freshly created* view was right on
+  every platform, and only restoring an offset onto a tensor rebuilt from a
+  `TensorDesc` was broken. `TensorStorage::Dma` compounds that: it is a
+  cfg-multiplexed *name* rather than one type, so the `cfg(target_os =
+  "linux")` arm did not fail to compile elsewhere, it silently became a
+  fall-through.
+
+  The fix is a set/clear pair, not a single arm: `set_format` drops the
+  offset when the format changes, through the same Linux-gated match, so
+  making only the setter take effect would have left `plane_offset()`
+  reporting `None` while `map()` still started at the old offset — trading a
+  lost window for a stale one. (`reshape`'s clear site needed nothing:
+  `IoSurfaceTensor::reshape` zeroes its own `view_offset`.) Three regression
+  tests in `edgefirst-tensor` pin it —
+  `set_plane_offset_moves_the_iosurface_map_window` for the restore,
+  `nested_iosurface_subviews_do_not_compound_their_plane_offset` for the
+  double-apply the restore risks, and
+  `set_format_clears_the_iosurface_map_window` for the clear — all on the
+  macOS CI lane, which runs the Rust suite the Python interop tests cannot
+  reach there.
 
 ### Changed
 

--- a/crates/image/src/gl/platform/angle.rs
+++ b/crates/image/src/gl/platform/angle.rs
@@ -350,6 +350,26 @@ impl GlPlatform for AngleClientBuffer {
     type Import = IoSurfacePbuffer;
     type ImportHandle = egl::Surface;
 
+    /// `EGL_ANGLE_iosurface_client_buffer` binds the whole surface from its
+    /// origin: the pbuffer is described by plane, width and height, and there
+    /// is no byte-offset attribute. A destination that carries a plane offset
+    /// but no `view_origin` -- one rebuilt from a descriptor, since a
+    /// `TensorDesc` transports the offset and not the origin -- therefore has
+    /// nothing to place it by, and attaching it renders the tile at the
+    /// surface's top-left instead of the window that was asked for.
+    ///
+    /// Declining sends the engine down the mapped-texture path, whose
+    /// readback writes through `map()` at the offset. The same rule as
+    /// `AngleD3d11`, for the same reason, and pinned by case D of
+    /// `reconstructed_view_convert.rs`, which fails with the tile at the
+    /// canvas's origin without this.
+    fn dst_import_places<T>(img: &Tensor<T>) -> bool
+    where
+        T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
+    {
+        super::unplaced_destination(img).is_none()
+    }
+
     // eglBindTexImage attachments are released at end_gpu_pass — the
     // engine's binding-skip cache must stay cold on macOS.
     const PERSISTENT_TEX_BINDINGS: bool = false;

--- a/crates/image/src/gl/platform/mod.rs
+++ b/crates/image/src/gl/platform/mod.rs
@@ -218,6 +218,27 @@ pub(super) trait GlPlatform {
         Ok(())
     }
 
+    /// Whether a zero-copy import of `img` as a destination can place the
+    /// render where the tensor's bytes start.
+    ///
+    /// A `view()` destination carries a `view_origin`, and the engine
+    /// imports its parent and lowers the tile to a viewport. A destination
+    /// reconstructed from a descriptor carries only a `plane_offset`: no
+    /// `view_origin` is transported, so the viewport is the surface's origin
+    /// and the import itself has to start at the offset. Linux's DMA-BUF
+    /// import does. A platform whose import always binds the whole buffer
+    /// from its origin returns `false` for such a tensor, and the engine
+    /// lowers it to the mapped texture path, whose readback writes through
+    /// `map()` at the offset.
+    ///
+    /// Default `true`: every import that can express an offset.
+    fn dst_import_places<T>(_img: &Tensor<T>) -> bool
+    where
+        T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
+    {
+        true
+    }
+
     /// Import an NV12/NV16/NV24 tensor's combined semi-planar plane as ONE
     /// R8 buffer (luma + interleaved chroma addressed by the shader — the
     /// "Path B" NV sampling strategy). On Linux a single-plane R8 EGLImage

--- a/crates/image/src/gl/platform/mod.rs
+++ b/crates/image/src/gl/platform/mod.rs
@@ -111,6 +111,30 @@ impl PackedImportFormat {
 /// One implementation per OS, selected by the [`Platform`] alias. Methods
 /// are associated functions (no `&self`) — the platform is stateless; all
 /// state lives in the `Display` it creates.
+/// A destination whose bytes start at a plane offset the engine cannot lower
+/// to a viewport: one rebuilt from a descriptor, which carries the offset but
+/// not the `view_origin` a `view()` would have given it.
+///
+/// Shared by the platforms whose import binds a whole buffer from its origin.
+/// ANGLE over a D3D11 texture and ANGLE over an IOSurface both do, and neither
+/// extension has a byte-offset attribute, so each one's `dst_import_places`
+/// asks the same question of the same two fields. Linux's DMA-BUF import can
+/// express the offset and keeps the default.
+///
+/// Gated to its callers' platforms: `angle` and `windows` are the only
+/// modules that use it, and both are `cfg`-gated, so on Linux and Android it
+/// would be dead code and fail those lanes under `-D warnings`.
+#[cfg(any(target_os = "windows", target_os = "macos", target_os = "ios"))]
+pub(super) fn unplaced_destination<T>(img: &Tensor<T>) -> Option<usize>
+where
+    T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
+{
+    match (img.plane_offset(), img.view_origin()) {
+        (Some(offset), None) if offset != 0 => Some(offset),
+        _ => None,
+    }
+}
+
 pub(super) trait GlPlatform {
     /// Owning handle for the platform's GL/EGL bring-up state: display,
     /// context, capability probes. On Linux this is

--- a/crates/image/src/gl/platform/windows.rs
+++ b/crates/image/src/gl/platform/windows.rs
@@ -851,25 +851,11 @@ where
     }
 }
 
-/// A destination whose bytes start at a plane offset the engine cannot lower
-/// to a viewport: one rebuilt from a descriptor, which carries the offset
-/// but not the `view_origin` a `view()` would have given it. Imported, it
-/// would be rendered at the texture's origin.
-fn unplaced_destination<T>(img: &Tensor<T>) -> Option<usize>
-where
-    T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
-{
-    match (img.plane_offset(), img.view_origin()) {
-        (Some(offset), None) if offset != 0 => Some(offset),
-        _ => None,
-    }
-}
-
 fn refuse_unplaced_destination<T>(img: &Tensor<T>) -> Result<()>
 where
     T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
 {
-    match unplaced_destination(img) {
+    match super::unplaced_destination(img) {
         None => Ok(()),
         Some(offset) => Err(Error::NotSupported(format!(
             "GL convert: destination starts {offset} bytes into its D3D11 texture \
@@ -1010,7 +996,7 @@ impl GlPlatform for AngleD3d11 {
     where
         T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
     {
-        unplaced_destination(img).is_none()
+        super::unplaced_destination(img).is_none()
     }
 
     fn validate_import_identity<T>(img: &Tensor<T>, what: &str) -> Result<()>

--- a/crates/image/src/gl/platform/windows.rs
+++ b/crates/image/src/gl/platform/windows.rs
@@ -827,6 +827,30 @@ fn check_identity_names_texture(
 /// the parent texture it imports. The check is skipped when the table has no
 /// entry for `fmt` at these dimensions (a packed-RGB view whose width breaks
 /// the 4-byte texel packing), which says nothing about the texture.
+/// Refuses to import a source whose pixels do not start at the texture's
+/// origin.
+///
+/// The image ANGLE creates over an `ID3D11Texture2D` covers the whole
+/// texture and carries no offset, and the engine samples a source from the
+/// origin of its import. A `view()` (or a whole tensor at a foreign offset)
+/// attached that way would convert the parent's top-left tile in place of
+/// the region it names -- silently. Declining here sends the engine down its
+/// upload path, whose `map()` starts at the offset. Issue #161's Windows
+/// half at the convert level.
+fn refuse_offset_source<T>(img: &Tensor<T>, what: &str) -> Result<()>
+where
+    T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
+{
+    match img.plane_offset() {
+        None | Some(0) => Ok(()),
+        Some(offset) => Err(Error::NotSupported(format!(
+            "GL convert: {what} starts {offset} bytes into its D3D11 texture, and \
+             EGL_ANGLE_image_d3d11_texture can only bind the whole texture from its \
+             origin; uploading the window instead"
+        ))),
+    }
+}
+
 fn check_dxgi_format<T>(
     layout: &edgefirst_tensor::d3d11_layout::D3d11ImageLayout,
     img: &Tensor<T>,
@@ -965,7 +989,7 @@ impl GlPlatform for AngleD3d11 {
         display: &D3d11Display,
         img: &Tensor<u8>,
         fmt: PixelFormat,
-        _for_dst: bool,
+        for_dst: bool,
     ) -> Result<D3d11EglImage> {
         // `EGL_ANGLE_image_d3d11_texture` has no sub-extent attribute, so
         // the image always covers the whole texture. That is what a
@@ -974,17 +998,23 @@ impl GlPlatform for AngleD3d11 {
         // no branch here. A source whose logical image is smaller than its
         // texture -- a pool buffer narrowed by `configure_image` -- is
         // sampled through the extent reported by `import_extent`, which the
-        // engine folds into the source rectangle.
+        // engine folds into the source rectangle from the texture's origin.
+        // A source whose pixels start elsewhere -- a `view()`, or a tensor
+        // carrying a plane offset -- therefore cannot be attached at all, and
+        // is refused so the engine uploads it through `map()`, which honours
+        // the offset.
         //
-        // `for_dst` is unused for the same reason there is no bind-flag
-        // refusal here: the tensor crate's layout ABI is frozen and carries
-        // no bind flags, so this leaf cannot ask whether an externally
-        // wrapped texture was created with `D3D11_BIND_RENDER_TARGET`. Such
-        // a texture is imported and attached, and rejected at
-        // `CheckFramebufferStatus`, which falls the frame back to the CPU
-        // converter -- correct, at the cost of one `eglCreateImage` and one
-        // FBO probe per frame. Textures the HAL allocates always carry the
-        // flag.
+        // There is no bind-flag refusal here: the tensor crate's layout ABI
+        // is frozen and carries no bind flags, so this leaf cannot ask
+        // whether an externally wrapped texture was created with
+        // `D3D11_BIND_RENDER_TARGET`. Such a texture is imported and
+        // attached, and rejected at `CheckFramebufferStatus`, which falls
+        // the frame back to the CPU converter -- correct, at the cost of one
+        // `eglCreateImage` and one FBO probe per frame. Textures the HAL
+        // allocates always carry the flag.
+        if !for_dst {
+            refuse_offset_source(img, "source")?;
+        }
         let (texture, layout) = texture_of(img, "source/destination")?;
         check_dxgi_format(&layout, img, fmt)?;
         import_texture(display, texture, &layout, "image")
@@ -995,6 +1025,7 @@ impl GlPlatform for AngleD3d11 {
         img: &Tensor<u8>,
         _fmt: PixelFormat,
     ) -> Result<D3d11EglImage> {
+        refuse_offset_source(img, "NV source")?;
         let (texture, layout) = texture_of(img, "NV source")?;
         // The HAL's own semi-planar allocations are always R8, and so is any
         // externally wrapped one the tensor crate accepted. That acceptance

--- a/crates/image/src/gl/platform/windows.rs
+++ b/crates/image/src/gl/platform/windows.rs
@@ -851,6 +851,35 @@ where
     }
 }
 
+/// A destination whose bytes start at a plane offset the engine cannot lower
+/// to a viewport: one rebuilt from a descriptor, which carries the offset
+/// but not the `view_origin` a `view()` would have given it. Imported, it
+/// would be rendered at the texture's origin.
+fn unplaced_destination<T>(img: &Tensor<T>) -> Option<usize>
+where
+    T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
+{
+    match (img.plane_offset(), img.view_origin()) {
+        (Some(offset), None) if offset != 0 => Some(offset),
+        _ => None,
+    }
+}
+
+fn refuse_unplaced_destination<T>(img: &Tensor<T>) -> Result<()>
+where
+    T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
+{
+    match unplaced_destination(img) {
+        None => Ok(()),
+        Some(offset) => Err(Error::NotSupported(format!(
+            "GL convert: destination starts {offset} bytes into its D3D11 texture \
+             with no view origin to place it by, and EGL_ANGLE_image_d3d11_texture \
+             can only bind the whole texture from its origin; rendering to a \
+             texture and reading back through map() instead"
+        ))),
+    }
+}
+
 fn check_dxgi_format<T>(
     layout: &edgefirst_tensor::d3d11_layout::D3d11ImageLayout,
     img: &Tensor<T>,
@@ -974,6 +1003,16 @@ impl GlPlatform for AngleD3d11 {
     ///
     /// A tensor with no texture is not this check's business: the import
     /// functions refuse it by name, with a message about what it is instead.
+    /// `EGL_ANGLE_image_d3d11_texture` binds the whole texture from its
+    /// origin, so a destination that starts elsewhere is placed only when
+    /// it carries a `view_origin` for the viewport.
+    fn dst_import_places<T>(img: &Tensor<T>) -> bool
+    where
+        T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
+    {
+        unplaced_destination(img).is_none()
+    }
+
     fn validate_import_identity<T>(img: &Tensor<T>, what: &str) -> Result<()>
     where
         T: num_traits::Num + Clone + std::fmt::Debug + Send + Sync + edgefirst_tensor::Element,
@@ -1002,7 +1041,11 @@ impl GlPlatform for AngleD3d11 {
         // A source whose pixels start elsewhere -- a `view()`, or a tensor
         // carrying a plane offset -- therefore cannot be attached at all, and
         // is refused so the engine uploads it through `map()`, which honours
-        // the offset.
+        // the offset. A destination carrying an offset without the
+        // `view_origin` a `view()` would have given it -- one rebuilt from a
+        // descriptor -- has no viewport to place it either, and is refused
+        // for the same reason (`dst_import_places` keeps the engine from
+        // asking, so this is the second line).
         //
         // There is no bind-flag refusal here: the tensor crate's layout ABI
         // is frozen and carries no bind flags, so this leaf cannot ask
@@ -1012,7 +1055,9 @@ impl GlPlatform for AngleD3d11 {
         // the frame back to the CPU converter -- correct, at the cost of one
         // `eglCreateImage` and one FBO probe per frame. Textures the HAL
         // allocates always carry the flag.
-        if !for_dst {
+        if for_dst {
+            refuse_unplaced_destination(img)?;
+        } else {
             refuse_offset_source(img, "source")?;
         }
         let (texture, layout) = texture_of(img, "source/destination")?;

--- a/crates/image/src/gl/processor/float.rs
+++ b/crates/image/src/gl/processor/float.rs
@@ -455,13 +455,16 @@ impl GLProcessorST {
         self.convert_stats.src_uploads += 1;
         tracing::Span::current().record("src_feed", "upload");
         let pixels = src_u8.map_read()?;
+        // Tight RGBA rows: no `UNPACK_ROW_LENGTH` is set on this path, and
+        // `UNPACK_ALIGNMENT` is 1, so GL reads exactly the image.
         self.camera_normal_texture.update_texture(
             edgefirst_gl::gl::TEXTURE_2D,
             src_w,
             src_h,
             edgefirst_gl::gl::RGBA,
+            src_w * src_h * 4,
             &pixels,
-        );
+        )?;
         Ok(FloatSrcFeed::Upload)
     }
 

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -5339,13 +5339,32 @@ impl GLProcessorST {
                     edgefirst_gl::gl::UNPACK_ROW_LENGTH,
                     row_len_px as i32,
                 );
-                self.camera_normal_texture.update_texture(
+                // What GL will read: every row but the last at the stride
+                // `UNPACK_ROW_LENGTH` just set, plus the last row's own
+                // pixels. `UNPACK_ALIGNMENT` is 1, so no row is padded
+                // further.
+                let row_stride_b = if row_len_px == 0 {
+                    src_w * src_bpp
+                } else {
+                    row_len_px * src_bpp
+                };
+                let required = if src_h == 0 {
+                    0
+                } else {
+                    (src_h - 1) * row_stride_b + src_w * src_bpp
+                };
+                let uploaded = self.camera_normal_texture.update_texture(
                     texture_target,
                     src_w,
                     src_h,
                     texture_format,
+                    required,
                     &src.map_read()?,
                 );
+                if uploaded.is_err() {
+                    edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::UNPACK_ROW_LENGTH, 0);
+                }
+                uploaded?;
                 edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::UNPACK_ROW_LENGTH, 0);
             }
 

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -2773,8 +2773,20 @@ impl GLProcessorST {
         dst_fmt: PixelFormat,
         crop: ResolvedCrop,
     ) -> crate::Result<DstTarget> {
+        // A zero-copy destination the platform cannot place -- one carrying a
+        // plane offset with no `view_origin` to lower to a viewport -- takes
+        // the mapped texture path, whose readback writes through `map()` at
+        // the offset.
+        let places = Platform::dst_import_places(dst);
+        if !places {
+            log::debug!(
+                "bind_dst: zero-copy destination at plane offset {} has no view \
+                 origin; rendering to a texture and reading back through map()",
+                dst.plane_offset().unwrap_or(0)
+            );
+        }
         match super::render::lower_dst(
-            self.gl_context.transfer_backend.is_zero_copy(),
+            self.gl_context.transfer_backend.is_zero_copy() && places,
             dst.memory(),
         ) {
             super::render::DstLowering::ZeroCopy => {

--- a/crates/image/src/gl/resources.rs
+++ b/crates/image/src/gl/resources.rs
@@ -39,14 +39,38 @@ impl Texture {
         }
     }
 
+    /// Upload `data` as this texture's contents.
+    ///
+    /// `required` is how many bytes GL will read: `(height - 1)` row strides
+    /// plus the last row's own pixels, where the stride is whatever
+    /// `UNPACK_ROW_LENGTH` the caller has set (`UNPACK_ALIGNMENT` is 1 from
+    /// `new`, so rows carry no extra padding). GL reads through a raw
+    /// pointer and cannot see the slice's length, so a `data` shorter than
+    /// that would have the driver read past the mapping -- which is not a
+    /// hypothetical: a tensor's map is clamped to what its window actually
+    /// covers (`HostView::len_elems`), so a plane offset restored from an
+    /// untrusted descriptor shortens the map while width and height stay
+    /// whole. Refusing here turns that into a fallback to the CPU converter
+    /// instead of an out-of-bounds read. See
+    /// `crates/tensor/src/d3d11/texture.rs::check_view_offset` and
+    /// `IoSurfaceTensor::check_view_offset`, which refuse the same window at
+    /// the source; this is the check that does not depend on which backing
+    /// produced the map.
     pub(super) fn update_texture(
         &mut self,
         target: edgefirst_gl::gl::types::GLenum,
         width: usize,
         height: usize,
         format: edgefirst_gl::gl::types::GLenum,
+        required: usize,
         data: &[u8],
-    ) {
+    ) -> crate::Result<()> {
+        if data.len() < required {
+            return Err(crate::Error::NotSupported(format!(
+                "GL upload: {width}x{height} texture needs {required} B but the                  source maps only {} B -- a window that does not cover its own                  image (a restored plane offset past the buffer?); converting                  on the CPU instead",
+                data.len()
+            )));
+        }
         if target != self.target
             || width != self.width
             || height != self.height
@@ -86,6 +110,7 @@ impl Texture {
                 );
             }
         }
+        Ok(())
     }
 
     /// Attach a platform import to this GL_TEXTURE_2D texture if the key

--- a/crates/image/tests/reconstructed_view_convert.rs
+++ b/crates/image/tests/reconstructed_view_convert.rs
@@ -29,8 +29,16 @@
 //!   the offset without `view()` having been involved at all.
 //!
 //! **`TensorMemory::DmaBuf` is the portable spelling of "platform zero-copy
-//! buffer"** — DMA-BUF on Linux, IOSurface on macOS — so this runs on both
-//! without a cfg, and skips where no such buffer can be allocated.
+//! buffer"** — DMA-BUF on Linux, IOSurface on macOS, a D3D11 texture on
+//! Windows — so this runs on all three without a cfg on the control, and
+//! skips where no such buffer can be allocated.
+//!
+//! On Windows the reconstructed cases go through the descriptor itself
+//! (`import_descriptor`, which now accepts a window of the texture), and the
+//! control is not a formality: the ANGLE D3D11 import binds the whole
+//! texture from its origin, so before the GL leaf refused to attach a source
+//! carrying a plane offset, a *fresh* `view()` converted the parent's origin
+//! on the GL path too.
 //!
 //! **RGBA, not RGB, and that is load-bearing on macOS.** An RGB IOSurface
 //! has no zero-copy GL mapping, so an RGB source silently converts on the
@@ -116,7 +124,23 @@ fn assert_tile(label: &str, out: &[u8]) {
 
 #[test]
 fn reconstructed_view_converts_its_own_sub_region_not_the_parents_origin() {
-    let src = match TensorDyn::new(&[H, W, BPP], DType::U8, Some(TensorMemory::DmaBuf), None) {
+    // A D3D11 texture is only ever allocated through the image constructor
+    // (`TensorDyn::new` with `DmaBuf` refuses by name on Windows), which
+    // sets the format itself; the byte-bag spelling stays for the others so
+    // the surface they get is the one the fix was verified on.
+    #[cfg(target_os = "windows")]
+    let alloc = TensorDyn::image(
+        W,
+        H,
+        PixelFormat::Rgba,
+        DType::U8,
+        Some(TensorMemory::DmaBuf),
+        CpuAccess::ReadWrite,
+    );
+    #[cfg(not(target_os = "windows"))]
+    let alloc = TensorDyn::new(&[H, W, BPP], DType::U8, Some(TensorMemory::DmaBuf), None)
+        .and_then(|t| t.with_format(PixelFormat::Rgba));
+    let src = match alloc {
         Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
         Ok(t) => {
             skip(&format!("zero-copy request fell back to {:?}", t.memory()));
@@ -127,13 +151,14 @@ fn reconstructed_view_converts_its_own_sub_region_not_the_parents_origin() {
             return;
         }
     };
-    let src = src.with_format(PixelFormat::Rgba).expect("source format");
+    // Rows at the allocation's own pitch: a texture's driver may pad them.
+    let pitch = src.effective_row_stride().unwrap_or(W * BPP);
     {
         let mut m = src.map_bytes(CpuAccess::Write).expect("map source");
         let s = m.as_mut_slice();
         for y in 0..H {
             for x in 0..W {
-                s[(y * W + x) * BPP..][..BPP].copy_from_slice(&want(x, y));
+                s[y * pitch + x * BPP..][..BPP].copy_from_slice(&want(x, y));
             }
         }
     }
@@ -193,6 +218,66 @@ fn reconstructed_view_converts_its_own_sub_region_not_the_parents_origin() {
             .expect("reconstruct whole image");
         whole.set_format(PixelFormat::Rgba).expect("whole format");
         whole.set_plane_offset(W * BPP);
+
+        let mut dst_c = TensorDyn::new(&[H - 1, W, BPP], DType::U8, Some(TensorMemory::Mem), None)
+            .expect("dst_c alloc")
+            .with_format(PixelFormat::Rgba)
+            .expect("dst_c format");
+        proc.convert(
+            &whole,
+            &mut dst_c,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("convert whole image at a foreign offset");
+        let out = read_all(&dst_c);
+        assert_eq!(
+            &out[..BPP],
+            &want(0, 1),
+            "a whole image at a one-row offset must start at parent row 1, \
+             not row 0 (issue #161)"
+        );
+    }
+
+    // B and C on Windows, spelled through the descriptor itself: a D3D11
+    // texture is imported from its NT handle, which names the whole texture,
+    // and `import_descriptor` narrows it to the descriptor's window. The
+    // offset is put back the way `interop::apply_plane_offset` puts it back.
+    #[cfg(target_os = "windows")]
+    {
+        let mut rebuilt = TensorDyn::import_descriptor(&fresh.descriptor_pinned(None))
+            .expect("reconstruct the view from its descriptor");
+        assert_eq!(
+            rebuilt.shape(),
+            &[SIDE, SIDE, BPP],
+            "imported at the window's shape"
+        );
+        assert_eq!(
+            rebuilt.effective_row_stride(),
+            Some(pitch),
+            "a narrowed import keeps the texture's pitch"
+        );
+        rebuilt.set_plane_offset(fresh.plane_offset().expect("a view carries its offset"));
+
+        let mut dst_b = dst();
+        proc.convert(
+            &rebuilt,
+            &mut dst_b,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("convert reconstructed view");
+        assert_tile("reconstructed view", &read_all(&dst_b));
+
+        // C -- the whole texture narrowed by one row and offset by one row.
+        let mut whole = TensorDyn::import_descriptor(&src.descriptor_pinned(None))
+            .expect("reconstruct whole image");
+        whole
+            .set_logical_shape(&[H - 1, W, BPP])
+            .expect("narrow by one row");
+        whole.set_plane_offset(pitch);
 
         let mut dst_c = TensorDyn::new(&[H - 1, W, BPP], DType::U8, Some(TensorMemory::Mem), None)
             .expect("dst_c alloc")

--- a/crates/image/tests/reconstructed_view_convert.rs
+++ b/crates/image/tests/reconstructed_view_convert.rs
@@ -298,5 +298,88 @@ fn reconstructed_view_converts_its_own_sub_region_not_the_parents_origin() {
             "a whole image at a one-row offset must start at parent row 1, \
              not row 0 (issue #161)"
         );
+
+        // D -- a one-row view. Its descriptor carries the tight stride
+        // `view()` records for a single row, while its offset is measured in
+        // the texture's pitch; the round trip must not confuse the two.
+        let row = src
+            .view(Region::new(X0, Y0, SIDE, 1))
+            .expect("one-row view");
+        let mut rebuilt_row = TensorDyn::import_descriptor(&row.descriptor_pinned(None))
+            .expect("reconstruct the one-row view from its descriptor");
+        rebuilt_row.set_plane_offset(row.plane_offset().expect("a view carries its offset"));
+        let mut dst_d = TensorDyn::new(&[1, SIDE, BPP], DType::U8, Some(TensorMemory::Mem), None)
+            .expect("dst_d alloc")
+            .with_format(PixelFormat::Rgba)
+            .expect("dst_d format");
+        proc.convert(
+            &rebuilt_row,
+            &mut dst_d,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("convert one-row reconstructed view");
+        let expected_row: Vec<u8> = (X0..X0 + SIDE).flat_map(|x| want(x, Y0)).collect();
+        assert_eq!(
+            read_all(&dst_d),
+            expected_row,
+            "a one-row reconstructed view must read parent row {Y0} from \
+             column {X0} (issue #161)"
+        );
+
+        // E -- the destination side. A destination window rebuilt from a
+        // descriptor has the offset but not the `view_origin` a fresh view()
+        // has, so the engine has no viewport to place it by; the ANGLE
+        // import binds the whole texture from its origin, and before the
+        // engine lowered such a destination to the mapped texture path the
+        // tile landed at the canvas's top-left.
+        const BLANK: u8 = 0x55;
+        let canvas = TensorDyn::image(
+            W,
+            H,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::DmaBuf),
+            CpuAccess::ReadWrite,
+        )
+        .expect("canvas alloc");
+        {
+            let mut m = canvas.map_bytes(CpuAccess::Write).expect("map canvas");
+            m.as_mut_slice().fill(BLANK);
+        }
+        let fresh_dst = canvas
+            .view(Region::new(X0, Y0, SIDE, SIDE))
+            .expect("fresh destination view");
+        let mut rebuilt_dst = TensorDyn::import_descriptor(&fresh_dst.descriptor_pinned(None))
+            .expect("reconstruct the destination view from its descriptor");
+        rebuilt_dst.set_plane_offset(fresh_dst.plane_offset().expect("a view carries its offset"));
+        proc.convert(
+            &fresh,
+            &mut rebuilt_dst,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("convert into a reconstructed destination view");
+        let out = read_all(&canvas);
+        let px = |x: usize, y: usize| &out[y * pitch + x * BPP..][..BPP];
+        assert_eq!(
+            px(0, 0),
+            &[BLANK; BPP],
+            "a reconstructed destination view wrote the canvas's ORIGIN, i.e. \
+             the plane offset was lost (issue #161)"
+        );
+        assert_eq!(
+            px(X0 - 1, Y0),
+            &[BLANK; BPP],
+            "left of the window untouched"
+        );
+        assert_eq!(px(X0, Y0 - 1), &[BLANK; BPP], "above the window untouched");
+        for y in Y0..Y0 + SIDE {
+            for x in X0..X0 + SIDE {
+                assert_eq!(px(x, y), &want(x, y), "tile pixel ({x}, {y})");
+            }
+        }
     }
 }

--- a/crates/image/tests/reconstructed_view_convert.rs
+++ b/crates/image/tests/reconstructed_view_convert.rs
@@ -238,6 +238,70 @@ fn reconstructed_view_converts_its_own_sub_region_not_the_parents_origin() {
             "a whole image at a one-row offset must start at parent row 1, \
              not row 0 (issue #161)"
         );
+
+        // D -- the destination side, the mirror of B. A destination rebuilt
+        // from a descriptor carries the offset but not the `view_origin` a
+        // fresh `view()` would have given it, so the engine has no viewport
+        // to place it by. The ANGLE IOSurface import binds the whole surface
+        // from its origin and has no plane-offset attribute, so if such a
+        // destination were zero-copy attached the tile would land at the
+        // canvas's top-left. Windows refuses that import explicitly
+        // (`dst_import_places`); Apple has no override, so this pins the
+        // behaviour rather than assuming it.
+        const BLANK: u8 = 0x55;
+        let canvas = TensorDyn::image(
+            W,
+            H,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::DmaBuf),
+            CpuAccess::ReadWrite,
+        )
+        .expect("canvas alloc");
+        {
+            let mut m = canvas.map_bytes(CpuAccess::Write).expect("map canvas");
+            m.as_mut_slice().fill(BLANK);
+        }
+        let canvas_pitch = canvas.effective_row_stride().unwrap_or(W * BPP);
+        let canvas_id = canvas.iosurface_id().expect("canvas is IOSurface-backed");
+        let mut rebuilt_dst =
+            TensorDyn::from_iosurface_id(canvas_id, &[SIDE, SIDE, BPP], DType::U8, None)
+                .expect("reconstruct the destination at the window's shape");
+        rebuilt_dst
+            .set_format(PixelFormat::Rgba)
+            .expect("rebuilt destination format");
+        rebuilt_dst
+            .set_row_stride(canvas_pitch)
+            .expect("rebuilt destination row stride");
+        rebuilt_dst.set_plane_offset(Y0 * canvas_pitch + X0 * BPP);
+
+        proc.convert(
+            &fresh,
+            &mut rebuilt_dst,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("convert into a reconstructed destination view");
+        let out = read_all(&canvas);
+        let px = |x: usize, y: usize| &out[y * canvas_pitch + x * BPP..][..BPP];
+        assert_eq!(
+            px(0, 0),
+            &[BLANK; BPP],
+            "a reconstructed destination view wrote the canvas's ORIGIN, i.e. \
+             the plane offset was lost (issue #161)"
+        );
+        assert_eq!(
+            px(X0 - 1, Y0),
+            &[BLANK; BPP],
+            "left of the window untouched"
+        );
+        assert_eq!(px(X0, Y0 - 1), &[BLANK; BPP], "above the window untouched");
+        for y in Y0..Y0 + SIDE {
+            for x in X0..X0 + SIDE {
+                assert_eq!(px(x, y), &want(x, y), "tile pixel ({x}, {y})");
+            }
+        }
     }
 
     // B and C on Windows, spelled through the descriptor itself: a D3D11

--- a/crates/image/tests/reconstructed_view_convert.rs
+++ b/crates/image/tests/reconstructed_view_convert.rs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Issue #161 at the `convert()` level — the path the bug was actually
+//! reported through.
+//!
+//! `crates/tensor/src/iosurface.rs`'s three offset tests prove the storage
+//! contract: `set_plane_offset` moves the CPU-map window, `set_format`
+//! clears it, and nested subviews do not compound. None of them proves the
+//! thing a user sees, which is
+//! `ImageProcessor.convert(reconstructed_view, dst)` returning the parent
+//! image's top-left tile instead of the region that was asked for. A fix
+//! that satisfied `map()` and left the converter reading the parent origin
+//! would pass all three and still ship the reported bug.
+//!
+//! So this covers the converter, and covers it from **both** directions:
+//!
+//! * **A fresh `view()`**, which was never broken — each backend's own
+//!   `view()` sets its own offset. It is here as the control: if A fails,
+//!   the harness is wrong, not the fix.
+//! * **A reconstructed view**, rebuilt the way `import_storage`'s
+//!   `kind::IOSURFACE` arm rebuilds one (`lookup_by_id` + `from_iosurface`,
+//!   spelled `TensorDyn::from_iosurface_id`) and handed its offset back the
+//!   way `interop::apply_plane_offset` hands it back. This is the case
+//!   `TensorDesc` drops the offset for.
+//! * **A whole-image tensor carrying a foreign offset**, the shape a
+//!   producer hands over when pixel data does not start at byte 0. Distinct
+//!   from a view: its logical extent is not a sub-rectangle, so it exercises
+//!   the offset without `view()` having been involved at all.
+//!
+//! **`TensorMemory::DmaBuf` is the portable spelling of "platform zero-copy
+//! buffer"** — DMA-BUF on Linux, IOSurface on macOS — so this runs on both
+//! without a cfg, and skips where no such buffer can be allocated.
+//!
+//! **RGBA, not RGB, and that is load-bearing on macOS.** An RGB IOSurface
+//! has no zero-copy GL mapping, so an RGB source silently converts on the
+//! CPU: under `EDGEFIRST_FORCE_BACKEND=opengl` it fails outright with
+//! `NotSupported("Opengl doesn't support RGB source texture")`. An RGB
+//! version of this test would therefore pass without the GL path ever
+//! running — vacuous on exactly the platform it exists for.
+//!
+//! Verified non-vacuous under `EDGEFIRST_FORCE_BACKEND=opengl` (which
+//! errors rather than falling back, so the GL path is proven, not assumed):
+//! all three cases pass with the fix, and B reads the parent's origin when
+//! the `set_plane_offset` call is removed.
+
+use edgefirst_image::{Crop, Flip, ImageProcessor, ImageProcessorTrait, Rotation};
+use edgefirst_tensor::{
+    CpuAccess, DType, PixelFormat, Region, TensorDyn, TensorMapTrait, TensorMemory,
+};
+
+const W: usize = 64;
+const H: usize = 64;
+const X0: usize = 8;
+const Y0: usize = 8;
+const SIDE: usize = 16;
+const BPP: usize = 4;
+
+/// libtest discards `println!` for *passing* tests, so a skip would be
+/// indistinguishable from a run. Write to stderr directly.
+fn skip(why: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {why}");
+}
+
+/// Distinct per-row and per-column values, so a convert that lands on the
+/// wrong region cannot coincidentally match the expected tile.
+fn want(x: usize, y: usize) -> [u8; BPP] {
+    [((y * 4) % 256) as u8, ((x * 4) % 256) as u8, 255, 255]
+}
+
+fn tile(x0: usize, y0: usize) -> Vec<u8> {
+    let mut v = Vec::with_capacity(SIDE * SIDE * BPP);
+    for y in y0..y0 + SIDE {
+        for x in x0..x0 + SIDE {
+            v.extend_from_slice(&want(x, y));
+        }
+    }
+    v
+}
+
+fn read_all(t: &TensorDyn) -> Vec<u8> {
+    let m = t.map_bytes(CpuAccess::Read).expect("map destination");
+    m.as_slice().to_vec()
+}
+
+fn dst() -> TensorDyn {
+    TensorDyn::new(&[SIDE, SIDE, BPP], DType::U8, Some(TensorMemory::Mem), None)
+        .expect("destination alloc")
+        .with_format(PixelFormat::Rgba)
+        .expect("destination format")
+}
+
+/// Assert the convert landed on the requested tile, and say *how* it went
+/// wrong when it did — reading the parent's origin is the specific
+/// signature of a lost plane offset, and worth naming in the failure.
+fn assert_tile(label: &str, out: &[u8]) {
+    let expected = tile(X0, Y0);
+    if out == expected.as_slice() {
+        return;
+    }
+    let origin = tile(0, 0);
+    if out == origin.as_slice() {
+        panic!(
+            "{label}: convert() read the parent buffer's ORIGIN, i.e. the \
+             plane offset was lost (issue #161)"
+        );
+    }
+    panic!(
+        "{label}: convert() read neither the requested tile nor the parent's \
+         origin; out[0..4]={:?} expected[0..4]={:?}",
+        &out[..BPP],
+        &expected[..BPP]
+    );
+}
+
+#[test]
+fn reconstructed_view_converts_its_own_sub_region_not_the_parents_origin() {
+    let src = match TensorDyn::new(&[H, W, BPP], DType::U8, Some(TensorMemory::DmaBuf), None) {
+        Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+        Ok(t) => {
+            skip(&format!("zero-copy request fell back to {:?}", t.memory()));
+            return;
+        }
+        Err(e) => {
+            skip(&format!("no zero-copy buffer here: {e}"));
+            return;
+        }
+    };
+    let src = src.with_format(PixelFormat::Rgba).expect("source format");
+    {
+        let mut m = src.map_bytes(CpuAccess::Write).expect("map source");
+        let s = m.as_mut_slice();
+        for y in 0..H {
+            for x in 0..W {
+                s[(y * W + x) * BPP..][..BPP].copy_from_slice(&want(x, y));
+            }
+        }
+    }
+
+    let mut proc = ImageProcessor::new().expect("create ImageProcessor");
+
+    // A — the control: a fresh view was correct on every platform already.
+    let fresh = src
+        .view(Region::new(X0, Y0, SIDE, SIDE))
+        .expect("fresh view");
+    let mut dst_a = dst();
+    proc.convert(
+        &fresh,
+        &mut dst_a,
+        Rotation::None,
+        Flip::None,
+        Crop::default(),
+    )
+    .expect("convert fresh view");
+    assert_tile("fresh view", &read_all(&dst_a));
+
+    // B — the regression: a view rebuilt from a descriptor. IOSurface-only,
+    // because `from_iosurface_id` is the Apple spelling of the import; the
+    // Linux DMA-BUF equivalent is already covered end-to-end by
+    // `test_view_converts_its_own_sub_region_not_the_parents_origin` in
+    // `tests/interop/test_cross_package.py`, which cannot run on macOS.
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        let id = src.iosurface_id().expect("source is IOSurface-backed");
+        let mut rebuilt = TensorDyn::from_iosurface_id(id, &[SIDE, SIDE, BPP], DType::U8, None)
+            .expect("reconstruct at the view's shape");
+        rebuilt
+            .set_format(PixelFormat::Rgba)
+            .expect("rebuilt format");
+        // The parent's pitch, as a descriptor round trip restores it: the
+        // sub-region's rows are strided across the parent, not contiguous.
+        rebuilt.set_row_stride(W * BPP).expect("rebuilt row stride");
+        // What `interop::apply_plane_offset` puts back, and what this PR
+        // makes take effect on IOSurface.
+        rebuilt.set_plane_offset((Y0 * W + X0) * BPP);
+
+        let mut dst_b = dst();
+        proc.convert(
+            &rebuilt,
+            &mut dst_b,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("convert reconstructed view");
+        assert_tile("reconstructed view", &read_all(&dst_b));
+
+        // C — a whole-image tensor whose pixels start one row in. Not a
+        // view: no sub-rectangle is involved, so this pins the offset
+        // itself rather than `view()`'s bookkeeping.
+        let mut whole = TensorDyn::from_iosurface_id(id, &[H - 1, W, BPP], DType::U8, None)
+            .expect("reconstruct whole image");
+        whole.set_format(PixelFormat::Rgba).expect("whole format");
+        whole.set_plane_offset(W * BPP);
+
+        let mut dst_c = TensorDyn::new(&[H - 1, W, BPP], DType::U8, Some(TensorMemory::Mem), None)
+            .expect("dst_c alloc")
+            .with_format(PixelFormat::Rgba)
+            .expect("dst_c format");
+        proc.convert(
+            &whole,
+            &mut dst_c,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("convert whole image at a foreign offset");
+        let out = read_all(&dst_c);
+        assert_eq!(
+            &out[..BPP],
+            &want(0, 1),
+            "a whole image at a one-row offset must start at parent row 1, \
+             not row 0 (issue #161)"
+        );
+    }
+}

--- a/crates/python-common/INTEROP.md
+++ b/crates/python-common/INTEROP.md
@@ -79,24 +79,38 @@ The consumer applies it only to a **handle-based** import. Under
 `kind::HOST` the descriptor's `ptr` is the producer's pinned address for the
 view itself, so the offset is already in it and re-applying it would advance
 past the sub-region a second time. `DMABUF` (dup's the fd), `IOSURFACE`
-(looks the surface up by id) and `PBO` (by buffer id) all re-derive the base
-from a handle naming the whole parent buffer, so for those it must be put
-back. See `interop::apply_plane_offset`.
+(looks the surface up by id), `D3D11_TEXTURE` (opens the NT handle) and
+`PBO` (by buffer id) all re-derive the base from a handle naming the whole
+parent buffer, so for those it must be put back. See
+`interop::apply_plane_offset`.
 
-**Known gap: D3D11 still needs fixing.**
 `Tensor::set_plane_offset` syncs the storage-internal offset that `map()`
-adds for `Mem`, `Dma` under `cfg(target_os = "linux")` and `Dma` under
-`cfg(any(target_os = "macos", target_os = "ios"))`; every other backing hits
-its `_ => {}` arm. `D3d11TextureTensor::view_offset` (Windows) is set by its
-own `view()` and added by its own `map()`, but nothing writes it back on
-reconstruction, so a reconstructed view there addresses the parent's origin.
+adds for `Mem` and for `Dma` on Linux, macOS/iOS and Windows; every other
+backing hits its `_ => {}` arm.
 
-IOSurface (macOS/iOS) had the same defect and is fixed. It was easy to miss
+IOSurface (macOS/iOS) had the defect and is fixed. It was easy to miss
 because `IoSurfaceTensor::view` always set its own `view_offset` correctly,
 so a *freshly created* view was right and only a tensor rebuilt from a
 `TensorDesc` was wrong — and because `TensorStorage::Dma` is a
 cfg-multiplexed name rather than one type, so the Linux-gated arm did not
 fail to compile on macOS, it silently became a fall-through.
+
+D3D11 (Windows) is fixed too, and the bug had a different shape there. A
+view's descriptor was refused rather than rebuilt at the wrong origin: the
+import checks the shape against the texture's own geometry, and a window
+was neither spelling it accepted. It now accepts a packed window, opens the
+whole texture and narrows it, keeping the texture's pitch as the row
+stride; the storage offset is then written back by `set_plane_offset` and
+cleared by `set_format` and `reshape`. Two Windows-only details follow from
+the texture being the unit of import. The ANGLE image binds the whole
+texture from its origin and cannot express an offset, so the GL engine's
+Windows leaf refuses to attach a *source* carrying a plane offset and the
+engine uploads it through `map()` instead — without that refusal even a
+fresh `view()` converted the parent's origin. And a texture tensor measures
+its offset in the row pitch of a staging texture the *local* driver
+chooses, so when the descriptor's stride (the producer's pitch) differs from
+the consumer's, `apply_plane_offset` re-expresses the offset row by row
+before applying it.
 
 The other backings are not silently affected: `Mem`/`Shm` report
 `kind::HOST` and take the pinned-pointer path; Android reports

--- a/crates/python-common/INTEROP.md
+++ b/crates/python-common/INTEROP.md
@@ -83,13 +83,20 @@ past the sub-region a second time. `DMABUF` (dup's the fd), `IOSURFACE`
 from a handle naming the whole parent buffer, so for those it must be put
 back. See `interop::apply_plane_offset`.
 
-**Known gap: IOSurface and D3D11 still need fixing.**
+**Known gap: D3D11 still needs fixing.**
 `Tensor::set_plane_offset` syncs the storage-internal offset that `map()`
-adds for `Mem` and (under `cfg(target_os = "linux")`) `Dma` only; every
-other backing hits its `_ => {}` arm. `IoSurfaceTensor::view_offset`
-(macOS/iOS) and `D3d11TextureTensor::view_offset` (Windows) are set by their
-own `view()` and added by their own `map()`, but nothing writes them back on
+adds for `Mem`, `Dma` under `cfg(target_os = "linux")` and `Dma` under
+`cfg(any(target_os = "macos", target_os = "ios"))`; every other backing hits
+its `_ => {}` arm. `D3d11TextureTensor::view_offset` (Windows) is set by its
+own `view()` and added by its own `map()`, but nothing writes it back on
 reconstruction, so a reconstructed view there addresses the parent's origin.
+
+IOSurface (macOS/iOS) had the same defect and is fixed. It was easy to miss
+because `IoSurfaceTensor::view` always set its own `view_offset` correctly,
+so a *freshly created* view was right and only a tensor rebuilt from a
+`TensorDesc` was wrong — and because `TensorStorage::Dma` is a
+cfg-multiplexed name rather than one type, so the Linux-gated arm did not
+fail to compile on macOS, it silently became a fall-through.
 
 The other backings are not silently affected: `Mem`/`Shm` report
 `kind::HOST` and take the pinned-pointer path; Android reports
@@ -97,8 +104,8 @@ The other backings are not silently affected: `Mem`/`Shm` report
 reconstructing; and a `view()` of a PBO-backed image comes back as host
 memory, so it never reaches the PBO arm. See
 `interop::apply_plane_offset`'s doc comment for the full per-backing
-accounting and why widening those `cfg`s needs per-platform tests rather
-than a one-liner.
+accounting, including the caller audit that showed no other
+`set_plane_offset` caller can reach either backing.
 
 `interop::reconstruct` — the same-module path, where no capsule is involved
 — carries the offset across the same way, because it reconstructs through

--- a/crates/python-common/INTEROP.md
+++ b/crates/python-common/INTEROP.md
@@ -106,11 +106,19 @@ the texture being the unit of import. The ANGLE image binds the whole
 texture from its origin and cannot express an offset, so the GL engine's
 Windows leaf refuses to attach a *source* carrying a plane offset and the
 engine uploads it through `map()` instead — without that refusal even a
-fresh `view()` converted the parent's origin. And a texture tensor measures
-its offset in the row pitch of a staging texture the *local* driver
-chooses, so when the descriptor's stride (the producer's pitch) differs from
-the consumer's, `apply_plane_offset` re-expresses the offset row by row
-before applying it.
+fresh `view()` converted the parent's origin. A *destination* rebuilt from a
+descriptor is the same problem from the other side — it has the offset but
+not the `view_origin` the engine lowers a fresh view's tile to a viewport
+from — so the engine asks the platform whether a zero-copy destination can
+be placed (`GlPlatform::dst_import_places`) and lowers one that cannot to
+the mapped texture path, whose readback writes through `map()` at the
+offset. The offset itself is applied as the producer measured it: a texture
+tensor measures it in the row pitch of its staging texture, and a consumer
+opens the same texture on the same adapter, so its own staging has the same
+pitch. The descriptor's stride is deliberately *not* used to translate it — a
+single-row `view()` records a tight stride for its map span while its offset
+is still in the pitch, so dividing by that stride would name a different
+row.
 
 The other backings are not silently affected: `Mem`/`Shm` report
 `kind::HOST` and take the pinned-pointer path; Android reports

--- a/crates/python-common/src/interop.rs
+++ b/crates/python-common/src/interop.rs
@@ -181,21 +181,31 @@ const _: () = {
 /// `IOSURFACE` looks the surface up by id, `PBO` by buffer id -- and so
 /// lands at the parent's origin unless the offset is put back.
 ///
-/// **Known gap: putting it back only takes effect on Linux DMA-BUF.**
+/// **Known gap: putting it back does not yet take effect on D3D11.**
 /// `Tensor::set_plane_offset` records the wrapper field for every backing,
 /// but only syncs the storage-internal offset that `map()` actually adds
-/// for `Mem` and, under `#[cfg(target_os = "linux")]`, `Dma`; every other
+/// for `Mem`, `Dma` under `#[cfg(target_os = "linux")]`, and `Dma` under
+/// `#[cfg(any(target_os = "macos", target_os = "ios"))]`; every other
 /// backing falls into its `_ => {}` arm. Backing by backing:
 ///
 /// * **Linux DMA-BUF** -- fixed, and verified end-to-end.
+/// * **IOSurface (macOS/iOS)** -- fixed (issue #161).
+///   `IoSurfaceTensor::view_offset` is now written back by
+///   `set_plane_offset` *and* cleared by `set_format`, so a reconstructed
+///   view addresses its own sub-region and a later format change does not
+///   leave a stale window behind. Pinned by three tests in
+///   `edgefirst-tensor`'s `iosurface` module, which the macOS CI lane runs:
+///   `set_plane_offset_moves_the_iosurface_map_window`,
+///   `nested_iosurface_subviews_do_not_compound_their_plane_offset` and
+///   `set_format_clears_the_iosurface_map_window`.
 /// * **`Mem`/`Shm`** -- never affected. Both report `kind::HOST`, so this
 ///   function skips them and the pinned `desc.ptr` already addresses the
 ///   view.
-/// * **IOSurface (macOS/iOS)** and **D3D11 (Windows)** -- **still wrong.**
-///   `IoSurfaceTensor::view_offset` and `D3d11TextureTensor::view_offset`
-///   are set by their own `view()` and added by their own `map()`, but
-///   nothing writes them back here, so a *reconstructed* view addresses the
-///   parent's origin. These are the two that still need fixing.
+/// * **D3D11 (Windows)** -- **still wrong.**
+///   `D3d11TextureTensor::view_offset` is set by its own `view()` and added
+///   by its own `map()`, but nothing writes it back here, so a
+///   *reconstructed* view addresses the parent's origin. The remaining half
+///   of issue #161.
 /// * **Android** -- not silently wrong: it reports `kind::DMABUF`, and
 ///   `import_storage`'s DMABUF arm is `cfg(target_os = "linux")`, so an
 ///   import there fails with "dma-buf import off Linux" rather than
@@ -204,15 +214,29 @@ const _: () = {
 ///   back reporting `TensorMemory::Mem`, so it takes the `HOST` path above.
 ///   (Why it demotes has not been traced, and such a view appears to be
 ///   detached from the parent buffer entirely -- reproducible on `main`,
-///   so a pre-existing PBO-view issue independent of this one.)
+///   so a pre-existing PBO-view issue independent of this one. Issue #162.
+///   If that is fixed so views stay PBO-backed, `PboTensor` needs an arm in
+///   `set_plane_offset` too.)
 ///
-/// So the outstanding work is IOSurface and D3D11. Not done here
-/// deliberately: `set_plane_offset` has callers beyond this one
-/// (`image::import_image`'s multiplane path, `tensor-capi`'s builder), so
-/// widening those `cfg`s changes behaviour on two platforms this repo's CI
-/// cannot exercise, and double-applying an offset is a failure this
-/// protocol has already produced once (see the `HOST` arm above). It wants
-/// a per-platform change with a test on each.
+/// The audit the IOSurface fix rested on applies unchanged to D3D11, and is
+/// recorded here so it need not be redone: `set_plane_offset`'s callers
+/// beyond this one cannot reach either backing. `image::import_image`
+/// rejects any tensor whose `memory()` is not `TensorMemory::DmaBuf` before
+/// it sets an offset, and `tensor-capi`'s builder only ever constructs
+/// storage through `TensorDyn::from_fd` under `cfg(unix)`. The one caller
+/// that does reach them, `Tensor::subview`, writes the same absolute value
+/// the storage's own `view()` already computed, so the write is idempotent
+/// rather than a double-apply -- the failure this protocol produced once on
+/// `MEM` (see the `HOST` arm above). What D3D11 still wants is the arm, a
+/// `pub(crate)` setter for its private `view_offset`, a matching arm at
+/// `set_format`'s clear site -- a setter that takes effect needs a clear
+/// that does too, or the wrapper reports `None` while `map()` still starts
+/// at the old offset -- and the three tests above mirrored under
+/// `cfg(windows)`, where the Windows CI lane's WARP device runs them.
+/// (`reshape`'s clear site needed no IOSurface arm because
+/// `IoSurfaceTensor::reshape` zeroes its own `view_offset`; whether
+/// `D3d11TextureTensor::reshape` does the same wants checking rather than
+/// assuming.)
 fn apply_plane_offset(tensor: &mut TensorDyn, desc: &TensorDesc, plane_offset: u64) {
     if plane_offset == 0 || desc.kind == edgefirst_tensor::tensor_kind::HOST {
         return;

--- a/crates/python-common/src/interop.rs
+++ b/crates/python-common/src/interop.rs
@@ -178,15 +178,16 @@ const _: () = {
 /// offset is already baked into it and applying it again would advance past
 /// the sub-region a second time. Every other kind re-derives the base from
 /// a handle naming the whole parent buffer -- `DMABUF` dup's the fd,
-/// `IOSURFACE` looks the surface up by id, `PBO` by buffer id -- and so
-/// lands at the parent's origin unless the offset is put back.
+/// `IOSURFACE` looks the surface up by id, `D3D11_TEXTURE` opens the NT
+/// handle, `PBO` by buffer id -- and so lands at the parent's origin unless
+/// the offset is put back.
 ///
-/// **Known gap: putting it back does not yet take effect on D3D11.**
 /// `Tensor::set_plane_offset` records the wrapper field for every backing,
 /// but only syncs the storage-internal offset that `map()` actually adds
-/// for `Mem`, `Dma` under `#[cfg(target_os = "linux")]`, and `Dma` under
-/// `#[cfg(any(target_os = "macos", target_os = "ios"))]`; every other
-/// backing falls into its `_ => {}` arm. Backing by backing:
+/// for `Mem`, `Dma` under `#[cfg(target_os = "linux")]`, `Dma` under
+/// `#[cfg(any(target_os = "macos", target_os = "ios"))]` and `Dma` under
+/// `#[cfg(target_os = "windows")]`; every other backing falls into its
+/// `_ => {}` arm. Backing by backing:
 ///
 /// * **Linux DMA-BUF** -- fixed, and verified end-to-end.
 /// * **IOSurface (macOS/iOS)** -- fixed (issue #161).
@@ -198,14 +199,26 @@ const _: () = {
 ///   `set_plane_offset_moves_the_iosurface_map_window`,
 ///   `nested_iosurface_subviews_do_not_compound_their_plane_offset` and
 ///   `set_format_clears_the_iosurface_map_window`.
+/// * **D3D11 (Windows)** -- fixed (issue #161), in three parts, because
+///   the bug had a different shape there. A view's descriptor was not
+///   reconstructed wrongly, it was *refused*: the `D3D11_TEXTURE` import
+///   checks the descriptor's shape against the texture's own geometry, and
+///   a window is neither of its two spellings. The import now accepts a
+///   packed window, narrows the whole-texture tensor to it and keeps the
+///   texture's pitch as the row stride. `D3d11TextureTensor::view_offset`
+///   is then written back by `set_plane_offset` and cleared by
+///   `set_format` and `reshape` (unlike `IoSurfaceTensor`, its own
+///   `reshape` leaves the offset alone). And because the ANGLE import binds
+///   the whole texture from its origin and cannot express an offset, the GL
+///   engine's Windows leaf refuses to attach a source carrying one and
+///   uploads it through `map()` instead -- without which even a *fresh*
+///   `view()` converted the parent's origin on the GL path. Pinned by the
+///   `d3d11` plane-offset tests in `crates/tensor/tests/d3d11_tensor.rs`
+///   and by `crates/image/tests/reconstructed_view_convert.rs`, which the
+///   Windows CI lanes run (the latter on WARP).
 /// * **`Mem`/`Shm`** -- never affected. Both report `kind::HOST`, so this
 ///   function skips them and the pinned `desc.ptr` already addresses the
 ///   view.
-/// * **D3D11 (Windows)** -- **still wrong.**
-///   `D3d11TextureTensor::view_offset` is set by its own `view()` and added
-///   by its own `map()`, but nothing writes it back here, so a
-///   *reconstructed* view addresses the parent's origin. The remaining half
-///   of issue #161.
 /// * **Android** -- not silently wrong: it reports `kind::DMABUF`, and
 ///   `import_storage`'s DMABUF arm is `cfg(target_os = "linux")`, so an
 ///   import there fails with "dma-buf import off Linux" rather than
@@ -218,7 +231,7 @@ const _: () = {
 ///   If that is fixed so views stay PBO-backed, `PboTensor` needs an arm in
 ///   `set_plane_offset` too.)
 ///
-/// The audit the IOSurface fix rested on applies unchanged to D3D11, and is
+/// The audit the IOSurface fix rested on applied unchanged to D3D11, and is
 /// recorded here so it need not be redone: `set_plane_offset`'s callers
 /// beyond this one cannot reach either backing.
 ///
@@ -237,22 +250,66 @@ const _: () = {
 /// * `Tensor::subview` -- does reach them, and writes the same absolute
 ///   value the storage's own `view()` already computed, so the write is
 ///   idempotent rather than a double-apply -- the failure this protocol
-///   produced once on `MEM` (see the `HOST` arm above). What D3D11 still wants is the arm, a
-/// `pub(crate)` setter for its private `view_offset`, a matching arm at
-/// `set_format`'s clear site -- a setter that takes effect needs a clear
-/// that does too, or the wrapper reports `None` while `map()` still starts
-/// at the old offset -- and the three tests above mirrored under
-/// `cfg(windows)`, where the Windows CI lane's WARP device runs them.
-/// (`reshape`'s clear site needed no IOSurface arm because
-/// `IoSurfaceTensor::reshape` zeroes its own `view_offset`; whether
-/// `D3d11TextureTensor::reshape` does the same wants checking rather than
-/// assuming.)
+///   produced once on `MEM` (see the `HOST` arm above).
+///
+/// **D3D11 measures the offset in a pitch the consumer may not share.** A
+/// texture tensor's `map()` goes through a staging texture whose row pitch
+/// the *local* driver chooses, and `view()` records its offset in that
+/// pitch (`y * pitch + x * bpp`). The descriptor carries the producer's
+/// pitch in `strides`, and the import records the consumer's own; when the
+/// two differ -- a producer on a padding driver handing a texture to a
+/// consumer on a tight one, or the reverse -- the offset is re-expressed
+/// row by row (`repitch_offset`) so it still names the same texel. Every
+/// other kind maps the producer's bytes as they are, so their offset needs
+/// no such translation.
 fn apply_plane_offset(tensor: &mut TensorDyn, desc: &TensorDesc, plane_offset: u64) {
     if plane_offset == 0 || desc.kind == edgefirst_tensor::tensor_kind::HOST {
         return;
     }
-    tensor.set_plane_offset(plane_offset as usize);
+    let mut offset = plane_offset as usize;
+    if desc.kind == edgefirst_tensor::tensor_kind::D3D11_TEXTURE {
+        let producer = desc
+            .strides()
+            .first()
+            .and_then(|s| usize::try_from(*s).ok())
+            .filter(|s| *s > 0);
+        offset = repitch_offset(offset, producer, tensor.effective_row_stride());
+    }
+    tensor.set_plane_offset(offset);
 }
+
+/// `offset`, a byte offset into rows `from` bytes apart, re-expressed for
+/// rows `to` bytes apart. The row and the byte within it are kept; only the
+/// row length changes. Unchanged when either pitch is unknown or the two
+/// agree, and saturating rather than wrapping when they do not: a wrapped
+/// offset would look small enough to pass a capacity check it should fail.
+const fn repitch_offset(offset: usize, from: Option<usize>, to: Option<usize>) -> usize {
+    match (from, to) {
+        (Some(from), Some(to)) if from != to && from > 0 => {
+            let row = offset / from;
+            let within = offset % from;
+            row.saturating_mul(to).saturating_add(within)
+        }
+        _ => offset,
+    }
+}
+
+/// `repitch_offset`'s contract, checked on every build for the same reason
+/// the capsule layout above is: nothing in this crate runs under
+/// `make test-rust`.
+const _: () = {
+    // Row 8, byte 32 within it: the same texel at a 256-byte and a 512-byte
+    // pitch.
+    assert!(repitch_offset(8 * 256 + 32, Some(256), Some(512)) == 8 * 512 + 32);
+    assert!(repitch_offset(8 * 512 + 32, Some(512), Some(256)) == 8 * 256 + 32);
+    // Agreeing or unknown pitches leave the offset alone.
+    assert!(repitch_offset(2080, Some(256), Some(256)) == 2080);
+    assert!(repitch_offset(2080, None, Some(512)) == 2080);
+    assert!(repitch_offset(2080, Some(256), None) == 2080);
+    assert!(repitch_offset(2080, Some(0), Some(512)) == 2080);
+    // Saturates rather than wrapping.
+    assert!(repitch_offset(usize::MAX, Some(1), Some(2)) == usize::MAX);
+};
 
 /// Payload of the `edgefirst_tensor_v2` capsule -- the cross-package tensor
 /// protocol's wire format.

--- a/crates/python-common/src/interop.rs
+++ b/crates/python-common/src/interop.rs
@@ -212,10 +212,16 @@ const _: () = {
 ///   the whole texture from its origin and cannot express an offset, the GL
 ///   engine's Windows leaf refuses to attach a source carrying one and
 ///   uploads it through `map()` instead -- without which even a *fresh*
-///   `view()` converted the parent's origin on the GL path. Pinned by the
-///   `d3d11` plane-offset tests in `crates/tensor/tests/d3d11_tensor.rs`
-///   and by `crates/image/tests/reconstructed_view_convert.rs`, which the
-///   Windows CI lanes run (the latter on WARP).
+///   `view()` converted the parent's origin on the GL path. A rebuilt
+///   *destination* has the offset but not the `view_origin` the engine
+///   lowers a fresh view's tile to a viewport from, so the engine asks the
+///   platform whether a zero-copy destination can be placed
+///   (`GlPlatform::dst_import_places`) and lowers one that cannot to the
+///   mapped texture path, whose readback writes through `map()` at the
+///   offset. Pinned by the `d3d11` plane-offset tests in
+///   `crates/tensor/tests/d3d11_tensor.rs` and by
+///   `crates/image/tests/reconstructed_view_convert.rs`, which the Windows
+///   CI lanes run (the latter on WARP).
 /// * **`Mem`/`Shm`** -- never affected. Both report `kind::HOST`, so this
 ///   function skips them and the pinned `desc.ptr` already addresses the
 ///   view.
@@ -252,64 +258,25 @@ const _: () = {
 ///   idempotent rather than a double-apply -- the failure this protocol
 ///   produced once on `MEM` (see the `HOST` arm above).
 ///
-/// **D3D11 measures the offset in a pitch the consumer may not share.** A
-/// texture tensor's `map()` goes through a staging texture whose row pitch
-/// the *local* driver chooses, and `view()` records its offset in that
-/// pitch (`y * pitch + x * bpp`). The descriptor carries the producer's
-/// pitch in `strides`, and the import records the consumer's own; when the
-/// two differ -- a producer on a padding driver handing a texture to a
-/// consumer on a tight one, or the reverse -- the offset is re-expressed
-/// row by row (`repitch_offset`) so it still names the same texel. Every
-/// other kind maps the producer's bytes as they are, so their offset needs
-/// no such translation.
+/// **D3D11 applies the offset verbatim, and the descriptor's stride is not
+/// a pitch to translate it by.** A texture tensor's `map()` goes through a
+/// staging texture whose row pitch the driver chooses, and `view()` measures
+/// its offset in that pitch (`y * pitch + x * bpp`). The consumer opens the
+/// same texture through its NT handle, which only the adapter that created
+/// it can open, so the staging texture it creates for its own `map()` gets
+/// the same pitch from the same driver, and the offset names the same texel
+/// without translation. Translating by `strides[0]` would be wrong in the
+/// one case it looks needed: a single-row `view()` records a *tight* row
+/// stride for its map span (`Tensor::view`), while its offset is still in
+/// the pitch, so dividing that offset by the descriptor's stride yields a
+/// different row. The offset is bounded on the consumer's side instead:
+/// `D3d11TextureTensor`'s pins refuse one past the backing.
 fn apply_plane_offset(tensor: &mut TensorDyn, desc: &TensorDesc, plane_offset: u64) {
     if plane_offset == 0 || desc.kind == edgefirst_tensor::tensor_kind::HOST {
         return;
     }
-    let mut offset = plane_offset as usize;
-    if desc.kind == edgefirst_tensor::tensor_kind::D3D11_TEXTURE {
-        let producer = desc
-            .strides()
-            .first()
-            .and_then(|s| usize::try_from(*s).ok())
-            .filter(|s| *s > 0);
-        offset = repitch_offset(offset, producer, tensor.effective_row_stride());
-    }
-    tensor.set_plane_offset(offset);
+    tensor.set_plane_offset(plane_offset as usize);
 }
-
-/// `offset`, a byte offset into rows `from` bytes apart, re-expressed for
-/// rows `to` bytes apart. The row and the byte within it are kept; only the
-/// row length changes. Unchanged when either pitch is unknown or the two
-/// agree, and saturating rather than wrapping when they do not: a wrapped
-/// offset would look small enough to pass a capacity check it should fail.
-const fn repitch_offset(offset: usize, from: Option<usize>, to: Option<usize>) -> usize {
-    match (from, to) {
-        (Some(from), Some(to)) if from != to && from > 0 => {
-            let row = offset / from;
-            let within = offset % from;
-            row.saturating_mul(to).saturating_add(within)
-        }
-        _ => offset,
-    }
-}
-
-/// `repitch_offset`'s contract, checked on every build for the same reason
-/// the capsule layout above is: nothing in this crate runs under
-/// `make test-rust`.
-const _: () = {
-    // Row 8, byte 32 within it: the same texel at a 256-byte and a 512-byte
-    // pitch.
-    assert!(repitch_offset(8 * 256 + 32, Some(256), Some(512)) == 8 * 512 + 32);
-    assert!(repitch_offset(8 * 512 + 32, Some(512), Some(256)) == 8 * 256 + 32);
-    // Agreeing or unknown pitches leave the offset alone.
-    assert!(repitch_offset(2080, Some(256), Some(256)) == 2080);
-    assert!(repitch_offset(2080, None, Some(512)) == 2080);
-    assert!(repitch_offset(2080, Some(256), None) == 2080);
-    assert!(repitch_offset(2080, Some(0), Some(512)) == 2080);
-    // Saturates rather than wrapping.
-    assert!(repitch_offset(usize::MAX, Some(1), Some(2)) == usize::MAX);
-};
 
 /// Payload of the `edgefirst_tensor_v2` capsule -- the cross-package tensor
 /// protocol's wire format.

--- a/crates/python-common/src/interop.rs
+++ b/crates/python-common/src/interop.rs
@@ -237,14 +237,15 @@ const _: () = {
 /// * `Tensor::subview` -- does reach them, and writes the same absolute
 ///   value the storage's own `view()` already computed, so the write is
 ///   idempotent rather than a double-apply -- the failure this protocol
-///   produced once on `MEM` (see the `HOST` arm above). What D3D11 still wants is the arm, a
-/// `pub(crate)` setter for its private `view_offset`, a matching arm at
-/// `set_format`'s clear site -- a setter that takes effect needs a clear
-/// that does too, or the wrapper reports `None` while `map()` still starts
-/// at the old offset -- and the three tests above mirrored under
-/// `cfg(windows)`, where the Windows CI lane's WARP device runs them.
-/// (`reshape`'s clear site needed no IOSurface arm because
-/// `IoSurfaceTensor::reshape` zeroes its own `view_offset`; whether
+///   produced once on `MEM` (see the `HOST` arm above).
+///
+/// What D3D11 still wants is the arm, a `pub(crate)` setter for its private
+/// `view_offset`, a matching arm at `set_format`'s clear site -- a setter
+/// that takes effect needs a clear that does too, or the wrapper reports
+/// `None` while `map()` still starts at the old offset -- and the three
+/// tests above mirrored under `cfg(windows)`, where the Windows CI lane's
+/// WARP device runs them. (`reshape`'s clear site needed no IOSurface arm
+/// because `IoSurfaceTensor::reshape` zeroes its own `view_offset`; whether
 /// `D3d11TextureTensor::reshape` does the same wants checking rather than
 /// assuming.)
 fn apply_plane_offset(tensor: &mut TensorDyn, desc: &TensorDesc, plane_offset: u64) {

--- a/crates/python-common/src/interop.rs
+++ b/crates/python-common/src/interop.rs
@@ -220,14 +220,24 @@ const _: () = {
 ///
 /// The audit the IOSurface fix rested on applies unchanged to D3D11, and is
 /// recorded here so it need not be redone: `set_plane_offset`'s callers
-/// beyond this one cannot reach either backing. `image::import_image`
-/// rejects any tensor whose `memory()` is not `TensorMemory::DmaBuf` before
-/// it sets an offset, and `tensor-capi`'s builder only ever constructs
-/// storage through `TensorDyn::from_fd` under `cfg(unix)`. The one caller
-/// that does reach them, `Tensor::subview`, writes the same absolute value
-/// the storage's own `view()` already computed, so the write is idempotent
-/// rather than a double-apply -- the failure this protocol produced once on
-/// `MEM` (see the `HOST` arm above). What D3D11 still wants is the arm, a
+/// beyond this one cannot reach either backing.
+///
+/// * `image::import_image` -- the whole method is
+///   `#[cfg(target_os = "linux")]` (`crates/image/src/lib.rs`), so it does
+///   not exist on macOS or Windows. Note that its internal
+///   `memory() != TensorMemory::DmaBuf` rejection is **not** what excludes
+///   them: `TensorMemory::DmaBuf` is the portable spelling of "platform
+///   zero-copy buffer", so IOSurface and D3D11 both report it and would
+///   pass that check. The `cfg` is the gate.
+/// * `tensor-capi`'s builder (`builder.rs`, the `wrap` path) -- constructs
+///   storage only through `TensorDyn::from_fd`. Its
+///   `cfg(all(unix, not(target_os = "linux")))` arm always yields a
+///   `ShmTensor`, never an `IoSurfaceTensor`, and its `cfg(not(unix))` arm
+///   returns `ENOSYS`, so neither backing is reachable.
+/// * `Tensor::subview` -- does reach them, and writes the same absolute
+///   value the storage's own `view()` already computed, so the write is
+///   idempotent rather than a double-apply -- the failure this protocol
+///   produced once on `MEM` (see the `HOST` arm above). What D3D11 still wants is the arm, a
 /// `pub(crate)` setter for its private `view_offset`, a matching arm at
 /// `set_format`'s clear site -- a setter that takes effect needs a clear
 /// that does too, or the wrapper reports `None` while `map()` still starts

--- a/crates/tensor/src/d3d11/texture.rs
+++ b/crates/tensor/src/d3d11/texture.rs
@@ -1062,23 +1062,53 @@ where
         }
     }
 
-    /// Refuses a window that starts past the backing.
+    /// Bytes this tensor's image occupies from the start of its window.
+    ///
+    /// Every row but the last at the backing's pitch, plus the last row's own
+    /// bytes. The final row is followed by no padding, which is what lets a
+    /// view in the texture's last row fit its backing exactly --
+    /// [`pitched_extent`](Self::pitched_extent) counts a full pitch for that
+    /// row too, so bounding an offset by it would refuse
+    /// `one_row_d3d11_view_descriptor_maps_the_producers_texels`.
+    fn addressable_span(&self) -> usize {
+        let tight_row = self.image_row_bytes();
+        if tight_row == 0 {
+            return 0;
+        }
+        let tight = self.shape.iter().product::<usize>() * self.dtype.size();
+        let rows = tight.div_ceil(tight_row);
+        if rows == 0 {
+            return 0;
+        }
+        let last_row = tight - (rows - 1) * tight_row;
+        (rows - 1) * self.backing_pitch() + last_row
+    }
+
+    /// Refuses a window that cannot hold this tensor's own image.
     ///
     /// `view` computes `view_offset` under a bounds check, but
     /// `set_view_offset` takes whatever `Tensor::set_plane_offset` was handed
     /// -- a descriptor's restored offset, untrusted cross-package input -- so
-    /// every pin re-checks before it offsets a base pointer by it. An offset
-    /// equal to the backing is the one-past-the-end address, which is a
-    /// legal pointer and an empty window.
+    /// every pin re-checks before it offsets a base pointer by it.
+    ///
+    /// Bounding only the *start* is not enough. A pin's length is the backing
+    /// less the offset, so an offset near the end yields a map shorter than
+    /// the image while the tensor still reports its full width and height; a
+    /// consumer reading `width x height` through the pointer then runs past
+    /// the allocation, which the GL upload path did. An offset equal to the
+    /// backing is the extreme case: a legal one-past-the-end pointer and an
+    /// empty window for a non-empty tensor. Both are refused here, and
+    /// `checked_add` keeps a hostile offset from wrapping into range.
     fn check_view_offset(&self) -> Result<()> {
         let capacity = self.backing_bytes();
-        if self.view_offset <= capacity {
-            return Ok(());
+        let end = self.view_offset.checked_add(self.addressable_span());
+        match end {
+            Some(end) if end <= capacity => Ok(()),
+            _ => Err(Error::InsufficientCapacity {
+                needed: end.unwrap_or(usize::MAX),
+                capacity,
+            }),
         }
-        Err(Error::InsufficientCapacity {
-            needed: self.view_offset,
-            capacity,
-        })
     }
 
     /// Moves this tensor's window to `offset` bytes from the backing's

--- a/crates/tensor/src/d3d11/texture.rs
+++ b/crates/tensor/src/d3d11/texture.rs
@@ -1025,6 +1025,7 @@ where
     /// `sync_for_device` move bytes between it and the texture.
     pub(crate) fn host_pin<'a>(&self, access: CpuAccess) -> Result<crate::pin::HostPin<'a>> {
         self.require_access(self.access)?;
+        self.check_view_offset()?;
         if access.writes() {
             // A pin outlives every guard, so there is no drop to notice the
             // write at: `sync_for_device` reads this to decide that the host
@@ -1032,8 +1033,8 @@ where
             self.wrote_host.store(true, Ordering::Release);
         }
         let (base, len) = self.host_buffer().span();
-        // SAFETY: `view` bounds-checks `view_offset` against `backing_bytes()`,
-        // which is the length this buffer was allocated at.
+        // SAFETY: `check_view_offset` above bounds `view_offset` by
+        // `backing_bytes()`, which is the length this buffer was allocated at.
         let at = unsafe { base.add(self.view_offset) };
         // The cell, not the buffer: holding it is what keeps the address live.
         let keepalive: Arc<dyn Send + Sync> = self.host.clone();
@@ -1053,11 +1054,44 @@ where
         non_blocking: bool,
     ) -> Result<crate::pin::HostPin<'a>> {
         self.require_access(access)?;
+        self.check_view_offset()?;
         self.refuse_partial_write(access)?;
         match self.staging.as_ref() {
             Some(st) => self.staging_pin(st, access, non_blocking),
             None => self.buffer_pin(access),
         }
+    }
+
+    /// Refuses a window that starts past the backing.
+    ///
+    /// `view` computes `view_offset` under a bounds check, but
+    /// `set_view_offset` takes whatever `Tensor::set_plane_offset` was handed
+    /// -- a descriptor's restored offset, untrusted cross-package input -- so
+    /// every pin re-checks before it offsets a base pointer by it. An offset
+    /// equal to the backing is the one-past-the-end address, which is a
+    /// legal pointer and an empty window.
+    fn check_view_offset(&self) -> Result<()> {
+        let capacity = self.backing_bytes();
+        if self.view_offset <= capacity {
+            return Ok(());
+        }
+        Err(Error::InsufficientCapacity {
+            needed: self.view_offset,
+            capacity,
+        })
+    }
+
+    /// Moves this tensor's window to `offset` bytes from the backing's
+    /// origin, in the pitched space `view` measures in.
+    ///
+    /// The write-back half of `Tensor::set_plane_offset` (and the clear half
+    /// of `set_format`/`reshape`): a tensor rebuilt from a descriptor is
+    /// opened at the texture's origin, and this is how the sub-region it
+    /// described is put back. Unchecked here so the setter stays infallible;
+    /// `check_view_offset` refuses an offset past the backing when a pin is
+    /// taken.
+    pub(crate) fn set_view_offset(&mut self, offset: usize) {
+        self.view_offset = offset;
     }
 
     /// Refuses a write-only window that covers less than the whole backing.
@@ -1208,8 +1242,8 @@ where
         len: usize,
         guard: G,
     ) -> crate::pin::HostPin<'a> {
-        // SAFETY: `view` bounds-checks `view_offset` against `backing_bytes()`,
-        // which is the length of both backings.
+        // SAFETY: `pin_impl` ran `check_view_offset`, which bounds
+        // `view_offset` by `backing_bytes()`, the length of both backings.
         let at = unsafe { base.add(self.view_offset) };
         crate::pin::HostPin::new(Arc::new(guard), at, len.saturating_sub(self.view_offset))
     }

--- a/crates/tensor/src/iosurface.rs
+++ b/crates/tensor/src/iosurface.rs
@@ -1535,4 +1535,191 @@ mod tests {
             "write through view is visible in parent"
         );
     }
+
+    /// Restoring a plane offset onto a *reconstructed* IOSurface tensor must
+    /// move where `map()` starts. Regression test for issue #161.
+    ///
+    /// `TensorDesc` has no field for the plane offset, so every path that
+    /// rebuilds a tensor from a descriptor puts the offset back by calling
+    /// `Tensor::set_plane_offset` — `edgefirst-python-common`'s
+    /// `interop::apply_plane_offset` is the caller that matters. That call was
+    /// a silent no-op on this backing: `set_plane_offset`'s `Dma` arm was
+    /// `cfg(target_os = "linux")`, and because `TensorStorage::Dma` is a
+    /// cfg-multiplexed *name* rather than one type, macOS did not fail to
+    /// compile — it fell through to the catch-all. A reconstructed `view()`
+    /// therefore addressed the parent surface's origin, silently, with no
+    /// error to follow.
+    ///
+    /// Distinct from `subview_iosurface_shares_identity_and_offsets_map`
+    /// above, which covers the *fresh* view path: `IoSurfaceTensor::view` sets
+    /// its own `view_offset` and always did. Only restoring an offset onto an
+    /// already-built tensor was broken — which is exactly why a freshly
+    /// created view was correct on every platform and only the descriptor
+    /// round trip was wrong.
+    ///
+    /// The reconstruction is spelled with `TensorDyn::from_iosurface_id`
+    /// because that is the same `lookup_by_id` + `from_iosurface` pair that
+    /// `import_storage`'s `kind::IOSURFACE` arm runs, without needing the
+    /// Python capsule layer to reach it.
+    #[test]
+    fn set_plane_offset_moves_the_iosurface_map_window() {
+        use crate::{DType, Tensor, TensorDyn, TensorTrait};
+
+        const PARENT: usize = 256;
+        const OFFSET: usize = 64;
+        const WINDOW: usize = 64;
+
+        // Ramp the parent surface so byte i holds i: a window that lands at
+        // the wrong origin cannot coincidentally match the expected bytes.
+        let parent = Tensor::<u8>::new(&[PARENT], Some(TensorMemory::DmaBuf), None).expect("alloc");
+        assert_eq!(parent.memory(), TensorMemory::DmaBuf);
+        {
+            let mut m = parent.map().expect("map parent");
+            for (i, b) in m.as_mut_slice().iter_mut().enumerate() {
+                *b = (i & 0xff) as u8;
+            }
+        }
+        let parent_dyn = TensorDyn::from(parent);
+        let id = parent_dyn
+            .iosurface_id()
+            .expect("parent is IOSurface-backed");
+
+        // Reopen the *whole* surface at the sub-region's shape, as an import
+        // does: the handle names the parent, so this lands at its origin.
+        let mut rebuilt = TensorDyn::from_iosurface_id(id, &[WINDOW], DType::U8, None)
+            .expect("reconstruct at the view's shape");
+        {
+            let m = rebuilt
+                .map_bytes(crate::CpuAccess::Read)
+                .expect("map rebuilt before the offset");
+            assert_eq!(
+                m.as_slice()[0],
+                0,
+                "precondition: a bare import starts at the parent's origin"
+            );
+        }
+
+        // The restore under test.
+        rebuilt.set_plane_offset(OFFSET);
+        assert_eq!(
+            rebuilt.plane_offset(),
+            Some(OFFSET),
+            "the wrapper field records the offset on every backing"
+        );
+
+        let m = rebuilt
+            .map_bytes(crate::CpuAccess::Read)
+            .expect("map rebuilt after the offset");
+        let s = m.as_slice();
+        assert_eq!(s.len(), WINDOW, "the window exposes its logical length");
+        assert_ne!(
+            s[0], 0,
+            "map() still starts at the parent's origin — set_plane_offset was \
+             a no-op on IOSurface storage (issue #161)"
+        );
+        for (i, b) in s.iter().enumerate() {
+            assert_eq!(
+                *b,
+                ((i + OFFSET) & 0xff) as u8,
+                "window byte {i} must be parent[{}]",
+                i + OFFSET
+            );
+        }
+    }
+
+    /// A nested `subview` must not compound its offset now that
+    /// `set_plane_offset` writes through to IOSurface storage.
+    ///
+    /// The double-apply guard for the fix above, and the reason it needed
+    /// checking rather than assuming: `Tensor::subview` sets the offset
+    /// *twice* by two different routes. `TensorStorage::view` computes
+    /// `view_offset + offset_bytes` inside `IoSurfaceTensor::view`, and then
+    /// `subview` calls `set_plane_offset(plane_offset + offset_bytes)` on the
+    /// result. Those are the same number only while the wrapper field and the
+    /// storage field stay in sync — which is what the new arm makes true, and
+    /// what an unguarded restore got wrong on `MEM` in the DMA-BUF half of
+    /// this fix (PR #160). Two levels, because a single level cannot tell an
+    /// idempotent write apart from one that compounds from zero.
+    #[test]
+    fn nested_iosurface_subviews_do_not_compound_their_plane_offset() {
+        use crate::{Tensor, TensorTrait};
+
+        let parent = Tensor::<u8>::new(&[256], Some(TensorMemory::DmaBuf), None).expect("alloc");
+        {
+            let mut m = parent.map().expect("map parent");
+            for (i, b) in m.as_mut_slice().iter_mut().enumerate() {
+                *b = (i & 0xff) as u8;
+            }
+        }
+
+        let outer = parent.subview(64, &[128]).expect("outer subview");
+        assert_eq!(outer.plane_offset(), Some(64));
+        let inner = outer.subview(32, &[64]).expect("inner subview");
+        assert_eq!(
+            inner.plane_offset(),
+            Some(96),
+            "offsets add once, not twice (64 + 32)"
+        );
+
+        let m = inner.map().expect("map nested subview");
+        for (i, b) in m.as_slice().iter().enumerate() {
+            assert_eq!(
+                *b,
+                ((i + 96) & 0xff) as u8,
+                "nested window byte {i} must be parent[{}], not a compounded offset",
+                i + 96
+            );
+        }
+    }
+
+    /// `set_format` must clear the IOSurface storage offset, not just the
+    /// wrapper field.
+    ///
+    /// The mirror of `set_plane_offset_moves_the_iosurface_map_window`, and
+    /// the reason the fix for it is a set/clear pair rather than one arm:
+    /// `set_format` deliberately drops stride and offset when the format
+    /// changes, because neither is necessarily valid for the new one. It
+    /// dropped them with the same Linux-gated match the setter had, so
+    /// clearing on macOS left `plane_offset()` reporting `None` while
+    /// `map()` still started at the old offset -- a stale window instead of
+    /// a lost one, and the failure mode that making the setter take effect
+    /// would otherwise have introduced.
+    #[test]
+    fn set_format_clears_the_iosurface_map_window() {
+        use crate::{PixelFormat, Tensor, TensorTrait};
+
+        const PARENT: usize = 256;
+        const OFFSET: usize = 64;
+
+        let mut t = Tensor::<u8>::new(&[PARENT], Some(TensorMemory::DmaBuf), None).expect("alloc");
+        {
+            let mut m = t.map().expect("map parent");
+            for (i, b) in m.as_mut_slice().iter_mut().enumerate() {
+                *b = (i & 0xff) as u8;
+            }
+        }
+
+        // An 8x8 greyscale window carrying an offset, so there is something
+        // to clear. The surface is a 256-byte byte-bag, so the 64-byte window
+        // plus the offset still fits.
+        t.set_logical_shape(&[8, 8, 1]).expect("logical shape");
+        t.set_format(PixelFormat::Grey).expect("format");
+        t.set_plane_offset(OFFSET);
+        assert_eq!(
+            t.map().expect("map before").as_slice()[0],
+            OFFSET as u8,
+            "precondition: the offset is live before the format change"
+        );
+
+        // Changing the format drops the offset it cannot vouch for.
+        t.set_logical_shape(&[4, 8, 3]).expect("rgb logical shape");
+        t.set_format(PixelFormat::Rgb).expect("new format");
+        assert_eq!(t.plane_offset(), None, "the wrapper field is cleared");
+        assert_eq!(
+            t.map().expect("map after").as_slice()[0],
+            0,
+            "map() still starts at the old offset — set_format cleared the \
+             wrapper field but not the IOSurface storage (issue #161)"
+        );
+    }
 }

--- a/crates/tensor/src/iosurface.rs
+++ b/crates/tensor/src/iosurface.rs
@@ -379,6 +379,9 @@ where
                 "IOSurfaceGetBaseAddress returned null after lock",
             ))
         })?;
+        // SAFETY: the sole caller, `map_inner`, refuses `view_offset + exposed`
+        // past `buf_size` before it gets here, so this stays inside the
+        // surface's allocation.
         let data = unsafe { (base_ptr.as_ptr() as *mut u8).add(self.view_offset) };
         let len = self.buf_size.saturating_sub(self.view_offset);
         Ok(crate::pin::HostPin::new(keepalive, data, len))
@@ -1533,6 +1536,91 @@ mod tests {
             mp.as_slice()[64],
             0xAB,
             "write through view is visible in parent"
+        );
+    }
+
+    /// Pins the bound `map_inner` already enforces, which issue #161 made
+    /// load-bearing: before it, `view_offset` could only come from `view()`
+    /// under that function's own bounds check, and now `set_plane_offset`
+    /// writes a descriptor's restored offset -- untrusted cross-package input
+    /// -- straight into it.
+    ///
+    /// Nothing here is new behaviour; the point is that removing the
+    /// `view_offset + exposed <= buf_size` check in `map_inner` would now be
+    /// reachable from a descriptor rather than only from a bug in `view()`.
+    /// Two things would go wrong. `scoped_pin` offsets the locked base
+    /// address by `view_offset`, which leaves the allocation entirely -- and
+    /// forming that pointer is undefined behaviour before anything reads it.
+    /// And an offset merely *close* to the end yields a map shorter than the
+    /// image while the tensor still reports its full shape, which the GL
+    /// upload path reads `width x height` from through a raw pointer that
+    /// cannot see a slice's length.
+    ///
+    /// `D3d11TextureTensor` had no equivalent of this check; see
+    /// `d3d11_map_refuses_a_plane_offset_past_the_backing`, which this test's
+    /// bounds now match.
+    #[test]
+    fn iosurface_map_refuses_a_plane_offset_that_cannot_hold_the_image() {
+        use crate::{DType, Tensor, TensorDyn, TensorTrait};
+
+        const PARENT: usize = 256;
+        const WINDOW: usize = 64;
+
+        let parent = Tensor::<u8>::new(&[PARENT], Some(TensorMemory::DmaBuf), None).expect("alloc");
+        assert_eq!(parent.memory(), TensorMemory::DmaBuf);
+        let parent_dyn = TensorDyn::from(parent);
+        let id = parent_dyn
+            .iosurface_id()
+            .expect("parent is IOSurface-backed");
+        // The surface's own allocation, which IOSurface may round up past the
+        // 256 bytes asked for -- the bound is the real one, not the request.
+        let capacity = parent_dyn
+            .map_bytes(crate::CpuAccess::Read)
+            .expect("map parent")
+            .as_slice()
+            .len();
+
+        let mut rebuilt = TensorDyn::from_iosurface_id(id, &[WINDOW], DType::U8, None)
+            .expect("reconstruct at the view's shape");
+
+        // A window that still holds its whole 64 bytes is fine, including the
+        // one that ends exactly at the surface's end.
+        rebuilt.set_plane_offset(capacity - WINDOW);
+        assert_eq!(
+            rebuilt
+                .map_bytes(crate::CpuAccess::Read)
+                .expect("the last window that fits")
+                .as_slice()
+                .len(),
+            WINDOW,
+            "a window ending exactly at the surface's end must still map"
+        );
+
+        // One byte further and the image no longer fits. Refused, rather than
+        // handed back one byte short.
+        rebuilt.set_plane_offset(capacity - WINDOW + 1);
+        let err = rebuilt
+            .map_bytes(crate::CpuAccess::Read)
+            .expect_err("a window one byte short of its image");
+        assert!(
+            matches!(err, Error::InsufficientCapacity { .. }),
+            "expected InsufficientCapacity, got {err}"
+        );
+
+        // The degenerate one-past-the-end offset: a legal pointer, an empty
+        // window, and a tensor that still calls itself 64 bytes wide.
+        rebuilt.set_plane_offset(capacity);
+        assert!(
+            rebuilt.map_bytes(crate::CpuAccess::Read).is_err(),
+            "an empty window for a non-empty tensor must not map"
+        );
+
+        // Far past the surface, and a value chosen to overflow if the bound
+        // were computed with wrapping arithmetic.
+        rebuilt.set_plane_offset(usize::MAX);
+        assert!(
+            rebuilt.map_bytes(crate::CpuAccess::Read).is_err(),
+            "usize::MAX must not wrap into range"
         );
     }
 

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -5923,24 +5923,41 @@ where
     /// pitch, so that pitch is recorded as the row stride whenever it exceeds
     /// the new shape's natural stride -- the same adoption `configure_image`
     /// makes. Without it a texture narrowed from 64 to 16 texels wide reports
-    /// a 64-byte stride over rows that are 256 bytes apart.
+    /// a 64-byte stride over rows that are 256 bytes apart. A single-row
+    /// shape records its own tight stride instead, by [`view`](Self::view)'s
+    /// rule: a strided `map()` spans `stride * rows`, and one pitched row
+    /// runs past the backing when the window sits in the last row.
     fn set_logical_shape(&mut self, shape: &[usize]) -> Result<()> {
         self.storage.set_logical_shape(shape)?;
         // Only a backing with a pitch of its own, and only while the shape
         // still has the rank the format's row is measured on: a caller may
         // flatten an image to one dimension and leave the format behind.
-        if let Some(pitch) = self.storage.backing_row_stride() {
-            let rank = self.format.map(|f| match f.layout() {
-                PixelLayout::Packed | PixelLayout::Planar => 3,
-                PixelLayout::SemiPlanar => 2,
-            });
-            if rank == Some(shape.len()) {
-                if let Some(natural) = self.effective_row_stride() {
-                    if pitch > natural {
-                        self.set_row_stride_unchecked(pitch);
-                    }
-                }
-            }
+        let Some(pitch) = self.storage.backing_row_stride() else {
+            return Ok(());
+        };
+        let Some((rank, rows)) = self.format.map(|f| match f.layout() {
+            PixelLayout::Packed => (3, shape.first().copied()),
+            PixelLayout::Planar => (3, shape.get(1).copied()),
+            PixelLayout::SemiPlanar => (2, shape.first().copied()),
+        }) else {
+            return Ok(());
+        };
+        if rank != shape.len() {
+            return Ok(());
+        }
+        // The natural stride of the new shape, not of the stride recorded for
+        // the old one.
+        let prior = self.row_stride.take();
+        let Some(natural) = self.effective_row_stride() else {
+            self.row_stride = prior;
+            return Ok(());
+        };
+        if rows == Some(1) {
+            self.set_row_stride_unchecked(natural);
+        } else if pitch > natural {
+            self.set_row_stride_unchecked(pitch);
+        } else {
+            self.row_stride = prior;
         }
         Ok(())
     }

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -4136,6 +4136,15 @@ where
                 TensorStorage::Mem(ref mut m) => m.set_offset(0),
                 #[cfg(target_os = "linux")]
                 TensorStorage::Dma(ref mut dma) => dma.mmap_offset = 0,
+                // Paired with the arm in `set_plane_offset`: a setter that
+                // takes effect on this backing needs a clear that does too,
+                // or the wrapper reports `None` while `map()` still starts at
+                // the old offset -- a stale window rather than a lost one.
+                // `reshape`'s clear site needs no such arm:
+                // `IoSurfaceTensor::reshape` zeroes `view_offset` itself
+                // before the match there runs.
+                #[cfg(any(target_os = "macos", target_os = "ios"))]
+                TensorStorage::Dma(ref mut io) => io.view_offset = 0,
                 _ => {}
             }
         }
@@ -4631,29 +4640,42 @@ where
         self.plane_offset = Some(offset);
         // The offset consulted by `map()` lives inside the storage variant.
         // Keep it in sync with the wrapper field for every backing that
-        // honors it (DMA and Mem); see also the clear sites in `set_format`
-        // and `reshape`.
+        // honors it; see also the clear sites in `set_format` and `reshape`.
         //
-        // INCOMPLETE, knowingly: `IoSurfaceTensor`, `PboTensor`,
-        // `D3d11TextureTensor` and `AHardwareBufferTensor` each have a
+        // Note that `TensorStorage::Dma` is a cfg-multiplexed *name* rather
+        // than one type -- `DmaTensor` on Linux, `IoSurfaceTensor` on
+        // macOS/iOS, `AHardwareBufferTensor` on Android,
+        // `D3d11TextureTensor` on Windows -- so a `cfg`-gated `Dma` arm does
+        // not fail to compile on the other targets, it silently becomes a
+        // fall-through to `_ => {}`. That is how macOS went without one.
+        //
+        // STILL INCOMPLETE: `D3d11TextureTensor` (Windows),
+        // `AHardwareBufferTensor` (Android) and `PboTensor` each have a
         // `view_offset` that their own `map()` adds and their own `view()`
-        // sets -- but nothing writes it here, so they fall into `_ => {}`
-        // and a caller that sets the offset on them gets a map at the
-        // parent's origin.
-        //
-        // The two that this demonstrably breaks are `IoSurfaceTensor`
-        // (macOS/iOS) and `D3d11TextureTensor` (Windows): both are
+        // sets, but nothing writes it here, so they fall into `_ => {}` and
+        // a caller that sets the offset on them gets a map at the parent's
+        // origin. D3D11 is the one that demonstrably matters -- it is
         // reachable through `TensorDyn::import_descriptor`, so a
-        // reconstructed `view()` reads the wrong region there. See
-        // `edgefirst-python-common`'s `interop::apply_plane_offset`, which
-        // fixes the Linux DMA-BUF case, records the full per-backing
-        // accounting, and explains why the remaining two want a
-        // per-platform change with a test on each rather than two more arms
-        // added blind.
+        // reconstructed `view()` reads the wrong region there (issue #161).
+        // Android cannot be reconstructed at all (its `import_storage` arm
+        // is `cfg(target_os = "linux")`), and a PBO `view()` demotes to host
+        // memory before it gets here (issue #162). See
+        // `edgefirst-python-common`'s `interop::apply_plane_offset` for the
+        // full per-backing accounting.
         match self.storage {
             TensorStorage::Mem(ref mut m) => m.set_offset(offset),
             #[cfg(target_os = "linux")]
             TensorStorage::Dma(ref mut dma) => dma.mmap_offset = offset,
+            // The offset `IoSurfaceTensor::scoped_pin`/`map_inner` add to the
+            // locked base address. Writing it here is what makes a
+            // *reconstructed* view address its own sub-region instead of the
+            // parent surface's origin; `IoSurfaceTensor::view` already set it
+            // on the fresh-view path, which is why only the descriptor round
+            // trip was ever wrong. Idempotent against `subview`, which sets
+            // the same absolute value by both routes -- pinned by
+            // `nested_iosurface_subviews_do_not_compound_their_plane_offset`.
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            TensorStorage::Dma(ref mut io) => io.view_offset = offset,
             _ => {}
         }
     }

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -4145,6 +4145,11 @@ where
                 // before the match there runs.
                 #[cfg(any(target_os = "macos", target_os = "ios"))]
                 TensorStorage::Dma(ref mut io) => io.view_offset = 0,
+                // The same pair for D3D11. Unlike `IoSurfaceTensor`,
+                // `D3d11TextureTensor::reshape` leaves `view_offset` alone, so
+                // `reshape`'s clear site carries this arm as well.
+                #[cfg(target_os = "windows")]
+                TensorStorage::Dma(ref mut tex) => tex.set_view_offset(0),
                 _ => {}
             }
         }
@@ -4649,17 +4654,14 @@ where
         // not fail to compile on the other targets, it silently becomes a
         // fall-through to `_ => {}`. That is how macOS went without one.
         //
-        // STILL INCOMPLETE: `D3d11TextureTensor` (Windows),
-        // `AHardwareBufferTensor` (Android) and `PboTensor` each have a
-        // `view_offset` that their own `map()` adds and their own `view()`
-        // sets, but nothing writes it here, so they fall into `_ => {}` and
-        // a caller that sets the offset on them gets a map at the parent's
-        // origin. D3D11 is the one that demonstrably matters -- it is
-        // reachable through `TensorDyn::import_descriptor`, so a
-        // reconstructed `view()` reads the wrong region there (issue #161).
-        // Android cannot be reconstructed at all (its `import_storage` arm
-        // is `cfg(target_os = "linux")`), and a PBO `view()` demotes to host
-        // memory before it gets here (issue #162). See
+        // STILL INCOMPLETE: `AHardwareBufferTensor` (Android) and
+        // `PboTensor` each have a `view_offset` that their own `map()` adds
+        // and their own `view()` sets, but nothing writes it here, so they
+        // fall into `_ => {}` and a caller that sets the offset on them gets
+        // a map at the parent's origin. Neither is reachable through
+        // `TensorDyn::import_descriptor` today: Android's `import_storage`
+        // arm is `cfg(target_os = "linux")`, and a PBO `view()` demotes to
+        // host memory before it gets here (issue #162). See
         // `edgefirst-python-common`'s `interop::apply_plane_offset` for the
         // full per-backing accounting.
         match self.storage {
@@ -4676,6 +4678,14 @@ where
             // `nested_iosurface_subviews_do_not_compound_their_plane_offset`.
             #[cfg(any(target_os = "macos", target_os = "ios"))]
             TensorStorage::Dma(ref mut io) => io.view_offset = offset,
+            // The offset every `D3d11TextureTensor` pin adds to its host or
+            // staging base, in backing (pitched) space like `row_stride()`.
+            // `view()` bounds-checks the value it computes; this route does
+            // not, so the pins refuse an offset past the backing instead
+            // (`check_view_offset` in `d3d11/texture.rs`). Pinned by the
+            // `d3d11` plane-offset tests in `crates/tensor/tests`.
+            #[cfg(target_os = "windows")]
+            TensorStorage::Dma(ref mut tex) => tex.set_view_offset(offset),
             _ => {}
         }
     }
@@ -5881,6 +5891,11 @@ where
             TensorStorage::Mem(ref mut m) => m.set_offset(0),
             #[cfg(target_os = "linux")]
             TensorStorage::Dma(ref mut dma) => dma.mmap_offset = 0,
+            // `IoSurfaceTensor::reshape` zeroes its own `view_offset`;
+            // `D3d11TextureTensor::reshape` does not, so the clear that
+            // pairs with `set_plane_offset`'s D3D11 arm lives here.
+            #[cfg(target_os = "windows")]
+            TensorStorage::Dma(ref mut tex) => tex.set_view_offset(0),
             _ => {}
         }
         Ok(())
@@ -5902,8 +5917,32 @@ where
     /// reconfiguring it to a smaller image without reallocating -- and it
     /// worked precisely because it bypassed this method. This forwards the
     /// same way, so the two agree.
+    ///
+    /// A narrower image inside a pitched backing (an IOSurface, an
+    /// AHardwareBuffer, a D3D11 texture) still advances rows by the backing's
+    /// pitch, so that pitch is recorded as the row stride whenever it exceeds
+    /// the new shape's natural stride -- the same adoption `configure_image`
+    /// makes. Without it a texture narrowed from 64 to 16 texels wide reports
+    /// a 64-byte stride over rows that are 256 bytes apart.
     fn set_logical_shape(&mut self, shape: &[usize]) -> Result<()> {
-        self.storage.set_logical_shape(shape)
+        self.storage.set_logical_shape(shape)?;
+        // Only a backing with a pitch of its own, and only while the shape
+        // still has the rank the format's row is measured on: a caller may
+        // flatten an image to one dimension and leave the format behind.
+        if let Some(pitch) = self.storage.backing_row_stride() {
+            let rank = self.format.map(|f| match f.layout() {
+                PixelLayout::Packed | PixelLayout::Planar => 3,
+                PixelLayout::SemiPlanar => 2,
+            });
+            if rank == Some(shape.len()) {
+                if let Some(natural) = self.effective_row_stride() {
+                    if pitch > natural {
+                        self.set_row_stride_unchecked(pitch);
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     fn map_with<'a>(&self, access: CpuAccess) -> Result<crate::view::HostView<'a, T>>

--- a/crates/tensor/src/protocol.rs
+++ b/crates/tensor/src/protocol.rs
@@ -530,12 +530,20 @@ pub(crate) fn descriptor_d3d11_handles(
 /// passed down to [`crate::d3d11_shared_handle_geometry`] rather than only
 /// checked here.
 ///
+/// A third spelling is accepted here and nowhere else: a packed *window* of
+/// the texture, which is what a `view()` describes (`[h', w', c]` with `h'`
+/// and `w'` no larger than the texture's, and no smaller than one). The
+/// import still opens the whole texture; `restore_d3d11_logical_shape`
+/// narrows it to the window and the producer's plane offset places it. The
+/// blob transport does not take this spelling because nothing narrows on
+/// that path, so a window shape would be accepted and then ignored.
+///
 /// # Errors
 ///
 /// [`crate::Error::InvalidArgument`] when the descriptor names no pixel
-/// format, or when its shape is neither spelling of the geometry the
-/// texture reports. Propagates whatever opening and describing the texture
-/// reports.
+/// format, or when its shape is none of the three spellings of the geometry
+/// the texture reports. Propagates whatever opening and describing the
+/// texture reports.
 ///
 /// # Safety
 ///
@@ -556,8 +564,39 @@ pub(crate) unsafe fn descriptor_d3d11_geometry(
     })?;
     // SAFETY: the caller guarantees `texture` is a shared NT handle valid in
     // this process.
-    let (width, height) = unsafe { d3d11_geometry_checked(format, texture, shape) }?;
+    let (width, height) =
+        unsafe { d3d11_geometry_with_rule(format, texture, shape, ShapeRule::OrWindow) }?;
     Ok((format, width, height))
+}
+
+/// Which spellings of a texture's geometry a `shape` may take.
+#[cfg(target_os = "windows")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ShapeRule {
+    /// The allocation shape or the addressing shape, exactly.
+    Exact,
+    /// `Exact`, or a packed window of the texture (a `view()`).
+    OrWindow,
+}
+
+/// Whether `shape` is a packed sub-rectangle of a `width` x `height` image
+/// in `format`: the allocation spelling with a smaller height or width. A
+/// window is never a semi-planar or planar image (`Tensor::view` makes
+/// packed views only) and never empty.
+#[cfg(target_os = "windows")]
+fn is_packed_window_of(
+    format: crate::PixelFormat,
+    shape: &[usize],
+    width: usize,
+    height: usize,
+) -> bool {
+    if format.layout() != crate::PixelLayout::Packed {
+        return false;
+    }
+    let [h, w, c] = shape else {
+        return false;
+    };
+    *c == format.channels() && (1..=height).contains(h) && (1..=width).contains(w)
 }
 
 /// The image dimensions a shared D3D11 texture reports, with `shape` checked
@@ -584,20 +623,38 @@ pub(crate) unsafe fn d3d11_geometry_checked(
     texture: std::os::windows::io::RawHandle,
     shape: &[usize],
 ) -> crate::Result<(usize, usize)> {
+    // SAFETY: forwarded unchanged.
+    unsafe { d3d11_geometry_with_rule(format, texture, shape, ShapeRule::Exact) }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn d3d11_geometry_with_rule(
+    format: crate::PixelFormat,
+    texture: std::os::windows::io::RawHandle,
+    shape: &[usize],
+    rule: ShapeRule,
+) -> crate::Result<(usize, usize)> {
     // SAFETY: the caller guarantees `texture` is a shared NT handle valid in
     // this process; the helper opens its own texture and drops it on return.
     let (width, height) =
         unsafe { crate::d3d11_shared_handle_geometry(texture, format, Some(shape)) }?;
     let allocation = format.allocation_shape(width, height);
     let addressing = format.addressing_shape(width, height);
-    if allocation.as_deref() != Some(shape) && addressing.as_deref() != Some(shape) {
-        return Err(crate::Error::InvalidArgument(format!(
-            "D3D11 texture shape {shape:?} is neither the {format:?} allocation \
-             shape {allocation:?} nor the addressing shape {addressing:?} of the \
-             {width}x{height} texture it names"
-        )));
+    if allocation.as_deref() == Some(shape) || addressing.as_deref() == Some(shape) {
+        return Ok((width, height));
     }
-    Ok((width, height))
+    if rule == ShapeRule::OrWindow && is_packed_window_of(format, shape, width, height) {
+        return Ok((width, height));
+    }
+    let window = match rule {
+        ShapeRule::OrWindow => " nor a packed window",
+        ShapeRule::Exact => "",
+    };
+    Err(crate::Error::InvalidArgument(format!(
+        "D3D11 texture shape {shape:?} is neither the {format:?} allocation \
+         shape {allocation:?} nor the addressing shape {addressing:?}{window} of the \
+         {width}x{height} texture it names"
+    )))
 }
 
 /// Inputs to [`from_parts`], grouped into one named-field struct rather than

--- a/crates/tensor/src/tensor_dyn/derived.rs
+++ b/crates/tensor/src/tensor_dyn/derived.rs
@@ -179,7 +179,9 @@ fn restore_descriptor_metadata(
 /// narrowing rebuilds a `view()`: its descriptor carries the window's shape,
 /// the import opens the whole texture, and this cuts it down to the window
 /// (`Tensor::set_logical_shape` keeps the texture's pitch as the row stride
-/// while it does). Where the window sits is the plane offset, which the
+/// while it does, or `view()`'s tight stride for a single-row window, so
+/// the window maps in the texture's last row). Where the window sits is the
+/// plane offset, which the
 /// descriptor cannot carry and the capsule restores afterwards. The import
 /// arm has already checked `shape` is one of those three spellings of the
 /// geometry the texture itself reports, so nothing untrusted reaches

--- a/crates/tensor/src/tensor_dyn/derived.rs
+++ b/crates/tensor/src/tensor_dyn/derived.rs
@@ -175,9 +175,14 @@ fn restore_descriptor_metadata(
 /// producer that called `set_logical_shape` was carrying the *addressing*
 /// shape instead (`[h, w]` for a semi-planar image rather than
 /// `[combined_h, w]`), and the descriptor faithfully reported it; without
-/// this the consumer would see a shape its producer did not have. The
-/// import arm has already checked `shape` is one of those two spellings of
-/// the geometry the texture itself reports, so nothing untrusted reaches
+/// this the consumer would see a shape its producer did not have. The same
+/// narrowing rebuilds a `view()`: its descriptor carries the window's shape,
+/// the import opens the whole texture, and this cuts it down to the window
+/// (`Tensor::set_logical_shape` keeps the texture's pitch as the row stride
+/// while it does). Where the window sits is the plane offset, which the
+/// descriptor cannot carry and the capsule restores afterwards. The import
+/// arm has already checked `shape` is one of those three spellings of the
+/// geometry the texture itself reports, so nothing untrusted reaches
 /// `set_logical_shape` here.
 ///
 /// After the format restore, not before: `set_format` validates the shape it

--- a/crates/tensor/tests/d3d11_tensor.rs
+++ b/crates/tensor/tests/d3d11_tensor.rs
@@ -1066,6 +1066,13 @@ fn reshape_clears_the_d3d11_map_window() {
 /// `set_plane_offset` takes any value -- a descriptor's restored offset is
 /// untrusted -- so the pins bound it rather than offsetting a base pointer
 /// past the backing.
+///
+/// The bound is the whole image, not just its first byte. A pin's length is
+/// the backing less the offset, so an offset near the end leaves a map
+/// shorter than the image while the tensor still reports its full width and
+/// height, and a consumer reading `width x height` through the map's pointer
+/// runs past the allocation -- which the GL upload path does, since GL takes
+/// a raw pointer and cannot see a slice's length.
 #[test]
 fn d3d11_map_refuses_a_plane_offset_past_the_backing() {
     let parent = ramped_rgba(64, 64);
@@ -1076,11 +1083,27 @@ fn d3d11_map_refuses_a_plane_offset_past_the_backing() {
         .map_bytes(CpuAccess::Read)
         .expect_err("a window past the backing");
     assert!(matches!(err, Error::InsufficientCapacity { .. }), "{err}");
-    // Exactly the backing is the one-past-the-end address: an empty window,
-    // not an error.
+
+    // Exactly the backing is a legal one-past-the-end pointer, but it is an
+    // empty window for a tensor that still calls itself 64x64 -- the shape
+    // that fed a short map to `TexImage2D`. Refused, not handed back empty.
     t.set_plane_offset(backing);
-    let m = t.map_bytes(CpuAccess::Read).expect("empty window");
-    assert!(m.as_slice().is_empty());
+    let err = t
+        .map_bytes(CpuAccess::Read)
+        .expect_err("an empty window for a non-empty tensor");
+    assert!(matches!(err, Error::InsufficientCapacity { .. }), "{err}");
+
+    // One byte short of the whole image is refused for the same reason: the
+    // map would be a byte shy of what width x height reads.
+    t.set_plane_offset(1);
+    let err = t
+        .map_bytes(CpuAccess::Read)
+        .expect_err("a window one byte short of the image");
+    assert!(matches!(err, Error::InsufficientCapacity { .. }), "{err}");
+
+    // The whole image at its own origin still maps.
+    t.set_plane_offset(0);
+    assert!(!t.map_bytes(CpuAccess::Read).expect("origin").is_empty());
 }
 
 /// A single-row view records a tight row stride (`Tensor::view`) while its

--- a/crates/tensor/tests/d3d11_tensor.rs
+++ b/crates/tensor/tests/d3d11_tensor.rs
@@ -1082,3 +1082,53 @@ fn d3d11_map_refuses_a_plane_offset_past_the_backing() {
     let m = t.map_bytes(CpuAccess::Read).expect("empty window");
     assert!(m.as_slice().is_empty());
 }
+
+/// A single-row view records a tight row stride (`Tensor::view`) while its
+/// offset is measured in the texture's pitch. The descriptor round trip
+/// keeps the two apart: the window imports at one row with the same tight
+/// stride, and the offset put back is the producer's own, so the rebuilt
+/// window maps the same texels -- including in the texture's last row,
+/// where one pitched row would run past the backing. Dividing the offset by
+/// the descriptor's stride, as a pitch translation once did, named row 32
+/// for a view of row 8.
+#[test]
+fn one_row_d3d11_view_descriptor_maps_the_producers_texels() {
+    let parent = ramped_rgba(64, 64);
+    let pitch = parent.effective_row_stride().expect("parent pitch");
+    for (x, y) in [(8usize, 8usize), (48, 63)] {
+        let view = parent
+            .view(edgefirst_tensor::Region::new(x, y, 16, 1))
+            .expect("one-row view");
+        assert_eq!(
+            view.effective_row_stride(),
+            Some(16 * 4),
+            "a one-row view is tight"
+        );
+        let offset = view.plane_offset().expect("a view carries its offset");
+        assert_eq!(offset, y * pitch + x * 4, "the offset is in the pitch");
+
+        let desc = view.descriptor_pinned(None);
+        let mut rebuilt = TensorDyn::import_descriptor(&desc).expect("a one-row window");
+        assert_eq!(rebuilt.shape(), &[1, 16, 4]);
+        assert_eq!(
+            rebuilt.effective_row_stride(),
+            Some(16 * 4),
+            "a narrowed one-row window keeps view()'s tight stride"
+        );
+        rebuilt.set_plane_offset(offset);
+
+        let expect: Vec<u8> = (offset..offset + 16 * 4)
+            .map(|i| (i & 0xff) as u8)
+            .collect();
+        let m = rebuilt
+            .map_bytes(CpuAccess::Read)
+            .expect("the window maps, last row included");
+        assert_eq!(
+            m.as_slice(),
+            expect.as_slice(),
+            "rebuilt window at ({x}, {y})"
+        );
+        let v = view.map_bytes(CpuAccess::Read).expect("map the view");
+        assert_eq!(v.as_slice(), expect.as_slice(), "fresh view at ({x}, {y})");
+    }
+}

--- a/crates/tensor/tests/d3d11_tensor.rs
+++ b/crates/tensor/tests/d3d11_tensor.rs
@@ -832,3 +832,253 @@ fn child_imports_the_exported_blob(path: &str) {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Plane offset on a reconstructed tensor -- issue #161, the Windows half.
+//
+// `TensorDesc` has no field for the plane offset, so a consumer rebuilding a
+// `view()` from a descriptor opens the whole texture and puts the offset back
+// with `Tensor::set_plane_offset`. That was a silent no-op on this backing:
+// the `Dma` arm was `cfg(target_os = "linux")` and `TensorStorage::Dma` is a
+// cfg-multiplexed *name* rather than one type, so Windows fell through to the
+// catch-all. And it could not even be reached: the import refused a window
+// shape outright. Each test below pins one piece of the fix and was seen to
+// fail without it.
+// ---------------------------------------------------------------------------
+
+/// A ramp so byte `i` holds `i & 0xff`: a window that lands at the wrong
+/// origin cannot coincidentally match the expected bytes.
+fn ramped_rgba(w: usize, h: usize) -> TensorDyn {
+    let t = TensorDyn::image(
+        w,
+        h,
+        PixelFormat::Rgba,
+        DType::U8,
+        Some(TensorMemory::DmaBuf),
+        CpuAccess::ReadWrite,
+    )
+    .expect("texture alloc");
+    assert_eq!(t.memory(), TensorMemory::DmaBuf);
+    let mut m = t.map_bytes(CpuAccess::Write).expect("map parent");
+    for (i, b) in m.as_mut_slice().iter_mut().enumerate() {
+        *b = (i & 0xff) as u8;
+    }
+    drop(m);
+    t
+}
+
+/// A view's descriptor imports at the window's shape, over the whole
+/// texture, keeping the texture's pitch as its row stride. Before the fix
+/// this import failed with "neither the allocation shape nor the addressing
+/// shape", which is the *loud* half of the Windows bug.
+#[test]
+fn d3d11_view_descriptor_imports_at_the_window_with_the_textures_pitch() {
+    let parent = ramped_rgba(64, 64);
+    let pitch = parent.effective_row_stride().expect("parent pitch");
+    let view = parent
+        .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+        .expect("view");
+    let desc = view.descriptor_pinned(None);
+    assert_eq!(desc.kind, edgefirst_tensor::protocol::kind::D3D11_TEXTURE);
+    assert_eq!(desc.shape(), &[16, 16, 4]);
+
+    let rebuilt = TensorDyn::import_descriptor(&desc).expect("a window is a valid shape");
+    assert_eq!(rebuilt.shape(), &[16, 16, 4], "narrowed to the window");
+    assert_eq!(
+        rebuilt.effective_row_stride(),
+        Some(pitch),
+        "rows are still the texture's rows"
+    );
+    assert_eq!(
+        rebuilt.plane_offset(),
+        None,
+        "the descriptor cannot carry the offset; the capsule restores it"
+    );
+    // Before the offset is put back, the window sits at the texture's
+    // origin -- the state `apply_plane_offset` corrects.
+    let m = rebuilt.map_bytes(CpuAccess::Read).expect("map rebuilt");
+    assert_eq!(m.as_slice()[0], 0);
+}
+
+/// A window is the only third spelling: a semi-planar sub-rectangle is not
+/// one (`Tensor::view` makes packed views only), nor a window with a
+/// different channel count, nor an empty one. Untrusted descriptor input
+/// keeps failing loudly.
+#[test]
+fn d3d11_window_descriptor_is_packed_and_non_empty_only() {
+    let nv12 = TensorDyn::image(
+        64,
+        64,
+        PixelFormat::Nv12,
+        DType::U8,
+        Some(TensorMemory::DmaBuf),
+        CpuAccess::ReadWrite,
+    )
+    .expect("nv12 alloc");
+    let mut desc = nv12.descriptor_pinned(None);
+    desc.ndim = 2;
+    desc.shape[0] = 32;
+    desc.shape[1] = 32;
+    let err = TensorDyn::import_descriptor(&desc).expect_err("semi-planar window");
+    assert!(matches!(err, Error::InvalidArgument(_)), "{err}");
+
+    let rgba = ramped_rgba(64, 64);
+    for (label, shape) in [
+        ("wrong channels", [16usize, 16, 3]),
+        ("empty rows", [0, 16, 4]),
+        ("taller than the texture", [65, 16, 4]),
+    ] {
+        let mut desc = rgba.descriptor_pinned(None);
+        desc.shape[0] = shape[0] as u64;
+        desc.shape[1] = shape[1] as u64;
+        desc.shape[2] = shape[2] as u64;
+        let err = TensorDyn::import_descriptor(&desc).expect_err(label);
+        assert!(matches!(err, Error::InvalidArgument(_)), "{label}: {err}");
+    }
+}
+
+/// Restoring a plane offset onto a reconstructed texture tensor must move
+/// where `map()` starts. The Windows twin of
+/// `set_plane_offset_moves_the_iosurface_map_window`.
+#[test]
+fn set_plane_offset_moves_the_d3d11_map_window() {
+    let parent = ramped_rgba(64, 64);
+    let view = parent
+        .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+        .expect("view");
+    let offset = view.plane_offset().expect("a view carries its offset");
+    let mut rebuilt =
+        TensorDyn::import_descriptor(&view.descriptor_pinned(None)).expect("reconstruct");
+
+    // The restore under test: what `interop::apply_plane_offset` does.
+    rebuilt.set_plane_offset(offset);
+    assert_eq!(rebuilt.plane_offset(), Some(offset));
+
+    let m = rebuilt
+        .map_bytes(CpuAccess::Read)
+        .expect("map after the offset");
+    let s = m.as_slice();
+    assert_ne!(
+        s[0], 0,
+        "map() still starts at the texture's origin -- set_plane_offset was a \
+         no-op on D3D11 storage (issue #161)"
+    );
+    let pitch = rebuilt.effective_row_stride().expect("pitch");
+    for row in 0..16 {
+        for x in 0..16 * 4 {
+            let at = row * pitch + x;
+            assert_eq!(
+                s[at],
+                ((offset + at) & 0xff) as u8,
+                "window byte {at} must be parent[{}]",
+                offset + at
+            );
+        }
+    }
+}
+
+/// A nested `subview` must not compound its offset now that
+/// `set_plane_offset` writes through to the texture storage: `Tensor::subview`
+/// sets the offset twice by two routes (`D3d11TextureTensor::view` computes
+/// `view_offset + offset_bytes`, then `subview` writes `plane_offset +
+/// offset_bytes` back), which agree only while the wrapper and storage fields
+/// stay in sync. Two levels, because one level cannot tell an idempotent
+/// write from one that compounds from zero.
+#[test]
+fn nested_d3d11_subviews_do_not_compound_their_plane_offset() {
+    let parent = ramped_rgba(64, 64);
+    let pitch = parent.effective_row_stride().expect("pitch");
+    let outer = parent
+        .view(edgefirst_tensor::Region::new(8, 8, 32, 32))
+        .expect("outer view");
+    assert_eq!(outer.plane_offset(), Some(8 * pitch + 8 * 4));
+    let inner = outer
+        .view(edgefirst_tensor::Region::new(4, 4, 16, 16))
+        .expect("inner view");
+    let expected = 12 * pitch + 12 * 4;
+    assert_eq!(
+        inner.plane_offset(),
+        Some(expected),
+        "offsets add once, not twice"
+    );
+    let m = inner.map_bytes(CpuAccess::Read).expect("map nested view");
+    assert_eq!(
+        m.as_slice()[0],
+        (expected & 0xff) as u8,
+        "nested window byte 0 must be parent[{expected}], not a compounded offset"
+    );
+}
+
+/// `set_format` must clear the texture storage offset, not just the wrapper
+/// field, or `plane_offset()` reports `None` while `map()` still starts at
+/// the old offset -- a stale window instead of a lost one.
+#[test]
+fn set_format_clears_the_d3d11_map_window() {
+    let parent = ramped_rgba(64, 64);
+    let view = parent
+        .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+        .expect("view");
+    let mut t = TensorDyn::import_descriptor(&view.descriptor_pinned(None)).expect("reconstruct");
+    t.set_plane_offset(view.plane_offset().expect("offset"));
+    assert_ne!(
+        t.map_bytes(CpuAccess::Read).expect("map before").as_slice()[0],
+        0,
+        "precondition: the offset is live before the format change"
+    );
+
+    // A different packed format of the same channel count keeps the shape
+    // valid; changing it drops the offset it cannot vouch for.
+    t.set_format(PixelFormat::Bgra).expect("new format");
+    assert_eq!(t.plane_offset(), None, "the wrapper field is cleared");
+    assert_eq!(
+        t.map_bytes(CpuAccess::Read).expect("map after").as_slice()[0],
+        0,
+        "map() still starts at the old offset -- set_format cleared the wrapper \
+         field but not the D3D11 storage (issue #161)"
+    );
+}
+
+/// `reshape` is the other clear site, and unlike `IoSurfaceTensor::reshape`
+/// the D3D11 storage's own `reshape` leaves `view_offset` alone, so the
+/// wrapper's arm is what clears it.
+#[test]
+fn reshape_clears_the_d3d11_map_window() {
+    let parent = ramped_rgba(64, 64);
+    let view = parent
+        .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+        .expect("view");
+    let mut t = TensorDyn::import_descriptor(&view.descriptor_pinned(None)).expect("reconstruct");
+    t.set_plane_offset(view.plane_offset().expect("offset"));
+    assert_ne!(
+        t.map_bytes(CpuAccess::Read).expect("map before").as_slice()[0],
+        0
+    );
+
+    t.reshape(&[16 * 16 * 4]).expect("same element count");
+    assert_eq!(t.plane_offset(), None);
+    assert_eq!(
+        t.map_bytes(CpuAccess::Read).expect("map after").as_slice()[0],
+        0,
+        "map() still starts at the old offset after reshape (issue #161)"
+    );
+}
+
+/// `set_plane_offset` takes any value -- a descriptor's restored offset is
+/// untrusted -- so the pins bound it rather than offsetting a base pointer
+/// past the backing.
+#[test]
+fn d3d11_map_refuses_a_plane_offset_past_the_backing() {
+    let parent = ramped_rgba(64, 64);
+    let mut t = TensorDyn::import_descriptor(&parent.descriptor_pinned(None)).expect("reconstruct");
+    let backing = t.effective_row_stride().expect("pitch") * 64;
+    t.set_plane_offset(backing + 1);
+    let err = t
+        .map_bytes(CpuAccess::Read)
+        .expect_err("a window past the backing");
+    assert!(matches!(err, Error::InsufficientCapacity { .. }), "{err}");
+    // Exactly the backing is the one-past-the-end address: an empty window,
+    // not an error.
+    t.set_plane_offset(backing);
+    let m = t.map_bytes(CpuAccess::Read).expect("empty window");
+    assert!(m.as_slice().is_empty());
+}


### PR DESCRIPTION
Closes #161 for both remaining backings. PR #160 fixed Linux DMA-BUF; this PR adds IOSurface (macOS/iOS) and, via #164 merged in, D3D11 (Windows).

Reconstructing a tensor from a `TensorDesc` drops the plane offset, so a consumer that rebuilds a `view()` and restores the offset with `Tensor::set_plane_offset` got a tensor that addressed the parent buffer's origin instead of the sub-region it named — silently, with no error and plausible-looking pixels.

## Why a `cfg`-gated arm vanished instead of failing to compile

`TensorStorage::Dma` is a cfg-multiplexed **name**, not one type — `DmaTensor` on Linux, `IoSurfaceTensor` on macOS/iOS, `AHardwareBufferTensor` on Android, `D3d11TextureTensor` on Windows, declared four times under mutually-exclusive `cfg`s so the public `TensorMemory::DmaBuf` discriminant stays stable. A `#[cfg]`-gated `Dma` match arm therefore does not fail to compile on the other targets: it compiles away into whatever catch-all follows. `set_plane_offset`'s was `_ => {}`.

The bug is asymmetric, which is why it survived: each backend's own `view()` sets its offset correctly, so a *freshly created* view was right everywhere. Only *restoring* an offset onto a tensor rebuilt from a descriptor was wrong.

## What changed

**Set and clear as a pair.** A setter that takes effect with a clear that does not trades a lost window for a *stale* one, so `set_format`'s clear site got the matching arm on both backings. `reshape` needs no IOSurface arm — `IoSurfaceTensor::reshape` zeroes `view_offset` itself — and does need one on D3D11, which does not.

**D3D11 additionally needed** a `pub(crate)` setter for its private `view_offset`, and a `D3D11_TEXTURE` import that checks the descriptor's shape against the texture's own rather than assuming they match.

**GL lowering.** Neither ANGLE extension can express a byte offset: `EGL_ANGLE_image_d3d11_texture` binds the whole texture from its origin, `EGL_ANGLE_iosurface_client_buffer` the whole surface. A *source* carrying an offset is refused so the engine uploads it through `map()`, which honours the offset. A *destination* rebuilt from a descriptor carries the offset but not the `view_origin` a `view()` would have given it, so there is no viewport to place it by; it is refused too and lowered to the mapped texture path, whose readback writes through `map()`. Linux keeps the zero-copy path — its DMA-BUF import can express the offset.

## Review round 2

**A restored offset could hand back a map shorter than the image.** A pin's length is the backing less `view_offset` and `HostView::len_elems` clamps a map to the pin, so an offset near the end of the backing yields a short-but-valid slice while the tensor still reports its full width and height. `update_texture` then calls `TexImage2D` with `src_w × src_h` and `data.as_ptr()`; GL reads through a raw pointer and cannot see a slice's length, so the driver reads past the mapping.

`D3d11TextureTensor::check_view_offset` bounded only the *start* of the window — `d3d11_map_refuses_a_plane_offset_past_the_backing` pinned `offset == capacity` as "an empty window, not an error" for a tensor still calling itself 64×64. It now bounds the whole image, with `checked_add` so a hostile offset cannot wrap into range, and row-aware (every row but the last at the backing pitch, plus the last row's own bytes) because bounding by `pitched_extent` would refuse a legitimate view in the texture's last row.

`IoSurfaceTensor` was already correct: `map_inner` has done exactly this check, `checked_add` included, all along, and `scoped_pin` has no other caller. No IOSurface code changed — only a test pinning that bound, now that #161 makes `view_offset` reachable from a descriptor rather than only from `view()`.

**An Apple destination rebuilt from a descriptor rendered at the surface's origin.** `dst_import_places` arrived defaulting to `true` and `AngleClientBuffer` inherited it. Confirmed before fixing: case D of `reconstructed_view_convert.rs` failed with `want(8, 8)` at pixel (0, 0). Apple now declines that import as Windows does.

## Scope note

This PR was opened as IOSurface-only with D3D11 promised separately. #164 was merged into it, so the title, this description and the CHANGELOG now describe both. The verification below is stated per platform rather than as one claim.

## Verification

- **macOS lane** (`scripts/test-macos.sh`, the CI lane): 1623 passed, 13 skipped, 0 failed.
- **Non-vacuity**: the convert test passes under `EDGEFIRST_FORCE_BACKEND=opengl`, which errors rather than falling back — an RGB source there fails with `NotSupported("Opengl doesn't support RGB source texture")`, which is why these cases are RGBA. Each new assertion was seen to fail with its fix reverted: the reconstructed source reads the parent's origin, the reconstructed destination writes the canvas's origin, and the IOSurface bound test hands back a 63-byte view for a tensor of shape `[64]`.
- **Lint**: clippy `-D warnings` clean for macOS, `x86_64-pc-windows-msvc` and `aarch64-unknown-linux-gnu` (zigbuild); `cargo fmt --all --check` clean.
- **Windows**: the D3D11 changes are type- and lint-checked locally against `x86_64-pc-windows-msvc`, but `crates/tensor/tests/d3d11_tensor.rs` runs only on the Windows lane (WARP), so that half is CI-verified, not locally verified.
- **Linux**: unchanged by this PR beyond the shared GL guard; covered by the existing `test_view_converts_its_own_sub_region_not_the_parents_origin` in `tests/interop/test_cross_package.py`.

## Caller audit

Recorded on `interop::apply_plane_offset` so it need not be redone. No other `set_plane_offset` caller can reach these backings: `image::import_image` is `#[cfg(target_os = "linux")]` in its entirety (its `TensorMemory::DmaBuf` check would *accept* them — that spelling is the portable name for "platform zero-copy buffer"), and `tensor-capi`'s builder only ever constructs storage through `TensorDyn::from_fd`, whose non-Linux unix arm always yields a `ShmTensor` and whose non-unix arm returns `ENOSYS`. `Tensor::subview` does reach them and writes the same absolute value the storage's own `view()` computed, so it is idempotent rather than a double-apply.

## Where the tests live

macOS and Windows CI both run the full Rust workspace, and exclude only the Python suite, so these regression tests are in Rust (`crates/tensor/src/iosurface.rs`, `crates/tensor/tests/d3d11_tensor.rs`, `crates/image/tests/reconstructed_view_convert.rs`). #161 proposed extending the Python cross-package test with IOSURFACE/D3D11 corners; those would never have executed on any runner.

## Still open

`PboTensor` needs an arm here too if #162 is fixed so that a PBO-backed `view()` stays PBO-backed — today it reports `TensorMemory::Mem` and takes the host path. Android reports `kind::DMABUF` and its import is Linux-gated, so it fails loudly rather than reconstructing.
