### PR TITLE
Close the review gaps in the IOSurface and D3D11 plane-offset fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,35 +96,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   macOS CI lane, which runs the Rust suite the Python interop tests cannot
   reach there.
 
+  Two more IOSurface gaps surfaced in review of that fix and are closed
+  here. `restore_imported_row_stride` was `HOST | DMABUF` only, so a real
+  capsule import of an IOSurface view kept the window's tight row over a
+  pitched surface; the merged test had hidden it by restoring the stride
+  by hand. An IOSurface's `bytesPerRow` is a property of the shared
+  surface — unlike a D3D11 staging pitch, which stays excluded — so the
+  producer's stride is now restored, bounded by the surface's capacity.
+  And ANGLE over IOSurface binds plane 0 from the surface origin with no
+  offset attribute, exactly as ANGLE over D3D11 does, so a *fresh* source
+  `view()` was sampled from the parent's origin on the zero-copy path; the
+  Apple leaf now shares Windows' `refuse_offset_source` and uploads such a
+  source through `map()`. The convert test allocates a real image surface
+  (its Apple source had been a one-row byte-bag ANGLE could not bind, so it
+  never reached the zero-copy import) and reconstructs through
+  `import_descriptor` on both platforms. The convert engine now asks
+  `dst_import_places` for two more destination imports: the packed-RGB
+  two-pass plan lowers one it cannot place to the mapped-texture path, whose
+  readback writes through `map()` at the offset, the same as `bind_dst`; the
+  float zero-copy path has no such texture to lower to, so it declines
+  outright and `ImageProcessor`'s CPU fallback handles it instead, pinned on
+  macOS by `reconstructed_planar_dst.rs`. The packed-RGB path has no
+  platform pin: no ANGLE leaf can allocate a zero-copy RGB destination to
+  test it against (IOSurface falls back to a byte-bag ANGLE cannot bind;
+  D3D11 has no 24-bit format), and Linux places the offset itself, so it is
+  verified by reasoning and by the Linux suite staying unchanged. And the NV
+  R8 upload no longer adds the plane offset on top of `map()`, which already
+  starts at the offset on every backing, pinned by
+  `offset_nv_source_upload.rs`.
+
   The D3D11 half had a different shape, and needed three parts. A view's
   descriptor was not reconstructed at the wrong origin, it was *refused*: the
   `D3D11_TEXTURE` import checks the descriptor's shape against the texture's
   own geometry, and a window is neither of the two spellings it accepted. The
   import now takes a packed window as a third spelling, opens the whole
   texture and narrows it to the window, with `Tensor::set_logical_shape`
-  keeping the texture's pitch as the row stride while it does. The storage
-  arms then follow the IOSurface pair — plus one at `reshape`'s clear site,
-  because `D3d11TextureTensor::reshape` does not zero its own offset — and
-  the pins refuse an offset past the backing rather than trusting a
-  descriptor's value. Last, and the part no `map()` test could see: the ANGLE
-  D3D11 import binds the whole texture from its origin and cannot express an
-  offset, so the GL engine sampled every offset *source* from the texture's
-  top-left — a *fresh* `view()` converted the parent's origin on Windows,
-  not only a reconstructed one. The Windows leaf now refuses to attach a
-  source carrying a plane offset and the engine uploads it through `map()`,
-  which honours the offset. A *destination* rebuilt from a descriptor has the
-  same problem from the other side: it carries the offset but not the
-  `view_origin` a `view()` would have given it, so the engine has no viewport
-  to place it by and the render would land at the texture's origin. The
-  engine now asks the platform whether a zero-copy destination import can
-  place the tensor (`GlPlatform::dst_import_places`), and lowers one it
-  cannot to the mapped texture path, whose readback writes through `map()`
-  at the offset. A single-row window keeps `view()`'s tight row stride when
-  a descriptor narrows it (`Tensor::set_logical_shape`), so it maps in the
-  texture's last row, and the offset is applied as the producer measured it:
-  the consumer opens the same texture on the same adapter, so its staging
-  pitch is the same, and the descriptor's stride is not a pitch to translate
-  it by. Pinned by eight `d3d11` tests in
+  keeping the texture's pitch as the row stride while it does.
+
+  That adoption is not D3D11-specific: `set_logical_shape` now keeps the
+  backing's own pitch for every backing that reports one — IOSurface and
+  Android `AHardwareBuffer` as well — matching what `configure_image`
+  already did, and reachable through `ef_tensor_set_logical_shape`. Same
+  rule, one place.
+
+  The storage arms then follow the IOSurface pair — plus one at
+  `reshape`'s clear site, because `D3d11TextureTensor::reshape` does not
+  zero its own offset — and the pins refuse an offset past the backing
+  rather than trusting a descriptor's value. Last, and the part no
+  `map()` test could see: the ANGLE D3D11 import binds the whole texture
+  from its origin and cannot express an offset, so the GL engine sampled
+  every offset *source* from the texture's top-left — a *fresh* `view()`
+  converted the parent's origin on Windows, not only a reconstructed one.
+  The engine's ANGLE leaves (D3D11 and IOSurface) refuse to attach a
+  source carrying a plane offset and the engine uploads it through
+  `map()`, which honours the offset. A *destination* rebuilt from a
+  descriptor has the same problem from the other side: it carries the
+  offset but not the `view_origin` a `view()` would have given it, so the
+  engine has no viewport to place it by and the render would land at the
+  texture's origin. The engine now asks the platform whether a zero-copy
+  destination import can place the tensor (`GlPlatform::dst_import_places`),
+  and lowers one it cannot to the mapped texture path, whose readback writes
+  through `map()` at the offset. A single-row window keeps `view()`'s tight
+  row stride when a descriptor narrows it (`Tensor::set_logical_shape`), so
+  it maps in the texture's last row, and the offset is applied as the
+  producer measured it: the consumer opens the same texture on the same
+  adapter, so its staging pitch is the same, and the descriptor's stride is
+  not a pitch to translate it by. Pinned by eight `d3d11` tests in
   `crates/tensor/tests/d3d11_tensor.rs` and the Windows arm of
   `crates/image/tests/reconstructed_view_convert.rs`, on the Windows CI
   lanes.

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1966,6 +1966,41 @@ impl GLProcessorST {
                 support,
                 <Platform as GlPlatform>::ZERO_COPY_FLOAT,
             );
