### PR TITLE
Fail the Windows CUDA interop tests when a located runtime does not load

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -237,6 +237,7 @@ Git Bash's `/usr/bin/link.exe` shadows it):
 pwsh scripts/test-windows.ps1 -RequireGl                       # real GPU: all crates, -j 1
 pwsh scripts/test-windows.ps1 -RequireGl -p edgefirst-image    # image crate only
 pwsh scripts/test-windows.ps1 -Warp -RequireGl -p edgefirst-image   # no GPU: D3D11 WARP
+pwsh scripts/test-windows.ps1 -RequireGl -RequireCuda -p edgefirst-tensor   # real GPU + CUDA
 ```
 
 The script defaults `EDGEFIRST_ANGLE_PATH` to the fetched directory, `-Warp`
@@ -244,6 +245,28 @@ sets `EDGEFIRST_ANGLE_ADAPTER=warp` + `EDGEFIRST_ALLOW_SOFTWARE_GL=1`, and
 `-RequireGl` sets `HAL_TEST_REQUIRE_GL=1`; everything after the switches is
 passed to `cargo nextest run`. `-j 1` is forced: ANGLE takes the Full GL
 serialization policy.
+
+`-RequireCuda` sets `HAL_TEST_REQUIRE_CUDA=1`, turning a silent
+`SKIP: no CUDA runtime` in `crates/tensor/tests/d3d11_tensor.rs`'s three
+D3D11 CUDA interop tests into a failure naming the test and the reason. The
+WARP-adapter skip is unaffected — it is correct by design, and those tests
+check the adapter *before* the gate so an armed gate cannot convert it into a
+failure.
+
+The script arms the gate without the switch when the host looks like an NVIDIA
+box (`nvidia-smi` on PATH and exiting zero, or `CUDA_PATH` set), printing
+"NVIDIA driver or toolkit present: requiring CUDA coverage". Read that for what
+it is: evidence about the *host*, not about the adapter the D3D11 device is
+created on. That adapter comes from `EDGEFIRST_D3D11_ADAPTER` (or the
+`EDGEFIRST_ANGLE_ADAPTER` alias), and unset means DXGI adapter 0, which on a
+hybrid laptop can be the integrated GPU. Auto-detection is therefore suppressed
+when WARP is the selected adapter — via `-Warp` or either variable inherited
+from the shell — which prints "WARP adapter selected: not auto-requiring CUDA
+coverage". On a hybrid box whose adapter 0 is not the NVIDIA one, either name
+the NVIDIA adapter (`EDGEFIRST_D3D11_ADAPTER=discrete`, or a description
+substring such as `RTX 3070`) or pass `-NoRequireCuda`. `-RequireCuda` passed
+explicitly, and an inherited `HAL_TEST_REQUIRE_CUDA=1`, arm the gate whatever
+the adapter; `-NoRequireCuda` disarms it whatever the environment.
 
 One variable picks the adapter for both the device and ANGLE's display, since
 ANGLE builds its display on the HAL's device: `EDGEFIRST_D3D11_ADAPTER` is the
@@ -322,6 +345,16 @@ somewhere the suite never looks.
 `HAL_TEST_REQUIRE_GL=1`, and then requires a GPU-backed destination. The
 Windows `edgefirst-image` wheel bundles ANGLE when built with
 `EDGEFIRST_ANGLE_PATH` set, so an installed wheel needs no env var.
+
+Export `EDGEFIRST_ANGLE_PATH` for the `maturin build` step itself, the way
+`scripts/test-windows.ps1` sets it for the cargo runs — `crates/python-image/build.rs`
+reads it at build time and ships the wheel CPU-only when it is unset. A wheel
+built without it fails seven of the gpu-marked tests with
+`create_image() yielded TensorMemory.MEM on Windows with HAL_TEST_REQUIRE_GL=1`,
+since nothing in the wheel supplies ANGLE and the runtime fallback has no
+`EDGEFIRST_ANGLE_PATH` to fall back to. The build says which it did: look for
+the `bundling ANGLE (libEGL.dll, libGLESv2.dll)` cargo warning, or check the
+installed package for `edgefirst/image/libEGL.dll`.
 
 One asymmetry to know when writing a test: after a Python `convert`,
 `convert_deferred` or `convert_with_fence`, the destination's
@@ -1173,7 +1206,7 @@ Tests run across multiple runner types:
 | Build & Test (macOS) | `macos-latest` | arm64 (Apple Silicon) | Paravirtual Metal GPU (ANGLE; Full GL serialization policy) |
 | Build & Link (iOS) | `macos-latest` | arm64 | No runtime tests — build + link closure only |
 | Build & Link (Android) | `ubuntu-22.04` | x86_64 host | No runtime tests — see Device Farm section below |
-| Build & Test (Windows) | `windows-latest` | x86_64 | Rust tests with GL self-skipping (gating) and image-crate GL tests on ANGLE Direct3D 11 WARP (software; best-effort), both under cargo-llvm-cov into one LCOV (`coverage-windows` → SonarCloud); C-API leaf tests and gpu pytest on WARP (best-effort). Real-GPU runs are local: `scripts/test-windows.ps1 -RequireGl` |
+| Build & Test (Windows) | `windows-latest` | x86_64 | Rust tests with GL self-skipping (gating) and image-crate GL tests on ANGLE Direct3D 11 WARP (software; best-effort), both under cargo-llvm-cov into one LCOV (`coverage-windows` → SonarCloud); C-API leaf tests and gpu pytest on WARP (best-effort). Real-GPU runs are local: `scripts/test-windows.ps1 -RequireGl -RequireCuda` |
 | Software-GL Coverage (llvmpipe) | `ubuntu-22.04-xlarge` | x86_64 | Mesa llvmpipe (software GL) |
 | Build (aarch64) | `ubuntu-22.04-arm-xlarge` | aarch64 | No GPU (compile only) |
 | Test (aarch64) | `ubuntu-22.04-arm` | aarch64 | No GPU |

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -114,7 +114,11 @@ opt-in every skip inside those tests — no runtime, no GL, no F32 render
 support, a destination that didn't land on a PBO, `cuda_map()` returning
 `None` — is a failure instead of a pass. `crates/image/src/gl/cuda_policy.rs`
 is the shared guard; a developer machine without CUDA still sees ordinary
-skips, since the opt-in is unset there.
+skips, since the opt-in is unset there. The Windows counterpart is
+`crates/tensor/tests/d3d11_tensor.rs`'s three D3D11 CUDA interop tests,
+gated the same way under `HAL_TEST_REQUIRE_CUDA=1` via
+`scripts/test-windows.ps1 -RequireCuda` — see
+[`crates/tensor/TESTING.md § Windows D3D11 CUDA interop tests`](https://github.com/EdgeFirstAI/hal/blob/main/crates/tensor/TESTING.md#windows-d3d11-cuda-interop-tests).
 
 The `test_opengl_*` integration tests in `src/lib.rs` (resize, grey,
 src/dst crop, the rotation × flip × backing matrix, 10-thread bring-up,

--- a/crates/tensor/TESTING.md
+++ b/crates/tensor/TESTING.md
@@ -170,6 +170,29 @@ To exercise just the CUDA tests by name:
 cargo test -p edgefirst-tensor cuda -- --test-threads=1
 ```
 
