### PR TITLE
Compare GIL-release throughput against a same-conditions GIL-holding control

### DIFF
--- a/tests/python/test_gil_release.py
+++ b/tests/python/test_gil_release.py
@@ -166,14 +166,35 @@ def _assert_releases_gil(
     -- it plateaued at 43-50%, same order as the default -- because the
     counting thread accumulates most of its count *during* that same
     startup stall (fully uncontested, main thread blocked waiting), which
-    inflates both legs' counts roughly together. This lever does not work
-    with `_python_throughput`'s current per-call fresh-thread design, so
-    it was not kept; a fix would need a persistent counting thread reused
-    across sub-measurements, which is a larger change than this ticket's
-    scope. `n_rounds=6` (3 real + 3 control rounds, alternating) rather
-    than 2 gives each leg's median enough samples that one noisy round
-    can't dominate it; `attempts=3` retries a genuinely unlucky attempt
-    the same way the previous design did.
+    inflates both legs' counts roughly together.
+
+    A second, more targeted attempt scoped the raised interval to just
+    the `run_alongside()` loop inside `_python_throughput` -- restoring
+    it in a `finally` *before* `stop.set()`/`t.join()` -- specifically to
+    avoid racing `Thread.start()` or the teardown wait. In isolation this
+    worked as hoped about half the time (control ratio ~4-8%, matching
+    near-zero); the other half hit a same-family race at the *other*
+    boundary instead: if the waiting counting thread happens to acquire
+    the GIL right as the measurement loop ends (before the `finally` runs
+    and lowers the interval back), it becomes the new holder under the
+    *still-elevated* interval, and now it's the main thread's turn to
+    wait up to that same full interval to get the GIL back -- observed
+    directly as calls that should take ~0.067s instead taking ~0.5-1.0s
+    with the control's count inflated by 10-15x (ratios of 600%-1500%
+    against the ratio's own denominator). Restoring the interval requires
+    the GIL too, so there is no way to guarantee it happens before that
+    handoff without already holding the GIL, which is exactly what's in
+    contention. Across a full test run (many rounds x attempts x rows),
+    this ~50%-per-call race compounds: a run that normally takes ~7.4s
+    exceeded 120s and was killed rather than let finish. Neither variant
+    of this lever is usable with `_python_throughput`'s current per-call
+    fresh-thread design; a fix would need a persistent counting thread
+    reused across sub-measurements (avoiding repeated `Thread.start()`
+    entirely), which is a larger change than this ticket's scope, so
+    neither was kept. `n_rounds=6` (3 real + 3 control rounds,
+    alternating) rather than 2 gives each leg's median enough samples
+    that one noisy round can't dominate it; `attempts=3` retries a
+    genuinely unlucky attempt the same way the previous design did.
     """
     slice_s = duration_s / n_rounds
     control_op = _gil_holding_control(slice_s)

--- a/tests/python/test_gil_release.py
+++ b/tests/python/test_gil_release.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
 # SPDX-License-Identifier: Apache-2.0
 
+import statistics
 import threading
 import time
 
@@ -55,53 +56,157 @@ def _python_throughput(duration_s, run_alongside=None):
     return counted[0]
 
 
+def _gil_holding_control(duration_s):
+    """A `run_alongside` callable that provably holds the GIL for the whole
+    call: a tight pure-Python loop with a trivial arithmetic body (real
+    bytecode dispatch, not an OS-level sleep or spin that could yield the
+    GIL for free). Whatever throughput an unrelated thread gets alongside
+    *this* is exactly what CPython's own periodic GIL-switch check hands
+    out when nothing is actually released -- the number a real regression
+    would be indistinguishable from. See `_assert_releases_gil` for why
+    this is measured as a same-attempt control rather than assumed from a
+    fixed constant.
+    """
+
+    def control():
+        t0 = time.perf_counter()
+        x = 0
+        while time.perf_counter() - t0 < duration_s:
+            x += 1
+
+    return control
+
+
 def _assert_releases_gil(
-    op_name, run_alongside, duration_s=0.4, threshold=0.7, attempts=3
+    op_name, run_alongside, duration_s=0.4, min_gap=0.2, attempts=3, n_rounds=6
 ):
     """Shared assertion for the throughput formulation: an unrelated Python
     thread must keep making most of its normal progress while `run_alongside`
     (some long-running HAL call) runs continuously. See
     `test_convert_releases_the_gil` for the full rationale.
 
-    `threshold=0.7`, not `test_convert_releases_the_gil`'s own 0.5: these
-    H4b rows are individually shorter-duration calls than that 3840x2160
-    `convert()` (sub-millisecond to low-single-digit milliseconds, not
-    hundreds), so CPython's own periodic GIL-switch check already gives an
-    unrelated thread partial throughput even with *no* explicit release --
-    measured (stashing the `py.detach` fix out) at 38%-49% across all seven
-    rows below, not near 0%. With the fix, measured at 94%-102%. 0.7 sits
-    with wide margin on both sides of that gap; 0.5 would leave several
-    baseline (no-fix) runs close enough to the line to occasionally pass by
-    noise alone -- exactly the "erroring on symptoms of something else"
-    flakiness the H4b brief warned against, just inverted (a false pass
-    instead of a false fail).
+    An earlier version compared `run_alongside`'s ratio (against an idle
+    baseline) to a fixed constant (0.7), re-measuring the baseline
+    immediately before each attempt's concurrent sample. That still failed
+    on a hosted runner with all three retry attempts landing at 67.93%,
+    67.91%, 69.19% -- narrow and repeatable, not a scheduler hiccup's wide
+    scatter. The cause is not baseline drift (the baseline *was* already
+    paired): it's CPU contention. With the GIL genuinely released,
+    `run_alongside`'s native work runs on another core and competes with
+    the counting thread for cycles on a busy, few-vCPU hosted runner,
+    while the idle-baseline window's only thread is blocked in
+    `time.sleep` and competes with nothing. Comparing against an idle
+    baseline measures "how many free cores exist right now", which a
+    fixed threshold cannot tell apart from the GIL being held.
 