+            // Sibling of the view_origin guard above, for the
+            // offset-without-view_origin case: none of the four zero-copy
+            // float destination imports (`convert_float_to_zero_copy`,
+            // `convert_nv_to_float_two_pass` -> `get_or_create_egl_image_rgb`
+            // -> `import_buffer_packed`) go through `bind_dst`'s placement
+            // gate, and on ANGLE they bind the whole buffer from its origin.
+            // A destination rebuilt from a descriptor has no `view_origin` to
+            // place it by, and there is no mapped-texture readback for a
+            // float DMA destination to lower to, so decline outright rather
+            // than render at the buffer's origin.
+            if matches!(
+                path,
+                FloatRenderPath::ZeroCopyF16Nchw
+                    | FloatRenderPath::ZeroCopyF32Nchw
+                    | FloatRenderPath::ZeroCopyFloatNhwc
+                    | FloatRenderPath::ZeroCopyFloatRgba
+            ) {
+                let places = match dst_dtype {
+                    edgefirst_tensor::DType::F16 => Platform::dst_import_places(
+                        dst.as_typed::<half::f16>().expect("dtype checked"),
+                    ),
+                    edgefirst_tensor::DType::F32 => {
+                        Platform::dst_import_places(dst.as_typed::<f32>().expect("dtype checked"))
+                    }
+                    _ => unreachable!("dst_dtype is F16 or F32 in this branch"),
+                };
+                if !places {
+                    return Err(Error::NotSupported(format!(
+                        "GL float destination at plane offset {} has no view origin \
+                         to place it by, and the zero-copy float import binds the \
+                         whole buffer from its origin; CPU fallback handles it",
+                        dst.plane_offset().unwrap_or(0)
+                    )));
+                }
+            }
             match path {
                 FloatRenderPath::ZeroCopyF16Nchw
                 | FloatRenderPath::ZeroCopyF32Nchw
@@ -2155,8 +2190,26 @@ impl GLProcessorST {
         flip: Flip,
         crop: ResolvedCrop,
     ) -> crate::Result<()> {
+        // Same gate as `bind_dst`, for the two destination imports that do
+        // not go through it: the packed-RGB two-pass plan's pass 2
+        // (`convert_to_packed_rgb` -> `get_or_create_egl_image_rgb`) and the
+        // planar two-pass plan, both zero-copy imports via
+        // `import_buffer_packed`, which on ANGLE binds the whole buffer from
+        // its origin. A destination rebuilt from a descriptor carries a
+        // plane offset but no `view_origin`, so without this it would still
+        // take `DstLowering::ZeroCopy` here and render at the buffer's
+        // origin.
+        let places = Platform::dst_import_places(dst);
+        if !places {
+            log::debug!(
+                "convert_via_engine: zero-copy destination at plane offset {} \
+                 has no view origin; rendering to a texture and reading back \
+                 through map()",
+                dst.plane_offset().unwrap_or(0)
+            );
+        }
         let lowering = super::render::lower_dst(
-            self.gl_context.transfer_backend.is_zero_copy(),
+            self.gl_context.transfer_backend.is_zero_copy() && places,
             dst.memory(),
         );
         let plan = super::render::plan_convert(src_fmt, dst_fmt, lowering);
@@ -5330,6 +5383,9 @@ impl GLProcessorST {
                 }
                 self.convert_stats.src_uploads += 1;
                 tracing::Span::current().record("src_feed", "upload");
+                // Map before touching pixel-store state: a `?` here must not
+                // leave `UNPACK_ROW_LENGTH` set for the next upload.
+                let pixels = src.map_read()?;
                 let row_len_px = src
                     .effective_row_stride()
                     .map(|s| s / src_bpp)
@@ -5359,13 +5415,12 @@ impl GLProcessorST {
                     src_h,
                     texture_format,
                     required,
-                    &src.map_read()?,
+                    &pixels,
                 );
-                if uploaded.is_err() {
-                    edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::UNPACK_ROW_LENGTH, 0);
-                }
-                uploaded?;
+                // Reset on both outcomes; nothing between the set and here
+                // can return early now.
                 edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::UNPACK_ROW_LENGTH, 0);
+                uploaded?;
             }
 
             edgefirst_gl::gl::BindBuffer(edgefirst_gl::gl::ARRAY_BUFFER, self.vertex_buffer.id);