+### Windows D3D11 CUDA interop tests
+
+`crates/tensor/tests/d3d11_tensor.rs` (Windows-only, `feature = "static"`)
+has three tests exercising CUDA's external-memory import of a D3D11 texture
+tensor (`cuda_map_matches_the_cpu_map_and_map_mut_writes_back`,
+`cuda_map_covers_a_texture_whose_allocation_the_driver_padded`,
+`cuda_map_reads_the_nv12_combined_plane`). Each self-skips on the WARP
+adapter (`cudaD3D11GetDevice` has no ordinal for it — that skip is correct by
+design), and then when `edgefirst_tensor::is_cuda_available()` is false. The
+order matters: the WARP skip is a property of the adapter that no runtime can
+satisfy, so checking it first keeps it a skip even under the gate below.
+
+`crates/tensor/tests/support/cuda_require.rs` is the guard, mirroring
+`crates/image/src/gl/cuda_policy.rs`: under `HAL_TEST_REQUIRE_CUDA=1` (set by
+`scripts/test-windows.ps1 -RequireCuda`, which also arms it from NVIDIA host
+detection unless WARP is the selected adapter) a "no CUDA runtime" skip fails
+instead of passing, naming the test and the reason. Its pure decision core,
+`decide`, is covered platform-generically — so on this box and every CI lane,
+not just Windows — by `crates/tensor/tests/cuda_require_policy.rs`, which is
+not Windows-gated and which `#[path]`-includes this same support module rather
+than copying it, so the tests pin the function `d3d11_tensor.rs` actually
+calls.
+
 ### On-target validation
 
 On-target tests require a CUDA-capable device with `libcudart.so` present.