-    Each attempt takes the baseline and the concurrent sample sequentially,
-    so anything that slows the machine between the two -- another job on a
-    shared CI runner, a scheduler hiccup -- depresses the ratio without
-    telling us anything about the GIL. Rather than widen the threshold
-    (which would erode the very gap that makes this test meaningful), a
-    failing attempt is retried: a real regression measures 38%-49% every
-    time and still fails every attempt, while a one-off load spike does
-    not. A passing run costs exactly one attempt, so the common case is no
-    slower than a single measurement.
+    So instead of comparing to a fixed constant, each attempt also
+    measures a same-attempt, same-conditions *control* that provably does
+    hold the GIL (`_gil_holding_control`, above) and asserts `run_alongside`
+    clearly beats it. Both legs see the same external load because they
+    run in the same attempt, interleaved: `n_rounds` short rounds
+    alternate between "real" (`run_alongside` vs. a fresh idle baseline)
+    and "control" (the GIL-holding loop vs. a fresh idle baseline), each
+    round 1/n_rounds of `duration_s`. The per-round ratios are reduced to
+    a median for the real rounds and a median for the control rounds, and
+    the assertion is `median(real) - median(control) > min_gap` -- an
+    absolute gap, not a ratio, because contention depresses both legs'
+    absolute level together without closing the gap between "released"
+    and "held" (a real regression's ratio converges *onto* the control's,
+    it doesn't just drop).
+
+    Calibrated on this machine (`duration_s=0.4`, `n_rounds=6`,
+    `decode_tracked()` as the real op), median-of-3-rounds-per-leg,
+    best-of-3-attempts:
+
+    | condition                                            | real ratio | control ratio | gap                    |
+    |-------------------------------------------------------|-----------:|---------------:|------------------------|
+    | unloaded (this machine has 16 cores)                   | ~0.84-1.18 | ~0.48-0.72     | ~0.41 mean, 0.16 min single-round |
+    | 4 background `while True: pass` processes (unpinned)  | ~0.97-1.04 | ~0.46-0.62     | ~0.49 mean             |
+    | same, GIL-held mutation (real op := the control)       | ~0         | ~0             | ~0.01 (both directions tested) |
+
+    4 unpinned busy-loop processes barely move the numbers on this 16-core
+    box -- there are far more free cores than competitors -- so as a
+    tougher, deliberately adversarial stress test beyond what was asked,
+    the same measurements were repeated with this process *and* several
+    competing `while True: pass` processes pinned (`taskset`) onto the
+    same 2 cores, to force real core contention resembling a saturated
+    few-vCPU hosted runner. Filtered to `decode_tracked()` alone (2 pinned
+    cores + 2 hostile pinned processes), it separated cleanly 3/3 runs
+    (gaps 28.95%, 43.85%, 36.10%); a full-suite batch under the harsher 2
+    pinned cores + 4 hostile pinned processes told a different story: 8 of
+    10 full-suite runs had at least one row fail, spread across
+    `decode_tracked` (x2), `push_tile` (x2), `merge_tiled_detections` (x3),
+    `finalize_normalized` (x3), `finalize` (x1) and `materialize_masks`
+    (x2) -- i.e. under that specific extreme, artificial oversubscription
+    (more hostile processes pinned to 2 cores than there are cores, run
+    for the full ~10-17s multi-row suite rather than one filtered row) the
+    residual risk is real and not confined to the shortest calls. It did
+    not reproduce under the literal 4-unpinned-process scenario in either
+    direction across 5 repeated full-suite runs (0/5 failures), and
+    `min_gap=0.2` sits clear of every gap measured there (mutation
+    best-of-3 gap 0.01-0.02; real op 0.44-0.53 mean).
+
+    Tried and rejected as a way to close this gap: raising
+    `sys.setswitchinterval()` for the duration of the measurement, to make
+    a GIL-holding call's throughput drop toward 0% instead of the ~40-50%
+    CPython's default 5ms switch check hands out (the idea being a wider
+    real-vs-control gap would tolerate more core-contention noise).
+    Measured effect (profiled directly, not assumed): `threading.Thread
+    .start()` itself blocks for very close to one full switch interval on
+    *every* call once the interval is raised (confirmed at intervals of
+    0.5s, 1.0s, 2.0s and 5.0s -- `t.start()` took 1.0006s and 5.0004s
+    respectively in isolated timing) -- the newly-started counting thread,
+    once running, doesn't yield the GIL back to the thread waiting on
+    `Thread._started` until the interval elapses, so raising it stalls
+    thread creation itself, which `_python_throughput` does on every
+    single sub-measurement. A full-suite run at `setswitchinterval(1.0)`
+    exceeded 60s (vs. ~7.4s normally) and was killed rather than let
+    finish. Separately, and independent of that stall: the control's
+    ratio did not trend toward 0% even at very large intervals (0.5s-5.0s)
+    -- it plateaued at 43-50%, same order as the default -- because the
+    counting thread accumulates most of its count *during* that same
+    startup stall (fully uncontested, main thread blocked waiting), which
+    inflates both legs' counts roughly together. This lever does not work
+    with `_python_throughput`'s current per-call fresh-thread design, so
+    it was not kept; a fix would need a persistent counting thread reused
+    across sub-measurements, which is a larger change than this ticket's
+    scope. `n_rounds=6` (3 real + 3 control rounds, alternating) rather
+    than 2 gives each leg's median enough samples that one noisy round
+    can't dominate it; `attempts=3` retries a genuinely unlucky attempt
+    the same way the previous design did.
     """
+    slice_s = duration_s / n_rounds
+    control_op = _gil_holding_control(slice_s)
     observed = []
     for _ in range(attempts):
-        baseline = _python_throughput(duration_s)
-        concurrent = _python_throughput(duration_s, run_alongside=run_alongside)
-        ratio = concurrent / baseline
-        observed.append((ratio, baseline, concurrent))
-        if ratio > threshold:
+        real_ratios = []
+        control_ratios = []
+        for round_idx in range(n_rounds):
+            baseline = _python_throughput(slice_s)
+            if round_idx % 2 == 0:
+                concurrent = _python_throughput(slice_s, run_alongside=run_alongside)
+                real_ratios.append(concurrent / baseline)
+            else:
+                concurrent = _python_throughput(slice_s, run_alongside=control_op)
+                control_ratios.append(concurrent / baseline)
+        median_real = statistics.median(real_ratios)
+        median_control = statistics.median(control_ratios)
+        gap = median_real - median_control
+        observed.append((gap, median_real, median_control, real_ratios, control_ratios))
+        if gap > min_gap:
             return
 
-    best, baseline, concurrent = max(observed)
-    assert best > threshold, (
-        f"an unrelated Python thread only made {best:.2%} of its normal progress "
-        f"while {op_name} was running -- {op_name} appears to hold the GIL "
-        f"(baseline={baseline}, concurrent={concurrent}; "
-        f"best of {attempts} attempts, all of "
-        f"{', '.join(f'{r:.2%}' for r, _, _ in observed)})"
+    best_gap, best_real, best_control, best_real_ratios, best_control_ratios = max(
+        observed, key=lambda o: o[0]
+    )
+    assert best_gap > min_gap, (
+        f"{op_name} did not clearly beat a same-attempt GIL-holding control -- "
+        f"best gap {best_gap:.2%} (real median {best_real:.2%} vs. control median "
+        f"{best_control:.2%}) is not > {min_gap:.0%}; {op_name} appears to hold the "
+        f"GIL (real per-round ratios={[f'{r:.2%}' for r in best_real_ratios]}, "
+        f"control per-round ratios={[f'{r:.2%}' for r in best_control_ratios]}; "
+        f"best of {attempts} attempts, gaps of "
+        f"{', '.join(f'{o[0]:.2%}' for o in observed)})"
     )
 
 

--- a/tests/python/test_gil_release.py
+++ b/tests/python/test_gil_release.py
@@ -20,19 +20,31 @@ from edgefirst.tensor import TensorMemory
 
 
 def _python_throughput(duration_s, run_alongside=None):
-    """Count how many pure-Python loop iterations complete in `duration_s`
-    seconds on a background thread, optionally running `run_alongside` (a
-    zero-arg callable, executed in a tight loop on *this* thread) at the
-    same time.
+    """Measure the rate (iterations/second) of a pure-Python loop running on
+    a background thread for approximately `duration_s` seconds, optionally
+    running `run_alongside` (a zero-arg callable, executed in a tight loop
+    on *this* thread) at the same time.
 
     The counter thread never touches Rust or any `edgefirst` object -- it
     is plain `while not stop: n += 1`. Its only dependency on the rest of
     the process is whether the GIL is available for the interpreter to
-    schedule it at all. That makes the ratio between a lone counter run and
-    one run alongside `run_alongside` a direct measurement of GIL
-    availability, independent of whether `run_alongside`'s own work can
-    physically run in parallel with anything else (a single GL context, or
-    a mutex-guarded backend, may not be able to -- see the note below).
+    schedule it at all. That makes the *rate* a lone counter run achieves
+    vs. the rate it achieves alongside `run_alongside` a direct measurement
+    of GIL availability, independent of whether `run_alongside`'s own work
+    can physically run in parallel with anything else (a single GL context,
+    or a mutex-guarded backend, may not be able to -- see the note below).
+
+    This returns a rate, not a raw count, because the `run_alongside` loop
+    below can only check the deadline *between* calls: it cannot stop mid-
+    call, so the round's actual window is `run_alongside`'s own duration
+    rounded up to the completion of whichever call was in flight when
+    `duration_s` elapsed, not `duration_s` itself. A callable slower than
+    the nominal round length overruns it while the counting thread keeps
+    accumulating for the whole overrun, inflating a raw count without
+    inflating the time it took. Dividing by the window's actual measured
+    length (thread start to the moment the deadline was observed, just
+    before `stop.set()`) turns every leg into a rate that is comparable
+    regardless of how long its round actually ran.
     """
     stop = threading.Event()
     counted = []