--- a/crates/image/src/gl/resources.rs
+++ b/crates/image/src/gl/resources.rs
@@ -67,7 +67,10 @@ impl Texture {
     ) -> crate::Result<()> {
         if data.len() < required {
             return Err(crate::Error::NotSupported(format!(
-                "GL upload: {width}x{height} texture needs {required} B but the                  source maps only {} B -- a window that does not cover its own                  image (a restored plane offset past the buffer?); converting                  on the CPU instead",
+                "GL upload: {width}x{height} texture needs {required} B but the \
+                 source maps only {} B -- a window that does not cover its own \
+                 image (a restored plane offset past the buffer?); converting \
+                 on the CPU instead",
                 data.len()
             )));
         }

--- a/crates/image/tests/offset_nv_source_upload.rs
+++ b/crates/image/tests/offset_nv_source_upload.rs
@@ -71,6 +71,13 @@ fn bytes(t: &TensorDyn) -> Vec<u8> {
 #[test]
 fn gl_uploads_an_offset_nv12_frame_from_its_own_offset_not_twice_it() {
     let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+    // The macOS coverage lane runs pass 1 with the ANGLE dlopen gate closed;
+    // the same guard `gl_backend_available_canary` carries.
+    #[cfg(target_os = "macos")]
+    if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+        skip("ANGLE dlopen gate closed (coverage pass 1)");
+        return;
+    }
     let mut gl = match GLProcessorThreaded::new(None) {
         Ok(gl) => gl,
         Err(e) => {
@@ -105,6 +112,17 @@ fn gl_uploads_an_offset_nv12_frame_from_its_own_offset_not_twice_it() {
     src.set_format(PixelFormat::Nv12).expect("nv12 format");
     src.set_plane_offset(elem);
     assert_eq!(src.plane_offset(), Some(elem), "precondition: frame 1");
+    // Tag BT.601 full-range so the new frame-1 assertion below can compare
+    // the reference's R byte directly to `LUMA`. Without a tag, the
+    // colorimetry heuristic resolves an untagged SD tensor to BT.601
+    // *limited*, which expands luma (e.g. 200 -> ~215) and would make that
+    // assertion misfire even on a correct read -- the same reason
+    // `odd_dim_cpu.rs`'s analytic reference tags full-range.
+    src.set_colorimetry(Some(
+        edgefirst_tensor::Colorimetry::default()
+            .with_encoding(edgefirst_tensor::ColorEncoding::Bt601)
+            .with_range(edgefirst_tensor::ColorRange::Full),
+    ));
 
     let mut reference = rgba_dst();
     CPUProcessor::new()
@@ -117,6 +135,16 @@ fn gl_uploads_an_offset_nv12_frame_from_its_own_offset_not_twice_it() {
         )
         .expect("CPU reference convert");
     let want = bytes(&reference);
+    // Both converters read through `map()`, so agreement alone cannot tell
+    // frame 1 from frame 0. The frames are 80 luma apart: the reference's
+    // first pixel must be near LUMA[1], not LUMA[0].
+    assert!(
+        want[0].abs_diff(LUMA[1]) <= 8,
+        "the CPU reference read frame {} (luma {}) instead of frame 1 (luma {})",
+        if want[0].abs_diff(LUMA[0]) <= 8 { 0 } else { 2 },
+        want[0],
+        LUMA[1]
+    );
 
     let mut dst = rgba_dst();
     gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())

--- a/crates/image/tests/reconstructed_planar_dst.rs
+++ b/crates/image/tests/reconstructed_planar_dst.rs
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! The zero-copy float render targets (`convert_float_to_zero_copy`,
+//! `convert_nv_to_float_two_pass`) import their destination through
+//! `get_or_create_egl_image_rgb` -> `import_buffer_packed`, which on ANGLE
+//! over IOSurface binds the whole buffer from its origin -- the same
+//! problem `bind_dst` and `convert_via_engine` already gate on
+//! `dst_import_places` for their own destination imports.
+//!
+//! This pins the float dispatch's own gate: a `PlanarRgb` F16 destination
+//! reconstructed from a descriptor (a plane offset, no `view_origin`) must
+//! be refused by the GL backend directly, and `ImageProcessor`'s convert
+//! (CPU fallback) must still land the bytes at that offset, not at the
+//! buffer's origin.
+//!
+//! macOS/iOS only: a D3D11 descriptor import accepts only packed windows, so
+//! a narrowed planar destination cannot exist on Windows, and Linux's
+//! DMA-BUF import expresses the offset itself, so `dst_import_places`
+//! defaults to `true` there and this reconstruction hits the ordinary
+//! zero-copy path.
+//!
+//! Two halves, so the gate cannot pass vacuously: first `GLProcessorThreaded`
+//! is driven directly and asserted to *refuse* the destination (the gate
+//! actually firing, not just "some path happened to place the bytes
+//! correctly"); the GL context is dropped before `ImageProcessor` opens its
+//! own, since nothing here establishes that two live ANGLE contexts coexist
+//! safely, and only one is ever needed at a time. Then `ImageProcessor`
+//! drives the same convert, which falls back to CPU on the same refusal, and
+//! its placement is checked.
+//!
+//! The decoded `f16` value check is intentionally coarse (32 ULPs): native
+//! FP16 widening on Apple silicon and an `f32`-divide-then-round golden can
+//! disagree by more than a couple of bits, and the untouched/written
+//! byte-range checks above it are the assertions this file actually exists
+//! to make.
+
+#![cfg(all(any(target_os = "macos", target_os = "ios"), feature = "opengl"))]
+
+use edgefirst_image::{
+    Crop, Flip, GLProcessorThreaded, ImageProcessor, ImageProcessorTrait, Rotation,
+};
+use edgefirst_tensor::{CpuAccess, DType, PixelFormat, TensorDyn, TensorMapTrait, TensorMemory};
+
+const W: usize = 64;
+const H: usize = 16;
+const BLANK: u8 = 0x55;
+const PIXEL: [u8; 4] = [200, 100, 50, 255];
+
+fn skip(why: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {why}");
+}
+
+#[test]
+fn reconstructed_planar_f16_destination_receives_its_convert_at_its_offset() {
+    let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+    // The macOS coverage lane runs pass 1 with the ANGLE dlopen gate closed;
+    // the same guard `gl_backend_available_canary` carries.
+    #[cfg(target_os = "macos")]
+    if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+        skip("ANGLE dlopen gate closed (coverage pass 1)");
+        return;
+    }
+
+    // `supported_render_dtypes` is only public on `ImageProcessor`; this
+    // instance exists only to ask the question and is dropped immediately
+    // after, before either of the two convert halves below opens its own
+    // GL context.
+    let support = {
+        let proc = ImageProcessor::new().expect("ImageProcessor::new");
+        proc.supported_render_dtypes()
+    };
+    if !support.f16 {
+        assert!(
+            !require_gl,
+            "HAL_TEST_REQUIRE_GL=1 but f16 render is not supported: {support:?}"
+        );
+        skip(&format!("f16 render not supported: {support:?}"));
+        return;
+    }
+
+    let canvas = match TensorDyn::image(
+        W,
+        H,
+        PixelFormat::PlanarRgb,
+        DType::F16,
+        Some(TensorMemory::DmaBuf),
+        CpuAccess::ReadWrite,
+    ) {
+        Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+        Ok(t) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but the zero-copy request fell back to {:?}",
+                t.memory()
+            );
+            skip(&format!("zero-copy request fell back to {:?}", t.memory()));
+            return;
+        }
+        Err(e) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but no zero-copy buffer could be allocated: {e}"
+            );
+            skip(&format!("no zero-copy buffer here: {e}"));
+            return;
+        }
+    };
+
+    // The RGBA16F packing stores the planar `[3, H, W]` stream at `(W/4, 3H)`
+    // texels of 4 `f16`s each, so one planar row is one surface row. The
+    // exact byte count is a platform packing/alignment detail, not something
+    // this test should pin: only that it is at least 64 `f16`s wide (`W`
+    // samples, 2 bytes each) and a multiple of the packing's 4-wide texel
+    // (`4 * 2 * 8` bytes) in that unit.
+    let pitch = canvas
+        .effective_row_stride()
+        .expect("planar f16 surface pitch");
+    assert!(
+        pitch >= 128 && pitch % 64 == 0,
+        "pitch {pitch} is not a plausible planar f16 row stride for width {W}"
+    );
+    {
+        let mut m = canvas.map_bytes(CpuAccess::Write).expect("map canvas");
+        m.as_mut_slice().fill(BLANK);
+    }
+
+    // A destination window rebuilt the way a capsule consumer rebuilds one:
+    // the descriptor carries the whole surface, then it is narrowed to the
+    // 15 rows past the first (skipping row 0) and the offset put back --
+    // `PlanarRgb`/`PlanarRgba` reject `Tensor::view()`, so a real capsule
+    // consumer narrows this way rather than through a view.
+    let mut rebuilt = TensorDyn::import_descriptor(&canvas.descriptor_pinned(None))
+        .expect("reconstruct the destination from its descriptor");
+    rebuilt
+        .set_logical_shape(&[3, H - 1, W])
+        .expect("narrow to the 15 rows past the first");
+    rebuilt.set_plane_offset(pitch);
+    assert!(
+        rebuilt.view_origin().is_none(),
+        "precondition: a rebuilt tensor has no view_origin"
+    );
+    assert_eq!(
+        rebuilt.effective_row_stride(),
+        Some(pitch),
+        "the narrowed tensor keeps the parent surface's pitch"
+    );
+
+    let src = TensorDyn::image(
+        W,
+        H - 1,
+        PixelFormat::Rgba,
+        DType::U8,
+        Some(TensorMemory::Mem),
+        CpuAccess::ReadWrite,
+    )
+    .expect("alloc source");
+    {
+        let mut m = src.map_bytes(CpuAccess::Write).expect("map source");
+        let s = m.as_mut_slice();
+        for i in (0..s.len()).step_by(4) {
+            s[i..i + 4].copy_from_slice(&PIXEL);
+        }
+    }
+
+    // First half: the GL backend itself must refuse this destination, not
+    // merely happen to place the bytes correctly. Scoped so the GL context
+    // is dropped before `ImageProcessor` opens its own below.
+    {
+        let mut gl = match GLProcessorThreaded::new(None) {
+            Ok(gl) => gl,
+            Err(e) => {
+                assert!(
+                    !require_gl,
+                    "HAL_TEST_REQUIRE_GL=1 but the GL backend failed to come up: {e}"
+                );
+                skip(&format!("no GL backend: {e}"));
+                return;
+            }
+        };
+        let err = gl
+            .convert(
+                &src,
+                &mut rebuilt,
+                Rotation::None,
+                Flip::None,
+                Crop::default(),
+            )
+            .expect_err("the GL float path must refuse a destination it cannot place");
+        assert!(
+            matches!(err, edgefirst_image::Error::NotSupported(_)),
+            "expected Error::NotSupported, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("has no view origin to place it by"),
+            "expected the float dispatch gate's refusal message, got: {msg}"
+        );
+    }
+
+    // Second half: `ImageProcessor`'s CPU fallback on that same refusal must
+    // still land the convert at the reconstructed tensor's own offset.
+    let mut proc = ImageProcessor::new().expect("ImageProcessor::new");
+    proc.convert(
+        &src,
+        &mut rebuilt,
+        Rotation::None,
+        Flip::None,
+        Crop::default(),
+    )
+    .expect("convert into the reconstructed planar destination");
+
+    let out = canvas.map_bytes(CpuAccess::Read).expect("map canvas");
+    let bytes = out.as_slice();
+    assert!(
+        bytes[0..pitch].iter().all(|&b| b == BLANK),
+        "row 0 of the canvas -- the byte before the reconstructed tensor's \
+         offset -- must stay untouched: a render at the buffer's origin \
+         would write here instead"
+    );
+    assert!(
+        !bytes[pitch..2 * pitch].iter().all(|&b| b == BLANK),
+        "row 1 of the canvas -- the reconstructed tensor's own row 0, at \
+         its plane offset -- must have received the convert"
+    );
+
+    // Row 1's first f16 is the R plane's first packed texel, channel 0: the
+    // source is one constant RGBA pixel, so it must be near R/255 regardless
+    // of which of the 4 packed positions it is. Coarse on purpose -- see the
+    // module doc comment.
+    let actual = half::f16::from_le_bytes([bytes[pitch], bytes[pitch + 1]]);
+    let expected = half::f16::from_f32(PIXEL[0] as f32 / 255.0);
+    assert!(
+        actual.to_bits().abs_diff(expected.to_bits()) <= 32,
+        "row 1's first f16 is {actual:?} ({:#06x}), expected near {expected:?} ({:#06x})",
+        actual.to_bits(),
+        expected.to_bits()
+    );
+}