--- a/crates/tensor/tests/cuda_require_policy.rs
+++ b/crates/tensor/tests/cuda_require_policy.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Platform-generic coverage of `decide`, the pure decision core in
+//! `crates/tensor/tests/support/cuda_require.rs` that gates the three D3D11
+//! CUDA interop tests in `crates/tensor/tests/d3d11_tensor.rs` (Windows-only)
+//! under `HAL_TEST_REQUIRE_CUDA=1`.
+//!
+//! The support module is `#[path]`-included here rather than copied, so these
+//! tests pin the function the Windows guard actually calls: the policy cannot
+//! regress in `d3d11_tensor.rs` while this file stays green. `decide` itself
+//! has no OS dependency -- it is a plain function of two bools and two
+//! strings -- so this file is not Windows-gated, and every lane (this Linux
+//! box included, where `d3d11_tensor.rs` compiles to nothing) exercises it.
+
+/// The Windows guard's own module, included whole so the tests below run
+/// against the shipped `decide` and not a copy of it. `cuda_available_or_skip`
+/// has no caller here -- it reads the environment and probes for a CUDA
+/// runtime, which is what makes it unsuitable as a unit under test -- hence
+/// the `dead_code` allowance, which is scoped to this include and leaves
+/// `d3d11_tensor.rs`'s copy of the module linted as usual.
+#[path = "support/cuda_require.rs"]
+#[allow(dead_code)]
+mod cuda_require;
+
+use cuda_require::decide;
+
+/// Satisfied and required: runs, no assertion, no output.
+#[test]
+fn satisfied_and_required_runs() {
+    assert!(decide(true, true, "what", "why"));
+}
+
+/// Satisfied and not required: runs regardless of the opt-in.
+#[test]
+fn satisfied_and_not_required_runs() {
+    assert!(decide(true, false, "what", "why"));
+}
+
+/// Unsatisfied and not required: an ordinary skip -- lanes without CUDA
+/// (this box included) must stay green.
+#[test]
+fn unsatisfied_and_not_required_is_an_ordinary_skip() {
+    assert!(!decide(false, false, "what", "why"));
+}
+
+/// Unsatisfied and required: a failure, not a skip. The panic message must
+/// name the opt-in plus both the caller (`what`) and the reason (`why`), so
+/// a CI failure is self-explanatory without extra digging. This never
+/// touches `HAL_TEST_REQUIRE_CUDA` itself -- `decide` takes `require` as a
+/// plain bool -- so the test means the same thing on every host and needs
+/// no env save/restore.
+#[test]
+fn unsatisfied_and_required_panics_naming_the_opt_in_what_and_why() {
+    // The panic itself is the point of this test. Silence the default
+    // hook's "thread '...' panicked at ..." stderr line while we provoke
+    // it, so this test's own output -- and the lane's output as a whole --
+    // stays pristine; restore the previous hook immediately after so it
+    // never leaks into any other test.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let caught = std::panic::catch_unwind(|| decide(false, true, "probe", "some reason"));
+    std::panic::set_hook(prev_hook);
+
+    let payload = caught.expect_err("a required-but-absent precondition must panic, not skip");
+    let message = payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .expect("panic payload should be a string");
+    assert!(
+        message.contains("HAL_TEST_REQUIRE_CUDA=1"),
+        "panic message must name the opt-in: {message}"
+    );
+    assert!(
+        message.contains("probe"),
+        "panic message must name the caller: {message}"
+    );
+    assert!(
+        message.contains("some reason"),
+        "panic message must name the reason: {message}"
+    );
+}

