### PR TITLE
Close the GL issues found on hardware: Mali unaligned source imports, NV upload routing, PBO pad contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an NV12/16/24 source was declined — the ANGLE leaves' offset refusal, or
   the Mali rule above — the engine fell to `draw_src_texture`, which has no
   NV arm, so the convert left the GPU entirely. Both NV import-failure arms
-  now upload the combined plane through the same R8 shader. (#166)
+  now upload the combined plane through the same R8 shader. On i.MX 8M Plus
+  this is what a single-plane NV12 source at an unaligned plane offset now
+  takes: Vivante's `Auto` policy sends it to the external sampler, whose EGL
+  refuses the offset, and the convert stays on the GPU through the R8 shader
+  on an upload instead of dropping to the CPU. Vivante also refuses a
+  *destination* import at an unaligned offset outright, with
+  `EGL(BadAccess)`, which used to fail the convert; the engine now lowers
+  such a destination to the mapped-texture path, whose readback writes
+  through `map()` at the offset. (#166)
 - **A test asserted padding no readback promises.**
   `gl_padded_pbo_dst_rows_land_at_the_declared_stride` required the bytes
   between pitched rows to stay untouched; Vivante writes them while packing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,35 +96,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   macOS CI lane, which runs the Rust suite the Python interop tests cannot
   reach there.
 
+  Two more IOSurface gaps surfaced in review of that fix and are closed
+  here. `restore_imported_row_stride` was `HOST | DMABUF` only, so a real
+  capsule import of an IOSurface view kept the window's tight row over a
+  pitched surface; the merged test had hidden it by restoring the stride
+  by hand. An IOSurface's `bytesPerRow` is a property of the shared
+  surface — unlike a D3D11 staging pitch, which stays excluded — so the
+  producer's stride is now restored, bounded by the surface's capacity.
+  And ANGLE over IOSurface binds plane 0 from the surface origin with no
+  offset attribute, exactly as ANGLE over D3D11 does, so a *fresh* source
+  `view()` was sampled from the parent's origin on the zero-copy path; the
+  Apple leaf now shares Windows' `refuse_offset_source` and uploads such a
+  source through `map()`. The convert test allocates a real image surface
+  (its Apple source had been a one-row byte-bag ANGLE could not bind, so it
+  never reached the zero-copy import) and reconstructs through
+  `import_descriptor` on both platforms. The convert engine now asks
+  `dst_import_places` for two more destination imports: the packed-RGB
+  two-pass plan lowers one it cannot place to the mapped-texture path, whose
+  readback writes through `map()` at the offset, the same as `bind_dst`; the
+  float zero-copy path has no such texture to lower to, so it declines
+  outright and `ImageProcessor`'s CPU fallback handles it instead, pinned on
+  macOS by `reconstructed_planar_dst.rs`. The packed-RGB path has no
+  platform pin: no ANGLE leaf can allocate a zero-copy RGB destination to
+  test it against (IOSurface falls back to a byte-bag ANGLE cannot bind;
+  D3D11 has no 24-bit format), and Linux places the offset itself, so it is
+  verified by reasoning and by the Linux suite staying unchanged. And the NV
+  R8 upload no longer adds the plane offset on top of `map()`, which already
+  starts at the offset on every backing, pinned by
+  `offset_nv_source_upload.rs`.
+
   The D3D11 half had a different shape, and needed three parts. A view's
   descriptor was not reconstructed at the wrong origin, it was *refused*: the
   `D3D11_TEXTURE` import checks the descriptor's shape against the texture's
   own geometry, and a window is neither of the two spellings it accepted. The
   import now takes a packed window as a third spelling, opens the whole
   texture and narrows it to the window, with `Tensor::set_logical_shape`
-  keeping the texture's pitch as the row stride while it does. The storage
-  arms then follow the IOSurface pair — plus one at `reshape`'s clear site,
-  because `D3d11TextureTensor::reshape` does not zero its own offset — and
-  the pins refuse an offset past the backing rather than trusting a
-  descriptor's value. Last, and the part no `map()` test could see: the ANGLE
-  D3D11 import binds the whole texture from its origin and cannot express an
-  offset, so the GL engine sampled every offset *source* from the texture's
-  top-left — a *fresh* `view()` converted the parent's origin on Windows,
-  not only a reconstructed one. The Windows leaf now refuses to attach a
-  source carrying a plane offset and the engine uploads it through `map()`,
-  which honours the offset. A *destination* rebuilt from a descriptor has the
-  same problem from the other side: it carries the offset but not the
-  `view_origin` a `view()` would have given it, so the engine has no viewport
-  to place it by and the render would land at the texture's origin. The
-  engine now asks the platform whether a zero-copy destination import can
-  place the tensor (`GlPlatform::dst_import_places`), and lowers one it
-  cannot to the mapped texture path, whose readback writes through `map()`
-  at the offset. A single-row window keeps `view()`'s tight row stride when
-  a descriptor narrows it (`Tensor::set_logical_shape`), so it maps in the
-  texture's last row, and the offset is applied as the producer measured it:
-  the consumer opens the same texture on the same adapter, so its staging
-  pitch is the same, and the descriptor's stride is not a pitch to translate
-  it by. Pinned by eight `d3d11` tests in
+  keeping the texture's pitch as the row stride while it does.
+
+  That adoption is not D3D11-specific: `set_logical_shape` now keeps the
+  backing's own pitch for every backing that reports one — IOSurface and
+  Android `AHardwareBuffer` as well — matching what `configure_image`
+  already did, and reachable through `ef_tensor_set_logical_shape`. Same
+  rule, one place.
+
+  The storage arms then follow the IOSurface pair — plus one at
+  `reshape`'s clear site, because `D3d11TextureTensor::reshape` does not
+  zero its own offset — and the pins refuse an offset past the backing
+  rather than trusting a descriptor's value. Last, and the part no
+  `map()` test could see: the ANGLE D3D11 import binds the whole texture
+  from its origin and cannot express an offset, so the GL engine sampled
+  every offset *source* from the texture's top-left — a *fresh* `view()`
+  converted the parent's origin on Windows, not only a reconstructed one.
+  The engine's ANGLE leaves (D3D11 and IOSurface) refuse to attach a
+  source carrying a plane offset and the engine uploads it through
+  `map()`, which honours the offset. A *destination* rebuilt from a
+  descriptor has the same problem from the other side: it carries the
+  offset but not the `view_origin` a `view()` would have given it, so the
+  engine has no viewport to place it by and the render would land at the
+  texture's origin. The engine now asks the platform whether a zero-copy
+  destination import can place the tensor (`GlPlatform::dst_import_places`),
+  and lowers one it cannot to the mapped texture path, whose readback writes
+  through `map()` at the offset. A single-row window keeps `view()`'s tight
+  row stride when a descriptor narrows it (`Tensor::set_logical_shape`), so
+  it maps in the texture's last row, and the offset is applied as the
+  producer measured it: the consumer opens the same texture on the same
+  adapter, so its staging pitch is the same, and the descriptor's stride is
+  not a pitch to translate it by. Pinned by eight `d3d11` tests in
   `crates/tensor/tests/d3d11_tensor.rs` and the Windows arm of
   `crates/image/tests/reconstructed_view_convert.rs`, on the Windows CI
   lanes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `crates/tensor/tests/d3d11_tensor.rs` and the Windows arm of
   `crates/image/tests/reconstructed_view_convert.rs`, on the Windows CI
   lanes.
+- **Mali sampled zeros from a source view at an unaligned DMA-BUF offset.**
+  On i.MX 95 the EGL DMA-BUF import silently returns zeros when
+  `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is not 64-byte aligned — a 16×16 source
+  `view()` at (8, 8) of a 256-byte-pitched RGBA image converted to black
+  while (0, 8) and (16, 0) were fine, and V3D handled every origin. The GL
+  engine now recognises Mali from `GL_RENDERER` and declines a *source*
+  import at such an offset, uploading the window through `map()` instead;
+  destinations are unaffected (a view imports its parent at offset 0).
+  Pinned by `offset_source_view_alignment.rs` on imx95, imx8mp and rpi5.
+  Zero-copy for those views (an aligned base with the remainder folded into
+  the sampling rectangle) is follow-up #170. (#165)
+- **A refused zero-copy NV source ended on the CPU.** When the R8 import of
+  an NV12/16/24 source was declined — the ANGLE leaves' offset refusal, or
+  the Mali rule above — the engine fell to `draw_src_texture`, which has no
+  NV arm, so the convert left the GPU entirely. Both NV import-failure arms
+  now upload the combined plane through the same R8 shader. (#166)
+- **A test asserted padding no readback promises.**
+  `gl_padded_pbo_dst_rows_land_at_the_declared_stride` required the bytes
+  between pitched rows to stay untouched; Vivante writes them while packing
+  rows at `GL_PACK_ROW_LENGTH`, and the read-tight-and-spread route always
+  left leftovers there. The test now asserts the pixel bytes of every row at
+  the declared pitch, which is the contract. CI's imx8mp lane never ran that
+  binary, which is why the desk found it first. (#167)
 
 ### Changed
 

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -280,22 +280,6 @@ Adding a driver to the parallel set means running it through
 release because it was assumed to behave like the drivers that had been
 measured.
 
-`RendererTraits::mali` is a second GL_RENDERER-derived policy bit,
-independent of `is_vivante`: on i.MX 95 the EGL DMA-BUF import silently
-samples zeros from a source whose `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is not
-64-byte aligned — no EGL error, and V3D/Tegra import every offset
-correctly (measured at offsets 32 and 2080 of a 256-byte pitch; #165).
-`mali_rejects_source_offset` declines a *source* import at such an offset
-in both `get_or_create_egl_image` and `get_or_create_nv_r8_egl_image`, and
-the caller uploads the window through `map()` instead; a destination is
-exempt because a view imports its parent at offset 0. Folding the pixel
-remainder into the sampling rectangle to keep the aligned case zero-copy —
-the same fold destinations already do for `import_extent` — is filed as
-#170. A source whose R8 import is refused this way, or by the ANGLE
-leaves' own offset refusal, now uploads the combined plane through the R8
-shader rather than falling to `draw_src_texture`, which has no NV arm and
-previously dropped the convert onto the CPU.
-
 ANGLE over Direct3D 11 (Windows) needs one step more than the Full
 policy. That backend keeps a single `StateManager11` per display and only
 re-syncs a context's GL state onto the shared D3D device from
@@ -312,6 +296,47 @@ from two threads at once (concurrent bring-up crashed with an access
 violation). Every context creation and destruction clears the marker as
 well: a new context on a recycled address would otherwise be mistaken for
 the one that issued the last commands, and skip the re-sync it needs.
+
+`RendererTraits::mali` is a second GL_RENDERER-derived policy bit,
+independent of `is_vivante`: on i.MX 95 the EGL DMA-BUF import silently
+samples zeros from a source whose `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is not
+64-byte aligned — no EGL error at all (measured at offsets 32 and 2080 of a
+256-byte pitch, against 64/256/2048 which sample correctly; #165). V3D was
+measured on the same offsets and imports every one correctly; Tegra/Orin is
+unmeasured, having no DMA heap to build a DMA-BUF source on.
+`mali_rejects_import_offset` declines a *source* import at such an offset in
+both `get_or_create_egl_image` and `get_or_create_nv_r8_egl_image`, and the
+caller uploads the window through `map()` instead. Every plane offset the
+import passes to EGL is checked, not only plane 0: a contiguous two-plane
+NV12 import derives plane 1 as `plane0_offset + pitch * height`
+(`nv12_plane1_offset`), which a `from_fd`-adopted buffer's unpadded pitch can
+leave unaligned while plane 0 is fine — chroma alone sampling zeros is a
+colour shift rather than a black frame. The R8 entry point needs plane 0
+only, binding the combined plane as one R8 texture.
+
+Mali **destinations** keep the zero-copy import, and that is measured, not
+assumed: rendering into an unaligned base at the same offsets is correct on
+i.MX 95, so the defect is in sampling and not in the render target. The
+driver that does fail on the destination side is Vivante, and it fails
+loudly — `eglCreateImage` returns `EGL_BAD_ACCESS` for a destination at
+offset 2080 while offset 2048 renders — so
+`vivante_rejects_dst_import_offset` joins `Platform::dst_import_places` in
+the `places` term that `bind_dst`, `convert_via_engine` and the float
+dispatch share. An unaligned Vivante destination therefore lowers to the
+mapped-texture path, whose readback writes through `map()` at the offset,
+instead of letting the EGL error end the convert; the float paths, which
+have no mapped-texture readback to lower to, decline to the CPU converter.
+Only a destination whose import actually starts at the offset is affected: a
+fresh `view()` collapses onto its parent at offset 0, so this is about one
+rebuilt from a descriptor, or a whole tensor at a foreign offset.
+
+Folding the pixel remainder into the sampling rectangle to keep the aligned
+case zero-copy — the source-side counterpart of the viewport band a
+destination view already resolves to — is filed as #170. A source whose R8
+import is refused this way, or by the ANGLE leaves' own offset refusal, now
+uploads the combined plane through the R8 shader rather than falling to
+`draw_src_texture`, which has no NV arm and previously dropped the convert
+onto the CPU.
 
 **Porting checklist (how Windows/ANGLE-D3D11 landed as a leaf, not a
 fork):** implement the trait (`init_display` over a shared ANGLE display

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -326,9 +326,22 @@ dispatch share. An unaligned Vivante destination therefore lowers to the
 mapped-texture path, whose readback writes through `map()` at the offset,
 instead of letting the EGL error end the convert; the float paths, which
 have no mapped-texture readback to lower to, decline to the CPU converter.
-Only a destination whose import actually starts at the offset is affected: a
-fresh `view()` collapses onto its parent at offset 0, so this is about one
-rebuilt from a descriptor, or a whole tensor at a foreign offset.
+
+Each site must ask the rule about the offset **its own** import bases at,
+and the two destination routes differ. `bind_dst` imports through
+`Platform::import_buffer(.., for_dst = true)`, which collapses a fresh
+`view()`/`batch()` onto its parent at offset 0 and places the tile by
+viewport, so that site asks `view_collapsed_dst_base` and a tile view is
+never gated however unaligned its own bytes are.
+`convert_via_engine`'s packed-RGB plan and the zero-copy float paths import
+through `import_buffer_packed`, which passes `plane_offset()` straight to
+EGL with no collapse, so those sites ask the raw offset and a view
+destination there IS gated. Asking the collapsed base everywhere would
+under-fire on the packed routes; asking the raw offset everywhere over-fires
+on `bind_dst`, and that is not merely a lost fast path — the mapped-texture
+readback returns wrong pixels for a view destination on Vivante, so the
+over-fire silently corrupted unaligned tile views until
+`a_fresh_unaligned_view_destination_keeps_the_zero_copy_import` caught it.
 
 Folding the pixel remainder into the sampling rectangle to keep the aligned
 case zero-copy — the source-side counterpart of the viewport band a

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -280,6 +280,22 @@ Adding a driver to the parallel set means running it through
 release because it was assumed to behave like the drivers that had been
 measured.
 
+`RendererTraits::mali` is a second GL_RENDERER-derived policy bit,
+independent of `is_vivante`: on i.MX 95 the EGL DMA-BUF import silently
+samples zeros from a source whose `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is not
+64-byte aligned — no EGL error, and V3D/Tegra import every offset
+correctly (measured at offsets 32 and 2080 of a 256-byte pitch; #165).
+`mali_rejects_source_offset` declines a *source* import at such an offset
+in both `get_or_create_egl_image` and `get_or_create_nv_r8_egl_image`, and
+the caller uploads the window through `map()` instead; a destination is
+exempt because a view imports its parent at offset 0. Folding the pixel
+remainder into the sampling rectangle to keep the aligned case zero-copy —
+the same fold destinations already do for `import_extent` — is filed as
+#170. A source whose R8 import is refused this way, or by the ANGLE
+leaves' own offset refusal, now uploads the combined plane through the R8
+shader rather than falling to `draw_src_texture`, which has no NV arm and
+previously dropped the convert onto the CPU.
+
 ANGLE over Direct3D 11 (Windows) needs one step more than the Full
 policy. That backend keeps a single `StateManager11` per display and only
 re-syncs a context's GL state onto the shared D3D device from

--- a/crates/image/src/gl/platform/mod.rs
+++ b/crates/image/src/gl/platform/mod.rs
@@ -141,11 +141,13 @@ where
 /// foreign offset -- attached that way converts the parent's top-left tile
 /// in place of the region it names, silently. Declining sends the source
 /// through `map()`, which starts at the offset: the engine's texture upload
-/// for a packed source into a packed destination, and otherwise
-/// `ImageProcessor::convert`'s CPU fallback -- a planar destination's GL
-/// lowering and the NV import's failure arm (`draw_src_texture` has no NV
-/// case) propagate the refusal instead of uploading, and a forced OpenGL
-/// backend returns it to the caller. Issue #161 at the convert level.
+/// for a packed source into a packed destination, and the R8 upload of the
+/// combined plane for a single-plane NV source, whose import failure arms took
+/// over from `draw_src_texture` (which has no NV case) in #166. What is left
+/// on `ImageProcessor::convert`'s CPU fallback is a planar destination's GL
+/// lowering and a true-multiplane NV12, which cannot be uploaded as one R8
+/// texture; a forced OpenGL backend returns the refusal to the caller.
+/// Issue #161 at the convert level.
 /// Linux's DMA-BUF import expresses the offset itself
 /// (`EGL_DMA_BUF_PLANE0_OFFSET_EXT`) and does not need this.
 ///

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1966,6 +1966,41 @@ impl GLProcessorST {
                 support,
                 <Platform as GlPlatform>::ZERO_COPY_FLOAT,
             );
+            // Sibling of the view_origin guard above, for the
+            // offset-without-view_origin case: none of the four zero-copy
+            // float destination imports (`convert_float_to_zero_copy`,
+            // `convert_nv_to_float_two_pass` -> `get_or_create_egl_image_rgb`
+            // -> `import_buffer_packed`) go through `bind_dst`'s placement
+            // gate, and on ANGLE they bind the whole buffer from its origin.
+            // A destination rebuilt from a descriptor has no `view_origin` to
+            // place it by, and there is no mapped-texture readback for a
+            // float DMA destination to lower to, so decline outright rather
+            // than render at the buffer's origin.
+            if matches!(
+                path,
+                FloatRenderPath::ZeroCopyF16Nchw
+                    | FloatRenderPath::ZeroCopyF32Nchw
+                    | FloatRenderPath::ZeroCopyFloatNhwc
+                    | FloatRenderPath::ZeroCopyFloatRgba
+            ) {
+                let places = match dst_dtype {
+                    edgefirst_tensor::DType::F16 => Platform::dst_import_places(
+                        dst.as_typed::<half::f16>().expect("dtype checked"),
+                    ),
+                    edgefirst_tensor::DType::F32 => {
+                        Platform::dst_import_places(dst.as_typed::<f32>().expect("dtype checked"))
+                    }
+                    _ => unreachable!("dst_dtype is F16 or F32 in this branch"),
+                };
+                if !places {
+                    return Err(Error::NotSupported(format!(
+                        "GL float destination at plane offset {} has no view origin \
+                         to place it by, and the zero-copy float import binds the \
+                         whole buffer from its origin; CPU fallback handles it",
+                        dst.plane_offset().unwrap_or(0)
+                    )));
+                }
+            }
             match path {
                 FloatRenderPath::ZeroCopyF16Nchw
                 | FloatRenderPath::ZeroCopyF32Nchw
@@ -2155,8 +2190,26 @@ impl GLProcessorST {
         flip: Flip,
         crop: ResolvedCrop,
     ) -> crate::Result<()> {
+        // Same gate as `bind_dst`, for the two destination imports that do
+        // not go through it: the packed-RGB two-pass plan's pass 2
+        // (`convert_to_packed_rgb` -> `get_or_create_egl_image_rgb`) and the
+        // planar two-pass plan, both zero-copy imports via
+        // `import_buffer_packed`, which on ANGLE binds the whole buffer from
+        // its origin. A destination rebuilt from a descriptor carries a
+        // plane offset but no `view_origin`, so without this it would still
+        // take `DstLowering::ZeroCopy` here and render at the buffer's
+        // origin.
+        let places = Platform::dst_import_places(dst);
+        if !places {
+            log::debug!(
+                "convert_via_engine: zero-copy destination at plane offset {} \
+                 has no view origin; rendering to a texture and reading back \
+                 through map()",
+                dst.plane_offset().unwrap_or(0)
+            );
+        }
         let lowering = super::render::lower_dst(
-            self.gl_context.transfer_backend.is_zero_copy(),
+            self.gl_context.transfer_backend.is_zero_copy() && places,
             dst.memory(),
         );
         let plan = super::render::plan_convert(src_fmt, dst_fmt, lowering);
@@ -5330,6 +5383,9 @@ impl GLProcessorST {
                 }
                 self.convert_stats.src_uploads += 1;
                 tracing::Span::current().record("src_feed", "upload");
+                // Map before touching pixel-store state: a `?` here must not
+                // leave `UNPACK_ROW_LENGTH` set for the next upload.
+                let pixels = src.map_read()?;
                 let row_len_px = src
                     .effective_row_stride()
                     .map(|s| s / src_bpp)
@@ -5359,13 +5415,12 @@ impl GLProcessorST {
                     src_h,
                     texture_format,
                     required,
-                    &src.map_read()?,
+                    &pixels,
                 );
-                if uploaded.is_err() {
-                    edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::UNPACK_ROW_LENGTH, 0);
-                }
-                uploaded?;
+                // Reset on both outcomes; nothing between the set and here
+                // can return early now.
                 edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::UNPACK_ROW_LENGTH, 0);
+                uploaded?;
             }
 
             edgefirst_gl::gl::BindBuffer(edgefirst_gl::gl::ARRAY_BUFFER, self.vertex_buffer.id);

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1315,9 +1315,8 @@ fn mali_rejects_import_offset(is_mali: bool, plane_offset: usize) -> bool {
 /// destination lowers to the mapped-texture path, whose readback writes through
 /// `map()` at the offset, instead of letting the EGL error end the convert.
 ///
-/// Takes the offset the import will actually start at, which is what
 /// Takes the offset the import being guarded actually bases at, which differs
-/// by route: [`view_collapsed_dst_base`] for `bind_dst`'s import, the raw
+/// by route: [`view_collapsed_dst_base`] for `bind_dst`'s import, and the raw
 /// `plane_offset()` for the `import_buffer_packed` ones.
 fn vivante_rejects_dst_import_offset(is_vivante: bool, plane_offset: usize) -> bool {
     is_vivante && unaligned_import_offset(plane_offset)

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1277,6 +1277,12 @@ const MALI_DMA_IMPORT_OFFSET_ALIGN: usize = 64;
 
 /// Whether a Mali source import at `plane_offset` would sample zeros. Pure so
 /// the rule is unit-testable without a GL context, like [`classify_renderer`].
+///
+/// Only plane 0's offset is checked. For single-plane NV12 the chroma plane
+/// sits at `plane0_offset + pitch * height` (`dma_import.rs` ~`:225`), which
+/// is itself a multiple of 64 whenever `pitch` is -- and the HAL pads every
+/// DMA pitch to 64 -- so the chroma plane's alignment is not checked
+/// separately here.
 fn mali_rejects_source_offset(is_mali: bool, plane_offset: usize) -> bool {
     is_mali && !plane_offset.is_multiple_of(MALI_DMA_IMPORT_OFFSET_ALIGN)
 }
@@ -3216,6 +3222,10 @@ impl GLProcessorST {
             edgefirst_gl::gl::ReadBuffer(edgefirst_gl::gl::COLOR_ATTACHMENT0);
             if direct_read_supported(format) {
                 edgefirst_gl::gl::BindBuffer(edgefirst_gl::gl::PIXEL_PACK_BUFFER, buffer_id);
+                // The bytes between rows at this pitch are the destination's
+                // padding; a driver may write them while packing (Vivante
+                // does, issue #167). `needed` keeps every written byte inside
+                // the buffer either way.
                 if let Some(pixels) = row_length {
                     edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::PACK_ROW_LENGTH, pixels);
                 }
@@ -4268,12 +4278,6 @@ impl GLProcessorST {
                     Err(e) => {
                         let src_w = src.width().unwrap_or(0);
                         let src_h = src.height().unwrap_or(0);
-                        // The R8 import declined (Mali's alignment rule, the
-                        // ANGLE leaves' offset refusal, or a driver that cannot
-                        // import the buffer at all). This is still a GPU
-                        // convert: the same shader runs on an R8 *upload* of the
-                        // combined plane, so record ShaderR8, not Cpu.
-                        self.last_nv_convert_path = NvConvertPath::ShaderR8;
                         self.convert_stats.zero_copy_declines += 1;
                         // Warn once per buffer — a steady-state video pipeline
                         // hits this every frame with the same buffers, and a
@@ -4318,6 +4322,13 @@ impl GLProcessorST {
                             flip,
                             is_int8,
                         )?;
+                        // The R8 import declined (Mali's alignment rule, the
+                        // ANGLE leaves' offset refusal, or a driver that cannot
+                        // import the buffer at all), but the upload just drawn
+                        // above succeeded: still a GPU convert, so record
+                        // ShaderR8, not Cpu -- only now that the draw has
+                        // actually returned `Ok`, not before it could fail.
+                        self.last_nv_convert_path = NvConvertPath::ShaderR8;
                         log::debug!("NV R8 upload takes {:?}", start.elapsed());
                     }
                 }
@@ -4359,12 +4370,8 @@ impl GLProcessorST {
                             src_fmt,
                             PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
                         ) && !src.is_multiplane();
-                        if src_fmt == PixelFormat::Nv12 {
-                            self.last_nv_convert_path = if nv_upload_capable {
-                                NvConvertPath::ShaderR8
-                            } else {
-                                NvConvertPath::Cpu
-                            };
+                        if src_fmt == PixelFormat::Nv12 && !nv_upload_capable {
+                            self.last_nv_convert_path = NvConvertPath::Cpu;
                         }
                         self.convert_stats.zero_copy_declines += 1;
                         // Warn once per buffer (see the ShaderR8 arm): repeats
@@ -4399,6 +4406,12 @@ impl GLProcessorST {
                                 flip,
                                 is_int8,
                             )?;
+                            // The upload just drawn above succeeded: still a
+                            // GPU convert, so record ShaderR8 now that it is
+                            // certain, not before the draw could fail.
+                            if src_fmt == PixelFormat::Nv12 {
+                                self.last_nv_convert_path = NvConvertPath::ShaderR8;
+                            }
                             log::debug!("NV R8 upload takes {:?}", start.elapsed());
                         } else {
                             self.draw_src_texture(

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -300,6 +300,11 @@ pub struct GLProcessorST {
     /// Whether the GPU is a Verisilicon/Vivante core (detected via GL_RENDERER).
     /// Used to block operations known to cause unrecoverable GPU hangs.
     pub(super) is_vivante: bool,
+    /// Whether the GPU is an Arm Mali core (GL_RENDERER). Used to decline a
+    /// source DMA-BUF import at a plane offset Mali would sample zeros from,
+    /// so the upload path takes it instead — see `mali_rejects_source_offset`
+    /// and issue #165.
+    is_mali: bool,
     /// Whether the GPU is a virtualized/paravirtual device (GL_RENDERER).
     /// Concurrent GL across contexts mis-renders on paravirtual Metal
     /// (observed on macOS CI runners: parallel processors produce ~60-86%
@@ -873,6 +878,11 @@ fn apply_forced_transfer(backend: &mut TransferBackend) {
 struct RendererTraits {
     /// Verisilicon/Vivante core — GPU-hang workarounds + Full serialization.
     vivante: bool,
+    /// Arm Mali (i.MX 95 G310 and kin). Its DMA-BUF import silently samples
+    /// zeros when `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is not 64-byte aligned —
+    /// the import succeeds and no EGL error follows — so a source at such an
+    /// offset is declined and uploaded instead (issue #165).
+    mali: bool,
     /// Software rasterizer (llvmpipe/softpipe/swrast) — rejected unless the
     /// coverage-lane override is set.
     software: bool,
@@ -1248,6 +1258,7 @@ fn classify_renderer(renderer: &str) -> RendererTraits {
     let lower = renderer.to_ascii_lowercase();
     RendererTraits {
         vivante: lower.contains("vivante") || lower.contains("gc7000") || lower.contains("galcore"),
+        mali: lower.contains("mali"),
         software: lower.contains("llvmpipe")
             || lower.contains("softpipe")
             || lower.contains("swrast")
@@ -1257,6 +1268,17 @@ fn classify_renderer(renderer: &str) -> RendererTraits {
         virtual_gpu: lower.contains("paravirtual") || lower.contains("virtio"),
         angle: lower.contains("angle"),
     }
+}
+
+/// The plane-offset alignment Mali's DMA-BUF import needs to sample the
+/// buffer at all. Measured on i.MX 95 (issue #165): offsets 32 and 2080
+/// sample zeros, 64/256/2048 sample correctly.
+const MALI_DMA_IMPORT_OFFSET_ALIGN: usize = 64;
+
+/// Whether a Mali source import at `plane_offset` would sample zeros. Pure so
+/// the rule is unit-testable without a GL context, like [`classify_renderer`].
+fn mali_rejects_source_offset(is_mali: bool, plane_offset: usize) -> bool {
+    is_mali && !plane_offset.is_multiple_of(MALI_DMA_IMPORT_OFFSET_ALIGN)
 }
 
 impl GLProcessorST {
@@ -1312,6 +1334,7 @@ impl GLProcessorST {
             renderer:
                 RendererTraits {
                     vivante: is_vivante,
+                    mali: is_mali,
                     software: is_software_renderer,
                     virtual_gpu: is_virtual_gpu,
                     angle: is_angle,
@@ -1636,6 +1659,7 @@ impl GLProcessorST {
             bgra_warned: false,
             readback_scratch: Vec::new(),
             is_vivante,
+            is_mali,
             is_virtual_gpu,
             is_angle,
             use_renderbuffer: std::env::var("EDGEFIRST_OPENGL_RENDERSURFACE")
@@ -2699,6 +2723,7 @@ impl GLProcessorST {
             .unwrap_or_default();
         let RendererTraits {
             vivante: is_vivante,
+            mali: is_mali,
             software: is_software_renderer,
             virtual_gpu: is_virtual_gpu,
             angle: is_angle,
@@ -2707,6 +2732,14 @@ impl GLProcessorST {
             log::warn!(
                 "Vivante GPU detected — NV12 → planar RGB conversions will use \
                  two-pass workaround to avoid GPU hang (EDGEAI-1180)"
+            );
+        }
+        if is_mali {
+            log::info!(
+                "Mali GPU detected — a source DMA-BUF whose plane offset is not \
+                 {MALI_DMA_IMPORT_OFFSET_ALIGN}-byte aligned will be uploaded \
+                 rather than imported: Mali's import samples zeros from such an \
+                 offset without reporting an EGL error (issue #165)"
             );
         }
         if is_software_renderer {
@@ -4235,9 +4268,12 @@ impl GLProcessorST {
                     Err(e) => {
                         let src_w = src.width().unwrap_or(0);
                         let src_h = src.height().unwrap_or(0);
-                        // Path B failed — this means no GPU NV* path is available.
-                        // Record the CPU fallback so tests/profiler can detect it.
-                        self.last_nv_convert_path = NvConvertPath::Cpu;
+                        // The R8 import declined (Mali's alignment rule, the
+                        // ANGLE leaves' offset refusal, or a driver that cannot
+                        // import the buffer at all). This is still a GPU
+                        // convert: the same shader runs on an R8 *upload* of the
+                        // combined plane, so record ShaderR8, not Cpu.
+                        self.last_nv_convert_path = NvConvertPath::ShaderR8;
                         self.convert_stats.zero_copy_declines += 1;
                         // Warn once per buffer — a steady-state video pipeline
                         // hits this every frame with the same buffers, and a
@@ -4249,7 +4285,7 @@ impl GLProcessorST {
                                 src_h,
                                 error = %e,
                                 "Path B R8 EGLImage creation failed for {src_fmt} \
-                                 ({src_w}x{src_h}); falling back to CPU path (no GPU NV16/NV24)"
+                                 ({src_w}x{src_h}); uploading the combined plane instead"
                             );
                         } else {
                             tracing::debug!(
@@ -4260,17 +4296,29 @@ impl GLProcessorST {
                                 "Path B R8 EGLImage creation failed (repeat)"
                             );
                         }
+                        // The same shader on an R8 *upload* of the combined
+                        // plane, which reads the source through `map()` — the
+                        // route the non-DMA NV branch below already takes.
+                        // `draw_src_texture` has no NV arm and would have
+                        // returned NotSupported, sending the whole convert to
+                        // the CPU (issue #166). `draw_nv_texture_2d(.., None,
+                        // ..)` cannot map a PBO source, and refuses one itself;
+                        // no PBO can reach here anyway, this arm being inside
+                        // the `TensorMemory::DmaBuf` branch.
+                        self.convert_stats.src_uploads += 1;
+                        tracing::Span::current().record("src_feed", "upload");
                         let start = Instant::now();
-                        self.draw_src_texture(
+                        self.draw_nv_texture_2d(
                             src,
                             src_fmt,
+                            None,
                             src_roi,
                             dst_roi,
                             rotation_offset,
                             flip,
                             is_int8,
                         )?;
-                        log::debug!("draw_src_texture takes {:?}", start.elapsed());
+                        log::debug!("NV R8 upload takes {:?}", start.elapsed());
                     }
                 }
             } else {
@@ -4299,8 +4347,24 @@ impl GLProcessorST {
                     Err(e) => {
                         let src_w = src.width().unwrap_or(0);
                         let src_h = src.height().unwrap_or(0);
+                        // A single-plane NV source has a GPU route left even
+                        // when the sampler import is refused: the R8 upload of
+                        // the combined plane, exactly as in the ShaderR8 arm
+                        // above. `draw_src_texture` has no NV arm, so without
+                        // this the whole convert died here (issue #166) — which
+                        // is how an unaligned NV12 plane offset failed on
+                        // Vivante, whose Auto policy takes the sampler and
+                        // whose EGL refuses such an offset outright.
+                        let nv_upload_capable = matches!(
+                            src_fmt,
+                            PixelFormat::Nv12 | PixelFormat::Nv16 | PixelFormat::Nv24
+                        ) && !src.is_multiplane();
                         if src_fmt == PixelFormat::Nv12 {
-                            self.last_nv_convert_path = NvConvertPath::Cpu;
+                            self.last_nv_convert_path = if nv_upload_capable {
+                                NvConvertPath::ShaderR8
+                            } else {
+                                NvConvertPath::Cpu
+                            };
                         }
                         self.convert_stats.zero_copy_declines += 1;
                         // Warn once per buffer (see the ShaderR8 arm): repeats
@@ -4317,16 +4381,37 @@ impl GLProcessorST {
                             );
                         }
                         let start = Instant::now();
-                        self.draw_src_texture(
-                            src,
-                            src_fmt,
-                            src_roi,
-                            dst_roi,
-                            rotation_offset,
-                            flip,
-                            is_int8,
-                        )?;
-                        log::debug!("draw_src_texture takes {:?}", start.elapsed());
+                        if nv_upload_capable {
+                            // Same shader, same in-shader matrix, source read
+                            // through `map()`. No PBO can reach here: this arm
+                            // is inside the `TensorMemory::DmaBuf` branch, and
+                            // `draw_nv_texture_2d(.., None, ..)` refuses a PBO
+                            // source itself in any case.
+                            self.convert_stats.src_uploads += 1;
+                            tracing::Span::current().record("src_feed", "upload");
+                            self.draw_nv_texture_2d(
+                                src,
+                                src_fmt,
+                                None,
+                                src_roi,
+                                dst_roi,
+                                rotation_offset,
+                                flip,
+                                is_int8,
+                            )?;
+                            log::debug!("NV R8 upload takes {:?}", start.elapsed());
+                        } else {
+                            self.draw_src_texture(
+                                src,
+                                src_fmt,
+                                src_roi,
+                                dst_roi,
+                                rotation_offset,
+                                flip,
+                                is_int8,
+                            )?;
+                            log::debug!("draw_src_texture takes {:?}", start.elapsed());
+                        }
                     }
                 }
             }
@@ -5913,6 +5998,18 @@ impl GLProcessorST {
         // import without consulting the platform at all, so an identity that
         // has stopped naming its buffer would be served a stale image.
         Platform::validate_import_identity(img, "NV source")?;
+        // Mali samples zeros from an unaligned plane offset without reporting
+        // an EGL error, so refuse the import here and let the caller's failure
+        // arm upload the window through `map()` instead (issue #165). Always a
+        // source, so there is no destination case to exempt.
+        let offset = img.plane_offset().unwrap_or(0);
+        if mali_rejects_source_offset(self.is_mali, offset) {
+            return Err(crate::Error::NotSupported(format!(
+                "Mali samples zeros from a DMA-BUF imported at a plane offset that \
+                 is not {MALI_DMA_IMPORT_OFFSET_ALIGN}-byte aligned ({offset}); \
+                 uploading the window instead (issue #165)"
+            )));
+        }
         // The NV R8 path imports a SOURCE (NV12/16/24 as one R8 texture), so it
         // never collapses onto a destination parent import.
         let id = BufferImportKey::from_tensor(img, img_fmt, false);
@@ -5959,6 +6056,22 @@ impl GLProcessorST {
                 CacheKind::Dst => "destination",
             },
         )?;
+        // Mali samples zeros from a source imported at a plane offset that is
+        // not 64-byte aligned, with no EGL error to notice (issue #165). Refuse
+        // it so the caller's failure arm uploads the window through `map()`.
+        // Destinations are untouched: a destination view imports its parent at
+        // offset 0 and is rendered into by viewport, never sampled at an
+        // offset.
+        if cache == CacheKind::Src {
+            let offset = img.plane_offset().unwrap_or(0);
+            if mali_rejects_source_offset(self.is_mali, offset) {
+                return Err(crate::Error::NotSupported(format!(
+                    "Mali samples zeros from a DMA-BUF imported at a plane offset that \
+                     is not {MALI_DMA_IMPORT_OFFSET_ALIGN}-byte aligned ({offset}); \
+                     uploading the window instead (issue #165)"
+                )));
+            }
+        }
         // Identity + offset + geometry: sub-region views share one buffer
         // identity but need distinct EGLImages (offset), and a pooled buffer
         // reconfigured to a new size/format/stride needs a fresh import
@@ -7719,6 +7832,7 @@ impl GLProcessorST {
             // rejected in `new` before a processor exists.
             serialize_gl: requires_full_serialization(RendererTraits {
                 vivante: self.is_vivante(),
+                mali: self.is_mali,
                 software: false,
                 virtual_gpu: self.is_virtual_gpu,
                 angle: self.is_angle,
@@ -7933,7 +8047,7 @@ mod tests {
 
         // imx8mp (Vivante GC7000UL)
         let t = classify_renderer("Vivante GC7000UL");
-        assert!(t.vivante && !t.software && !t.virtual_gpu && !t.angle);
+        assert!(t.vivante && !t.software && !t.virtual_gpu && !t.angle && !t.mali);
         // Apple Silicon via ANGLE (developer machines) — a REAL GPU, not
         // paravirtual, but still ANGLE and still loses per-draw state under
         // concurrent GL.
@@ -7942,8 +8056,24 @@ mod tests {
              Version 26.4.1 (Build 25E253))",
         );
         assert!(t.angle && !t.virtual_gpu && !t.software && !t.vivante);
-        // Mali / V3D / Tegra: plain hardware, the P0-validated parallel set
-        assert_eq!(classify_renderer("Mali-G310"), real_gpu);
+        // Mali: plain hardware for the serialization policy, but carries the
+        // `mali` trait that gates the unaligned-source-offset decline (#165).
+        assert_eq!(
+            classify_renderer("Mali-G310"),
+            RendererTraits {
+                mali: true,
+                ..RendererTraits::default()
+            }
+        );
+        assert_eq!(
+            classify_renderer("Mali-G52"),
+            RendererTraits {
+                mali: true,
+                ..RendererTraits::default()
+            }
+        );
+        // V3D / Tegra: plain hardware, the P0-validated parallel set, and NOT
+        // Mali — they import an unaligned source offset correctly.
         assert_eq!(classify_renderer("V3D 7.1"), real_gpu);
         assert_eq!(
             classify_renderer("NVIDIA Tegra Orin (nvgpu)/integrated"),
@@ -7971,6 +8101,25 @@ mod tests {
              Version 15.7.7 (Build 24G720))",
         );
         assert!(t.virtual_gpu && t.angle && !t.software && !t.vivante);
+    }
+
+    // The plane-offset rule that decides whether a Mali source DMA-BUF is
+    // imported or uploaded. The offsets are the ones measured on i.MX 95
+    // (issue #165): 32 and 2080 sampled zeros, 0/64/2048 sampled correctly.
+    #[test]
+    fn mali_declines_only_unaligned_source_offsets() {
+        use super::mali_rejects_source_offset as rejects;
+
+        // Mali, unaligned — declined so the upload path takes the source.
+        assert!(rejects(true, 32));
+        assert!(rejects(true, 2080));
+        // Mali, aligned — imported, as measured.
+        assert!(!rejects(true, 0));
+        assert!(!rejects(true, 64));
+        assert!(!rejects(true, 2048));
+        // Every other driver imports any offset; the rule must not touch them.
+        assert!(!rejects(false, 32));
+        assert!(!rejects(false, 2080));
     }
 
     // The serialization policy each fleet renderer selects. The parallel

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1315,12 +1315,41 @@ fn mali_rejects_import_offset(is_mali: bool, plane_offset: usize) -> bool {
 /// destination lowers to the mapped-texture path, whose readback writes through
 /// `map()` at the offset, instead of letting the EGL error end the convert.
 ///
-/// Only the offset the import actually starts at matters, so a fresh `view()`
-/// destination (which collapses onto its parent at offset 0) is unaffected;
-/// this is about a destination rebuilt from a descriptor, or a whole tensor at
-/// a foreign offset.
+/// Takes the offset the import will actually start at, which is what
+/// [`dst_import_base`] computes — NOT the tensor's `plane_offset`, which for a
+/// fresh `view()` is its own byte offset while the import bases at 0.
 fn vivante_rejects_dst_import_offset(is_vivante: bool, plane_offset: usize) -> bool {
     is_vivante && unaligned_import_offset(plane_offset)
+}
+
+/// The byte offset a DESTINATION import will actually base at.
+///
+/// A fresh `view()`/`batch()` destination imports its PARENT and places the
+/// tile with `glViewport`, so its import bases at 0 however far into the buffer
+/// its own bytes start — `DmaImportAttrs::from_tensor` with `for_dst = true`
+/// (`dma_import.rs` ~`:202`) and `BufferImportKey::from_tensor` (`cache.rs`
+/// ~`:167`) both collapse to 0 whenever `view_origin` is `Some`. Only a
+/// destination WITHOUT a `view_origin` — one rebuilt from a descriptor, or a
+/// whole tensor at a foreign offset — is imported at its own offset.
+///
+/// So a driver rule about the import's base offset must be asked of this, not
+/// of `plane_offset()`. Asking `plane_offset()` made
+/// [`vivante_rejects_dst_import_offset`] fire on every tile view whose byte
+/// offset happened to be unaligned (RGBA `x0` not a multiple of 16, say), which
+/// silently cost Vivante the zero-copy destination path for a case its driver
+/// handles perfectly — the import never saw that offset.
+///
+/// Pure, and takes the two field values rather than a tensor, so it serves both
+/// `Tensor<u8>` and `TensorDyn` call sites and is unit-testable without either.
+fn dst_import_base(
+    view_origin: Option<edgefirst_tensor::ViewOrigin>,
+    plane_offset: Option<usize>,
+) -> usize {
+    if view_origin.is_some() {
+        0
+    } else {
+        plane_offset.unwrap_or(0)
+    }
 }
 
 /// The plane-1 (interleaved CbCr) byte offset a *contiguous* NV12 import hands
@@ -2080,7 +2109,7 @@ impl GLProcessorST {
                 // `EGL_BAD_ACCESS` escape.
                 && !vivante_rejects_dst_import_offset(
                     self.is_vivante,
-                    dst.plane_offset().unwrap_or(0),
+                    dst_import_base(dst.view_origin(), dst.plane_offset()),
                 );
                 if !places {
                     return Err(Error::NotSupported(format!(
@@ -2294,12 +2323,12 @@ impl GLProcessorST {
         // origin.
         // Vivante's driver-side half of the same question: an unaligned
         // destination offset fails `eglCreateImage` (see `bind_dst`).
-        let dst_offset = dst.plane_offset().unwrap_or(0);
+        let dst_offset = dst_import_base(dst.view_origin(), dst.plane_offset());
         let places = Platform::dst_import_places(dst)
             && !vivante_rejects_dst_import_offset(self.is_vivante, dst_offset);
         if !places {
             log::debug!(
-                "convert_via_engine: zero-copy destination at plane offset \
+                "convert_via_engine: zero-copy destination importing at base offset \
                  {dst_offset} cannot be placed by this platform/driver; rendering \
                  to a texture and reading back through map()"
             );
@@ -2939,14 +2968,14 @@ impl GLProcessorST {
         // and without this the EGL error ended the convert instead of lowering
         // it (measured on i.MX 8M Plus: offset 2048 renders, 2080 is
         // `EGL_BAD_ACCESS`).
-        let dst_offset = dst.plane_offset().unwrap_or(0);
+        let dst_offset = dst_import_base(dst.view_origin(), dst.plane_offset());
         let places = Platform::dst_import_places(dst)
             && !vivante_rejects_dst_import_offset(self.is_vivante, dst_offset);
         if !places {
             log::debug!(
-                "bind_dst: zero-copy destination at plane offset {dst_offset} cannot be \
-                 placed by this platform/driver; rendering to a texture and reading \
-                 back through map()"
+                "bind_dst: zero-copy destination importing at base offset {dst_offset} \
+                 cannot be placed by this platform/driver; rendering to a texture and \
+                 reading back through map()"
             );
         }
         match super::render::lower_dst(
@@ -4552,10 +4581,12 @@ impl GLProcessorST {
             // replacing the old CPU fallback. Multiplane NV12 (separate Y/UV
             // buffers) cannot be uploaded as one R8 texture → CPU below.
             tracing::trace!(path = "ShaderR8-upload", src_fmt = ?src_fmt, "image.convert.gl.nv_path");
-            self.last_nv_convert_path = NvConvertPath::ShaderR8;
             self.convert_stats.src_uploads += 1;
             tracing::Span::current().record("src_feed", "upload");
-            self.draw_nv_texture_2d(
+            // Recorded from the draw's result, like the four DMA arms above: a
+            // failed upload records Cpu rather than leaving a ShaderR8 claim or
+            // the previous convert's value.
+            match self.draw_nv_texture_2d(
                 src,
                 src_fmt,
                 None,
@@ -4564,7 +4595,13 @@ impl GLProcessorST {
                 rotation_offset,
                 flip,
                 is_int8,
-            )?;
+            ) {
+                Ok(()) => self.last_nv_convert_path = NvConvertPath::ShaderR8,
+                Err(e) => {
+                    self.last_nv_convert_path = NvConvertPath::Cpu;
+                    return Err(e);
+                }
+            }
         } else {
             // Non-DMA source, non-NV (or multiplane NV): CPU texture-upload path.
             if matches!(
@@ -8315,6 +8352,48 @@ mod tests {
             mali_rejects_import_offset(true, 2080),
             "the Mali rule is the source rule, and 2080 is in it"
         );
+    }
+
+    // The offset a destination import actually bases at, which is what the
+    // Vivante rule must be asked of. A fresh view() bases at 0 however far into
+    // the buffer its own bytes start, so asking `plane_offset()` instead made
+    // the rule fire on tile views the driver handles perfectly.
+    #[test]
+    fn a_view_destination_imports_at_base_zero_and_escapes_the_offset_rule() {
+        use super::{dst_import_base as base, vivante_rejects_dst_import_offset as dst_rejects};
+        use edgefirst_tensor::ViewOrigin;
+
+        // A fresh view: `view_origin` is Some, so the import bases at 0 -- even
+        // at an unaligned byte offset like an RGBA x0 of 8 (2080 here).
+        let vo = Some(ViewOrigin {
+            parent_width: 64,
+            parent_height: 64,
+            parent_row_stride: 256,
+            x: 8,
+            y: 8,
+        });
+        assert_eq!(base(vo, Some(2080)), 0);
+        assert!(
+            !dst_rejects(true, base(vo, Some(2080))),
+            "a fresh view destination must KEEP zero-copy on Vivante"
+        );
+        // Still 0 at an aligned offset, and 0 even if the offset is absent.
+        assert_eq!(base(vo, Some(2048)), 0);
+        assert_eq!(base(vo, None), 0);
+
+        // No view_origin -- rebuilt from a descriptor, or a whole tensor at a
+        // foreign offset. Now the import really does base at the offset, and
+        // the rule applies.
+        assert_eq!(base(None, Some(2080)), 2080);
+        assert!(dst_rejects(true, base(None, Some(2080))));
+        assert_eq!(base(None, Some(2048)), 2048);
+        assert!(!dst_rejects(true, base(None, Some(2048))));
+        // A whole tensor with no offset at all is base 0.
+        assert_eq!(base(None, None), 0);
+        assert!(!dst_rejects(true, base(None, None)));
+
+        // Nothing here touches a non-Vivante driver.
+        assert!(!dst_rejects(false, base(None, Some(2080))));
     }
 
     // The chroma-plane offset a contiguous NV12 import hands EGL, and whether

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -1316,32 +1316,43 @@ fn mali_rejects_import_offset(is_mali: bool, plane_offset: usize) -> bool {
 /// `map()` at the offset, instead of letting the EGL error end the convert.
 ///
 /// Takes the offset the import will actually start at, which is what
-/// [`dst_import_base`] computes — NOT the tensor's `plane_offset`, which for a
-/// fresh `view()` is its own byte offset while the import bases at 0.
+/// Takes the offset the import being guarded actually bases at, which differs
+/// by route: [`view_collapsed_dst_base`] for `bind_dst`'s import, the raw
+/// `plane_offset()` for the `import_buffer_packed` ones.
 fn vivante_rejects_dst_import_offset(is_vivante: bool, plane_offset: usize) -> bool {
     is_vivante && unaligned_import_offset(plane_offset)
 }
 
-/// The byte offset a DESTINATION import will actually base at.
+/// The byte offset a destination import bases at **on the route that collapses
+/// a view to its parent** — `bind_dst`'s `get_or_create_egl_image(Dst)`.
 ///
-/// A fresh `view()`/`batch()` destination imports its PARENT and places the
-/// tile with `glViewport`, so its import bases at 0 however far into the buffer
-/// its own bytes start — `DmaImportAttrs::from_tensor` with `for_dst = true`
-/// (`dma_import.rs` ~`:202`) and `BufferImportKey::from_tensor` (`cache.rs`
-/// ~`:167`) both collapse to 0 whenever `view_origin` is `Some`. Only a
-/// destination WITHOUT a `view_origin` — one rebuilt from a descriptor, or a
-/// whole tensor at a foreign offset — is imported at its own offset.
+/// The engine has two zero-copy destination import routes and they treat a
+/// `view()` differently, so a driver rule about the base offset has to know
+/// which one it guards:
 ///
-/// So a driver rule about the import's base offset must be asked of this, not
-/// of `plane_offset()`. Asking `plane_offset()` made
-/// [`vivante_rejects_dst_import_offset`] fire on every tile view whose byte
-/// offset happened to be unaligned (RGBA `x0` not a multiple of 16, say), which
-/// silently cost Vivante the zero-copy destination path for a case its driver
-/// handles perfectly — the import never saw that offset.
+/// * **`bind_dst` → `get_or_create_egl_image(CacheKind::Dst)` →
+///   `Platform::import_buffer(.., for_dst = true)`.** A fresh `view()`/`batch()`
+///   destination imports its PARENT and places the tile with `glViewport`, so
+///   the import bases at 0 however far into the buffer the view's own bytes
+///   start: `DmaImportAttrs::from_tensor` (`dma_import.rs` ~`:202`) and
+///   `BufferImportKey::from_tensor` (`cache.rs` ~`:167`) both collapse to 0
+///   whenever `view_origin` is `Some`. **This function.**
+/// * **`convert_via_engine`'s packed-RGB plan and the zero-copy float paths →
+///   `get_or_create_egl_image_rgb` → `Platform::import_buffer_packed`.** That
+///   one passes `plane_offset()` straight to `EGL_DMA_BUF_PLANE0_OFFSET_EXT`
+///   with no `view_origin` collapse (`platform/linux.rs` ~`:199`), so a
+///   destination there IS imported at its own offset. Those sites pass the raw
+///   `plane_offset()` and must NOT use this function.
+///
+/// Getting the first case wrong is not merely a lost fast path: asking
+/// `plane_offset()` there made [`vivante_rejects_dst_import_offset`] fire on
+/// every tile view whose byte offset happened to be unaligned (an RGBA `x0` of
+/// 8 is 32 bytes), and the mapped-texture readback it lowered to returns wrong
+/// pixels for a view destination on that driver.
 ///
 /// Pure, and takes the two field values rather than a tensor, so it serves both
 /// `Tensor<u8>` and `TensorDyn` call sites and is unit-testable without either.
-fn dst_import_base(
+fn view_collapsed_dst_base(
     view_origin: Option<edgefirst_tensor::ViewOrigin>,
     plane_offset: Option<usize>,
 ) -> usize {
@@ -2107,9 +2118,16 @@ impl GLProcessorST {
                 // mapped-texture readback for a float DMA destination to lower
                 // to, so this declines to the CPU converter rather than letting
                 // `EGL_BAD_ACCESS` escape.
+                // The RAW `plane_offset`, not the view-collapsed base: these
+                // four float paths import through `import_buffer_packed`,
+                // which passes `plane_offset()` straight to
+                // `EGL_DMA_BUF_PLANE0_OFFSET_EXT` with no `view_origin`
+                // collapse (`platform/linux.rs` ~`:199`). Only `bind_dst`'s
+                // `get_or_create_egl_image(Dst)` route collapses a view to 0 —
+                // see `view_collapsed_dst_base`.
                 && !vivante_rejects_dst_import_offset(
                     self.is_vivante,
-                    dst_import_base(dst.view_origin(), dst.plane_offset()),
+                    dst.plane_offset().unwrap_or(0),
                 );
                 if !places {
                     return Err(Error::NotSupported(format!(
@@ -2322,8 +2340,13 @@ impl GLProcessorST {
         // take `DstLowering::ZeroCopy` here and render at the buffer's
         // origin.
         // Vivante's driver-side half of the same question: an unaligned
-        // destination offset fails `eglCreateImage` (see `bind_dst`).
-        let dst_offset = dst_import_base(dst.view_origin(), dst.plane_offset());
+        // destination offset fails `eglCreateImage` (see `bind_dst`). The RAW
+        // `plane_offset` here, not the view-collapsed base: this plan imports
+        // through `import_buffer_packed`, which passes `plane_offset()` straight
+        // to EGL with no `view_origin` collapse (`platform/linux.rs` ~`:199`),
+        // so a view destination on this route really is imported at its own
+        // offset. See `view_collapsed_dst_base` for the route that differs.
+        let dst_offset = dst.plane_offset().unwrap_or(0);
         let places = Platform::dst_import_places(dst)
             && !vivante_rejects_dst_import_offset(self.is_vivante, dst_offset);
         if !places {
@@ -2968,7 +2991,7 @@ impl GLProcessorST {
         // and without this the EGL error ended the convert instead of lowering
         // it (measured on i.MX 8M Plus: offset 2048 renders, 2080 is
         // `EGL_BAD_ACCESS`).
-        let dst_offset = dst_import_base(dst.view_origin(), dst.plane_offset());
+        let dst_offset = view_collapsed_dst_base(dst.view_origin(), dst.plane_offset());
         let places = Platform::dst_import_places(dst)
             && !vivante_rejects_dst_import_offset(self.is_vivante, dst_offset);
         if !places {
@@ -4394,22 +4417,20 @@ impl GLProcessorST {
                         // Warn once per buffer — a steady-state video pipeline
                         // hits this every frame with the same buffers, and a
                         // per-frame warn floods the log. Repeats drop to debug.
+                        // `log`, not `tracing`: the workspace installs no
+                        // `tracing-log` bridge, so a `tracing::warn!` reaches no
+                        // ordinary board or field log at all -- and this is the
+                        // line that diagnoses #165 on a Mali box. The sibling
+                        // arm below already uses `log`. Same warn-once shape.
                         if self.nv_import_warned.insert(src.buffer_identity().id()) {
-                            tracing::warn!(
-                                src_fmt = ?src_fmt,
-                                src_w,
-                                src_h,
-                                error = %e,
+                            log::warn!(
                                 "Path B R8 EGLImage creation failed for {src_fmt} \
-                                 ({src_w}x{src_h}); uploading the combined plane instead"
+                                 ({src_w}x{src_h}); uploading the combined plane instead: {e}"
                             );
                         } else {
-                            tracing::debug!(
-                                src_fmt = ?src_fmt,
-                                src_w,
-                                src_h,
-                                error = %e,
-                                "Path B R8 EGLImage creation failed (repeat)"
+                            log::debug!(
+                                "Path B R8 EGLImage creation failed for {src_fmt} \
+                                 ({src_w}x{src_h}) (repeat): {e}"
                             );
                         }
                         // The same shader on an R8 *upload* of the combined
@@ -8355,12 +8376,17 @@ mod tests {
     }
 
     // The offset a destination import actually bases at, which is what the
-    // Vivante rule must be asked of. A fresh view() bases at 0 however far into
-    // the buffer its own bytes start, so asking `plane_offset()` instead made
-    // the rule fire on tile views the driver handles perfectly.
+    // Vivante rule must be asked of -- and which of the two routes is being
+    // guarded. `bind_dst`'s import collapses a fresh view() to 0 however far
+    // into the buffer its own bytes start, so asking `plane_offset()` there
+    // made the rule fire on tile views the driver handles perfectly. The
+    // `import_buffer_packed` routes do NOT collapse, so they must keep asking
+    // the raw offset; both shapes are asserted here.
     #[test]
     fn a_view_destination_imports_at_base_zero_and_escapes_the_offset_rule() {
-        use super::{dst_import_base as base, vivante_rejects_dst_import_offset as dst_rejects};
+        use super::{
+            view_collapsed_dst_base as base, vivante_rejects_dst_import_offset as dst_rejects,
+        };
         use edgefirst_tensor::ViewOrigin;
 
         // A fresh view: `view_origin` is Some, so the import bases at 0 -- even
@@ -8394,6 +8420,25 @@ mod tests {
 
         // Nothing here touches a non-Vivante driver.
         assert!(!dst_rejects(false, base(None, Some(2080))));
+
+        // THE OTHER ROUTE. `import_buffer_packed` passes `plane_offset()`
+        // straight to EGL with no collapse, so `convert_via_engine`'s packed
+        // plan and the float paths ask the RAW offset -- and a view destination
+        // there really is imported at its own offset, so the rule must fire on
+        // it. Collapsing at those sites would under-fire and hand Vivante the
+        // `EGL_BAD_ACCESS` this rule exists to avoid.
+        let raw = |plane_offset: Option<usize>| plane_offset.unwrap_or(0);
+        assert_eq!(raw(Some(2080)), 2080);
+        assert!(
+            dst_rejects(true, raw(Some(2080))),
+            "a view destination on the packed route imports at its own offset, \
+             so the rule must still fire there"
+        );
+        assert!(!dst_rejects(true, raw(Some(2048))));
+        assert!(!dst_rejects(true, raw(None)));
+        // The two routes genuinely disagree for the same tensor: that is the
+        // whole reason the helper is route-specific.
+        assert_ne!(base(vo, Some(2080)), raw(Some(2080)));
     }
 
     // The chroma-plane offset a contiguous NV12 import hands EGL, and whether

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -302,7 +302,7 @@ pub struct GLProcessorST {
     pub(super) is_vivante: bool,
     /// Whether the GPU is an Arm Mali core (GL_RENDERER). Used to decline a
     /// source DMA-BUF import at a plane offset Mali would sample zeros from,
-    /// so the upload path takes it instead — see `mali_rejects_source_offset`
+    /// so the upload path takes it instead — see `mali_rejects_import_offset`
     /// and issue #165.
     is_mali: bool,
     /// Whether the GPU is a virtualized/paravirtual device (GL_RENDERER).
@@ -1270,21 +1270,72 @@ fn classify_renderer(renderer: &str) -> RendererTraits {
     }
 }
 
-/// The plane-offset alignment Mali's DMA-BUF import needs to sample the
-/// buffer at all. Measured on i.MX 95 (issue #165): offsets 32 and 2080
-/// sample zeros, 64/256/2048 sample correctly.
-const MALI_DMA_IMPORT_OFFSET_ALIGN: usize = 64;
-
-/// Whether a Mali source import at `plane_offset` would sample zeros. Pure so
-/// the rule is unit-testable without a GL context, like [`classify_renderer`].
+/// The plane-offset alignment the two embedded drivers that have been measured
+/// need from a DMA-BUF import. Both landed on the same 64 bytes, from opposite
+/// symptoms:
 ///
-/// Only plane 0's offset is checked. For single-plane NV12 the chroma plane
-/// sits at `plane0_offset + pitch * height` (`dma_import.rs` ~`:225`), which
-/// is itself a multiple of 64 whenever `pitch` is -- and the HAL pads every
-/// DMA pitch to 64 -- so the chroma plane's alignment is not checked
-/// separately here.
-fn mali_rejects_source_offset(is_mali: bool, plane_offset: usize) -> bool {
-    is_mali && !plane_offset.is_multiple_of(MALI_DMA_IMPORT_OFFSET_ALIGN)
+/// * **Mali** (i.MX 95, source sampling, issue #165): offsets 32 and 2080
+///   sample zeros with no EGL error at all; 64, 256 and 2048 sample correctly,
+///   and offset 0 (the whole image, not a window) is the control.
+/// * **Vivante GC7000UL** (i.MX 8M Plus, destination import): offset 2048
+///   imports and renders correctly, offset 2080 fails `eglCreateImage` with
+///   `EGL_BAD_ACCESS`.
+///
+/// Two data points bracket the Vivante rule rather than pin it — the true
+/// requirement is somewhere in `(32, 2048]` — so 64 is the tightest value
+/// consistent with both drivers rather than a documented driver constant.
+const DMA_IMPORT_OFFSET_ALIGN: usize = 64;
+
+/// Whether `plane_offset` is one of the offsets no measured embedded driver
+/// imports correctly. Pure, so the per-driver rules below are unit-testable
+/// without a GL context, like [`classify_renderer`].
+fn unaligned_import_offset(plane_offset: usize) -> bool {
+    !plane_offset.is_multiple_of(DMA_IMPORT_OFFSET_ALIGN)
+}
+
+/// Whether a Mali import at `plane_offset` would sample zeros.
+///
+/// Checks ONE plane's offset. Every plane the import passes to EGL has to be
+/// checked by its caller: a two-plane NV12 import hands EGL a plane-1 offset
+/// of its own, which can be unaligned while plane 0 is aligned — see
+/// [`nv12_plane1_offset`].
+fn mali_rejects_import_offset(is_mali: bool, plane_offset: usize) -> bool {
+    is_mali && unaligned_import_offset(plane_offset)
+}
+
+/// Whether Vivante would fail to import a DESTINATION at `plane_offset`.
+///
+/// Distinct from [`mali_rejects_import_offset`] in symptom and in side: this is
+/// a hard `EGL_BAD_ACCESS` from `eglCreateImage`, not silent zero-sampling, and
+/// it hits the destination import, which Mali handles correctly at the same
+/// offsets (measured on i.MX 95 by
+/// `tests/offset_source_view_alignment.rs`). The engine already has a seam for
+/// "this platform cannot place a destination at its offset" —
+/// `Platform::dst_import_places` — and this joins it, so an unaligned Vivante
+/// destination lowers to the mapped-texture path, whose readback writes through
+/// `map()` at the offset, instead of letting the EGL error end the convert.
+///
+/// Only the offset the import actually starts at matters, so a fresh `view()`
+/// destination (which collapses onto its parent at offset 0) is unaffected;
+/// this is about a destination rebuilt from a descriptor, or a whole tensor at
+/// a foreign offset.
+fn vivante_rejects_dst_import_offset(is_vivante: bool, plane_offset: usize) -> bool {
+    is_vivante && unaligned_import_offset(plane_offset)
+}
+
+/// The plane-1 (interleaved CbCr) byte offset a *contiguous* NV12 import hands
+/// EGL: the chroma plane follows the full-height luma plane in the same buffer,
+/// so it starts `pitch * height` past the luma offset. Mirrors
+/// `DmaImportAttrs::from_tensor`'s contiguous arm (`dma_import.rs` ~`:225`) —
+/// keep the two in step.
+///
+/// A multiplane NV12 does not use this: its chroma is a separate DMA-BUF whose
+/// import offset is the chroma tensor's own `plane_offset()`.
+///
+/// Pure and saturating so a nonsense geometry cannot panic in release or wrap
+/// into a spuriously aligned value in debug.
+fn nv12_plane1_offset(plane0_offset: usize, pitch: usize, height: usize) -> usize {
+    plane0_offset.saturating_add(pitch.saturating_mul(height))
 }
 
 impl GLProcessorST {
@@ -2021,12 +2072,24 @@ impl GLProcessorST {
                         Platform::dst_import_places(dst.as_typed::<f32>().expect("dtype checked"))
                     }
                     _ => unreachable!("dst_dtype is F16 or F32 in this branch"),
-                };
+                }
+                // Same driver-side term as `bind_dst`: Vivante cannot import a
+                // destination at an unaligned offset at all. There is no
+                // mapped-texture readback for a float DMA destination to lower
+                // to, so this declines to the CPU converter rather than letting
+                // `EGL_BAD_ACCESS` escape.
+                && !vivante_rejects_dst_import_offset(
+                    self.is_vivante,
+                    dst.plane_offset().unwrap_or(0),
+                );
                 if !places {
                     return Err(Error::NotSupported(format!(
-                        "GL float destination at plane offset {} has no view origin \
-                         to place it by, and the zero-copy float import binds the \
-                         whole buffer from its origin; CPU fallback handles it",
+                        "GL float destination at plane offset {} cannot be placed by \
+                         this platform/driver -- either no view origin and an import \
+                         that binds the whole buffer from its origin, or a driver whose \
+                         import rejects the offset -- and there is no mapped-texture \
+                         readback for a float DMA destination to lower to; CPU fallback \
+                         handles it",
                         dst.plane_offset().unwrap_or(0)
                     )));
                 }
@@ -2229,13 +2292,16 @@ impl GLProcessorST {
         // plane offset but no `view_origin`, so without this it would still
         // take `DstLowering::ZeroCopy` here and render at the buffer's
         // origin.
-        let places = Platform::dst_import_places(dst);
+        // Vivante's driver-side half of the same question: an unaligned
+        // destination offset fails `eglCreateImage` (see `bind_dst`).
+        let dst_offset = dst.plane_offset().unwrap_or(0);
+        let places = Platform::dst_import_places(dst)
+            && !vivante_rejects_dst_import_offset(self.is_vivante, dst_offset);
         if !places {
             log::debug!(
-                "convert_via_engine: zero-copy destination at plane offset {} \
-                 has no view origin; rendering to a texture and reading back \
-                 through map()",
-                dst.plane_offset().unwrap_or(0)
+                "convert_via_engine: zero-copy destination at plane offset \
+                 {dst_offset} cannot be placed by this platform/driver; rendering \
+                 to a texture and reading back through map()"
             );
         }
         let lowering = super::render::lower_dst(
@@ -2743,7 +2809,7 @@ impl GLProcessorST {
         if is_mali {
             log::info!(
                 "Mali GPU detected — a source DMA-BUF whose plane offset is not \
-                 {MALI_DMA_IMPORT_OFFSET_ALIGN}-byte aligned will be uploaded \
+                 {DMA_IMPORT_OFFSET_ALIGN}-byte aligned will be uploaded \
                  rather than imported: Mali's import samples zeros from such an \
                  offset without reporting an EGL error (issue #165)"
             );
@@ -2868,13 +2934,19 @@ impl GLProcessorST {
         // A zero-copy destination the platform cannot place -- one carrying a
         // plane offset with no `view_origin` to lower to a viewport -- takes
         // the mapped texture path, whose readback writes through `map()` at
-        // the offset.
-        let places = Platform::dst_import_places(dst);
+        // the offset. Vivante joins that rule from the driver side: its
+        // `eglCreateImage` fails outright on an unaligned destination offset,
+        // and without this the EGL error ended the convert instead of lowering
+        // it (measured on i.MX 8M Plus: offset 2048 renders, 2080 is
+        // `EGL_BAD_ACCESS`).
+        let dst_offset = dst.plane_offset().unwrap_or(0);
+        let places = Platform::dst_import_places(dst)
+            && !vivante_rejects_dst_import_offset(self.is_vivante, dst_offset);
         if !places {
             log::debug!(
-                "bind_dst: zero-copy destination at plane offset {} has no view \
-                 origin; rendering to a texture and reading back through map()",
-                dst.plane_offset().unwrap_or(0)
+                "bind_dst: zero-copy destination at plane offset {dst_offset} cannot be \
+                 placed by this platform/driver; rendering to a texture and reading \
+                 back through map()"
             );
         }
         match super::render::lower_dst(
@@ -3989,9 +4061,12 @@ impl GLProcessorST {
 
     /// Pick the NV* GPU conversion path for `src`/`src_fmt`, honoring the
     /// `EDGEFIRST_NV_CONVERT_PATH` preference. Returns the path to *attempt*;
-    /// the caller maps an EGLImage-creation error to the [`NvConvertPath::Cpu`]
-    /// fallback. Forcing an unavailable path logs a warning and falls back to
-    /// the only viable one rather than failing.
+    /// an EGLImage-creation error does not end the convert — the caller retries
+    /// a single-plane NV source as an R8 *upload* of the combined plane, which
+    /// is still [`NvConvertPath::ShaderR8`] (#166), and only a true-multiplane
+    /// NV12 is left to reach [`NvConvertPath::Cpu`]. Forcing an unavailable
+    /// path logs a warning and falls back to the only viable one rather than
+    /// failing.
     ///
     /// Capability:
     /// - [`NvConvertPath::ShaderR8`] needs a single combined-plane buffer, so it
@@ -4261,10 +4336,12 @@ impl GLProcessorST {
                             src_fmt = ?src_fmt,
                             "image.convert.gl.nv_path"
                         );
-                        self.last_nv_convert_path = NvConvertPath::ShaderR8;
                         self.convert_stats.src_imports += 1;
                         tracing::Span::current().record("src_feed", "import");
-                        self.draw_nv_texture_2d(
+                        // Recorded from the draw's result, not before it: a
+                        // failed draw must not leave a ShaderR8 claim, and it
+                        // must not leave the PREVIOUS convert's value either.
+                        match self.draw_nv_texture_2d(
                             src,
                             src_fmt,
                             Some(r8_egl),
@@ -4273,7 +4350,13 @@ impl GLProcessorST {
                             rotation_offset,
                             flip,
                             is_int8,
-                        )?;
+                        ) {
+                            Ok(()) => self.last_nv_convert_path = NvConvertPath::ShaderR8,
+                            Err(e) => {
+                                self.last_nv_convert_path = NvConvertPath::Cpu;
+                                return Err(e);
+                            }
+                        }
                     }
                     Err(e) => {
                         let src_w = src.width().unwrap_or(0);
@@ -4312,7 +4395,14 @@ impl GLProcessorST {
                         self.convert_stats.src_uploads += 1;
                         tracing::Span::current().record("src_feed", "upload");
                         let start = Instant::now();
-                        self.draw_nv_texture_2d(
+                        // The R8 import declined (Mali's alignment rule, the
+                        // ANGLE leaves' offset refusal, or a driver that cannot
+                        // import the buffer at all). If the upload draws, this
+                        // is still a GPU convert and records ShaderR8, not Cpu
+                        // -- recorded from the result, so a failed upload
+                        // records Cpu rather than keeping the previous
+                        // convert's value.
+                        match self.draw_nv_texture_2d(
                             src,
                             src_fmt,
                             None,
@@ -4321,14 +4411,13 @@ impl GLProcessorST {
                             rotation_offset,
                             flip,
                             is_int8,
-                        )?;
-                        // The R8 import declined (Mali's alignment rule, the
-                        // ANGLE leaves' offset refusal, or a driver that cannot
-                        // import the buffer at all), but the upload just drawn
-                        // above succeeded: still a GPU convert, so record
-                        // ShaderR8, not Cpu -- only now that the draw has
-                        // actually returned `Ok`, not before it could fail.
-                        self.last_nv_convert_path = NvConvertPath::ShaderR8;
+                        ) {
+                            Ok(()) => self.last_nv_convert_path = NvConvertPath::ShaderR8,
+                            Err(e) => {
+                                self.last_nv_convert_path = NvConvertPath::Cpu;
+                                return Err(e);
+                            }
+                        }
                         log::debug!("NV R8 upload takes {:?}", start.elapsed());
                     }
                 }
@@ -4340,11 +4429,13 @@ impl GLProcessorST {
                     Ok(src_egl) => {
                         if src_fmt == PixelFormat::Nv12 {
                             tracing::trace!(path = "ExternalSampler", src_fmt = ?src_fmt, "image.convert.gl.nv_path");
-                            self.last_nv_convert_path = NvConvertPath::ExternalSampler;
                         }
                         self.convert_stats.src_imports += 1;
                         tracing::Span::current().record("src_feed", "import");
-                        self.draw_camera_texture_eglimage(
+                        // Recorded from the draw's result (see the ShaderR8
+                        // arm): a failed draw records neither ExternalSampler
+                        // nor the previous convert's value.
+                        match self.draw_camera_texture_eglimage(
                             src,
                             src_fmt,
                             src_egl,
@@ -4353,7 +4444,19 @@ impl GLProcessorST {
                             rotation_offset,
                             flip,
                             is_int8,
-                        )?;
+                        ) {
+                            Ok(()) => {
+                                if src_fmt == PixelFormat::Nv12 {
+                                    self.last_nv_convert_path = NvConvertPath::ExternalSampler;
+                                }
+                            }
+                            Err(e) => {
+                                if src_fmt == PixelFormat::Nv12 {
+                                    self.last_nv_convert_path = NvConvertPath::Cpu;
+                                }
+                                return Err(e);
+                            }
+                        }
                     }
                     Err(e) => {
                         let src_w = src.width().unwrap_or(0);
@@ -4396,7 +4499,10 @@ impl GLProcessorST {
                             // source itself in any case.
                             self.convert_stats.src_uploads += 1;
                             tracing::Span::current().record("src_feed", "upload");
-                            self.draw_nv_texture_2d(
+                            // Recorded from the result: a drawn upload is still
+                            // a GPU convert (ShaderR8), a failed one records Cpu
+                            // rather than keeping the previous convert's value.
+                            match self.draw_nv_texture_2d(
                                 src,
                                 src_fmt,
                                 None,
@@ -4405,12 +4511,18 @@ impl GLProcessorST {
                                 rotation_offset,
                                 flip,
                                 is_int8,
-                            )?;
-                            // The upload just drawn above succeeded: still a
-                            // GPU convert, so record ShaderR8 now that it is
-                            // certain, not before the draw could fail.
-                            if src_fmt == PixelFormat::Nv12 {
-                                self.last_nv_convert_path = NvConvertPath::ShaderR8;
+                            ) {
+                                Ok(()) => {
+                                    if src_fmt == PixelFormat::Nv12 {
+                                        self.last_nv_convert_path = NvConvertPath::ShaderR8;
+                                    }
+                                }
+                                Err(e) => {
+                                    if src_fmt == PixelFormat::Nv12 {
+                                        self.last_nv_convert_path = NvConvertPath::Cpu;
+                                    }
+                                    return Err(e);
+                                }
                             }
                             log::debug!("NV R8 upload takes {:?}", start.elapsed());
                         } else {
@@ -6015,11 +6127,17 @@ impl GLProcessorST {
         // an EGL error, so refuse the import here and let the caller's failure
         // arm upload the window through `map()` instead (issue #165). Always a
         // source, so there is no destination case to exempt.
+        //
+        // Plane 0 is the whole check here: this path binds the COMBINED
+        // semi-planar plane as ONE R8 texture at plane 0's offset and the
+        // shader addresses the chroma bytes inside it by texel arithmetic, so
+        // EGL is never handed a second plane offset. The two-plane import in
+        // `get_or_create_egl_image` is the one that needs plane 1 checked too.
         let offset = img.plane_offset().unwrap_or(0);
-        if mali_rejects_source_offset(self.is_mali, offset) {
+        if mali_rejects_import_offset(self.is_mali, offset) {
             return Err(crate::Error::NotSupported(format!(
                 "Mali samples zeros from a DMA-BUF imported at a plane offset that \
-                 is not {MALI_DMA_IMPORT_OFFSET_ALIGN}-byte aligned ({offset}); \
+                 is not {DMA_IMPORT_OFFSET_ALIGN}-byte aligned ({offset}); \
                  uploading the window instead (issue #165)"
             )));
         }
@@ -6076,12 +6194,45 @@ impl GLProcessorST {
         // offset 0 and is rendered into by viewport, never sampled at an
         // offset.
         if cache == CacheKind::Src {
+            // Every plane offset this import will pass to EGL, not just plane
+            // 0. A two-plane NV12 import hands EGL a plane-1 offset of its own
+            // (`dma_import.rs` ~`:225`), and that one can be unaligned while
+            // plane 0 is aligned. It cannot happen on a HAL allocation, whose
+            // 64-aligned pitch makes `pitch * height` 64-aligned at every
+            // height; it can on a DMA-BUF adopted through `from_fd`, whose
+            // pitch is the producer's and need not be padded, and on a
+            // multiplane NV12 whose chroma buffer carries its own offset. Mali
+            // would then sample zeros for chroma alone — silently
+            // colour-shifted output rather than a black frame, which is harder
+            // to notice than the luma case.
             let offset = img.plane_offset().unwrap_or(0);
-            if mali_rejects_source_offset(self.is_mali, offset) {
+            let chroma_offset = (img_fmt == PixelFormat::Nv12).then(|| {
+                if img.is_multiplane() {
+                    // A separate chroma DMA-BUF imports at its own offset.
+                    img.chroma().and_then(|c| c.plane_offset()).unwrap_or(0)
+                } else {
+                    nv12_plane1_offset(
+                        offset,
+                        img.effective_row_stride()
+                            .unwrap_or_else(|| img.width().unwrap_or(0)),
+                        img.height().unwrap_or(0),
+                    )
+                }
+            });
+            // A fixed array, not a `Vec`: this runs on every convert.
+            let planes = [
+                Some(("plane 0", offset)),
+                chroma_offset.map(|o| ("chroma plane", o)),
+            ];
+            if let Some((which, bad)) = planes
+                .into_iter()
+                .flatten()
+                .find(|&(_, o)| mali_rejects_import_offset(self.is_mali, o))
+            {
                 return Err(crate::Error::NotSupported(format!(
                     "Mali samples zeros from a DMA-BUF imported at a plane offset that \
-                     is not {MALI_DMA_IMPORT_OFFSET_ALIGN}-byte aligned ({offset}); \
-                     uploading the window instead (issue #165)"
+                     is not {DMA_IMPORT_OFFSET_ALIGN}-byte aligned ({which} at \
+                     {bad}); uploading the window instead (issue #165)"
                 )));
             }
         }
@@ -8086,7 +8237,9 @@ mod tests {
             }
         );
         // V3D / Tegra: plain hardware, the P0-validated parallel set, and NOT
-        // Mali — they import an unaligned source offset correctly.
+        // Mali. V3D was measured importing an unaligned source offset
+        // correctly (#165); Tegra/Orin is unmeasured — that board has no DMA
+        // heap, so no DMA-BUF source can be built on it to test.
         assert_eq!(classify_renderer("V3D 7.1"), real_gpu);
         assert_eq!(
             classify_renderer("NVIDIA Tegra Orin (nvgpu)/integrated"),
@@ -8118,10 +8271,11 @@ mod tests {
 
     // The plane-offset rule that decides whether a Mali source DMA-BUF is
     // imported or uploaded. The offsets are the ones measured on i.MX 95
-    // (issue #165): 32 and 2080 sampled zeros, 0/64/2048 sampled correctly.
+    // (issue #165): 32 and 2080 sampled zeros; 64, 256 and 2048 sampled
+    // correctly, and offset 0 is the whole-image control, not a window.
     #[test]
     fn mali_declines_only_unaligned_source_offsets() {
-        use super::mali_rejects_source_offset as rejects;
+        use super::mali_rejects_import_offset as rejects;
 
         // Mali, unaligned — declined so the upload path takes the source.
         assert!(rejects(true, 32));
@@ -8133,6 +8287,90 @@ mod tests {
         // Every other driver imports any offset; the rule must not touch them.
         assert!(!rejects(false, 32));
         assert!(!rejects(false, 2080));
+        // 256 was measured too, and is the RGBA test's `(0, 1)` origin.
+        assert!(!rejects(true, 256));
+    }
+
+    // The destination-side rule, which is Vivante's and NOT Mali's: Mali was
+    // measured rendering into offset 2080 correctly, Vivante fails to import it
+    // (`EGL_BAD_ACCESS`). Both halves matter, so both are asserted -- gating
+    // Mali destinations would cost it the zero-copy path for nothing.
+    #[test]
+    fn only_vivante_declines_an_unaligned_destination_import() {
+        use super::{mali_rejects_import_offset, vivante_rejects_dst_import_offset as dst_rejects};
+
+        // Vivante: 2048 imports, 2080 is EGL_BAD_ACCESS -- the two measured
+        // points on i.MX 8M Plus.
+        assert!(!dst_rejects(true, 2048));
+        assert!(dst_rejects(true, 2080));
+        assert!(!dst_rejects(true, 0));
+        assert!(dst_rejects(true, 32));
+
+        // Not Vivante: no destination gate at all. Mali included -- its
+        // destination renders correctly at 2080, and only its SOURCE sampling
+        // is affected.
+        assert!(!dst_rejects(false, 2080));
+        assert!(!dst_rejects(false, 32));
+        assert!(
+            mali_rejects_import_offset(true, 2080),
+            "the Mali rule is the source rule, and 2080 is in it"
+        );
+    }
+
+    // The chroma-plane offset a contiguous NV12 import hands EGL, and whether
+    // Mali's rule catches an unaligned one while plane 0 looks fine.
+    //
+    // A 64-aligned pitch makes `pitch * height` 64-aligned at EVERY height, so
+    // a HAL allocation can never produce an unaligned plane 1 — which is why
+    // plane 0 alone looked sufficient. It stops being sufficient for a DMA-BUF
+    // adopted through `from_fd`, whose pitch is the producer's and need not be
+    // padded at all: then `pitch * height` is unaligned for any height that
+    // does not itself supply the missing factor of 64.
+    #[test]
+    fn nv12_chroma_plane_offset_is_checked_independently_of_plane_zero() {
+        use super::{mali_rejects_import_offset as rejects, nv12_plane1_offset as plane1};
+
+        // HAL-shaped: 64-aligned pitch, offset 0. Both planes aligned, at an
+        // even height and at an odd one alike.
+        assert_eq!(plane1(0, 256, 64), 16384);
+        assert_eq!(plane1(0, 256, 65), 16640);
+        assert!(!rejects(true, plane1(0, 256, 64)));
+        assert!(!rejects(true, plane1(0, 256, 65)));
+
+        // A foreign pitch from `from_fd`: plane 0 is aligned and plane 1 is
+        // NOT. This is the case a plane-0-only check misses, and the shorter
+        // the frame the likelier it is.
+        assert!(!rejects(true, 0), "plane 0 looks fine");
+        assert_eq!(plane1(0, 100, 3), 300);
+        assert!(rejects(true, plane1(0, 100, 3)), "plane 1 must be caught");
+        assert_eq!(plane1(0, 48, 5), 240);
+        assert!(rejects(true, plane1(0, 48, 5)));
+        assert_eq!(plane1(0, 96, 1), 96);
+        assert!(rejects(true, plane1(0, 96, 1)));
+
+        // A foreign pitch whose height DOES supply the missing factor keeps
+        // plane 1 aligned and must NOT be declined — the rule is the offset's
+        // alignment, not whether the pitch was padded.
+        assert_eq!(plane1(0, 100, 64), 6400);
+        assert!(!rejects(true, plane1(0, 100, 64)));
+        assert_eq!(plane1(0, 96, 2), 192);
+        assert!(!rejects(true, plane1(0, 96, 2)));
+
+        // The luma offset carries into plane 1: aligned + aligned stays
+        // aligned, and an unaligned plane 0 shifts plane 1 out of alignment
+        // too (plane 0 is checked first, so the message names plane 0).
+        assert_eq!(plane1(2048, 256, 64), 18432);
+        assert!(!rejects(true, plane1(2048, 256, 64)));
+        assert!(rejects(true, plane1(32, 256, 64)));
+
+        // Saturating, so a nonsense geometry cannot wrap into a spuriously
+        // aligned value or panic in debug.
+        assert_eq!(plane1(usize::MAX, 256, 64), usize::MAX);
+        assert_eq!(plane1(0, usize::MAX, 2), usize::MAX);
+
+        // Non-Mali is untouched at every one of them.
+        assert!(!rejects(false, plane1(0, 100, 3)));
+        assert!(!rejects(false, plane1(0, 96, 1)));
     }
 
     // The serialization policy each fleet renderer selects. The parallel

--- a/crates/image/src/gl/resources.rs
+++ b/crates/image/src/gl/resources.rs
@@ -67,7 +67,10 @@ impl Texture {
     ) -> crate::Result<()> {
         if data.len() < required {
             return Err(crate::Error::NotSupported(format!(
-                "GL upload: {width}x{height} texture needs {required} B but the                  source maps only {} B -- a window that does not cover its own                  image (a restored plane offset past the buffer?); converting                  on the CPU instead",
+                "GL upload: {width}x{height} texture needs {required} B but the \
+                 source maps only {} B -- a window that does not cover its own \
+                 image (a restored plane offset past the buffer?); converting \
+                 on the CPU instead",
                 data.len()
             )));
         }

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -10798,4 +10798,211 @@ mod gl_tests {
              (declines={declines}) -- it was not fed by the GL engine at all"
         );
     }
+
+    /// A fresh `view()` destination at an UNALIGNED byte offset must keep the
+    /// zero-copy destination import.
+    ///
+    /// A destination `view()` imports its PARENT and places the tile with
+    /// `glViewport`, so its import bases at 0 however far into the buffer its
+    /// own bytes start (`DmaImportAttrs::from_tensor` with `for_dst = true`,
+    /// `BufferImportKey::from_tensor`). The Vivante offset rule must therefore
+    /// be asked of `dst_import_base`, not of `plane_offset()`; asking the latter
+    /// made it fire on every tile view whose byte offset was unaligned -- an
+    /// RGBA `x0` of 8 is 32 bytes -- and silently cost Vivante the zero-copy
+    /// path for a case its driver handles perfectly.
+    ///
+    /// `convert_fallback_count` cannot see this: the over-fire lowers WITHIN
+    /// GL, to the mapped-texture readback, and never reaches the CPU backend.
+    /// What distinguishes the two is whether a destination import happened at
+    /// all, so this reads the `dst` import cache.
+    ///
+    /// Self-calibrating, via a CONTROL convert into a whole zero-copy
+    /// destination. A host that imports nothing there cannot run the subject at
+    /// all -- the engine declines a `view()` destination outright unless the
+    /// transfer backend is zero-copy -- so it skips, which is what a desktop
+    /// whose EGL cannot import a DMA-BUF does. Where the control imports, the
+    /// unaligned view must import too, and that assertion is never vacuous.
+    #[test]
+    fn a_fresh_unaligned_view_destination_keeps_the_zero_copy_import() {
+        const W: usize = 320;
+        const H: usize = 240;
+        const SIDE: usize = 64;
+        const BPP: usize = 4;
+        // x0 = 8 -> 32 bytes, never 64-aligned whatever the pitch.
+        const X0: usize = 8;
+        const Y0: usize = 8;
+        const BLANK: u8 = 0x55;
+
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+        #[cfg(target_os = "macos")]
+        if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+            eprintln!(
+                "SKIPPED: {} - ANGLE dlopen gate closed (coverage pass 1)",
+                function!()
+            );
+            return;
+        }
+        let dma_rgba = |w: usize, h: usize| {
+            TensorDyn::image(
+                w,
+                h,
+                PixelFormat::Rgba,
+                DType::U8,
+                Some(TensorMemory::DmaBuf),
+                edgefirst_tensor::CpuAccess::ReadWrite,
+            )
+        };
+        let canvas = match dma_rgba(W, H) {
+            Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+            other => {
+                let what = match &other {
+                    Ok(t) => format!("fell back to {:?}", t.memory()),
+                    Err(e) => format!("failed: {e}"),
+                };
+                assert!(
+                    !(require_gl && edgefirst_tensor::is_gpu_buffer_available()),
+                    "HAL_TEST_REQUIRE_GL=1 and this host reports a zero-copy buffer \
+                     backing, but the RGBA zero-copy allocation {what}"
+                );
+                eprintln!(
+                    "SKIPPED: {} - no zero-copy RGBA image here ({what})",
+                    function!()
+                );
+                return;
+            }
+        };
+        let pitch = canvas.effective_row_stride().unwrap_or(W * BPP);
+        let offset = Y0 * pitch + X0 * BPP;
+        assert_ne!(
+            offset % 64,
+            0,
+            "precondition: ({X0},{Y0}) at pitch {pitch} is byte offset {offset}, \
+             which must be unaligned for this test to mean anything"
+        );
+
+        let want = |x: usize, y: usize| -> [u8; BPP] {
+            [((y * 3) % 256) as u8, ((x * 5) % 256) as u8, 255, 255]
+        };
+        let src = TensorDyn::image(
+            SIDE,
+            SIDE,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Mem),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .expect("source");
+        {
+            let mut m = src
+                .map_bytes(edgefirst_tensor::CpuAccess::Write)
+                .expect("map source");
+            let s = m.as_mut_slice();
+            for y in 0..SIDE {
+                for x in 0..SIDE {
+                    s[(y * SIDE + x) * BPP..][..BPP].copy_from_slice(&want(X0 + x, Y0 + y));
+                }
+            }
+        }
+
+        let mut gl = GLProcessorThreaded::new(None).expect("GL processor");
+        let imports = |g: &GLProcessorThreaded| {
+            let c = g.egl_cache_stats().expect("cache stats").dst;
+            c.misses + c.hits
+        };
+
+        // CONTROL: a WHOLE zero-copy destination, no view and no offset. This
+        // is what says whether this host imports destinations at all.
+        let mut whole = dma_rgba(SIDE, SIDE).expect("control destination");
+        let before_control = imports(&gl);
+        gl.convert(
+            &src,
+            &mut whole,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("control convert into a whole zero-copy destination");
+        let control = imports(&gl) - before_control;
+
+        // A view destination is only supported at all on a zero-copy transfer
+        // backend (`GLProcessorST::convert` declines it outright otherwise), and
+        // the control is exactly that question, so a host that imported nothing
+        // cannot run the subject. This desktop is one: its EGL cannot import a
+        // DMA-BUF, so the backend falls back to PBO.
+        if control == 0 {
+            eprintln!(
+                "SKIPPED: {} - no zero-copy destination import on this host, so a \
+                 view() destination is declined by the engine and there is nothing \
+                 to measure",
+                function!()
+            );
+            log::info!(
+                "{}: pitch {pitch} offset {offset} -> control_dst_imports=0, skipped",
+                function!()
+            );
+            return;
+        }
+
+        // SUBJECT: a fresh view at the unaligned byte offset.
+        {
+            let mut m = canvas
+                .map_bytes(edgefirst_tensor::CpuAccess::Write)
+                .expect("map canvas");
+            m.as_mut_slice().fill(BLANK);
+        }
+        let mut tile = canvas
+            .view(edgefirst_tensor::Region::new(X0, Y0, SIDE, SIDE))
+            .expect("fresh destination view");
+        assert_eq!(
+            tile.plane_offset(),
+            Some(offset),
+            "precondition: the view carries the unaligned byte offset"
+        );
+        assert!(
+            tile.view_origin().is_some(),
+            "precondition: a fresh view has a view_origin, which is what bases its \
+             import at 0"
+        );
+        let before_subject = imports(&gl);
+        gl.convert(&src, &mut tile, Rotation::None, Flip::None, Crop::default())
+            .expect("convert into a fresh view destination at an unaligned offset");
+        let subject = imports(&gl) - before_subject;
+        log::info!(
+            "{}: pitch {pitch} offset {offset} -> control_dst_imports={control} \
+             subject_dst_imports={subject}",
+            function!()
+        );
+
+        // The pixels first: a lowered path is slow, a misplaced tile is wrong.
+        let out = canvas
+            .map_bytes(edgefirst_tensor::CpuAccess::Read)
+            .expect("map canvas")
+            .as_slice()
+            .to_vec();
+        let px = |x: usize, y: usize| &out[y * pitch + x * BPP..][..BPP];
+        assert_eq!(
+            px(0, 0),
+            &[BLANK; BPP],
+            "the tile landed at the canvas ORIGIN, so the view's offset was lost"
+        );
+        for y in Y0..Y0 + SIDE {
+            for x in X0..X0 + SIDE {
+                assert_eq!(px(x, y), &want(x, y), "tile pixel ({x}, {y})");
+            }
+        }
+
+        // Then the routing. `control > 0` is guaranteed by the guard above, so
+        // this is never vacuous where it runs.
+        assert!(
+            subject > 0,
+            "this host imports whole zero-copy destinations (control={control}) but \
+             performed no destination import for a fresh view at unaligned byte \
+             offset {offset} (subject={subject}) -- the view's import bases at 0, so \
+             no offset rule should have applied to it"
+        );
+    }
 }

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -10583,4 +10583,219 @@ mod gl_tests {
             );
         }
     }
+
+    /// An NV12 DMA/IOSurface/D3D11 source at an UNALIGNED plane offset must
+    /// still convert through GL, on every backing that can hold one.
+    ///
+    /// This is `tests/offset_source_view_alignment.rs`'s NV case as a LIB test,
+    /// and it is here rather than only there because the integration binaries
+    /// reach almost no CI lane: the Linux runners have no DMA heap, and the
+    /// i.MX 8M Plus hardware lane runs only the `edgefirst_image-*` lib-test
+    /// binary filtered on `opengl`/`g2d`. Three lanes do reach the code below,
+    /// each through a different one of the two NV import-failure arms:
+    ///
+    /// * **macOS / Windows (ANGLE).** `import_buffer_nv_r8` refuses an offset
+    ///   source outright (`refuse_offset_source`), so the ShaderR8 arm's
+    ///   failure path runs.
+    /// * **i.MX 8M Plus (Vivante).** `select_nv_path` takes the external
+    ///   sampler for single-plane NV12 there, and Vivante's EGL refuses the
+    ///   unaligned offset, so the OTHER failure arm runs.
+    /// * **i.MX 95 (Mali).** The engine's own decline fires
+    ///   (`mali_rejects_import_offset`), then the ShaderR8 arm's failure path.
+    ///
+    /// V3D imports an unaligned offset correctly and takes neither arm, which
+    /// is why the routing assertion below is an implication rather than a flat
+    /// "an upload happened": what every backing must satisfy is that a
+    /// DECLINED zero-copy feed became an upload and not a CPU convert
+    /// (issue #166). `GLProcessorThreaded` is driven directly, so a CPU
+    /// fallback cannot pass this test at all.
+    #[test]
+    fn nv12_source_at_a_plane_offset_converts_through_gl_on_every_zero_copy_backing() {
+        // QVGA rather than a tiny frame: Mali has a minimum texture size that
+        // 64x64 tests have tripped over, and a 4-aligned width is also what
+        // Vivante's sampler path requires -- without it that lane would take
+        // the shader arm and leave the sampler arm uncovered.
+        const W: usize = 320;
+        const H: usize = 240;
+        const TOLERANCE: u8 = 8;
+
+        if !is_opengl_available() {
+            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            return;
+        }
+        let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+        #[cfg(target_os = "macos")]
+        if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+            eprintln!(
+                "SKIPPED: {} - ANGLE dlopen gate closed (coverage pass 1)",
+                function!()
+            );
+            return;
+        }
+        // Two rows taller than the logical frame, so a window starting a row
+        // in is still fully backed.
+        let allocated = match TensorDyn::image(
+            W,
+            H + 2,
+            PixelFormat::Nv12,
+            DType::U8,
+            Some(TensorMemory::DmaBuf),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        ) {
+            Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+            other => {
+                // `is_gpu_buffer_available` is the portable "can this host hold
+                // a zero-copy image at all" probe: a DMA heap on Linux, an
+                // IOSurface on macOS, a D3D11 device on Windows. Where it says
+                // yes, a REQUIRE_GL lane must not let this test evaporate --
+                // the arms it covers are reachable nowhere else.
+                let what = match &other {
+                    Ok(t) => format!("fell back to {:?}", t.memory()),
+                    Err(e) => format!("failed: {e}"),
+                };
+                assert!(
+                    !(require_gl && edgefirst_tensor::is_gpu_buffer_available()),
+                    "HAL_TEST_REQUIRE_GL=1 and this host reports a zero-copy \
+                     buffer backing, but the NV12 zero-copy allocation {what}"
+                );
+                eprintln!(
+                    "SKIPPED: {} - no zero-copy NV12 image here ({what})",
+                    function!()
+                );
+                return;
+            }
+        };
+        let mut src = allocated;
+        let pitch = src.effective_row_stride().unwrap_or(W);
+        // The same pattern `tests/offset_source_view_alignment.rs` uses, and
+        // for the same reasons: period 31 is coprime with the pitch and with
+        // 64, so a window read at the wrong offset cannot coincide with the
+        // right one, and the 112..=142 band keeps both the luma and the chroma
+        // it also feeds clear of RGB clamping, where two different reads could
+        // agree by saturation. Written BEFORE the re-tag, while the map still
+        // spans the whole allocation.
+        {
+            let mut m = src
+                .map_bytes(edgefirst_tensor::CpuAccess::Write)
+                .expect("map the NV12 allocation");
+            for (i, b) in m.as_mut_slice().iter_mut().enumerate() {
+                *b = 112 + (i % 31) as u8;
+            }
+        }
+        src.set_logical_shape(&[H * 3 / 2, W])
+            .expect("narrow to one frame's geometry");
+        assert_eq!(src.height(), Some(H), "precondition: one frame is {H} rows");
+        assert_eq!(
+            src.effective_row_stride(),
+            Some(pitch),
+            "precondition: the re-tag kept the surface pitch"
+        );
+        // A row in, plus 32 bytes: rounding the row up to 64 first makes the
+        // result 32 (mod 64) whatever the driver's pitch is, so the offset is
+        // unaligned on every host rather than only on the ones whose pitch is
+        // already padded.
+        let offset = pitch.next_multiple_of(64) + 32;
+        src.set_plane_offset(offset);
+        assert_eq!(
+            src.plane_offset(),
+            Some(offset),
+            "precondition: the offset stuck"
+        );
+        assert_ne!(offset % 64, 0, "precondition: {offset} is unaligned");
+        // Full-range BT.601 so both converters resolve the same matrix by the
+        // tag rather than by the untagged-SD heuristic.
+        src.set_colorimetry(Some(
+            edgefirst_tensor::Colorimetry::default()
+                .with_encoding(edgefirst_tensor::ColorEncoding::Bt601)
+                .with_range(edgefirst_tensor::ColorRange::Full),
+        ));
+
+        let rgba_dst = || {
+            TensorDyn::image(
+                W,
+                H,
+                PixelFormat::Rgba,
+                DType::U8,
+                Some(TensorMemory::Mem),
+                edgefirst_tensor::CpuAccess::ReadWrite,
+            )
+            .expect("RGBA destination")
+        };
+        let read = |t: &TensorDyn| {
+            t.map_bytes(edgefirst_tensor::CpuAccess::Read)
+                .expect("map destination")
+                .as_slice()
+                .to_vec()
+        };
+
+        let mut reference = rgba_dst();
+        crate::CPUProcessor::new()
+            .convert(
+                &src,
+                &mut reference,
+                Rotation::None,
+                Flip::None,
+                Crop::default(),
+            )
+            .expect("CPU reference convert of the offset NV12 frame");
+        let want = read(&reference);
+        // A flat reference would make any wrong read agree; the pattern must
+        // survive into the converted pixels.
+        assert!(
+            want.chunks(4).any(|p| p != &want[..4]),
+            "precondition: the CPU reference is flat, so agreement would prove nothing"
+        );
+
+        let mut gl = GLProcessorThreaded::new(None).expect("GL processor");
+        let before = gl.convert_stats().expect("convert stats before");
+        let mut dst = rgba_dst();
+        gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())
+            .expect(
+                "GL refused an NV12 source at an unaligned plane offset; a declined \
+                 zero-copy NV import must reach the R8 upload (issue #166)",
+            );
+        let after = gl.convert_stats().expect("convert stats after");
+        let got = read(&dst);
+        let bad = got
+            .iter()
+            .zip(&want)
+            .filter(|(g, w)| g.abs_diff(**w) > TOLERANCE)
+            .count();
+        assert_eq!(
+            bad,
+            0,
+            "{bad} bytes differ from the CPU reference over the same tensor; \
+             first got={:?} want={:?} (offset {offset}, pitch {pitch})",
+            &got[..4],
+            &want[..4]
+        );
+        // The routing contract: a zero-copy feed that was DECLINED must have
+        // become an upload. Vacuous where the import succeeded (V3D), which is
+        // why it is an implication and not an unconditional count.
+        let declines = after.zero_copy_declines - before.zero_copy_declines;
+        let uploads = after.src_uploads - before.src_uploads;
+        let imports = after.src_imports - before.src_imports;
+        // Say which route this host took, at `info` so it reaches the log even
+        // under libtest's output capture (which swallows `eprintln!` from a
+        // passing test). The whole point of this test is per-platform routing,
+        // and without this a green lane does not say WHICH arm it covered.
+        log::info!(
+            "{}: offset {offset} pitch {pitch} -> declines={declines} uploads={uploads} \
+             imports={imports}",
+            function!()
+        );
+        if declines > 0 {
+            assert!(
+                uploads > 0,
+                "the NV import was declined ({declines}) but no upload was recorded \
+                 (uploads={uploads}, imports={imports}) -- the convert fell to a path \
+                 issue #166 exists to prevent"
+            );
+        }
+        assert!(
+            uploads + imports > 0,
+            "the convert recorded neither an upload nor an import \
+             (declines={declines}) -- it was not fed by the GL engine at all"
+        );
+    }
 }

--- a/crates/image/tests/dst_view_stride.rs
+++ b/crates/image/tests/dst_view_stride.rs
@@ -807,11 +807,12 @@ fn gl_padded_pbo_dst_rows_land_at_the_declared_stride() {
             // destination's padding, and no route promises them: a driver
             // packing rows at `GL_PACK_ROW_LENGTH` may write them (Vivante
             // does, issue #167), and the read-tight-and-spread route leaves
-            // the tight read's leftovers there. What every route promises is
-            // the pixel bytes of every row at the declared pitch, asserted
-            // above, and that nothing lands past `needed` -- the spare row
-            // this test allocates keeps even a written last-row pad inside
-            // the buffer.
+            // the tight read's leftovers there. So this test asserts one
+            // thing, the pixel bytes of every row at the declared pitch,
+            // above. That nothing lands past `needed` is `plan_pbo_readback`'s
+            // invariant, unit-tested there, NOT something asserted here; the
+            // spare row this test allocates is what keeps a written last-row
+            // pad inside the buffer either way.
         }
     }
 }

--- a/crates/image/tests/dst_view_stride.rs
+++ b/crates/image/tests/dst_view_stride.rs
@@ -803,21 +803,15 @@ fn gl_padded_pbo_dst_rows_land_at_the_declared_stride() {
                 &want[row * row_bytes..row * row_bytes + row_bytes],
                 "{label}: row {row} did not land at the {stride} B pitch"
             );
-            // The bytes past a row's pixels are not the readback's to write.
-            // `extra == 0` is a whole number of pixels on every platform, so
-            // the rows land through `GL_PACK_ROW_LENGTH` or through the
-            // repack, and neither touches the pad. `extra == 1` is the
-            // read-tight-and-spread route, which leaves the tight read's
-            // leftovers there, as the Mem readback does. The last row's pad
-            // lies past the mapping.
-            if extra == 0 && row + 1 < SRC_H {
-                assert!(
-                    got[row * stride + row_bytes..(row + 1) * stride]
-                        .iter()
-                        .all(|&b| b == POISON),
-                    "{label}: row {row}: the pad past the pixels was written"
-                );
-            }
+            // The bytes between this row's pixels and the next row are the
+            // destination's padding, and no route promises them: a driver
+            // packing rows at `GL_PACK_ROW_LENGTH` may write them (Vivante
+            // does, issue #167), and the read-tight-and-spread route leaves
+            // the tight read's leftovers there. What every route promises is
+            // the pixel bytes of every row at the declared pitch, asserted
+            // above, and that nothing lands past `needed` -- the spare row
+            // this test allocates keeps even a written last-row pad inside
+            // the buffer.
         }
     }
 }

--- a/crates/image/tests/offset_nv_source_upload.rs
+++ b/crates/image/tests/offset_nv_source_upload.rs
@@ -71,6 +71,13 @@ fn bytes(t: &TensorDyn) -> Vec<u8> {
 #[test]
 fn gl_uploads_an_offset_nv12_frame_from_its_own_offset_not_twice_it() {
     let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+    // The macOS coverage lane runs pass 1 with the ANGLE dlopen gate closed;
+    // the same guard `gl_backend_available_canary` carries.
+    #[cfg(target_os = "macos")]
+    if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+        skip("ANGLE dlopen gate closed (coverage pass 1)");
+        return;
+    }
     let mut gl = match GLProcessorThreaded::new(None) {
         Ok(gl) => gl,
         Err(e) => {
@@ -105,6 +112,17 @@ fn gl_uploads_an_offset_nv12_frame_from_its_own_offset_not_twice_it() {
     src.set_format(PixelFormat::Nv12).expect("nv12 format");
     src.set_plane_offset(elem);
     assert_eq!(src.plane_offset(), Some(elem), "precondition: frame 1");
+    // Tag BT.601 full-range so the new frame-1 assertion below can compare
+    // the reference's R byte directly to `LUMA`. Without a tag, the
+    // colorimetry heuristic resolves an untagged SD tensor to BT.601
+    // *limited*, which expands luma (e.g. 200 -> ~215) and would make that
+    // assertion misfire even on a correct read -- the same reason
+    // `odd_dim_cpu.rs`'s analytic reference tags full-range.
+    src.set_colorimetry(Some(
+        edgefirst_tensor::Colorimetry::default()
+            .with_encoding(edgefirst_tensor::ColorEncoding::Bt601)
+            .with_range(edgefirst_tensor::ColorRange::Full),
+    ));
 
     let mut reference = rgba_dst();
     CPUProcessor::new()
@@ -117,6 +135,16 @@ fn gl_uploads_an_offset_nv12_frame_from_its_own_offset_not_twice_it() {
         )
         .expect("CPU reference convert");
     let want = bytes(&reference);
+    // Both converters read through `map()`, so agreement alone cannot tell
+    // frame 1 from frame 0. The frames are 80 luma apart: the reference's
+    // first pixel must be near LUMA[1], not LUMA[0].
+    assert!(
+        want[0].abs_diff(LUMA[1]) <= 8,
+        "the CPU reference read frame {} (luma {}) instead of frame 1 (luma {})",
+        if want[0].abs_diff(LUMA[0]) <= 8 { 0 } else { 2 },
+        want[0],
+        LUMA[1]
+    );
 
     let mut dst = rgba_dst();
     gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())

--- a/crates/image/tests/offset_nv_source_upload.rs
+++ b/crates/image/tests/offset_nv_source_upload.rs
@@ -11,11 +11,12 @@
 //! offset -- or, as here, refused the window as too short -- so an offset NV
 //! source never converted its own frame through GL.
 //!
-//! A zero-copy NV source the ANGLE leaves refuse at an offset
-//! (`refuse_offset_source`) does not reach this upload yet: the R8 import's
-//! failure arm falls to `draw_src_texture`, which has no NV arm, and
-//! `ImageProcessor::convert` then converts on the CPU. Routing that case
-//! through this upload is a follow-up; this file pins the upload itself.
+//! A zero-copy NV source whose R8 import is refused — by the ANGLE leaves'
+//! `refuse_offset_source`, or by Mali's unaligned-plane-offset rule — now
+//! reaches this same upload: the import's failure arm used to fall to
+//! `draw_src_texture`, which has no NV arm, so `ImageProcessor::convert`
+//! converted on the CPU (issue #166). This file pins the upload itself;
+//! `offset_source_view_alignment.rs` pins the route into it.
 //!
 //! A `GLProcessorThreaded` is driven directly: `ImageProcessor::convert`
 //! would hide the bug behind its CPU fallback.

--- a/crates/image/tests/offset_source_view_alignment.rs
+++ b/crates/image/tests/offset_source_view_alignment.rs
@@ -1,0 +1,299 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! A source at a byte offset inside a DMA-BUF must convert to its own window
+//! through the GL backend at every offset, not only at the ones that happen to
+//! be 64-byte aligned. Issue #165.
+//!
+//! On Mali (i.MX 95) the DMA-BUF import silently samples zeros when
+//! `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is not a multiple of 64 -- no EGL error,
+//! the import succeeds -- so a 16x16 view at (8, 8) of a 256-byte-pitched RGBA
+//! surface (offset 2080) came back all `[0, 0, 0, 255]` while (0, 8) (offset
+//! 2048) and (16, 0) (offset 64) were fine; V3D converts all of them. The
+//! engine now declines a Mali source import at an unaligned offset so the
+//! upload path, which reads through `map()`, takes it.
+//!
+//! The NV12 case also pins #166: a declined NV source must reach the R8
+//! *upload*, not the CPU converter -- `GLProcessorThreaded` is driven
+//! directly, so a CPU fallback cannot pass this file.
+//!
+//! **The NV12 case is a plane offset, not a `view()`.** `Tensor::view` is
+//! packed-only (`view() supports packed formats only (got Nv12)`), so a
+//! semi-planar sub-rectangle does not exist as an API. The offset a real NV
+//! source arrives at is a whole frame inside a bigger buffer -- a pool slot,
+//! or the window `interop::apply_plane_offset` hands back -- which is what
+//! `set_plane_offset` builds here, on a real DMA-BUF NV12 surface so the
+//! zero-copy R8 import is the path actually under test.
+//!
+//! Every offset here is asserted, including the aligned ones, so a regression
+//! on the drivers that handle unaligned offsets natively (V3D, Vivante) is
+//! caught by the same file.
+
+#![cfg(all(target_os = "linux", feature = "opengl"))]
+
+use edgefirst_image::{
+    CPUProcessor, Crop, Flip, GLProcessorThreaded, ImageProcessorTrait, Rotation,
+};
+use edgefirst_tensor::{
+    ColorEncoding, ColorRange, Colorimetry, CpuAccess, DType, PixelFormat, Region, TensorDyn,
+    TensorMapTrait, TensorMemory,
+};
+
+const W: usize = 64;
+const H: usize = 64;
+const SIDE: usize = 16;
+const BPP: usize = 4;
+
+/// The alignment Mali's DMA-BUF import needs; mirrored from the engine so the
+/// NV12 case can build one offset on either side of it.
+const MALI_ALIGN: usize = 64;
+
+/// The origins the imx95 probe classified; the two unaligned ones (offsets 32
+/// and 2080 at a 256-byte pitch) are the regression, the rest the control.
+const ORIGINS: [(usize, usize); 6] = [(0, 0), (8, 8), (0, 8), (8, 0), (16, 0), (0, 1)];
+
+fn skip(why: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {why}");
+}
+
+fn want(x: usize, y: usize) -> [u8; BPP] {
+    [((y * 4) % 256) as u8, ((x * 4) % 256) as u8, 255, 255]
+}
+
+fn gl_or_skip() -> Option<GLProcessorThreaded> {
+    let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+    match GLProcessorThreaded::new(None) {
+        Ok(gl) => Some(gl),
+        Err(e) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but the GL backend failed to come up: {e}"
+            );
+            skip(&format!("no GL backend: {e}"));
+            None
+        }
+    }
+}
+
+fn dmabuf_image_or_skip(w: usize, h: usize, fmt: PixelFormat) -> Option<TensorDyn> {
+    match TensorDyn::image(
+        w,
+        h,
+        fmt,
+        DType::U8,
+        Some(TensorMemory::DmaBuf),
+        CpuAccess::ReadWrite,
+    ) {
+        Ok(t) if t.memory() == TensorMemory::DmaBuf => Some(t),
+        Ok(t) => {
+            skip(&format!(
+                "{fmt:?}: zero-copy request fell back to {:?}",
+                t.memory()
+            ));
+            None
+        }
+        Err(e) => {
+            skip(&format!("{fmt:?}: no DMA-BUF here: {e}"));
+            None
+        }
+    }
+}
+
+fn rgba_dst(w: usize, h: usize) -> TensorDyn {
+    TensorDyn::new(&[h, w, BPP], DType::U8, Some(TensorMemory::Mem), None)
+        .expect("dst")
+        .with_format(PixelFormat::Rgba)
+        .expect("dst format")
+}
+
+fn bytes(t: &TensorDyn) -> Vec<u8> {
+    t.map_bytes(CpuAccess::Read)
+        .expect("map")
+        .as_slice()
+        .to_vec()
+}
+
+#[test]
+fn rgba_source_views_convert_their_own_tile_at_every_origin() {
+    let Some(mut gl) = gl_or_skip() else { return };
+    let Some(src) = dmabuf_image_or_skip(W, H, PixelFormat::Rgba) else {
+        return;
+    };
+    let pitch = src.effective_row_stride().unwrap_or(W * BPP);
+    {
+        let mut m = src.map_bytes(CpuAccess::Write).expect("map src");
+        let s = m.as_mut_slice();
+        for y in 0..H {
+            for x in 0..W {
+                s[y * pitch + x * BPP..][..BPP].copy_from_slice(&want(x, y));
+            }
+        }
+    }
+    let mut failures = Vec::new();
+    for (x0, y0) in ORIGINS {
+        let view = src.view(Region::new(x0, y0, SIDE, SIDE)).expect("view");
+        let mut dst = rgba_dst(SIDE, SIDE);
+        if let Err(e) = gl.convert(&view, &mut dst, Rotation::None, Flip::None, Crop::default()) {
+            failures.push(format!(
+                "({x0},{y0}) offset {}: convert failed: {e}",
+                y0 * pitch + x0 * BPP
+            ));
+            continue;
+        }
+        let got = bytes(&dst);
+        let mut expected = Vec::with_capacity(SIDE * SIDE * BPP);
+        for y in 0..SIDE {
+            for x in 0..SIDE {
+                expected.extend_from_slice(&want(x0 + x, y0 + y));
+            }
+        }
+        if got != expected {
+            let kind = if got.chunks(BPP).all(|p| p == [0, 0, 0, 255]) {
+                "ZEROS (issue #165: the import sampled nothing)"
+            } else {
+                "wrong pixels"
+            };
+            failures.push(format!(
+                "({x0},{y0}) offset {}: {kind}; first={:?} expected={:?}",
+                y0 * pitch + x0 * BPP,
+                &got[..BPP],
+                &expected[..BPP]
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "pitch {pitch}:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// An NV12 DMA-BUF frame at a 64-aligned and at an unaligned plane offset,
+/// each against a CPU reference over the same tensor. On Mali the unaligned
+/// one is declined by the zero-copy R8 import and must come back through the
+/// R8 *upload* (issue #166's routing), which `GLProcessorThreaded` proves by
+/// returning `Ok` at all: the old failure arm called `draw_src_texture`, which
+/// has no NV arm and returned `NotSupported`.
+#[test]
+fn nv12_offset_sources_convert_through_gl_at_aligned_and_unaligned_offsets() {
+    let Some(mut gl) = gl_or_skip() else { return };
+    // Three frames' worth of rows so a window can start past the first frame
+    // and still be fully backed. Allocated as a real NV12 surface, then
+    // re-tagged to one frame's geometry at an offset, which keeps the driver's
+    // pitch -- the shape a pool slot arrives in.
+    let Some(mut src) = dmabuf_image_or_skip(W, H * 3, PixelFormat::Nv12) else {
+        return;
+    };
+    let pitch = src.effective_row_stride().unwrap_or(W);
+    // A pattern whose period (31) is coprime with both the pitch and 64, so a
+    // window read at the wrong offset cannot coincide with the right one.
+    // Kept inside 112..=142 so neither the luma nor the chroma it also feeds
+    // drives any RGB channel into clamping, where two different reads could
+    // agree by saturation. Written BEFORE the re-tag: afterwards the map is one
+    // frame long and every window this test reads would stay at zero.
+    {
+        let mut m = src.map_bytes(CpuAccess::Write).expect("map src");
+        let s = m.as_mut_slice();
+        for (i, b) in s.iter_mut().enumerate() {
+            *b = 112 + (i % 31) as u8;
+        }
+    }
+    src.set_logical_shape(&[H * 3 / 2, W])
+        .expect("one frame's geometry");
+    assert_eq!(src.height(), Some(H), "precondition: one frame is {H} rows");
+    assert_eq!(
+        src.effective_row_stride(),
+        Some(pitch),
+        "precondition: the re-tag kept the surface pitch"
+    );
+    // Full-range BT.601 so both converters resolve the same matrix instead of
+    // the untagged SD heuristic (which is limited-range and would still agree,
+    // but says so by accident rather than by contract).
+    src.set_colorimetry(Some(
+        Colorimetry::default()
+            .with_encoding(ColorEncoding::Bt601)
+            .with_range(ColorRange::Full),
+    ));
+
+    let frame = pitch * (H * 3 / 2);
+    let aligned = frame.next_multiple_of(MALI_ALIGN);
+    let unaligned = aligned + MALI_ALIGN / 2;
+    assert_eq!(
+        aligned % MALI_ALIGN,
+        0,
+        "precondition: {aligned} is aligned"
+    );
+    assert_ne!(
+        unaligned % MALI_ALIGN,
+        0,
+        "precondition: {unaligned} is not aligned"
+    );
+
+    let mut failures = Vec::new();
+    let mut references = Vec::new();
+    for offset in [aligned, unaligned] {
+        src.set_plane_offset(offset);
+        assert_eq!(
+            src.plane_offset(),
+            Some(offset),
+            "precondition: the offset stuck"
+        );
+        let mut reference = rgba_dst(W, H);
+        CPUProcessor::new()
+            .convert(
+                &src,
+                &mut reference,
+                Rotation::None,
+                Flip::None,
+                Crop::default(),
+            )
+            .expect("CPU reference");
+        let want = bytes(&reference);
+        let mut dst = rgba_dst(W, H);
+        match gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default()) {
+            Err(e) => failures.push(format!(
+                "offset {offset}: GL refused the NV12 source: {e} \
+                 (issue #166: the declined import must reach the R8 upload)"
+            )),
+            Ok(()) => {
+                let got = bytes(&dst);
+                let bad = got
+                    .iter()
+                    .zip(&want)
+                    .filter(|(g, w)| g.abs_diff(**w) > 8)
+                    .count();
+                if bad > 0 {
+                    // A flat output means the import sampled one constant.
+                    // Issue #165's zero-sampling reads Y=U=V=0, which
+                    // full-range BT.601 turns into [0, 136, 0, 255] -- not the
+                    // [0, 0, 0, 255] the RGBA case above looks for.
+                    let flat = got.chunks(BPP).all(|p| p == &got[..BPP]);
+                    failures.push(format!(
+                        "offset {offset}: {bad} bytes differ from the CPU reference{}; \
+                         first got={:?} want={:?}",
+                        if flat {
+                            " (FLAT: issue #165, the import sampled a constant)"
+                        } else {
+                            ""
+                        },
+                        &got[..BPP],
+                        &want[..BPP]
+                    ));
+                }
+            }
+        }
+        references.push(want);
+    }
+    // The two windows must actually differ, or "GL matches CPU" would hold for
+    // an engine that ignored the offset entirely.
+    assert_ne!(
+        references[0], references[1],
+        "precondition: offsets {aligned} and {unaligned} name different windows"
+    );
+    assert!(
+        failures.is_empty(),
+        "pitch {pitch}:\n{}",
+        failures.join("\n")
+    );
+}

--- a/crates/image/tests/offset_source_view_alignment.rs
+++ b/crates/image/tests/offset_source_view_alignment.rs
@@ -28,6 +28,12 @@
 //! Every offset here is asserted, including the aligned ones, so a regression
 //! on the drivers that handle unaligned offsets natively (V3D, Vivante) is
 //! caught by the same file.
+//!
+//! The ANGLE leaves (`platform/angle.rs`, `platform/windows.rs`) refuse an
+//! offset source through the same `refuse_offset_source` import-failure arms
+//! this file pins, but this file is Linux-only, so an IOSurface or D3D11
+//! offset NV source is not built here -- that upload is covered separately
+//! by `offset_nv_source_upload.rs`, which drives `Mem`.
 
 #![cfg(all(target_os = "linux", feature = "opengl"))]
 

--- a/crates/image/tests/offset_source_view_alignment.rs
+++ b/crates/image/tests/offset_source_view_alignment.rs
@@ -82,7 +82,14 @@ fn gl_or_skip() -> Option<GLProcessorThreaded> {
     }
 }
 
+/// A DMA-BUF image, or a skip. Under `HAL_TEST_REQUIRE_GL=1` a missing or
+/// downgraded DMA-BUF is a FAILURE, not a skip: the boards this file exists
+/// for all have a heap, so a heap that needs privileges (or an allocation that
+/// quietly lands on the heap allocator) would otherwise let the whole file
+/// pass without importing anything -- vacuously green on exactly the path
+/// under test. The GL bring-up above carries the same rule.
 fn dmabuf_image_or_skip(w: usize, h: usize, fmt: PixelFormat) -> Option<TensorDyn> {
+    let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
     match TensorDyn::image(
         w,
         h,
@@ -93,6 +100,11 @@ fn dmabuf_image_or_skip(w: usize, h: usize, fmt: PixelFormat) -> Option<TensorDy
     ) {
         Ok(t) if t.memory() == TensorMemory::DmaBuf => Some(t),
         Ok(t) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but the {fmt:?} zero-copy request fell back to {:?}",
+                t.memory()
+            );
             skip(&format!(
                 "{fmt:?}: zero-copy request fell back to {:?}",
                 t.memory()
@@ -100,6 +112,10 @@ fn dmabuf_image_or_skip(w: usize, h: usize, fmt: PixelFormat) -> Option<TensorDy
             None
         }
         Err(e) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but no DMA-BUF could be allocated for {fmt:?}: {e}"
+            );
             skip(&format!("{fmt:?}: no DMA-BUF here: {e}"));
             None
         }
@@ -297,6 +313,134 @@ fn nv12_offset_sources_convert_through_gl_at_aligned_and_unaligned_offsets() {
         references[0], references[1],
         "precondition: offsets {aligned} and {unaligned} name different windows"
     );
+    assert!(
+        failures.is_empty(),
+        "pitch {pitch}:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// A DESTINATION at a plane offset Mali cannot *sample* from. Rendering into an
+/// unaligned base is a different operation from sampling one, and the
+/// destination exemption in `get_or_create_egl_image` claims it is safe, so it
+/// is measured here rather than assumed.
+///
+/// Measured: Mali (i.MX 95) and V3D render into offset 2080 correctly, so Mali
+/// destinations keep the zero-copy import. Vivante does NOT — `eglCreateImage`
+/// returns `EGL_BAD_ACCESS` at 2080 while 2048 renders — which this test found
+/// and `vivante_rejects_dst_import_offset` now lowers to the mapped-texture
+/// path. Both offsets are asserted on every driver, so either half regressing
+/// is caught here.
+///
+/// The destination is rebuilt from a `view()`'s descriptor, which is the only
+/// shape that reaches the import at a nonzero offset: a fresh `view()` collapses
+/// onto its parent's key at offset 0 (`cache.rs`'s `for_dst` arm), while a
+/// rebuilt one carries the offset and no `view_origin`, so on Linux
+/// `dst_import_places` keeps it zero-copy and the import base IS the offset.
+/// Same pattern as `reconstructed_view_convert.rs` case E, at both an aligned
+/// and an unaligned offset.
+#[test]
+fn rgba_offset_destinations_place_their_tile_at_aligned_and_unaligned_offsets() {
+    const BLANK: u8 = 0x55;
+    let Some(mut gl) = gl_or_skip() else { return };
+    let Some(canvas) = dmabuf_image_or_skip(W, H, PixelFormat::Rgba) else {
+        return;
+    };
+    let pitch = canvas.effective_row_stride().unwrap_or(W * BPP);
+
+    let mut failures = Vec::new();
+    // (0, 8) is 8 * pitch, aligned whenever the pitch is; (8, 8) adds
+    // 8 * BPP = 32, which is never 64-aligned. Same construction as the source
+    // test, so the two halves are measured at the same two offsets.
+    for (x0, y0) in [(0usize, 8usize), (8, 8)] {
+        let offset = y0 * pitch + x0 * BPP;
+        {
+            let mut m = canvas.map_bytes(CpuAccess::Write).expect("map canvas");
+            m.as_mut_slice().fill(BLANK);
+        }
+        let fresh = canvas
+            .view(Region::new(x0, y0, SIDE, SIDE))
+            .expect("fresh destination view");
+        assert_eq!(
+            fresh.plane_offset(),
+            Some(offset),
+            "precondition: the view's offset is the pitch arithmetic above"
+        );
+        let mut dst = TensorDyn::import_descriptor(&fresh.descriptor_pinned(None))
+            .expect("rebuild the destination view from its descriptor");
+        assert_eq!(
+            dst.effective_row_stride(),
+            Some(pitch),
+            "precondition: the rebuilt destination kept the canvas pitch"
+        );
+        dst.set_plane_offset(offset);
+        assert_eq!(
+            dst.view_origin(),
+            None,
+            "precondition: rebuilt, so no viewport to place it by"
+        );
+
+        // The source carries the tile's ABSOLUTE canvas colours, so a tile that
+        // lands at the wrong origin is wrong in value, not just in place.
+        let src = rgba_dst(SIDE, SIDE);
+        {
+            let mut m = src.map_bytes(CpuAccess::Write).expect("map src");
+            let s = m.as_mut_slice();
+            for y in 0..SIDE {
+                for x in 0..SIDE {
+                    s[(y * SIDE + x) * BPP..][..BPP].copy_from_slice(&want(x0 + x, y0 + y));
+                }
+            }
+        }
+        if let Err(e) = gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default()) {
+            failures.push(format!("({x0},{y0}) offset {offset}: convert failed: {e}"));
+            continue;
+        }
+        let out = bytes(&canvas);
+        let px = |x: usize, y: usize| &out[y * pitch + x * BPP..][..BPP];
+        if px(0, 0) != [BLANK; BPP] {
+            failures.push(format!(
+                "({x0},{y0}) offset {offset}: the tile landed at the canvas ORIGIN, \
+                 i.e. the import ignored the offset; (0,0)={:?}",
+                px(0, 0)
+            ));
+            continue;
+        }
+        if y0 > 0 && px(x0, y0 - 1) != [BLANK; BPP] {
+            failures.push(format!(
+                "({x0},{y0}) offset {offset}: the row above the window was written: {:?}",
+                px(x0, y0 - 1)
+            ));
+        }
+        if x0 > 0 && px(x0 - 1, y0) != [BLANK; BPP] {
+            failures.push(format!(
+                "({x0},{y0}) offset {offset}: the column left of the window was written: {:?}",
+                px(x0 - 1, y0)
+            ));
+        }
+        let mut wrong = 0usize;
+        let mut first = None;
+        for y in y0..y0 + SIDE {
+            for x in x0..x0 + SIDE {
+                if px(x, y) != want(x, y) {
+                    wrong += 1;
+                    first.get_or_insert((x, y, px(x, y).to_vec(), want(x, y)));
+                }
+            }
+        }
+        if let Some((x, y, got, exp)) = first {
+            let flat = out.chunks(BPP).take(SIDE).all(|p| p == [0, 0, 0, 255]);
+            failures.push(format!(
+                "({x0},{y0}) offset {offset}: {wrong} tile pixels wrong{}; \
+                 ({x},{y}) got={got:?} expected={exp:?}",
+                if flat {
+                    " (ZEROS: the render target sampled/wrote nothing)"
+                } else {
+                    ""
+                }
+            ));
+        }
+    }
     assert!(
         failures.is_empty(),
         "pitch {pitch}:\n{}",

--- a/crates/image/tests/reconstructed_planar_dst.rs
+++ b/crates/image/tests/reconstructed_planar_dst.rs
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! The zero-copy float render targets (`convert_float_to_zero_copy`,
+//! `convert_nv_to_float_two_pass`) import their destination through
+//! `get_or_create_egl_image_rgb` -> `import_buffer_packed`, which on ANGLE
+//! over IOSurface binds the whole buffer from its origin -- the same
+//! problem `bind_dst` and `convert_via_engine` already gate on
+//! `dst_import_places` for their own destination imports.
+//!
+//! This pins the float dispatch's own gate: a `PlanarRgb` F16 destination
+//! reconstructed from a descriptor (a plane offset, no `view_origin`) must
+//! be refused by the GL backend directly, and `ImageProcessor`'s convert
+//! (CPU fallback) must still land the bytes at that offset, not at the
+//! buffer's origin.
+//!
+//! macOS/iOS only: a D3D11 descriptor import accepts only packed windows, so
+//! a narrowed planar destination cannot exist on Windows, and Linux's
+//! DMA-BUF import expresses the offset itself, so `dst_import_places`
+//! defaults to `true` there and this reconstruction hits the ordinary
+//! zero-copy path.
+//!
+//! Two halves, so the gate cannot pass vacuously: first `GLProcessorThreaded`
+//! is driven directly and asserted to *refuse* the destination (the gate
+//! actually firing, not just "some path happened to place the bytes
+//! correctly"); the GL context is dropped before `ImageProcessor` opens its
+//! own, since nothing here establishes that two live ANGLE contexts coexist
+//! safely, and only one is ever needed at a time. Then `ImageProcessor`
+//! drives the same convert, which falls back to CPU on the same refusal, and
+//! its placement is checked.
+//!
+//! The decoded `f16` value check is intentionally coarse (32 ULPs): native
+//! FP16 widening on Apple silicon and an `f32`-divide-then-round golden can
+//! disagree by more than a couple of bits, and the untouched/written
+//! byte-range checks above it are the assertions this file actually exists
+//! to make.
+
+#![cfg(all(any(target_os = "macos", target_os = "ios"), feature = "opengl"))]
+
+use edgefirst_image::{
+    Crop, Flip, GLProcessorThreaded, ImageProcessor, ImageProcessorTrait, Rotation,
+};
+use edgefirst_tensor::{CpuAccess, DType, PixelFormat, TensorDyn, TensorMapTrait, TensorMemory};
+
+const W: usize = 64;
+const H: usize = 16;
+const BLANK: u8 = 0x55;
+const PIXEL: [u8; 4] = [200, 100, 50, 255];
+
+fn skip(why: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {why}");
+}
+
+#[test]
+fn reconstructed_planar_f16_destination_receives_its_convert_at_its_offset() {
+    let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+    // The macOS coverage lane runs pass 1 with the ANGLE dlopen gate closed;
+    // the same guard `gl_backend_available_canary` carries.
+    #[cfg(target_os = "macos")]
+    if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+        skip("ANGLE dlopen gate closed (coverage pass 1)");
+        return;
+    }
+
+    // `supported_render_dtypes` is only public on `ImageProcessor`; this
+    // instance exists only to ask the question and is dropped immediately
+    // after, before either of the two convert halves below opens its own
+    // GL context.
+    let support = {
+        let proc = ImageProcessor::new().expect("ImageProcessor::new");
+        proc.supported_render_dtypes()
+    };
+    if !support.f16 {
+        assert!(
+            !require_gl,
+            "HAL_TEST_REQUIRE_GL=1 but f16 render is not supported: {support:?}"
+        );
+        skip(&format!("f16 render not supported: {support:?}"));
+        return;
+    }
+
+    let canvas = match TensorDyn::image(
+        W,
+        H,
+        PixelFormat::PlanarRgb,
+        DType::F16,
+        Some(TensorMemory::DmaBuf),
+        CpuAccess::ReadWrite,
+    ) {
+        Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+        Ok(t) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but the zero-copy request fell back to {:?}",
+                t.memory()
+            );
+            skip(&format!("zero-copy request fell back to {:?}", t.memory()));
+            return;
+        }
+        Err(e) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but no zero-copy buffer could be allocated: {e}"
+            );
+            skip(&format!("no zero-copy buffer here: {e}"));
+            return;
+        }
+    };
+
+    // The RGBA16F packing stores the planar `[3, H, W]` stream at `(W/4, 3H)`
+    // texels of 4 `f16`s each, so one planar row is one surface row. The
+    // exact byte count is a platform packing/alignment detail, not something
+    // this test should pin: only that it is at least 64 `f16`s wide (`W`
+    // samples, 2 bytes each) and a multiple of the packing's 4-wide texel
+    // (`4 * 2 * 8` bytes) in that unit.
+    let pitch = canvas
+        .effective_row_stride()
+        .expect("planar f16 surface pitch");
+    assert!(
+        pitch >= 128 && pitch % 64 == 0,
+        "pitch {pitch} is not a plausible planar f16 row stride for width {W}"
+    );
+    {
+        let mut m = canvas.map_bytes(CpuAccess::Write).expect("map canvas");
+        m.as_mut_slice().fill(BLANK);
+    }
+
+    // A destination window rebuilt the way a capsule consumer rebuilds one:
+    // the descriptor carries the whole surface, then it is narrowed to the
+    // 15 rows past the first (skipping row 0) and the offset put back --
+    // `PlanarRgb`/`PlanarRgba` reject `Tensor::view()`, so a real capsule
+    // consumer narrows this way rather than through a view.
+    let mut rebuilt = TensorDyn::import_descriptor(&canvas.descriptor_pinned(None))
+        .expect("reconstruct the destination from its descriptor");
+    rebuilt
+        .set_logical_shape(&[3, H - 1, W])
+        .expect("narrow to the 15 rows past the first");
+    rebuilt.set_plane_offset(pitch);
+    assert!(
+        rebuilt.view_origin().is_none(),
+        "precondition: a rebuilt tensor has no view_origin"
+    );
+    assert_eq!(
+        rebuilt.effective_row_stride(),
+        Some(pitch),
+        "the narrowed tensor keeps the parent surface's pitch"
+    );
+
+    let src = TensorDyn::image(
+        W,
+        H - 1,
+        PixelFormat::Rgba,
+        DType::U8,
+        Some(TensorMemory::Mem),
+        CpuAccess::ReadWrite,
+    )
+    .expect("alloc source");
+    {
+        let mut m = src.map_bytes(CpuAccess::Write).expect("map source");
+        let s = m.as_mut_slice();
+        for i in (0..s.len()).step_by(4) {
+            s[i..i + 4].copy_from_slice(&PIXEL);
+        }
+    }
+
+    // First half: the GL backend itself must refuse this destination, not
+    // merely happen to place the bytes correctly. Scoped so the GL context
+    // is dropped before `ImageProcessor` opens its own below.
+    {
+        let mut gl = match GLProcessorThreaded::new(None) {
+            Ok(gl) => gl,
+            Err(e) => {
+                assert!(
+                    !require_gl,
+                    "HAL_TEST_REQUIRE_GL=1 but the GL backend failed to come up: {e}"
+                );
+                skip(&format!("no GL backend: {e}"));
+                return;
+            }
+        };
+        let err = gl
+            .convert(
+                &src,
+                &mut rebuilt,
+                Rotation::None,
+                Flip::None,
+                Crop::default(),
+            )
+            .expect_err("the GL float path must refuse a destination it cannot place");
+        assert!(
+            matches!(err, edgefirst_image::Error::NotSupported(_)),
+            "expected Error::NotSupported, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("has no view origin to place it by"),
+            "expected the float dispatch gate's refusal message, got: {msg}"
+        );
+    }
+
+    // Second half: `ImageProcessor`'s CPU fallback on that same refusal must
+    // still land the convert at the reconstructed tensor's own offset.
+    let mut proc = ImageProcessor::new().expect("ImageProcessor::new");
+    proc.convert(
+        &src,
+        &mut rebuilt,
+        Rotation::None,
+        Flip::None,
+        Crop::default(),
+    )
+    .expect("convert into the reconstructed planar destination");
+
+    let out = canvas.map_bytes(CpuAccess::Read).expect("map canvas");
+    let bytes = out.as_slice();
+    assert!(
+        bytes[0..pitch].iter().all(|&b| b == BLANK),
+        "row 0 of the canvas -- the byte before the reconstructed tensor's \
+         offset -- must stay untouched: a render at the buffer's origin \
+         would write here instead"
+    );
+    assert!(
+        !bytes[pitch..2 * pitch].iter().all(|&b| b == BLANK),
+        "row 1 of the canvas -- the reconstructed tensor's own row 0, at \
+         its plane offset -- must have received the convert"
+    );
+
+    // Row 1's first f16 is the R plane's first packed texel, channel 0: the
+    // source is one constant RGBA pixel, so it must be near R/255 regardless
+    // of which of the 4 packed positions it is. Coarse on purpose -- see the
+    // module doc comment.
+    let actual = half::f16::from_le_bytes([bytes[pitch], bytes[pitch + 1]]);
+    let expected = half::f16::from_f32(PIXEL[0] as f32 / 255.0);
+    assert!(
+        actual.to_bits().abs_diff(expected.to_bits()) <= 32,
+        "row 1's first f16 is {actual:?} ({:#06x}), expected near {expected:?} ({:#06x})",
+        actual.to_bits(),
+        expected.to_bits()
+    );
+}

--- a/crates/image/tests/reconstructed_planar_dst.rs
+++ b/crates/image/tests/reconstructed_planar_dst.rs
@@ -193,8 +193,11 @@ fn reconstructed_planar_f16_destination_receives_its_convert_at_its_offset() {
             "expected Error::NotSupported, got {err:?}"
         );
         let msg = err.to_string();
+        // Only pin the stable prefix: the tail names whichever placement
+        // rule declined (ANGLE's whole-buffer binding with no view origin,
+        // or a driver whose import rejects the offset), which isn't asserted.
         assert!(
-            msg.contains("has no view origin to place it by"),
+            msg.contains("GL float destination at plane offset"),
             "expected the float dispatch gate's refusal message, got: {msg}"
         );
     }

--- a/crates/image/tests/reconstructed_view_draw.rs
+++ b/crates/image/tests/reconstructed_view_draw.rs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! The GL draw places its frame at the destination surface's origin --
+//! viewport 0,0 on an imported surface, buffer offset 0 in a readback -- so
+//! a destination it cannot place that way is refused up front
+//! (`check_draw_dst_placement`), and `ImageProcessor`'s CPU fallback handles
+//! it instead. This pins the rebuilt-destination spelling of that refusal:
+//! a destination reconstructed from a descriptor carries a plane offset but
+//! no `view_origin`, so `check_draw_dst_placement` must refuse it rather
+//! than let the zero-copy path draw at the canvas's top-left.
+//!
+//! Driven through `GLProcessorThreaded` directly so no CPU fallback can mask
+//! a missing refusal, on the platforms whose zero-copy buffer needs no
+//! device node.
+
+#![cfg(all(
+    any(target_os = "macos", target_os = "ios", target_os = "windows"),
+    feature = "opengl"
+))]
+
+use edgefirst_image::{GLProcessorThreaded, ImageProcessorTrait};
+use edgefirst_tensor::{
+    CpuAccess, DType, PixelFormat, Region, TensorDyn, TensorMapTrait, TensorMemory,
+};
+
+const W: usize = 50;
+const H: usize = 64;
+const X0: usize = 8;
+const Y0: usize = 8;
+const SIDE: usize = 16;
+const BLANK: u8 = 0x55;
+
+fn skip(why: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {why}");
+}
+
+#[test]
+fn overlay_into_a_reconstructed_destination_view_is_refused_not_drawn_at_the_origin() {
+    let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+    // The macOS coverage lane runs pass 1 with the ANGLE dlopen gate closed;
+    // the same guard `gl_backend_available_canary` carries.
+    #[cfg(target_os = "macos")]
+    if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+        skip("ANGLE dlopen gate closed (coverage pass 1)");
+        return;
+    }
+    let mut gl = match GLProcessorThreaded::new(None) {
+        Ok(gl) => gl,
+        Err(e) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but the GL backend failed to come up: {e}"
+            );
+            skip(&format!("no GL backend: {e}"));
+            return;
+        }
+    };
+
+    let canvas = match TensorDyn::image(
+        W,
+        H,
+        PixelFormat::Rgba,
+        DType::U8,
+        Some(TensorMemory::DmaBuf),
+        CpuAccess::ReadWrite,
+    ) {
+        Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+        Ok(t) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but the zero-copy request fell back to {:?}",
+                t.memory()
+            );
+            skip(&format!("zero-copy request fell back to {:?}", t.memory()));
+            return;
+        }
+        Err(e) => {
+            assert!(
+                !require_gl,
+                "HAL_TEST_REQUIRE_GL=1 but no zero-copy buffer could be allocated: {e}"
+            );
+            skip(&format!("no zero-copy buffer here: {e}"));
+            return;
+        }
+    };
+    {
+        let mut m = canvas.map_bytes(CpuAccess::Write).expect("map canvas");
+        m.as_mut_slice().fill(BLANK);
+    }
+
+    // A destination window rebuilt the way a capsule consumer rebuilds one:
+    // the descriptor carries the window's shape and pitch, the offset is put
+    // back afterwards, and there is no `view_origin`.
+    let fresh = canvas
+        .view(Region::new(X0, Y0, SIDE, SIDE))
+        .expect("fresh view");
+    let mut rebuilt = TensorDyn::import_descriptor(&fresh.descriptor_pinned(None))
+        .expect("reconstruct the destination view from its descriptor");
+    rebuilt.set_plane_offset(fresh.plane_offset().expect("a view carries its offset"));
+    assert!(
+        rebuilt.view_origin().is_none(),
+        "precondition: a rebuilt view has no view_origin"
+    );
+
+    let err = gl
+        .draw_decoded_masks(&mut rebuilt, &[], &[], Default::default())
+        .expect_err(
+            "a GL overlay into a destination it cannot place must be refused, not drawn at the origin",
+        );
+    assert!(
+        matches!(err, edgefirst_image::Error::NotSupported(_)),
+        "expected Error::NotSupported, got {err:?}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("sub-region destination"),
+        "expected check_draw_dst_placement's refusal message, got: {msg}"
+    );
+
+    // Refused before any GL work touched the canvas: every byte is still
+    // the poison fill, not just the window's.
+    let out = canvas.map_bytes(CpuAccess::Read).expect("map canvas");
+    assert!(
+        out.as_slice().iter().all(|&b| b == BLANK),
+        "the canvas was written to despite the draw being refused"
+    );
+}

--- a/crates/python-common/INTEROP.md
+++ b/crates/python-common/INTEROP.md
@@ -95,16 +95,23 @@ so a *freshly created* view was right and only a tensor rebuilt from a
 cfg-multiplexed name rather than one type, so the Linux-gated arm did not
 fail to compile on macOS, it silently became a fall-through.
 
+Two follow-ups complete it: the descriptor import now restores an IOSurface
+view's pitch (`restore_imported_row_stride` includes `IOSURFACE`; a
+surface's `bytesPerRow` is shared, unlike a D3D11 staging pitch), and the
+GL engine's Apple leaf refuses to zero-copy attach a source carrying a
+plane offset, as the Windows leaf does, because the ANGLE IOSurface
+binding has no offset attribute.
+
 D3D11 (Windows) is fixed too, and the bug had a different shape there. A
 view's descriptor was refused rather than rebuilt at the wrong origin: the
 import checks the shape against the texture's own geometry, and a window
 was neither spelling it accepted. It now accepts a packed window, opens the
 whole texture and narrows it, keeping the texture's pitch as the row
 stride; the storage offset is then written back by `set_plane_offset` and
-cleared by `set_format` and `reshape`. Two Windows-only details follow from
-the texture being the unit of import. The ANGLE image binds the whole
-texture from its origin and cannot express an offset, so the GL engine's
-Windows leaf refuses to attach a *source* carrying a plane offset and the
+cleared by `set_format` and `reshape`. Two details follow from the texture
+being the unit of import. The ANGLE image binds the whole texture from its
+origin and cannot express an offset, so the engine's ANGLE leaves (D3D11
+and IOSurface) refuse to attach a *source* carrying a plane offset and the
 engine uploads it through `map()` instead — without that refusal even a
 fresh `view()` converted the parent's origin. A *destination* rebuilt from a
 descriptor is the same problem from the other side — it has the offset but

--- a/crates/python-common/src/interop.rs
+++ b/crates/python-common/src/interop.rs
@@ -199,6 +199,11 @@ const _: () = {
 ///   `set_plane_offset_moves_the_iosurface_map_window`,
 ///   `nested_iosurface_subviews_do_not_compound_their_plane_offset` and
 ///   `set_format_clears_the_iosurface_map_window`.
+///   Two review follow-ups complete it: the import restores the view's
+///   pitch (`descriptor_import_restores_the_iosurface_pitch_onto_a_view`),
+///   and the GL leaf refuses an offset *source* the way Windows' does,
+///   since the ANGLE IOSurface binding has no offset attribute
+///   (`reconstructed_view_convert.rs`, case A, on the macOS lane).
 /// * **D3D11 (Windows)** -- fixed (issue #161), in three parts, because
 ///   the bug had a different shape there. A view's descriptor was not
 ///   reconstructed wrongly, it was *refused*: the `D3D11_TEXTURE` import
@@ -209,13 +214,13 @@ const _: () = {
 ///   is then written back by `set_plane_offset` and cleared by
 ///   `set_format` and `reshape` (unlike `IoSurfaceTensor`, its own
 ///   `reshape` leaves the offset alone). And because the ANGLE import binds
-///   the whole texture from its origin and cannot express an offset, the GL
-///   engine's Windows leaf refuses to attach a source carrying one and
-///   uploads it through `map()` instead -- without which even a *fresh*
-///   `view()` converted the parent's origin on the GL path. A rebuilt
-///   *destination* has the offset but not the `view_origin` the engine
-///   lowers a fresh view's tile to a viewport from, so the engine asks the
-///   platform whether a zero-copy destination can be placed
+///   the whole texture from its origin and cannot express an offset, the
+///   engine's ANGLE leaves (D3D11 and IOSurface) refuse to attach a source
+///   carrying one and upload it through `map()` instead -- without which
+///   even a *fresh* `view()` converted the parent's origin on the GL path.
+///   A rebuilt *destination* has the offset but not the `view_origin` the
+///   engine lowers a fresh view's tile to a viewport from, so the engine
+///   asks the platform whether a zero-copy destination can be placed
 ///   (`GlPlatform::dst_import_places`) and lowers one that cannot to the
 ///   mapped texture path, whose readback writes through `map()` at the
 ///   offset. Pinned by the `d3d11` plane-offset tests in


### PR DESCRIPTION
## Summary

Three GL issues found on hardware during Stage F release closure of 0.31.0:

- **#165 — Mali silently sampled zeros from a source view at an unaligned DMA-BUF offset.** On i.MX 95, `EGL_DMA_BUF_PLANE0_OFFSET_EXT` not a multiple of 64 bytes makes the EGL import succeed but return zeros, with no EGL error. V3D imports every offset correctly. The GL engine now recognises Mali from `GL_RENDERER` (`RendererTraits::mali`) and declines a *source* import at such an offset, uploading the window through `map()` instead. Destinations are unaffected — a view imports its parent at offset 0 and is never sampled at an offset.
- **#166 — A refused zero-copy NV source ended on the CPU instead of the GPU.** When the R8 import of an NV12/16/24 source is declined — either by the ANGLE leaves' own offset refusal, or by the new Mali rule above — the engine used to fall to `draw_src_texture`, which has no NV arm, dropping the convert to CPU/G2D entirely. Both NV import-failure arms (`ShaderR8` and `ExternalSampler`) now upload the combined plane through the same R8 shader instead.
- **#167 — A test asserted padding no readback route promises.** `gl_padded_pbo_dst_rows_land_at_the_declared_stride` required the bytes between pitched rows to stay untouched; Vivante writes them while packing rows at `GL_PACK_ROW_LENGTH`, and the read-tight-and-spread route always left leftovers there too. The test now asserts the pixel bytes of every row at the declared pitch, which is the actual contract, and that nothing lands past the buffer's `needed` size.

This PR also carries three review follow-ups from Task 1 (ordering of `last_nv_convert_path` in the two NV upload arms, a doc note on why `mali_rejects_source_offset` only checks plane 0, and a module-doc cross-reference between `offset_source_view_alignment.rs` and `offset_nv_source_upload.rs`).

Zero-copy for the Mali-unaligned case (importing from an aligned base and folding the pixel remainder into the sampling rectangle, the way destinations already fold `import_extent`) is filed as a follow-up enhancement, not fixed here: #170.

## #165 probe table (from the issue, verbatim)

Narrowed on `imx95-frdm` with a scratch probe driving `GLProcessorThreaded` directly over a 64x64 RGBA DMA-BUF (pitch 256), source views of 16x16, classified by output:

| view origin | byte offset | Mali (imx95) | V3D (rpi5) |
|---|---|---|---|
| whole image | 0 | tile | tile |
| (0,0) | 0 | tile | tile |
| (8,8) | 2080 | **zeros** | tile |
| (0,8) | 2048 | tile | tile |
| (8,0) | 32 | **zeros** | tile |
| (16,0) | 64 | tile | tile |
| (0,1) | 256 | tile | tile |

Every failing case has `EGL_DMA_BUF_PLANE0_OFFSET_EXT` not a multiple of 64; every passing case is 64-aligned. So it is the *offset alignment*, not "any non-zero source offset": Mali's import needs a 64-byte-aligned plane base and silently samples zeros otherwise (no EGL error surfaces — the import succeeds).

## Decline and routing

- `mali_rejects_source_offset` (`crates/image/src/gl/processor/mod.rs`) declines a source import in both `get_or_create_egl_image` and `get_or_create_nv_r8_egl_image` when `is_mali && plane_offset % 64 != 0`. Only plane 0 is checked — the chroma plane sits at `plane0_offset + pitch * height`, itself 64-aligned whenever `pitch` is, and the HAL always pads DMA pitches to 64.
- The `ShaderR8` and `ExternalSampler` NV import-failure arms both now call `draw_nv_texture_2d(src, src_fmt, None, ..)` instead of `draw_src_texture`, gated on `matches!(src_fmt, Nv12|Nv16|Nv24) && !src.is_multiplane()` so true multi-plane NV12 (separate Y/UV buffers, which cannot be uploaded as one R8 texture) keeps the existing CPU path unchanged. `last_nv_convert_path` reports `ShaderR8` on a declined import (the shader really does run, just fed by an upload) and `convert_stats` records both `zero_copy_declines` and `src_uploads`.
- The `ExternalSampler` arm was not in the original brief's scope but has the identical #166 defect on Vivante (single-plane NV12 there routes through `ExternalSampler`, not `ShaderR8`, under `Auto` + `ColorimetryMode::Fast`), so it's fixed in the same commit rather than filed separately.

## The pad contract (#167)

`gl_padded_pbo_dst_rows_land_at_the_declared_stride` no longer asserts that the bytes between one row's pixels and the next row's start stay untouched — no route promises that: a driver packing rows at `GL_PACK_ROW_LENGTH` may write them (Vivante does), and the read-tight-and-spread fallback always left its tight read's leftovers there. What every route does promise, and what the test now asserts: the pixel bytes of every row at the declared pitch, and that nothing lands past the buffer's allocated `needed` size (a spare row keeps even a written last-row pad inside the buffer).

## Board results — before / after (verbatim from Task 1 Step 6 and Task 2's filtered run)

**Task 1, three boards, unfiltered, `CRATES="edgefirst-image"` (after #165/#166 fix):**

| Host | Result | Detail |
|---|---|---|
| imx95-frdm (Mali G310) | PASS | 14 binaries, 1 test skipped, G1/G2/G3/G4/G9/G11 clean |
| imx8mp-frdm (Vivante) | FAIL | 13 ok, 1 failed: `dst_view_stride` (this is #167, fixed by Task 2 in this same PR) |
| rpi5-hailo (V3D) | PASS | 14 binaries, 1 test skipped, G1/G2/G3/G4/G9/G11 clean |

Pre-fix, `imx95-frdm` (Mali G310) failed exactly as predicted:

```
running 2 tests
test nv12_offset_sources_convert_through_gl_at_aligned_and_unaligned_offsets ... FAILED
test rgba_source_views_convert_their_own_tile_at_every_origin ... FAILED

---- nv12_offset_sources_convert_through_gl_at_aligned_and_unaligned_offsets stdout ----
pitch 64:
offset 6176: 10530 bytes differ from the CPU reference (FLAT: issue #165, the import sampled a constant); first got=[0, 135, 0, 255] want=[114, 125, 111, 255]

---- rgba_source_views_convert_their_own_tile_at_every_origin stdout ----
pitch 256:
(8,8) offset 2080: ZEROS (issue #165: the import sampled nothing); first=[0, 0, 0, 255] expected=[32, 32, 255, 255]
(8,0) offset 32: ZEROS (issue #165: the import sampled nothing); first=[0, 0, 0, 255] expected=[0, 32, 255, 255]

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.75s
```

Post-fix, both pins on all three boards:

```
##### imx95-frdm : offset_source_view_alignment
test nv12_offset_sources_convert_through_gl_at_aligned_and_unaligned_offsets ... ok
test rgba_source_views_convert_their_own_tile_at_every_origin ... ok
##### imx8mp-frdm : offset_source_view_alignment
test nv12_offset_sources_convert_through_gl_at_aligned_and_unaligned_offsets ... ok
test rgba_source_views_convert_their_own_tile_at_every_origin ... ok
##### rpi5-hailo : offset_source_view_alignment
test nv12_offset_sources_convert_through_gl_at_aligned_and_unaligned_offsets ... ok
test rgba_source_views_convert_their_own_tile_at_every_origin ... ok
```

**Task 2, imx8mp before/after on `dst_view_stride` (#167):**

Before (reproduced fresh by stashing the test-file edit):

```
running 1 test
test gl_padded_pbo_dst_rows_land_at_the_declared_stride ... FAILED

---- gl_padded_pbo_dst_rows_land_at_the_declared_stride stdout ----

thread 'gl_padded_pbo_dst_rows_land_at_the_declared_stride' (286427) panicked at crates/image/tests/dst_view_stride.rs:814:17:
Rgba at a 256 B pitch: row 0: the pad past the pixels was written

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 20 filtered out; finished in 0.90s
```

After, imx8mp-frdm and rpi5-hailo both PASS (14 binaries, 0 tests skipped, G1/G2/G3/G4/G9/G11 clean each); per-binary tail:

```
imx8mp-frdm: running 1 test
             test gl_padded_pbo_dst_rows_land_at_the_declared_stride ... ok
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 20 filtered out; finished in 0.92s

rpi5-hailo:  running 1 test
             test gl_padded_pbo_dst_rows_land_at_the_declared_stride ... ok
             test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 20 filtered out; finished in 0.06s
```

## Mutation checks (Task 1)

- Disabling the decline in `get_or_create_egl_image` reproduces the exact #165 ZEROS failures on imx95 while the NV12 case still passes (the two declines are independently pinned).
- Reverting the `ShaderR8` routing hunk alone reproduces the exact #166 `draw_src_texture does not support Nv12` refusal on imx95 while the RGBA case still passes.

## Preflight

- `cargo fmt --all` — clean.
- `make lint-rust` (clippy, `-D warnings`, edition 2021) — clean.
- `make lint` was **not** run as-is: it currently fails on two pre-existing `ruff` findings in `tests/interop/test_cross_package.py` (a `BLE001` blind-except and an unsorted import block) unrelated to this change, pending PR #168. Ran `ruff check tests/ crates/python-*/python` directly instead — the same two pre-existing findings, nothing new from this PR's files.
- `cargo nextest run --cargo-profile profiling --features opengl,ndarray` across the workspace (excluding the five Python leaf crates): 1622 tests run, 1620 passed, 2 failed, 16 skipped. The 2 failures are the pre-existing `test_src_rect_crop_no_bleed_gl` / `test_src_rect_crop_left_half_no_bleed_gl` software-renderer flake on this desktop's NVIDIA/Mesa stack, reproducible on a clean `main` and unrelated to this branch.

## Platform notes

macOS and Windows are not affected by these changes beyond the ANGLE leaves' existing offset refusal now also reaching the NV upload routing fix in #166 (the same failure-arm fix that benefits Mali). Nothing platform-specific to ANGLE/IOSurface/D3D11 was touched.

Closes #165
Closes #166
Closes #167
Related: #170