--- a/crates/image/tests/reconstructed_view_draw.rs
+++ b/crates/image/tests/reconstructed_view_draw.rs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! The GL draw places its frame at the destination surface's origin --
+//! viewport 0,0 on an imported surface, buffer offset 0 in a readback -- so
+//! a destination it cannot place that way is refused up front
+//! (`check_draw_dst_placement`), and `ImageProcessor`'s CPU fallback handles
+//! it instead. This pins the rebuilt-destination spelling of that refusal:
+//! a destination reconstructed from a descriptor carries a plane offset but
+//! no `view_origin`, so `check_draw_dst_placement` must refuse it rather
+//! than let the zero-copy path draw at the canvas's top-left.
+//!
+//! Driven through `GLProcessorThreaded` directly so no CPU fallback can mask
+//! a missing refusal, on the platforms whose zero-copy buffer needs no
+//! device node.
+
+#![cfg(all(
+    any(target_os = "macos", target_os = "ios", target_os = "windows"),
+    feature = "opengl"
+))]
+
+use edgefirst_image::{GLProcessorThreaded, ImageProcessorTrait};
+use edgefirst_tensor::{
+    CpuAccess, DType, PixelFormat, Region, TensorDyn, TensorMapTrait, TensorMemory,
+};
+
+const W: usize = 50;
+const H: usize = 64;
+const X0: usize = 8;
+const Y0: usize = 8;
+const SIDE: usize = 16;
+const BLANK: u8 = 0x55;
+
+fn skip(why: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {why}");
+}
+
+#[test]
+fn overlay_into_a_reconstructed_destination_view_is_refused_not_drawn_at_the_origin() {
+    let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+    // The macOS coverage lane runs pass 1 with the ANGLE dlopen gate closed;
+    // the same guard `gl_backend_available_canary` carries.
+    #[cfg(target_os = "macos")]
+    if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+        skip("ANGLE dlopen gate closed (coverage pass 1)");
+        return;
+    }
+    let mut gl = match GLProcessorThreaded::new(None) {
+        Ok(gl) => gl,
+        Err(e) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but the GL backend failed to come up: {e}"
+            );
+            skip(&format!("no GL backend: {e}"));
+            return;
+        }
+    };
+
+    let canvas = match TensorDyn::image(
+        W,
+        H,
+        PixelFormat::Rgba,
+        DType::U8,
+        Some(TensorMemory::DmaBuf),
+        CpuAccess::ReadWrite,
+    ) {
+        Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+        Ok(t) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but the zero-copy request fell back to {:?}",
+                t.memory()
+            );
+            skip(&format!("zero-copy request fell back to {:?}", t.memory()));
+            return;
+        }
+        Err(e) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but no zero-copy buffer could be allocated: {e}"
+            );
+            skip(&format!("no zero-copy buffer here: {e}"));
+            return;
+        }
+    };
+    {
+        let mut m = canvas.map_bytes(CpuAccess::Write).expect("map canvas");
+        m.as_mut_slice().fill(BLANK);
+    }
+
+    // A destination window rebuilt the way a capsule consumer rebuilds one:
+    // the descriptor carries the window's shape and pitch, the offset is put
+    // back afterwards, and there is no `view_origin`.
+    let fresh = canvas
+        .view(Region::new(X0, Y0, SIDE, SIDE))
+        .expect("fresh view");
+    let mut rebuilt = TensorDyn::import_descriptor(&fresh.descriptor_pinned(None))
+        .expect("reconstruct the destination view from its descriptor");
+    rebuilt.set_plane_offset(fresh.plane_offset().expect("a view carries its offset"));
+    assert!(
+        rebuilt.view_origin().is_none(),
+        "precondition: a rebuilt view has no view_origin"
+    );
+
+    let err = gl
+        .draw_decoded_masks(&mut rebuilt, &[], &[], Default::default())
+        .expect_err(
+            "a GL overlay into a destination it cannot place must be refused, not drawn at the origin",
+        );
+    assert!(
+        matches!(err, edgefirst_image::Error::NotSupported(_)),
+        "expected Error::NotSupported, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sub-region destination"),
+        "expected check_draw_dst_placement's refusal message, got: {msg}"
+    );
+
+    // Refused before any GL work touched the canvas: every byte is still
+    // the poison fill, not just the window's.
+    let out = canvas.map_bytes(CpuAccess::Read).expect("map canvas");
+    assert!(
+        out.as_slice().iter().all(|&b| b == BLANK),
+        "the canvas was written to despite the draw being refused"
+    );
+}