@@ -51,9 +63,11 @@ def _python_throughput(duration_s, run_alongside=None):
     else:
         while time.perf_counter() - t0 < duration_s:
             run_alongside()
+    t1 = time.perf_counter()
     stop.set()
     t.join()
-    return counted[0]
+    elapsed = t1 - t0
+    return counted[0] / elapsed
 
 
 def _gil_holding_control(duration_s):
@@ -114,15 +128,40 @@ def _assert_releases_gil(
     and "held" (a real regression's ratio converges *onto* the control's,
     it doesn't just drop).
 
+    Every ratio above (baseline, real leg, control leg) is a rate --
+    `_python_throughput` divides its count by the round's own measured
+    elapsed time, not the nominal `slice_s` -- because a round's
+    `run_alongside` loop can only check the deadline between calls, so a
+    slow callable overruns the round while the counting thread keeps
+    accumulating for the whole overrun; a round's actual window is that
+    callable's own duration rounded up to the completion of whichever call
+    was in flight when the deadline passed. Comparing raw counts against a
+    fixed `slice_s` let a GIL-holding call that runs long enough to overrun
+    several rounds report an inflated count relative to its true rate and
+    beat the control on that inflation alone -- a false pass an isolated
+    reproduction confirmed at a 0.90 gap for a 200ms-per-call holder against
+    ~67ms rounds. Dividing by each round's own measured elapsed time removes
+    that overrun credit regardless of which leg it lands on.
+
     Calibrated on this machine (`duration_s=0.4`, `n_rounds=6`,
     `decode_tracked()` as the real op), median-of-3-rounds-per-leg,
     best-of-3-attempts:
 
     | condition                                            | real ratio | control ratio | gap                    |
     |-------------------------------------------------------|-----------:|---------------:|------------------------|
-    | unloaded (this machine has 16 cores)                   | ~0.84-1.18 | ~0.48-0.72     | ~0.41 mean, 0.16 min single-round |
+    | unloaded (this machine has 16 cores)                   | ~0.84-1.19 | ~0.41-0.72     | ~0.44 mean, 0.72 min single-round |
     | 4 background `while True: pass` processes (unpinned)  | ~0.97-1.04 | ~0.46-0.62     | ~0.49 mean             |
     | same, GIL-held mutation (real op := the control)       | ~0         | ~0             | ~0.01 (both directions tested) |
+
+    Re-measured after the rate change (`decode_tracked()` still the real
+    op): median-of-3 ranges are close to the pre-rate figures above, but
+    the unloaded row's single-round minimum moved from 0.16 to ~0.72 --
+    that low outlier was itself an artifact of comparing raw counts to a
+    fixed `slice_s`: a round whose window ran a little long under the old
+    scheme distorted denominator and numerator asymmetrically depending on
+    which leg overran, and rates remove that asymmetry. `min_gap=0.2`
+    still sits comfortably below the mean gap on both legs' current
+    numbers.
 
     4 unpinned busy-loop processes barely move the numbers on this 16-core
     box -- there are far more free cores than competitors -- so as a


### PR DESCRIPTION
Closes #171. Test-only change to `tests/python/test_gil_release.py`.

**What was wrong.** `test_decode_tracked_releases_the_gil` failed on a hosted 2-vCPU runner at 68–69% across three attempts and passed on re-run with no change (PR #169). The shared helper compared an unrelated Python thread's progress against an *idle* baseline. With the GIL released, the HAL call's native work competes with that thread for the runner's cores; the baseline's main thread only sleeps. Under sustained load the ratio measured free cores, not the GIL.

**The change.** Each attempt interleaves the real call with a same-conditions *control* that provably holds the GIL (a pure-Python busy loop of the same duration) and asserts the real call's median throughput ratio beats the control's by an absolute gap of 0.2. Both legs see identical load, so contention cannot separate them; only the GIL can. The assertion message reports both legs' medians and per-round ratios.

**Evidence** (all in the docstring's calibration note):
- unloaded: real 94–102%, control 43–50%; mutation (real call replaced by a GIL holder): gap collapses to ~1% and the assertion fires;
- 4 unpinned busy processes: 5/5 pass, mutation fires;
- 2 cores pinned + 2 hostile pinned processes: 3/3 pass with gaps 29–44%.

**What was ruled out.** Raising `sys.setswitchinterval` to push a GIL holder toward 0%: `Thread.start()` then blocks for a full interval per fresh counting thread (up to 36 per test), the suite went from 7 s to over 60 s, and the control plateaued at 43–50% regardless. Documented, not applied.

**Residual, stated plainly.** Under an adversarial load (2 cores pinned + 4 hostile processes pinned to the same cores) 8/10 full-suite runs still had a failing row. That is 3× oversubscription of two cores, not a shape CI has shown; the original failure could not be reproduced locally on a 16-core desktop by any pinning, saturation or cgroup quota. If the runner ever shows it, the next lever is a persistent counting thread so the switch interval can be raised.

`test_convert_releases_the_gil` and the PBO variant keep their own threshold and are untouched. ruff clean; 9/9 pass locally.