--- a/crates/tensor/tests/d3d11_tensor.rs
+++ b/crates/tensor/tests/d3d11_tensor.rs
@@ -11,6 +11,31 @@ use edgefirst_tensor::{
 };
 use std::os::windows::io::AsRawHandle;
 
+#[path = "support/cuda_require.rs"]
+mod cuda_require;
+
+/// The WARP exclusion for the three CUDA interop tests, printing
+/// `SKIP {what}: ...` and returning `true` when the caller must return early.
+///
+/// `cudaD3D11GetDevice` has no ordinal for the WARP adapter, so no amount of
+/// working CUDA runtime can give a WARP device a CUDA import: the skip is a
+/// property of the adapter, not a missing precondition, and it is deliberately
+/// checked *before* `cuda_require::cuda_available_or_skip`. Ordered the other
+/// way, a WARP run with `HAL_TEST_REQUIRE_CUDA=1` (which
+/// `scripts/test-windows.ps1` can arm from host detection alone) would panic
+/// on the absent runtime before reaching this skip, contradicting the
+/// documented promise that the WARP path is unaffected by the gate.
+///
+/// A failure to create the device at all is not treated as WARP: that host has
+/// no D3D11 at all, and the CUDA gate below is the one that should speak.
+fn warp_has_no_cuda_device(what: &str) -> bool {
+    let warp = edgefirst_tensor::d3d11::device().is_ok_and(|d| d.is_warp());
+    if warp {
+        eprintln!("SKIP {what}: WARP adapter has no CUDA device");
+    }
+    warp
+}
+
 #[test]
 fn image_with_dmabuf_on_windows_is_a_texture_tensor() {
     if !edgefirst_tensor::is_gpu_buffer_available() {
@@ -431,17 +456,14 @@ fn copy_rows(dst: &mut [u8], src: &[u8], row_bytes: usize, dst_stride: usize) {
 /// into the texture when the guard drops.
 #[test]
 fn cuda_map_matches_the_cpu_map_and_map_mut_writes_back() {
-    if !edgefirst_tensor::is_cuda_available() {
-        eprintln!("SKIP: no CUDA runtime");
+    if warp_has_no_cuda_device("cuda_map_matches_the_cpu_map_and_map_mut_writes_back") {
+        return;
+    }
+    if !cuda_require::cuda_available_or_skip("cuda_map_matches_the_cpu_map_and_map_mut_writes_back")
+    {
         return;
     }
     let device = edgefirst_tensor::d3d11::device().unwrap();
-    if device.is_warp() {
-        // `cudaD3D11GetDevice` has no ordinal for the WARP adapter, so the
-        // import fails and the tensor is CUDA-less by design.
-        eprintln!("SKIP: WARP adapter has no CUDA device");
-        return;
-    }
     let t = Tensor::<u8>::image(
         256,
         128,
@@ -509,12 +531,12 @@ fn cuda_map_matches_the_cpu_map_and_map_mut_writes_back() {
 /// 256x128 is one it accepts, so only this test covers the fallback).
 #[test]
 fn cuda_map_covers_a_texture_whose_allocation_the_driver_padded() {
-    if !edgefirst_tensor::is_cuda_available() {
-        eprintln!("SKIP: no CUDA runtime");
+    if warp_has_no_cuda_device("cuda_map_covers_a_texture_whose_allocation_the_driver_padded") {
         return;
     }
-    if edgefirst_tensor::d3d11::device().unwrap().is_warp() {
-        eprintln!("SKIP: WARP adapter has no CUDA device");
+    if !cuda_require::cuda_available_or_skip(
+        "cuda_map_covers_a_texture_whose_allocation_the_driver_padded",
+    ) {
         return;
     }
     let (w, h) = (640usize, 480usize);
@@ -556,12 +578,10 @@ fn cuda_map_covers_a_texture_whose_allocation_the_driver_padded() {
 /// laid out identically and the whole plane round-trips byte for byte.
 #[test]
 fn cuda_map_reads_the_nv12_combined_plane() {
-    if !edgefirst_tensor::is_cuda_available() {
-        eprintln!("SKIP: no CUDA runtime");
+    if warp_has_no_cuda_device("cuda_map_reads_the_nv12_combined_plane") {
         return;
     }
-    if edgefirst_tensor::d3d11::device().unwrap().is_warp() {
-        eprintln!("SKIP: WARP adapter has no CUDA device");
+    if !cuda_require::cuda_available_or_skip("cuda_map_reads_the_nv12_combined_plane") {
         return;
     }
     let (w, h) = (640usize, 480usize);

--- a/crates/tensor/tests/support/cuda_require.rs
+++ b/crates/tensor/tests/support/cuda_require.rs
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! CUDA test policy for the D3D11 interop tests: a skip must not be able to
+//! masquerade as coverage.
+//!
+//! `d3d11_tensor.rs`'s CUDA tests used to return early whenever
+//! `edgefirst_tensor::is_cuda_available()` was false, printing
+//! `SKIP: no CUDA runtime` and reporting `ok`. On an NVIDIA Windows box
+//! whose runtime soname `cuda.rs`'s probe does not recognise (or that is
+//! simply not on `PATH`/`CUDA_PATH\bin`), that is indistinguishable from
+//! real coverage -- the same vacuity PR #168 closed on Linux for
+//! `crates/image/src/gl/cuda_policy.rs`. `HAL_TEST_REQUIRE_CUDA=1` turns
+//! that skip into a failure naming the test and the reason, and
+//! `scripts/test-windows.ps1 -RequireCuda` sets it whenever an NVIDIA
+//! adapter is present, so the lane cannot silently stop testing again.
+//!
+//! The WARP-adapter skip (`cudaD3D11GetDevice` has no ordinal for WARP) is
+//! correct by design and does not go through this module. Its callers test
+//! for it *before* calling in here, so an armed gate cannot turn that skip
+//! into a failure -- see `d3d11_tensor.rs`'s `warp_has_no_cuda_device`.
+//!
+//! [`decide`] is the pure core, and it is `pub` so this module can be
+//! `#[path]`-included by `crates/tensor/tests/cuda_require_policy.rs` as
+//! well as by `d3d11_tensor.rs`. Integration tests are separate compilation
+//! units, so that include is the sharing mechanism: the policy tests cover
+//! the very function the Windows guard calls, on every lane -- the Linux
+//! ones included, where `d3d11_tensor.rs` compiles to nothing -- rather
+//! than a copy that could drift from it.
+//! [`cuda_available_or_skip`] is the one env-reading, printing caller
+//! `d3d11_tensor.rs` uses.
+
+/// `true` when `HAL_TEST_REQUIRE_CUDA=1` is set -- the opt-in that turns a
+/// quiet skip into a visible failure.
+fn required() -> bool {
+    std::env::var("HAL_TEST_REQUIRE_CUDA").as_deref() == Ok("1")
+}
+
+/// The pure decision: `true` when `satisfied`; otherwise a failure or a skip
+/// depending on `require`. No environment access and no output -- the
+/// caller reads `HAL_TEST_REQUIRE_CUDA` and passes the result in as
+/// `require`, and prints the `SKIP` line itself on a `false` return. That
+/// purity is what lets `crates/tensor/tests/cuda_require_policy.rs` test
+/// this exact function on hosts with no CUDA and no D3D11.
+///
+/// # Panics
+///
+/// When `require` is `true` and `satisfied` is `false` -- the opt-in that
+/// turns "quietly skipped" into a visible failure. The panic message names
+/// `HAL_TEST_REQUIRE_CUDA=1`, `what`, and `why`.
+pub fn decide(satisfied: bool, require: bool, what: &str, why: &str) -> bool {
+    if satisfied {
+        return true;
+    }
+    assert!(
+        !require,
+        "HAL_TEST_REQUIRE_CUDA=1 but {what} would have skipped while \
+         reporting success: {why}"
+    );
+    false
+}
+
+/// `true` when the caller should run; `false` when it should return early.
+/// Prints `SKIP {what}: {why}` to stderr on a `false` return.
+///
+/// # Panics
+///
+/// When `HAL_TEST_REQUIRE_CUDA=1` and CUDA is unavailable -- see [`decide`].
+pub fn cuda_available_or_skip(what: &str) -> bool {
+    let why = "no CUDA runtime (a supported soname missing from cuda.rs's \
+         probe list -- cudart64_13.dll, cudart64_12.dll, cudart64_110.dll -- \
+         or it is not on PATH or CUDA_PATH\\bin)";
+    let run = decide(edgefirst_tensor::is_cuda_available(), required(), what, why);
+    if !run {
+        eprintln!("SKIP {what}: {why}");
+    }
+    run
+}

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -20,10 +20,39 @@
 .PARAMETER Warp
   Use ANGLE's D3D11 WARP (software) adapter: sets EDGEFIRST_ANGLE_ADAPTER=warp
   and EDGEFIRST_ALLOW_SOFTWARE_GL=1 (the backend rejects software renderers
-  otherwise). For CI runners and machines without a GPU.
+  otherwise). For CI runners and machines without a GPU. Also suppresses the
+  -RequireCuda auto-detection below: WARP has no CUDA device, so a host
+  signal must not require CUDA coverage of it.
 .PARAMETER RequireGl
   Set HAL_TEST_REQUIRE_GL=1 so a GL backend that fails to come up fails the
   run (the `gl_backend_available_canary` test) instead of silently skipping.
+.PARAMETER RequireCuda
+  Set HAL_TEST_REQUIRE_CUDA=1 so the D3D11 CUDA interop tests in
+  crates/tensor/tests/d3d11_tensor.rs fail loudly, naming the test and the
+  reason, instead of printing `SKIP: no CUDA runtime` when the probe in
+  crates/tensor/src/cuda.rs cannot load a runtime. The WARP-adapter skip
+  (no CUDA device on the software adapter) is correct by design and is
+  unaffected: those tests check the adapter before the gate.
+
+  Auto-set when the *host* looks like an NVIDIA box -- `nvidia-smi` on PATH
+  and exiting zero, or CUDA_PATH set -- so a real NVIDIA box requires CUDA
+  coverage even without passing this switch. Note what those two signals do
+  and do not say: they establish that an NVIDIA driver or toolkit is
+  installed, not that the D3D11 device will be created on that adapter.
+  The adapter is chosen by EDGEFIRST_D3D11_ADAPTER (or its
+  EDGEFIRST_ANGLE_ADAPTER alias), and unset means DXGI adapter 0, which on a
+  hybrid laptop can be the integrated GPU -- see
+  crates/tensor/src/d3d11/adapter.rs. So auto-detection is suppressed when
+  WARP is the selected adapter, by -Warp or by either variable inherited
+  from the shell; on a hybrid box where adapter 0 is not the NVIDIA one,
+  name it (EDGEFIRST_D3D11_ADAPTER=discrete, or a description substring such
+  as 'RTX 3070') or pass -NoRequireCuda. Passing -RequireCuda explicitly
+  always arms the gate, whatever the adapter.
+.PARAMETER NoRequireCuda
+  Suppress the NVIDIA-adapter auto-detection for -RequireCuda above, leaving
+  HAL_TEST_REQUIRE_CUDA unset even when an NVIDIA adapter is present. Clears
+  the variable if the calling shell already exported it, so this switch
+  disarms the gate whatever the environment says.
 .PARAMETER Release
   Build tests with --release.
 .PARAMETER Coverage
@@ -35,7 +64,7 @@
   SonarCloud. Needs `rustup component add llvm-tools-preview` and
   `cargo install cargo-llvm-cov --locked`.
 .NOTES
-  Everything after the three switches is passed to `cargo nextest run`
+  Everything after the named switches is passed to `cargo nextest run`
   (e.g. `-p edgefirst-image -E 'test(~pbo)'`) via the automatic `$args`.
   Not an advanced script (no [CmdletBinding()] and no [Parameter()]
   attributes): either would add PowerShell's common parameters and make
@@ -45,10 +74,13 @@
   pwsh scripts/test-windows.ps1 -RequireGl                 # real GPU
   pwsh scripts/test-windows.ps1 -Warp -RequireGl -p edgefirst-image
   pwsh scripts/test-windows.ps1 -Coverage -Warp -RequireGl -p edgefirst-image --profile ci
+  pwsh scripts/test-windows.ps1 -RequireGl -RequireCuda    # real GPU + CUDA coverage required
 #>
 param(
     [switch]$Warp,
     [switch]$RequireGl,
+    [switch]$RequireCuda,
+    [switch]$NoRequireCuda,
     [switch]$Release,
     [switch]$Coverage
 )
@@ -68,6 +100,55 @@ if ($Warp) {
     $env:EDGEFIRST_ALLOW_SOFTWARE_GL = '1'
 }
 if ($RequireGl) { $env:HAL_TEST_REQUIRE_GL = '1' }
+
+# Which adapter the D3D11 device will actually be created on, resolved by the
+# same rule as crates/tensor/src/d3d11/adapter.rs: EDGEFIRST_D3D11_ADAPTER is
+# the current name and EDGEFIRST_ANGLE_ADAPTER the alias it wins over. -Warp
+# set the alias above, so this catches both the switch and a value inherited
+# from the calling shell.
+$adapterSel = if ($env:EDGEFIRST_D3D11_ADAPTER) {
+    $env:EDGEFIRST_D3D11_ADAPTER
+} else {
+    $env:EDGEFIRST_ANGLE_ADAPTER
+}
+$warpSelected = (
+    $null -ne $adapterSel -and
+    $adapterSel.Trim().ToLowerInvariant() -in @('warp', 'software')
+)
+
+# An NVIDIA host without -RequireCuda used to let the D3D11 CUDA interop tests
+# skip silently -- the same vacuity -RequireGl closes for GL. Detect it the
+# simplest robust way available from PowerShell: `nvidia-smi` on PATH and
+# exiting zero (works even if the box has no CUDA *toolkit*, just the driver),
+# or CUDA_PATH set (the toolkit installer's own marker). Both describe the
+# host; neither says which adapter the D3D11 device lands on, so do not arm
+# the gate when WARP is the selected adapter -- an NVIDIA box run under -Warp
+# is exactly the combination where a host signal would require CUDA coverage
+# of a device that can never have it.
+if (-not $NoRequireCuda -and -not $RequireCuda -and -not $warpSelected) {
+    $nvidiaSmi = Get-Command nvidia-smi -ErrorAction Ignore
+    $nvidiaPresent = $false
+    if ($nvidiaSmi) {
+        & nvidia-smi | Out-Null
+        if ($LASTEXITCODE -eq 0) { $nvidiaPresent = $true }
+    }
+    if ($env:CUDA_PATH) { $nvidiaPresent = $true }
+    if ($nvidiaPresent) {
+        Write-Host 'NVIDIA driver or toolkit present: requiring CUDA coverage'
+        $RequireCuda = $true
+    }
+}
+# The switches decide, not the calling shell. HAL_TEST_REQUIRE_CUDA is
+# exported to the nextest child, so an inherited value would otherwise
+# survive -NoRequireCuda and contradict the banner below: clear it when the
+# gate is off, and treat an inherited `1` as arming when nothing suppresses
+# it so the banner reports what the tests will actually see.
+if (-not $NoRequireCuda -and $env:HAL_TEST_REQUIRE_CUDA -eq '1') { $RequireCuda = $true }
+if ($warpSelected -and -not $RequireCuda) {
+    Write-Host 'WARP adapter selected: not auto-requiring CUDA coverage'
+}
+$env:HAL_TEST_REQUIRE_CUDA = if ($RequireCuda) { '1' } else { $null }
+
 if (-not (Get-Command cargo -ErrorAction Ignore)) {
     throw 'cargo not found on PATH'
 }
@@ -97,7 +178,7 @@ $profile = @(); if ($Release) { $profile = @('--release') }
 $scope = @('--workspace') + $exclude
 if ($NextestArgs -match '^(-p|--package)(=.*)?$') { $scope = @() }
 
-Write-Host "[test-windows] EDGEFIRST_ANGLE_PATH=$env:EDGEFIRST_ANGLE_PATH adapter=$($env:EDGEFIRST_ANGLE_ADAPTER ?? 'default') require_gl=$([bool]$RequireGl) coverage=$([bool]$Coverage)"
+Write-Host "[test-windows] EDGEFIRST_ANGLE_PATH=$env:EDGEFIRST_ANGLE_PATH adapter=$($env:EDGEFIRST_ANGLE_ADAPTER ?? 'default') require_gl=$([bool]$RequireGl) require_cuda=$([bool]$RequireCuda) coverage=$([bool]$Coverage)"
 Set-Location $root
 if ($Coverage) {
     # --no-report leaves the profraw under target\llvm-cov-target so several


### PR DESCRIPTION
Closes #172 once the hardware run below is green.

**What was wrong.** `crates/tensor/tests/d3d11_tensor.rs`'s three CUDA/D3D11 interop tests returned early with `SKIP: no CUDA runtime` whenever `is_cuda_available()` was false, so on an NVIDIA Windows box a runtime the probe failed to load made the lane report `ok` while testing nothing — the same vacuity PR #168 closed on Linux. The WARP skip (no CUDA device on the software adapter) is correct by design and is unchanged.

**The change.**
- A tensor-crate test-support helper (`tests/support/cuda_require.rs`) with the same pure `decide` shape as `crates/image/src/gl/cuda_policy.rs`: under `HAL_TEST_REQUIRE_CUDA=1` a "no CUDA runtime" skip becomes a failure naming the test; otherwise an ordinary `SKIP` line from the wrapper only. The three sites route through it. The policy itself is pinned by a platform-generic integration test (`tests/cuda_require_policy.rs`, 4 tests, runs on Linux and in CI).
- `scripts/test-windows.ps1` gains `-RequireCuda` (sets `HAL_TEST_REQUIRE_CUDA=1`) and auto-arms it when an NVIDIA adapter is detected (`nvidia-smi` on PATH exiting 0, or `CUDA_PATH` set); `-NoRequireCuda` suppresses the auto-detection. Documented in the script's help block, the root `TESTING.md`, and the tensor/image crates' `TESTING.md`.

**Verification so far (Linux, cross-compiled).** `cargo check` and `cargo clippy -D warnings` for `x86_64-pc-windows-gnu` clean; `make lint-rust` clean; the policy tests pass here. PowerShell cannot run on the build host; the script was read twice against the existing `-RequireGl` pattern.

**Hardware verification (pending, on the NVIDIA Windows box).** `pwsh scripts/test-windows.ps1 -RequireGl -RequireCuda` must execute the three CUDA tests with no SKIP; a mutation (renaming the probe's DLL candidates) must fail all three with the `HAL_TEST_REQUIRE_CUDA=1` diagnostic; then the full 0.31.0 suite and the wheel GPU pytest on the real adapter. The transcript gets posted here as a comment.