--- a/crates/python-common/INTEROP.md
+++ b/crates/python-common/INTEROP.md
@@ -95,16 +95,23 @@ so a *freshly created* view was right and only a tensor rebuilt from a
 cfg-multiplexed name rather than one type, so the Linux-gated arm did not
 fail to compile on macOS, it silently became a fall-through.
 
+Two follow-ups complete it: the descriptor import now restores an IOSurface
+view's pitch (`restore_imported_row_stride` includes `IOSURFACE`; a
+surface's `bytesPerRow` is shared, unlike a D3D11 staging pitch), and the
+GL engine's Apple leaf refuses to zero-copy attach a source carrying a
+plane offset, as the Windows leaf does, because the ANGLE IOSurface
+binding has no offset attribute.
+
 D3D11 (Windows) is fixed too, and the bug had a different shape there. A
 view's descriptor was refused rather than rebuilt at the wrong origin: the
 import checks the shape against the texture's own geometry, and a window
 was neither spelling it accepted. It now accepts a packed window, opens the
 whole texture and narrows it, keeping the texture's pitch as the row
 stride; the storage offset is then written back by `set_plane_offset` and
-cleared by `set_format` and `reshape`. Two Windows-only details follow from
-the texture being the unit of import. The ANGLE image binds the whole
-texture from its origin and cannot express an offset, so the GL engine's
-Windows leaf refuses to attach a *source* carrying a plane offset and the
+cleared by `set_format` and `reshape`. Two details follow from the texture
+being the unit of import. The ANGLE image binds the whole texture from its
+origin and cannot express an offset, so the engine's ANGLE leaves (D3D11
+and IOSurface) refuse to attach a *source* carrying a plane offset and the
 engine uploads it through `map()` instead — without that refusal even a
 fresh `view()` converted the parent's origin. A *destination* rebuilt from a
 descriptor is the same problem from the other side — it has the offset but

--- a/crates/python-common/src/interop.rs
+++ b/crates/python-common/src/interop.rs
@@ -199,6 +199,11 @@ const _: () = {
 ///   `set_plane_offset_moves_the_iosurface_map_window`,
 ///   `nested_iosurface_subviews_do_not_compound_their_plane_offset` and
 ///   `set_format_clears_the_iosurface_map_window`.
+///   Two review follow-ups complete it: the import restores the view's
+///   pitch (`descriptor_import_restores_the_iosurface_pitch_onto_a_view`),
+///   and the GL leaf refuses an offset *source* the way Windows' does,
+///   since the ANGLE IOSurface binding has no offset attribute
+///   (`reconstructed_view_convert.rs`, case A, on the macOS lane).
 /// * **D3D11 (Windows)** -- fixed (issue #161), in three parts, because
 ///   the bug had a different shape there. A view's descriptor was not
 ///   reconstructed wrongly, it was *refused*: the `D3D11_TEXTURE` import
@@ -209,13 +214,13 @@ const _: () = {
 ///   is then written back by `set_plane_offset` and cleared by
 ///   `set_format` and `reshape` (unlike `IoSurfaceTensor`, its own
 ///   `reshape` leaves the offset alone). And because the ANGLE import binds
-///   the whole texture from its origin and cannot express an offset, the GL
-///   engine's Windows leaf refuses to attach a source carrying one and
-///   uploads it through `map()` instead -- without which even a *fresh*
-///   `view()` converted the parent's origin on the GL path. A rebuilt
-///   *destination* has the offset but not the `view_origin` the engine
-///   lowers a fresh view's tile to a viewport from, so the engine asks the
-///   platform whether a zero-copy destination can be placed
+///   the whole texture from its origin and cannot express an offset, the
+///   engine's ANGLE leaves (D3D11 and IOSurface) refuse to attach a source
+///   carrying one and upload it through `map()` instead -- without which
+///   even a *fresh* `view()` converted the parent's origin on the GL path.
+///   A rebuilt *destination* has the offset but not the `view_origin` the
+///   engine lowers a fresh view's tile to a viewport from, so the engine
+///   asks the platform whether a zero-copy destination can be placed
 ///   (`GlPlatform::dst_import_places`) and lowers one that cannot to the
 ///   mapped texture path, whose readback writes through `map()` at the
 ///   offset. Pinned by the `d3d11` plane-offset tests in


### PR DESCRIPTION
> **Squashed to one commit** (`b05018bf`) on top of `release/0.31.0` @ `c4f7be30`. The walkthrough below names the pre-squash commits by SHA for traceability against the review ledger; they no longer exist as separate commits. Stacks logically after #168 (Stage A): once #168 merges this branch is rebased so `make lint` is green locally (its two ruff fixes live there); CI's lint is unaffected either way.

## Origin

Copilot's 2026-09-09 review of PR #160 on the merged IOSurface (#163) and D3D11 (#164)
plane-offset fixes raised three findings, all confirmed on inspection:

- The GL engine's ANGLE leaves bind a texture/surface from its own origin and cannot
  express an offset, so a *fresh* source `view()` was sampled from the parent's origin
  on the zero-copy path — the same bug #164 had fixed for D3D11, still open on IOSurface.
- `restore_imported_row_stride` only covered `HOST | DMABUF`, so a descriptor-reconstructed
  IOSurface view kept the window's tight row over a pitched surface instead of the
  surface's own `bytesPerRow`.
- `update_texture` set `UNPACK_ROW_LENGTH` and mapped the upload source afterward inside
  the same call, so a failed map returned with the row length still set for the next
  upload.

The same review surfaced three further defects, unrelated to the three findings above:
a doc comment split from the item it described by an insertion, a GL upload capacity
error whose string literal had lost its `\` line continuations (producing runs of literal
whitespace in the message text instead of a wrapped sentence), and `Tensor::set_logical_shape`
gaining IOSurface/`AHardwareBuffer` pitch-keeping reach that no CHANGELOG entry recorded.

## Why the merged test did not catch it

`reconstructed_view_convert.rs`'s Apple case built its source from a one-row L008
byte-bag — a shape ANGLE cannot bind an RGBA pbuffer over — so the import declined and
every case fell through to the upload path, which honours the offset regardless of the
ANGLE-binding bug; the zero-copy path the test meant to cover was never reached. The
same test's pitch assertion passed by calling `set_row_stride` on the reconstructed
tensor by hand, standing in for the restore the code was supposed to perform on its own.
And the test's 64-texel width made the IOSurface pitch and the natural row width
coincide, so a dropped pitch and a correct one were indistinguishable by size alone.

## The fixes

Already on the branch, landed directly on `release/0.31.0` as `c4f7be30`:

- IOSurface's ANGLE leaf now shares Windows' `refuse_offset_source` and uploads an
  offset source through `map()` instead of zero-copy attaching it. `reconstructed_view_convert.rs`
  now allocates a real image surface and reconstructs through `import_descriptor` on
  Apple and Windows alike, so it actually reaches the zero-copy path; a skip under
  `HAL_TEST_REQUIRE_GL=1` is now a failure. Runs on `build-and-test-macos` with
  `HAL_TEST_REQUIRE_GL=1`.
- `restore_imported_row_stride` now includes `IOSURFACE`, bounded by the surface's
  capacity the same way the DMA-BUF value is. Pinned by the protocol round-trip test's
  restore assertion and by `reconstructed_view_convert.rs`'s 50-texel width, which makes
  the IOSurface pitch (256 B) differ from the natural row (200 B). Same lane.
- The NV R8 upload no longer adds `plane_offset` on top of `map()`, which already starts
  at the offset on every backing. Pinned by `offset_nv_source_upload.rs`. Same lane.

This PR (Tasks 4, 5 and 7, plus 7's own review follow-ups):

- **Task 4** (`cef00c35`) maps the upload source before setting `UNPACK_ROW_LENGTH` in
  `update_texture`, and resets it once unconditionally, so a failed map can no longer
  leave it set for the next upload. No dedicated regression test: triggering a map
  failure deterministically is not currently supported by the test harness; verified by
  inspection.
- **Task 5** (`440587af`) fixes the GL upload capacity error's string literal, restoring
  the `\` line continuations that had been lost, so the message reads as a wrapped
  sentence instead of embedding runs of literal whitespace. No dedicated test: message
  text only, no behavior change.
- **`2f13b83d`** records `c4f7be30`'s IOSurface pitch restore and ANGLE source refusal,
  and Task 7's first-pass draw gate, in `CHANGELOG.md`, `crates/python-common/INTEROP.md`
  and `interop.rs`.
- **`391b73a7`** — the whole-branch review of Task 7's gate found its premise wrong: at
  the top of both `GLProcessorST::draw_decoded_masks` and `draw_proto_masks`,
  `check_draw_dst_placement` already refuses any destination carrying a `view_origin` or
  a nonzero `plane_offset` — a strict superset of the placement check Task 7's first
  pass had added *inside* `setup_draw_renderbuffer_dma`, which neither caller can reach
  with such a destination in the first place. That gate could therefore never fire.
  This also means `c4f7be30`'s removal of Windows' in-leaf `refuse_unplaced_destination`
  (as unreachable) was correct, not a regression: the higher-level
  `check_draw_dst_placement` refusal already covers what it used to catch. `391b73a7`
  deletes the dead gate and repurposes `reconstructed_view_draw.rs` to pin the refusal
  itself — `draw_decoded_masks` into a destination reconstructed from a descriptor must
  return `NotSupported` with `check_draw_dst_placement`'s message and leave the canvas
  untouched, not draw at its origin — drops the CHANGELOG sentence `2f13b83d` had added
  about a "mask-draw gate" (there is none; the refusal is pre-existing behaviour, so it
  gets no changelog entry of its own), and reflows one `interop.rs` doc line.
- **`e0a49f84`** — the same review found two *other* destination imports that genuinely
  did bypass `dst_import_places`: `convert_via_engine`'s `lower_dst` call (feeding the
  packed-RGB and planar two-pass plans) computed its zero-copy flag from
  `transfer_backend.is_zero_copy()` alone, and the float dispatch's four `ZeroCopy*`
  paths (`classify_float_render`) never consulted the gate at all — both reach
  `import_buffer_packed` unconditionally, which on ANGLE binds the whole buffer from its
  origin. Fixed by mirroring `bind_dst` inside `convert_via_engine` (AND `places` into
  the zero-copy flag before it reaches `lower_dst`), and by declining outright with
  `NotSupported` in the float dispatch before its `ZeroCopy*` match — there is no
  mapped-texture path to lower a float DMA destination to, so it goes straight to the
  `ImageProcessor` CPU fallback instead. Adds `crates/image/tests/reconstructed_planar_dst.rs`
  (macOS/iOS only) pinning the float refusal.
- **This doc commit** — `e0a49f84`'s own CHANGELOG sentence said both new paths were
  "lowered", which is wrong for the float path: it is refused outright, not lowered.
  Reworded to describe each path's actual fate (packed-RGB lowered to the mapped-texture
  path; float declined to the CPU converter) and to attribute
  `reconstructed_planar_dst.rs`'s pin to the float refusal specifically. Notes that the
  packed-RGB lowering has no platform-level pin of its own: no ANGLE leaf can allocate a
  zero-copy RGB destination to test it against (IOSurface falls back to a byte-bag ANGLE
  cannot bind; D3D11 has no 24-bit format) and Linux places the offset itself, so that
  path is verified by reasoning and by the Linux suite staying unchanged, not by a
  dedicated test. Also fixes a pre-existing 24-column orphan line in the nearby D3D11
  paragraph, unrelated to this PR's own edits.
- **`478a1a30`** — the re-review's Mac-run risk list flagged `reconstructed_planar_dst.rs`
  as it stood: it only drove `ImageProcessor`'s CPU fallback, so it never actually
  asserted the new float dispatch gate fires — a placement bug hidden behind a
  coincidentally-correct GL render would still have passed. Adds a first half that
  drives `GLProcessorThreaded` directly and asserts its `convert` returns `NotSupported`
  containing the gate's own "has no view origin to place it by" message, with that GL
  context dropped before `ImageProcessor` opens its own (nothing establishes two live
  ANGLE contexts coexist safely, so the file never holds both at once). Also stops
  hard-coding the planar f16 surface's pitch (asserts only `>= 128 && % 64 == 0` and
  reads the real value throughout) and loosens the decoded-`f16` tolerance from 4 to 32
  ULPs, since native FP16 widening on Apple silicon and an `f32`-divide golden can
  disagree by more than a couple of bits — the byte-range checks are the assertions
  that matter, not that value.

## Must run on macOS before merge

Two tests are `cfg`'d to `macos`/`ios` (`opengl` feature) and have not executed anywhere
on this branch — the Linux box that did this implementation has no ANGLE/macOS toolchain,
so both are `cfg`'d out there entirely:

- `crates/image/tests/reconstructed_view_draw.rs` — pins `check_draw_dst_placement`'s
  refusal of a destination reconstructed from a descriptor (`391b73a7`). Also runs on
  Windows via `test-windows-warp` (it is `cfg`'d to `windows` too). Compiled and
  clippy-clean for `aarch64-apple-darwin`; never actually run.
- `crates/image/tests/reconstructed_planar_dst.rs` — pins the float zero-copy refusal for
  a narrowed `PlanarRgb` F16 destination reconstructed from a descriptor (`e0a49f84`,
  non-vacuity and pitch/tolerance fixes in `478a1a30`). macOS/iOS only. Compiled and
  clippy-clean for `aarch64-apple-darwin`; **has never been executed anywhere, on any
  platform.**

```
HAL_TEST_REQUIRE_GL=1 ./scripts/test-macos.sh -p edgefirst-image \
  --test reconstructed_view_draw --test reconstructed_planar_dst --no-capture
```

Both must PASS. `reconstructed_view_draw.rs` additionally has a documented mutation
check from its brief — comment out `check_draw_dst_placement`'s body, confirm the
refusal disappears and the draw succeeds instead, restore — that has not been run on
this branch either.

## Mutation evidence

`c4f7be30`'s commit message records: "Verified on macOS (`HAL_TEST_REQUIRE_GL=1`, full
suite: 1626 passed, 13 skipped), with the ANGLE refusal removed as a mutation check (case
A reads the parent's origin)."

No mutation check for `391b73a7` or `e0a49f84` has run yet. Both diagnoses were instead
verified by reading the gating code directly on the Linux implementation box —
`check_draw_dst_placement` and its two call sites for `391b73a7`; `convert_via_engine`'s
`lower_dst` call and `classify_float_render`'s complete absence of any `lower_dst`
reference for `e0a49f84` — since every affected test file is `cfg`'d out on Linux and a
mutation check needs the test to run at all. See "Must run on macOS before merge" above
for what CI still owes this PR before merge.

## What stays excluded and why

- **D3D11's staging pitch** is never restored or translated the way the IOSurface and
  DMA-BUF strides are: it belongs to the local driver's own staging texture, not to
  anything the two ends of a transfer share, so a producer's pitch has no meaning for a
  consumer to restore.
- **PBO and CUDA** have no strided-reconstruction path to fix: a `view()` of a PBO-backed
  image comes back as host memory rather than a windowed re-import, so the plane-offset
  bug this PR closes does not reach either backing.

## On-target runs (edgefirst-image suite, `scripts/on-target-test.sh`, branch @ `478a1a30`)

- `rpi5-hailo` (V3D): PASS, 13 binaries.
- `imx95-frdm` (Mali): only `reconstructed_view_convert` fails, the pre-existing #165 (`[0, 0, 0, 255]` per pixel), identical to the file as merged in #163.
- `imx8mp-frdm` (Vivante): only `dst_view_stride::gl_padded_pbo_dst_rows_land_at_the_declared_stride` fails ("the pad past the pixels was written"). Reproduced identically at the release tip `c4f7be30` from a separate worktree, so pre-existing; CI's imx8mp lane never runs that binary. Filed as #167.

The two Apple/Windows-only test binaries deploy and report zero tests on every Linux board, as their `cfg`s intend.

## Follow-ups

Three issues filed from findings made verifying this work on macOS and on-target hardware:

- **#165** — Mali on i.MX 95 converts an offset RGBA DMA-BUF source view to zeros; this
  predates this PR, present identically in the file as merged in #163.
- **#166** — a refused zero-copy NV source at an offset falls through to the CPU
  converter instead of the R8 upload path.
- **#167** — Vivante's GL PBO readback into a padded destination writes the row padding;
  pre-existing, invisible to CI because the imx8mp lane skips the GL integration binaries.

The PBO arm remains coupled to #162's fix (Stage B) and is not addressed here.
