### PR TITLE
Keep an unaligned DMA-BUF source zero-copy via an aligned base and ROI fold

### DIFF
--- a/.github/scripts/generate_junit_xml.py
+++ b/.github/scripts/generate_junit_xml.py
@@ -8,23 +8,88 @@ Usage:
     python scripts/generate_junit_xml.py build/rust-test-results build/rust_hardware_results.xml
 """
 
+import argparse
 import glob
 import os
 import re
 import sys
 from datetime import datetime
 
+# libtest's per-binary summary, one per suite run in the file:
+#   "test result: ok. 29 passed; 2 failed; 3 ignored; 0 measured; 515 filtered out"
+SUMMARY_RE = re.compile(
+    r'test result: (?:ok|FAILED)\. (\d+) passed; (\d+) failed; (\d+) ignored'
+)
 
-def generate_junit_xml(results_dir: str, output_file: str) -> None:
+# The start of a single test's line: "test some::name ... ".
+# `test result: ok.` cannot match: after the name it needs a literal " ... ".
+TEST_START_RE = re.compile(r'^test ([\w:]+) \.\.\. ?', re.M)
+
+# A verdict, either immediately after the "... " or at the start of a later
+# line. With --test-threads=1 libtest prints "test NAME ... ", then the test
+# runs and its own log output lands on the same stream, then the verdict is
+# printed. So the verdict can be many lines below the name it belongs to.
+VERDICT_RE = re.compile(r'(?:\A|^)(ok|FAILED|ignored)\b', re.M)
+
+# Boundaries that a verdict search must never run past.
+STOP_RE = re.compile(r'^(?:test result:|failures:|running \d+ tests?)', re.M)
+
+
+def _parse_tests(content: str, test_binary: str) -> list:
+    """Extract one entry per `test NAME ... VERDICT`, tolerating log noise.
+
+    The naive single-line pattern `test ([\\w:]+) \\.\\.\\. (ok|FAILED|ignored)`
+    silently drops every test that logs between its name and its verdict,
+    which on the hardware lane is most of the GL suite. Here the name and the
+    verdict are matched separately and paired by position, with the search
+    for a verdict bounded by the next test's name or the suite summary so a
+    test that produces no verdict at all (a process abort mid-run) cannot
+    steal the next test's.
+    """
+    starts = list(TEST_START_RE.finditer(content))
+    tests = []
+    for i, start in enumerate(starts):
+        window_end = starts[i + 1].start() if i + 1 < len(starts) else len(content)
+        window = content[start.end():window_end]
+        stop = STOP_RE.search(window)
+        if stop:
+            window = window[:stop.start()]
+        verdict = VERDICT_RE.search(window)
+        if verdict is None:
+            # No verdict before the next test or the summary: the test did
+            # not report (e.g. the process died inside it). Counted by the
+            # summary line if libtest got far enough to print one; not
+            # inventable here, so it is left out of the testcase list rather
+            # than guessed at.
+            continue
+        tests.append({
+            'name': start.group(1),
+            'classname': test_binary,
+            'status': verdict.group(1),
+            'time': '0.001',
+        })
+    return tests
+
+
+def generate_junit_xml(results_dir: str, output_file: str, min_tests: int = 0) -> int:
     """Parse Rust test output files and generate JUnit XML.
 
     Args:
         results_dir: Directory containing test output .txt files
         output_file: Path to write the JUnit XML output
+        min_tests: Minimum number of executed tests (passed + failed, summed
+            from the per-binary `test result:` summary lines) the run must
+            report. When the executed count is below this floor, an
+            `::error::` is printed and a non-zero status is returned, after
+            the XML has still been written.
+
+    Returns:
+        0 on success, 1 if the executed count is below `min_tests`.
     """
     tests = []
     total_passed = 0
     total_failed = 0
+    total_ignored = 0
 
     if not os.path.exists(results_dir):
         print(f"No results directory: {results_dir}")
@@ -32,37 +97,32 @@ def generate_junit_xml(results_dir: str, output_file: str) -> None:
         with open(output_file, 'w') as f:
             f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
             f.write('<testsuites name="rust-hardware" tests="0" failures="0" errors="0"></testsuites>\n')
-        return
+        if min_tests > 0:
+            print(f"::error::junit reports 0 executed tests, floor is {min_tests}")
+            return 1
+        return 0
 
     for txt_file in glob.glob(f"{results_dir}/*.txt"):
         test_binary = os.path.basename(txt_file).replace('.txt', '')
         with open(txt_file, 'r') as f:
             content = f.read()
 
-        # Parse test result line: "test result: ok. X passed; Y failed; Z ignored"
-        match = re.search(
-            r'test result: (ok|FAILED)\. (\d+) passed; (\d+) failed; (\d+) ignored',
-            content
-        )
-        if match:
-            passed = int(match.group(2))
-            failed = int(match.group(3))
-            total_passed += passed
-            total_failed += failed
+        # Every summary line in the file, not just the first: one output file
+        # can hold more than one suite.
+        summaries = list(SUMMARY_RE.finditer(content))
+        if not summaries:
+            continue
+        for summary in summaries:
+            total_passed += int(summary.group(1))
+            total_failed += int(summary.group(2))
+            total_ignored += int(summary.group(3))
 
-            # Parse individual test lines: "test name ... ok/FAILED"
-            for test_match in re.finditer(
-                r'test ([\w:]+) \.\.\. (ok|FAILED|ignored)',
-                content
-            ):
-                test_name = test_match.group(1)
-                test_status = test_match.group(2)
-                tests.append({
-                    'name': test_name,
-                    'classname': test_binary,
-                    'status': test_status,
-                    'time': '0.001'
-                })
+        tests.extend(_parse_tests(content, test_binary))
+
+    # The authoritative count of tests that actually ran. It comes from
+    # libtest's own summary lines, so unlike a per-test scrape it cannot move
+    # when a test becomes more or less chatty.
+    executed = total_passed + total_failed
 
     # Generate JUnit XML
     timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
@@ -84,20 +144,42 @@ def generate_junit_xml(results_dir: str, output_file: str) -> None:
         f.write('  </testsuite>\n')
         f.write('</testsuites>\n')
 
-    print(f"Generated {output_file} with {len(tests)} tests "
-          f"({total_passed} passed, {total_failed} failed)")
+    print(f"Generated {output_file} with {executed} executed tests "
+          f"({total_passed} passed, {total_failed} failed, "
+          f"{total_ignored} ignored), {len(tests)} named test cases")
+
+    # The testcase list is a scrape and the summaries are authoritative, so
+    # say so when they disagree instead of letting the smaller number pass
+    # for the truth.
+    named_expected = executed + total_ignored
+    if len(tests) != named_expected:
+        print(f"::warning::named {len(tests)} test cases but the summary lines "
+              f"report {named_expected} (passed + failed + ignored); the "
+              f"executed-count floor uses the summary lines")
+
+    if executed < min_tests:
+        print(f"::error::junit reports {executed} executed tests, floor is {min_tests}")
+        return 1
+    return 0
 
 
 def main() -> int:
-    if len(sys.argv) < 3:
-        print("Usage: generate_junit_xml.py <results_dir> <output_file>")
-        return 1
+    parser = argparse.ArgumentParser(
+        description="Generate JUnit XML from Rust test output files."
+    )
+    parser.add_argument("results_dir", help="Directory containing test output .txt files")
+    parser.add_argument("output_file", help="Path to write the JUnit XML output")
+    parser.add_argument(
+        "--min-tests",
+        type=int,
+        default=0,
+        help="Minimum number of executed tests (passed + failed, summed from "
+             "the per-binary summary lines) the run must report "
+             "(default: 0, i.e. no floor)",
+    )
+    args = parser.parse_args()
 
-    results_dir = sys.argv[1]
-    output_file = sys.argv[2]
-
-    generate_junit_xml(results_dir, output_file)
-    return 0
+    return generate_junit_xml(args.results_dir, args.output_file, args.min_tests)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,39 @@ jobs:
       - name: Checkout LFS objects
         run: git lfs checkout
 
+      - name: Merge per-crate testdata into the shared testdata/ tree
+        run: |
+          # Every `crates/<name>/testdata/` (currently only
+          # `crates/decoder/testdata/infer/`) merges into the top-level
+          # `testdata/` tree uploaded below, so every job that downloads the
+          # `testdata-lfs` artifact -- rather than doing its own full LFS
+          # checkout -- gets crate-local fixtures too, at the same relative
+          # path `EDGEFIRST_TESTDATA_DIR`-aware fixture loaders resolve
+          # against (see e.g. `infer.rs`'s `infer_fixture_dir()`, and
+          # `scripts/on-target-test.sh`'s testdata sync, which merges the
+          # same way). A second `path:` entry on the upload step below would
+          # do this too, but `upload-artifact` strips only the paths' least
+          # common ancestor, which for `testdata/` and
+          # `crates/decoder/testdata/` is the repo root -- every job that
+          # downloads this artifact expecting a bare `testdata/` layout
+          # would break.
+          for dir in crates/*/testdata; do
+            [ -d "${dir}" ] || continue
+            # `cp -a` silently overwrites on a name collision (with the
+            # root testdata/ tree, or with an earlier crate merged this
+            # same loop) -- checked file by file before copying so a
+            # collision fails the step loudly, naming the exact path,
+            # instead of one crate's fixture silently replacing another's.
+            while IFS= read -r -d '' f; do
+              rel="${f#"${dir}"/}"
+              if [ -e "testdata/${rel}" ]; then
+                echo "::error::${dir}/${rel} collides with an existing testdata/${rel}"
+                exit 1
+              fi
+            done < <(find "${dir}" -type f -print0)
+            cp -a "${dir}/." testdata/
+          done
+
       - name: Upload testdata as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -1729,7 +1762,14 @@ jobs:
 
       - name: Generate JUnit XML from Rust results
         if: always()
-        run: python3 .github/scripts/generate_junit_xml.py build/rust-test-results build/rust_runner_results.xml
+        run: |
+          # Executed tests (passed + failed) summed from libtest's summary
+          # lines. Run 34435075152 reported 1669 passed / 0 failed here, so
+          # 1000 keeps a wide margin; it guards against a collapse toward
+          # zero, not against small movement.
+          python3 .github/scripts/generate_junit_xml.py \
+            build/rust-test-results build/rust_runner_results.xml \
+            --min-tests 1000
 
       - name: Process Rust coverage
         if: always()
@@ -1919,7 +1959,10 @@ jobs:
           # Only run tests that exercise hardware (G2D, OpenGL/EGL, DMA).
           # CPU-only tests already run on the ubuntu-22.04-arm-xlarge runner.
           mkdir -p build/rust-test-results build/profraw
-          chmod +x hardware-test-binaries/* 2>/dev/null || true
+          # The artifact round trip does not preserve the executable bit, so
+          # every binary arrives 0644 and the `[[ -x ]]` guard below skips it.
+          # This MUST name the same directory the loop iterates.
+          chmod +x hardware-test-binaries-stripped/*
           TEST_FAILED=0
 
           run_filtered() {
@@ -1930,6 +1973,31 @@ jobs:
             EXIT_CODE=0
             local logfile="build/rust-test-results/${test_name}-${label// /-}.txt"
             "$test_bin" "$filter" --test-threads=1 2>&1 | tee "$logfile" || EXIT_CODE=$?
+            if [ $EXIT_CODE -ne 0 ]; then
+              # Check if all tests actually passed but process crashed on
+              # exit (Vivante GPU driver SIGABRT during library unload)
+              if grep -q 'test result: ok' "$logfile" && \
+                 ! grep -q 'FAILED' "$logfile"; then
+                echo "::warning::$test_name ($label) exited with code $EXIT_CODE (likely GPU driver crash during shutdown) but all tests passed"
+              else
+                echo "FAILED: $test_name ($label)"
+                TEST_FAILED=1
+              fi
+            fi
+          }
+
+          run_unfiltered() {
+            # Same as run_filtered but without a substring filter: used for
+            # the crates/image/tests/*.rs integration binaries below, which
+            # are each a single dedicated whole-binary GL test rather than a
+            # multi-category lib test binary split by g2d/opengl/dma filter.
+            local test_bin="$1" label="$2"
+            local test_name
+            test_name=$(basename "$test_bin")
+            echo "=== Running $test_name ($label) ==="
+            EXIT_CODE=0
+            local logfile="build/rust-test-results/${test_name}-${label// /-}.txt"
+            "$test_bin" --test-threads=1 2>&1 | tee "$logfile" || EXIT_CODE=$?
             if [ $EXIT_CODE -ne 0 ]; then
               # Check if all tests actually passed but process crashed on
               # exit (Vivante GPU driver SIGABRT during library unload)
@@ -1956,15 +2024,94 @@ jobs:
             elif [[ "$test_name" == edgefirst_tensor-* ]]; then
               # DMA-heap tensor tests only
               run_filtered "$test_bin" dma "DMA tests"
+            elif [[ "$test_name" == dst_view_stride-* || "$test_name" == offset_nv_source_upload-* || \
+                    "$test_name" == offset_source_view_alignment-* || "$test_name" == gl_concurrent_stress-* || \
+                    "$test_name" == reconstructed_view_convert-* || "$test_name" == pin_convert-* || \
+                    "$test_name" == crop_golden-* || "$test_name" == mask_golden-* || "$test_name" == odd_dim_cpu-* ]]; then
+              # crates/image/tests/*.rs GL integration binaries: whole-binary
+              # GPU/EGL tests, run unfiltered (no g2d/opengl/dma split).
+              run_unfiltered "$test_bin" "GL integration test"
+            elif [[ "$test_name" == pin-* || "$test_name" == protocol-* || \
+                    "$test_name" == protocol_roundtrip-* || "$test_name" == dynamic_primitives-* || \
+                    "$test_name" == identity-* || "$test_name" == vocabulary-* ]]; then
+              # crates/tensor/tests/*.rs DMA-BUF-touching integration
+              # binaries: whole-binary tests, run unfiltered, same reasoning
+              # as the crates/image/tests/*.rs branch above. `dynamic_
+              # primitives-*` is `#![cfg(feature = "dynamic")]`-gated and
+              # this artifact is built with default features only (no
+              # `dynamic`), so it currently runs zero tests here -- routed
+              # anyway rather than silently left in the skip branch, so it
+              # picks up coverage for free the day this crate's hardware
+              # build gains that feature.
+              run_unfiltered "$test_bin" "tensor integration test"
+            elif [[ "$test_name" == reconstructed_planar_dst-* || "$test_name" == reconstructed_view_draw-* ]]; then
+              # These two compile to a zero-test binary on this Linux
+              # runner: `reconstructed_planar_dst.rs` is
+              # `#![cfg(all(any(target_os = "macos", target_os = "ios"),
+              # feature = "opengl"))]` and `reconstructed_view_draw.rs` is
+              # `#![cfg(all(any(target_os = "macos", target_os = "ios",
+              # target_os = "windows"), feature = "opengl"))]` -- neither
+              # cfg includes linux, so running them here is a guaranteed
+              # "0 tests" no-op, not coverage. Every other routed binary in
+              # the branches above was checked the same way and has no such
+              # gate (or, for `offset_nv_source_upload`/
+              # `offset_source_view_alignment`, includes linux).
+              echo "=== Skipping $test_name (compiles to 0 tests on linux: macOS/iOS/Windows-only) ==="
             else
+              # What actually lands in hardware-test-binaries-stripped/ is
+              # NOT scoped to edgefirst-image/edgefirst-tensor: this job's
+              # earlier "Build runner test binaries" step (`cargo nextest
+              # run --no-run --workspace --exclude <the six python-*
+              # crates>`) and this step both run under the SAME
+              # `CARGO_TARGET_DIR=target/llvm-cov-target` (`source
+              # /tmp/coverage-env.sh` in both), so the `find
+              # target/llvm-cov-target/profiling/deps/ -type f -executable`
+              # above -- which has no package filter -- copies every
+              # lib-test and integration-test binary the workspace build
+              # produced, not just the two packages this step explicitly
+              # names. So this branch actually sees: edgefirst-codec,
+              # edgefirst-decoder, edgefirst-tracker, edgefirst-bench,
+              # edgefirst-egl, edgefirst-gl, edgefirst-gpu-probe,
+              # edgefirst-tensor-abi, edgefirst-decoder-abi,
+              # edgefirst-tensor-ffi, and the five -capi crates' own
+              # lib-test binaries (and edgefirst-tensor's non-DMA
+              # `crates/tensor/tests/*.rs`: logical_shape, map_access,
+              # no_global_state, scenarios, plus `d3d11_tensor` --
+              # `#![cfg(target_os = "windows")]`-gated, empty here
+              # regardless of routing). None of these exercise the GPU/DMA
+              # hardware this lane exists for; they are already covered by
+              # `Test (aarch64)`, which runs the full `--workspace` set on
+              # real hardware. The fourteen `edgefirst-image`
+              # `[[bench]]` targets (image_benchmark, ...) are NOT here:
+              # every one is `harness = false` with no explicit
+              # `test = true`, so cargo's default (`test = false` for a
+              # bench target) means nextest never builds them as test
+              # binaries in the first place -- there is nothing from them
+              # to skip.
               echo "=== Skipping $test_name (CPU-only, covered by aarch64 runner) ==="
             fi
           done
+          ran=$(find build/rust-test-results -maxdepth 1 -name '*.txt' | wc -l)
+          if [ "$ran" -eq 0 ]; then
+            echo "::error::imx8mp hardware lane executed 0 test binaries"
+            exit 1
+          fi
           [ $TEST_FAILED -eq 0 ] || exit 1
 
       - name: Generate JUnit XML from Rust results
         if: always()
-        run: python3 .github/scripts/generate_junit_xml.py build/rust-test-results build/rust_hardware_results.xml
+        run: |
+          # Floor set from the lane's first real runs after the chmod fix
+          # (runs 34472605256 and 34477168418, identical): the 36 summary
+          # lines sum to 752 passed + 5 failed = 757 executed, so the floor is
+          # 757 - 15% rounded down. It counts executed tests from libtest's
+          # own summary lines, so it does not move when a test becomes more or
+          # less chatty. Raise it deliberately when the suite grows; it exists
+          # to catch a silent collapse toward zero, not to track the exact
+          # count.
+          python3 .github/scripts/generate_junit_xml.py \
+            build/rust-test-results build/rust_hardware_results.xml \
+            --min-tests 643
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Bright highlights rendered as black on Cortex-A53 CPU conversion.** Any
+  NV12/NV16/NV24 → RGB(A) convert on a core without the ARMv8.1 `rdm` feature
+  — Cortex-A53/A35-class, which includes the i.MX8MP — takes the `yuv` crate's
+  `Fast` kernel, and that kernel accumulates each channel in a non-saturating
+  signed 16-bit lane. Super-white luma (above the limited-range white point
+  235) combined with strong chroma pushes the accumulator past `i16::MAX`; it
+  wraps negative and the final saturating narrow emits 0, so the brightest
+  pixel in a frame comes out black instead of clipping to white. Decoded video
+  reaches that range routinely — a specular highlight is enough.
+
+  `cpu/convert.rs` now caps luma at the white point before the fast kernel, on
+  that path only. The plane is scanned with a vectorized chunked max-reduction
+  and copied only when the frame really carries super-white luma, so an
+  in-range frame keeps byte-identical output and pays 8% (6.06 → 6.56
+  ns/pixel, 1920×1080 NV12 → RGBA on an i.MX8MP); a frame that would otherwise
+  be wrong pays 26%. Clipping super-white is an approximation bounded at ~23
+  levels, against the 255 the unguarded kernel got wrong, and 235 is
+  limited-range white so a conforming frame never reaches it. The exact
+  alternative, running the accurate kernel on these cores, costs ~2× on every
+  frame. Full range and the accurate kernel are untouched — neither can
+  overflow.
+
+  Exposed by the G2D odd-dimension tests (`d01_nv12_odd_w_g2d_vs_cpu`,
+  `d03_nv12_odd_both_g2d_vs_cpu`), which had never run in CI and failed at
+  `max_diff=255` on the imx8mp lane's first execution in four months. The
+  divergence was the CPU *reference*, not G2D: G2D was correct throughout, and
+  the residual against a correct reference is 23–24 across widths 63–81, well
+  inside the tests' existing bound. Upstream `yuv` 0.8.17 does not fix the
+  kernel.
+
 - **BREAKING (Python interop): the tensor capsule now carries quantization,
   and is renamed `edgefirst_tensor_v2`.** An int8 `ProtoData` produced by
   `edgefirst.decoder` could not be used by `edgefirst.image` at all:
@@ -174,8 +204,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   import at such an offset, uploading the window through `map()` instead;
   destinations are unaffected (a view imports its parent at offset 0).
   Pinned by `offset_source_view_alignment.rs` on imx95, imx8mp and rpi5.
-  Zero-copy for those views (an aligned base with the remainder folded into
-  the sampling rectangle) is follow-up #170. (#165)
+  Those views are zero-copy again as of #170: the import starts at the
+  64-byte-aligned base below the offset, widened by the remainder in pixels,
+  and the engine folds that shift into the sampling rectangle. (#165, #170)
 - **A refused zero-copy NV source ended on the CPU.** When the R8 import of
   an NV12/16/24 source was declined — the ANGLE leaves' offset refusal, or
   the Mali rule above — the engine fell to `draw_src_texture`, which has no
@@ -264,6 +295,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and leaves the map window intact rather than accepting the call and
   reading the wrong bytes.
 
+- **The imx8mp hardware lane executed zero Rust tests, silently, since
+  2026-05-14 (`a87ae59c`).** The artifact-restoring `chmod +x` named
+  `hardware-test-binaries/`, a directory the artifact stopped shipping the
+  day that commit switched to `hardware-test-binaries-stripped/`; the glob
+  matched nothing, the error was swallowed by `2>/dev/null || true`, and
+  every binary then failed the loop's `[[ -x ]]` guard in complete silence
+  -- no `=== Running`, no `=== Skipping`, and the JUnit generator reported
+  `tests="0"` with nothing downstream asserting a floor. Four months of a
+  green-but-empty gate. Fixed by naming the directory the loop actually
+  iterates, dropping the error suppression so a real mismatch fails loudly
+  instead of vanishing, and adding a zero-tests guard plus a `--min-tests`
+  floor on the generated JUnit XML (also applied to the aarch64 runner's
+  identical step). The lane now also runs 15 integration binaries
+  (`crates/image/tests/*.rs`'s GL binaries and `crates/tensor/tests/*.rs`'s
+  DMA-BUF-touching ones) that previously fell into a CPU-only skip branch
+  unconditionally, and every crate's `testdata/` (not just the repository
+  root's) is shipped to the boards and to CI's own testdata artifact, so
+  fixtures under a crate-local `testdata/` directory reach on-target runs
+  the same way root-level fixtures already did. The JUnit generator now
+  counts executed tests from libtest's own `test result:` summary lines
+  rather than from a per-test regex that could not span a test's interleaved
+  log output: on the lane's first real run that regex named 574 of the 778
+  cases the summaries account for, so the floor moved with logging verbosity
+  as much as with test count. Both the reported count and the floor are now
+  the summary-line total (757 executed on that run), and the recovered cases
+  appear in the XML.
+- **A hardware-gated test that returned early after `eprintln!`-ing its
+  skip reason reported bare `ok`, indistinguishable from having actually
+  run.** libtest captures `println!`/`eprintln!` and replays it only for a
+  *failing* test, so the reason was silently discarded on every passing
+  skip -- both locally and on the boards. Every such site across
+  `edgefirst-image`, `edgefirst-tensor`, `edgefirst-codec`, and
+  `edgefirst-decoder` now writes `SKIPPED: <reason>` directly to stderr,
+  bypassing libtest's capture hook, so `scripts/on-target-test.sh`'s
+  per-board skip count (and a human reading captured CI logs) can actually
+  see it.
+- **Cross-building `edgefirst-tensor`'s `dynamic` backend test lane for a
+  board needed a hand-rolled `RUSTFLAGS`.** `crates/tensor/build.rs`'s
+  `dynamic-test-link` feature hardcoded a link-search path relative to this
+  crate's own manifest directory, which is wrong for any cross (`--target`)
+  build. It now honours `EDGEFIRST_TENSOR_LIB_DIR` when set and otherwise
+  derives the search path from `OUT_DIR`, matching whatever `target/
+  <profile>` or `target/<target-triple>/<profile>` layout the actual build
+  used.
+- **`test_merge_tiled_detections_releases_the_gil`'s 20% gap floor failed
+  on a two-vCPU hosted CI runner** that measured a real, repeatable ~17-19%
+  gap for a short CPU-bound op -- a headroom shortfall on that runner, not
+  a regression (a GIL-holding mutation still measures a gap near 0% under
+  the same harness). Lowered to 10%, which still discriminates a genuine
+  hold from a genuine release by roughly an order of magnitude.
+
 ### Changed
 
 - **`Tensor::as_pbo()` is removed** (Rust API; pre-1.0, so removed rather
@@ -283,6 +365,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returned a capsule whose descriptor carried a host address in the field
   consumers read as the PBO op-vtable pointer. The `access=None` form, which
   is what `convert` uses, is unaffected.
+
+- **A packed DMA-BUF source at an unaligned plane offset is zero-copy again.**
+  Where 0.31.0 declined such a source on Mali and uploaded it through `map()`,
+  the GL engine now imports it from the largest 64-byte-aligned base a whole
+  number of pixels below the offset — `lcm(64, bpp)`, so RGB steps by 192 —
+  widens the import by the remainder in texels at the same pitch, and folds
+  the shift into the sampling rectangle through the new
+  `GlPlatform::import_origin`, beside the extent it already folded. Aligned
+  offsets are untouched. RGBA/BGRA/RGB/Grey sources only: NV's combined-plane
+  R8 import has no room to widen (its pitch is its width) and keeps the upload,
+  YUYV carries a two-pixel macropixel phase, and destinations are unchanged.
+  The two external-OES camera programs gained the sample clamp the `sampler2D`
+  ones already had. Pinned on imx95 (Mali), imx8mp (Vivante) and rpi5 (V3D) by
+  `offset_source_view_alignment.rs`, which now asserts the route was an import
+  and not an upload. (#170)
+
+- **The Mali offset gate asks about the offset the import will present.** A
+  gate keyed on the pixel format alone would exempt sources the rebase cannot
+  actually move — a 64-wide RGBA window into a tight 256-byte pitch, whose
+  widened row would run past the pitch, and a 100-wide RGB surface whose
+  64-byte-padded 320-byte stride puts a view at byte 323, which is not a whole
+  number of pixels — and both would then import unaligned on Mali and sample
+  zeros silently, where 0.31.0 declined and uploaded. `resolve_source_plane0`
+  is now the one place the decision lives: the import is built from it and the
+  gate reads the same function, held together by a test that asserts the two
+  agree over five real DMA shapes. (#170)
+
+- **A clamped sample coordinate is computed at `highp`.** The `tc` varying
+  defaulted to `mediump`, which was harmless while it only reached
+  `texture()`; routing it through the new `clamp()` put it on Mali's fp16 ALU,
+  quantizing the coordinate to about 0.625 texel at 1280 wide, which `LINEAR`
+  then smeared across the whole frame (max_diff 50 on i.MX 95, flat, not an
+  edge artifact). Every shader that computes on `tc` declares it `highp`,
+  including two that predate this change, pinned by name — not by count — in
+  `mod tc_precision`. The rule tracks the name `tc`; a sample coordinate under
+  another name needs its own recorded decision. (#170)
+
+- `scripts/on-target-test.sh` takes a `FEATURES` variable, applied to the test
+  build only. Feature-gated tests such as the `dma_test_formats` DMA-BUF import
+  suite otherwise never ran on a board, although CI's hardware lane builds
+  them; `FEATURES=edgefirst-image/dma_test_formats` is what verified this
+  change's gated tests on the three boards. See TESTING.md.
 
 - A malformed quantization descriptor in a tensor capsule is now reported
   rather than silently treated as "no quantization". Conflating the two is

--- a/TESTING.md
+++ b/TESTING.md
@@ -689,6 +689,15 @@ Two details worth knowing:
   because the Vivante driver has an intermittent double-free that otherwise
   masquerades as a regression in whatever you just changed. The workaround
   keys off the hardware, so it applies to any Vivante board.
+- **Feature-gated tests need `FEATURES`.** The script builds the test crates
+  with their default features, so a test behind a cargo feature never runs on
+  a board unless you ask for it. `FEATURES=edgefirst-image/dma_test_formats`
+  reaches the DMA-BUF import suite, which CI's hardware lane builds and this
+  script did not; spell a feature that is not shared by every selected package
+  as `<pkg>/<feature>`, which is what cargo requires with more than one `-p`.
+  It applies to the test build only, not to the C-API leaves. `g2d_test_formats`
+  is imx8mp-only, so enabling it across a mixed set of boards lights up tests
+  the others cannot serve.
 
 ### What a given board can actually exercise
 
@@ -741,6 +750,29 @@ ssh imx95-frdm 'cd /tmp/hal-tests && EDGEFIRST_TESTDATA_DIR=$(pwd)/testdata ./<b
 
 The `python-*` crates are excluded from cross-builds — PyO3 requires a
 target Python installation.
+
+**Cross-compiling the `dynamic` backend's tests** (`dynamic_primitives`,
+`protocol_roundtrip`, and the rest of `make test-tensor-dynamic`'s
+`DYNAMIC_TEST_TARGETS`) needs one more step: these link against
+`libedgefirst_tensor.so`, cross-built from `crates/tensor-capi`, not the
+plain `edgefirst-tensor` rlib. `crates/tensor/build.rs`'s
+`dynamic-test-link` feature honours `EDGEFIRST_TENSOR_LIB_DIR` when set,
+otherwise it derives the search path from `OUT_DIR` (the
+`target/<target-triple>/<profile>` layout `cargo-zigbuild` itself produces)
+— so cross-building this lane no longer needs a hand-rolled `RUSTFLAGS`:
+
+```bash
+cargo-zigbuild build --target aarch64-unknown-linux-gnu.2.35 \
+  --manifest-path crates/tensor-capi/Cargo.toml --target-dir target
+cargo-zigbuild test --target aarch64-unknown-linux-gnu.2.35 --no-run \
+  -p edgefirst-tensor --no-default-features --features dynamic,dynamic-test-link,ndarray \
+  --test dynamic_primitives
+```
+
+Set `EDGEFIRST_TENSOR_LIB_DIR` to the directory containing
+`libedgefirst_tensor.so` only when the producer build landed somewhere the
+derived path can't find on its own (a different `--target-dir`, or a `.so`
+fetched from elsewhere).
 
 CI automates this flow in
 [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml).

--- a/crates/codec/src/jpeg/idct/avx2.rs
+++ b/crates/codec/src/jpeg/idct/avx2.rs
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_random_strided() {
         if !is_x86_feature_detected!("avx2") {
-            eprintln!("AVX2 not available, skipping");
+            crate::test_support::report_skip("AVX2 not available");
             return;
         }
         const STRIDE: usize = 24;

--- a/crates/codec/src/jpeg/idct/fast.rs
+++ b/crates/codec/src/jpeg/idct/fast.rs
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn fast_neon_matches_fast_scalar_exactly() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut quant = [0u16; 64];

--- a/crates/codec/src/jpeg/idct/neon.rs
+++ b/crates/codec/src/jpeg/idct/neon.rs
@@ -693,7 +693,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         // Default coefficients live in rows 0–3 / cols 0–3: exercises both
@@ -705,7 +705,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_row0_only() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = [0i16; 64];
@@ -724,7 +724,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_left_dc_right_ac() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = [0i16; 64];
@@ -740,7 +740,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_right_half_coeffs() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = make_test_coeffs();
@@ -755,7 +755,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_bottom_row_coeffs() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = make_test_coeffs();
@@ -769,7 +769,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_dense() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = make_test_coeffs();
@@ -783,7 +783,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_with_quant() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut quant = [0u16; 64];
@@ -802,7 +802,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_zero_block() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         assert_parity(&[0i16; 64], &UNIT_QUANT, "zero-block");
@@ -811,7 +811,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_strided() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
 
@@ -845,7 +845,7 @@ mod tests {
     #[test]
     fn idct_8x8_k_tiers_match_scalar() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut quant = [0u16; 64];
@@ -893,7 +893,7 @@ mod tests {
     #[test]
     fn idct_dc_only_parity() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
 

--- a/crates/codec/src/jpeg/v4l2/mod.rs
+++ b/crates/codec/src/jpeg/v4l2/mod.rs
@@ -2013,7 +2013,7 @@ mod tests {
         // SAFETY: mplane variant.
         let cap_fmt = *unsafe { gfmt.pix_mp() };
         if cap_fmt.num_planes != 1 {
-            eprintln!("  capture is not single-plane; skipping");
+            crate::test_support::report_skip("capture is not single-plane");
             return None;
         }
         let sizeimage = cap_fmt.plane_fmt[0].sizeimage as usize;

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -54,6 +54,8 @@ mod options;
 mod pixel;
 #[cfg(feature = "png")]
 mod png;
+#[cfg(test)]
+mod test_support;
 mod traits;
 
 pub use decoder::{peek_info, ChromaUpsample, DctMethod, ImageDecoder};

--- a/crates/codec/src/test_support.rs
+++ b/crates/codec/src/test_support.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test-only helper for reporting a skipped test so the report
+//! survives libtest's output capture.
+//!
+//! `eprintln!`/`println!` route through `std::io::_eprint`/`_print`, which
+//! libtest hooks to capture per-test output and replay it only for a
+//! *failing* test. A hardware- or CPU-feature-gated test that returns
+//! early after printing its reason with `eprintln!` therefore reports `ok`
+//! with the reason silently discarded -- indistinguishable from having
+//! actually exercised the code, both locally (`cargo test` without
+//! `--nocapture`) and in CI. Writing directly to `std::io::stderr()`
+//! bypasses that hook, so the `SKIPPED: ...` line survives capture in both
+//! directions; `scripts/on-target-test.sh` greps captured logs for the
+//! literal string `SKIPPED` to report a skip count per board.
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it.
+#[cfg(test)]
+pub(crate) fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}

--- a/crates/decoder/src/infer.rs
+++ b/crates/decoder/src/infer.rs
@@ -1047,6 +1047,26 @@ pub fn infer_ultralytics_schema(signals: &ModelSignals) -> Result<InferredSchema
 mod tests {
     use super::*;
 
+    /// Root of the `testdata/infer` fixture directory.
+    ///
+    /// `EDGEFIRST_TESTDATA_DIR` wins when set -- `scripts/on-target-test.sh`
+    /// and CI both mirror `crates/decoder/testdata/infer` into
+    /// `$EDGEFIRST_TESTDATA_DIR/infer` (see `on-target-test.sh`'s testdata
+    /// sync and `.github/workflows/test.yml`'s "Upload testdata as
+    /// artifact" step). The manifest-relative fallback is baked in at
+    /// **compile** time, so a cross-compiled binary carries the build
+    /// host's absolute path and can never find fixtures on a different
+    /// target -- same reasoning as `decoder_from_edgefirst_json.rs`'s
+    /// `testdata_root()`.
+    fn infer_fixture_dir() -> std::path::PathBuf {
+        std::env::var("EDGEFIRST_TESTDATA_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata")
+            })
+            .join("infer")
+    }
+
     #[test]
     fn parse_names_python_dict_repr() {
         let s = "{0: 'person', 1: 'bicycle', 2: \"fire hydrant\"}";
@@ -1152,12 +1172,9 @@ mod tests {
     /// regardless of whether the source was ONNX (flat props) or TFLite
     /// (single `metadata.json` envelope entry).
     fn load_fixture_metadata(name: &str) -> BTreeMap<String, String> {
-        let path = format!(
-            "{}/testdata/infer/{name}.signals.json",
-            env!("CARGO_MANIFEST_DIR")
-        );
+        let path = infer_fixture_dir().join(format!("{name}.signals.json"));
         let content = std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"));
+            .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
         let json: serde_json::Value =
             serde_json::from_str(&content).expect("fixture is valid JSON");
         json["metadata"]
@@ -1199,12 +1216,9 @@ mod tests {
     /// inference runtime would report it: tensor names/shapes/dtypes plus
     /// the raw metadata map.
     fn signals_from_fixture(name: &str) -> ModelSignals {
-        let path = format!(
-            "{}/testdata/infer/{name}.signals.json",
-            env!("CARGO_MANIFEST_DIR")
-        );
+        let path = infer_fixture_dir().join(format!("{name}.signals.json"));
         let content = std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"));
+            .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
         let json: serde_json::Value =
             serde_json::from_str(&content).expect("fixture is valid JSON");
 
@@ -2162,9 +2176,9 @@ mod tests {
         // Without this, a fixture can be added (or renamed) and silently
         // never asserted on -- which is exactly how `yolo11n-seg` and
         // `yolov8n-seg_int8` ended up with no field-level coverage.
-        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata/infer");
-        let mut on_disk: Vec<String> = std::fs::read_dir(dir)
-            .expect("testdata/infer exists")
+        let dir = infer_fixture_dir();
+        let mut on_disk: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("{} exists: {e}", dir.display()))
             .filter_map(|e| {
                 let name = e.ok()?.file_name().into_string().ok()?;
                 name.strip_suffix(".signals.json").map(str::to_string)

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -85,6 +85,8 @@ pub use infer::{
 
 mod decoder;
 pub use decoder::*;
+#[cfg(test)]
+mod test_support;
 
 // The detection vocabulary lives in edgefirst-tensor so edgefirst-image can
 // render from it without depending on this crate. Re-exported here so the

--- a/crates/decoder/src/per_scale/kernels/neon_baseline.rs
+++ b/crates/decoder/src/per_scale/kernels/neon_baseline.rs
@@ -2097,7 +2097,9 @@ mod tests {
     #[test]
     fn expf_neon_f32x8_via_f16_matches_libm_relative() {
         if !fp16_supported() {
-            eprintln!("fp16 not supported on this CPU; skipping FP16 expf parity test");
+            crate::test_support::report_skip(
+                "fp16 not supported on this CPU (FP16 expf parity test)",
+            );
             return;
         }
         // f16 polynomial expf has ~1% relative error in exp(r) — wider
@@ -2142,7 +2144,7 @@ mod tests {
     #[test]
     fn sigmoid_slice_f32_neon_fp16_matches_scalar() {
         if !fp16_supported() {
-            eprintln!("fp16 not supported; skipping");
+            crate::test_support::report_skip("fp16 not supported");
             return;
         }
         // 32 elements: 4 chunks of 8, no tail.
@@ -2168,7 +2170,7 @@ mod tests {
     #[test]
     fn softmax_neon_fp16_matches_scalar() {
         if !fp16_supported() {
-            eprintln!("fp16 not supported; skipping");
+            crate::test_support::report_skip("fp16 not supported");
             return;
         }
         // 16 elements: 2 chunks of 8, exact reg_max boundary.

--- a/crates/decoder/src/test_support.rs
+++ b/crates/decoder/src/test_support.rs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test-only helper for reporting a skipped test so the report
+//! survives libtest's output capture.
+//!
+//! `eprintln!`/`println!` route through `std::io::_eprint`/`_print`, which
+//! libtest hooks to capture per-test output and replay it only for a
+//! *failing* test. A hardware- or CPU-feature-gated test that returns
+//! early after printing its reason with `eprintln!` therefore reports `ok`
+//! with the reason silently discarded -- indistinguishable from having
+//! actually exercised the code, both locally (`cargo test` without
+//! `--nocapture`) and in CI. Writing directly to `std::io::stderr()`
+//! bypasses that hook, so the `SKIPPED: ...` line survives capture in both
+//! directions; `scripts/on-target-test.sh` greps captured logs for the
+//! literal string `SKIPPED` to report a skip count per board.
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it.
+///
+/// `cfg(target_arch = "aarch64")`, not just `cfg(test)`: this crate's only
+/// call site today is `per_scale/kernels/neon_baseline.rs`, whose module
+/// declaration in `per_scale/kernels/mod.rs` carries an outer
+/// `#[cfg(target_arch = "aarch64")]` (NEON kernels have no other target),
+/// so the file compiles only on aarch64. An unconditional `pub(crate) fn`
+/// here would be dead code on x86_64 and fail a `-D warnings` build there.
+/// Widen this if a non-aarch64 caller is ever added.
+#[cfg(all(test, target_arch = "aarch64"))]
+pub(crate) fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}

--- a/crates/decoder/tests/infer_builder.rs
+++ b/crates/decoder/tests/infer_builder.rs
@@ -15,21 +15,35 @@ use edgefirst_decoder::schema::{DType, SchemaV2};
 use edgefirst_decoder::DecoderBuilder;
 use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
 
-/// Loads a captured Task-0 fixture into `ModelSignals`, exactly as the
-/// inference runtime would report it: tensor names/shapes/dtypes plus the
-/// raw metadata map.
+/// Root of the `testdata/infer` fixture directory.
+///
+/// `EDGEFIRST_TESTDATA_DIR` wins when set -- `scripts/on-target-test.sh`
+/// and CI both mirror `crates/decoder/testdata/infer` into
+/// `$EDGEFIRST_TESTDATA_DIR/infer` (see `on-target-test.sh`'s testdata sync
+/// and `.github/workflows/test.yml`'s "Upload testdata as artifact" step).
+/// The manifest-relative fallback is baked in at **compile** time, so a
+/// cross-compiled binary carries the build host's absolute path and can
+/// never find fixtures on a different target -- same reasoning as
+/// `decoder_from_edgefirst_json.rs`'s `testdata_root()`.
 ///
 /// Copied from `infer.rs`'s unit-test module rather than shared: this is a
 /// separate integration-test crate, and reusing a `#[cfg(test)]`-only
 /// helper across crates would force a public (non-test) API just for test
 /// convenience.
+fn infer_fixture_dir() -> std::path::PathBuf {
+    std::env::var("EDGEFIRST_TESTDATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata"))
+        .join("infer")
+}
+
+/// Loads a captured Task-0 fixture into `ModelSignals`, exactly as the
+/// inference runtime would report it: tensor names/shapes/dtypes plus the
+/// raw metadata map.
 fn signals_from_fixture(name: &str) -> ModelSignals {
-    let path = format!(
-        "{}/testdata/infer/{name}.signals.json",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let path = infer_fixture_dir().join(format!("{name}.signals.json"));
     let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"));
+        .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
     let json: serde_json::Value = serde_json::from_str(&content).expect("fixture is valid JSON");
 
     let source = match json["source"]

--- a/crates/decoder/tests/per_scale_parity.rs
+++ b/crates/decoder/tests/per_scale_parity.rs
@@ -682,9 +682,8 @@ fn parity_yolov8n_seg_per_scale_int8() {
         .join("per_scale")
         .join("yolov8n_seg_per_scale_int8.tflite");
     if !model.exists() {
-        eprintln!(
-            "skipping: real-model fixture not present at {model:?} — \
-                   contact validator team for the binary"
+        skip_note!(
+            "real-model fixture not present at {model:?} — contact validator team for the binary"
         );
         return;
     }

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -305,15 +305,64 @@ samples zeros from a source whose `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is not
 256-byte pitch, against 64/256/2048 which sample correctly; #165). V3D was
 measured on the same offsets and imports every one correctly; Tegra/Orin is
 unmeasured, having no DMA heap to build a DMA-BUF source on.
-`mali_rejects_import_offset` declines a *source* import at such an offset in
-both `get_or_create_egl_image` and `get_or_create_nv_r8_egl_image`, and the
-caller uploads the window through `map()` instead. Every plane offset the
-import passes to EGL is checked, not only plane 0: a contiguous two-plane
-NV12 import derives plane 1 as `plane0_offset + pitch * height`
+A source no longer meets that offset. `DmaImportAttrs::from_tensor` imports a
+packed source from the largest 64-byte-aligned base a whole number of pixels
+below its plane offset — the step is `lcm(64, bpp)`, so RGB walks back by 192
+and not 64, because a 64-byte floor lands mid-pixel for a 3-byte texel — and
+widens the import by that remainder in texels at the unchanged pitch. The
+tensor's pixel `(x, y)` is then import texel `(x + x_shift_px, y)`, and
+`GlPlatform::import_origin` carries the shift to the engine, which folds it
+into the sampling rectangle beside the extent it already folded
+(`render::ImportMap`, and the same `scale_roi_to_import` /
+`scale_uv_rect_to_import` / `sample_clamp_rect` the Windows pool-narrowing case
+uses). The rebase runs on every driver rather than only Mali, so the path is
+exercised wherever an unaligned source runs; an aligned offset yields a zero
+shift and is bit-identical to before. Two declines remain: an offset that is
+not a whole number of pixels (a 64-byte-padded pitch need not be a multiple of
+3) and a widened row that would run past the pitch (`rebase_fits_pitch`).
+
+`mali_rejects_import_offset` therefore now guards only the imports the rebase
+could not move, and it is asked about the offset the import will actually
+present rather than the one the tensor carries. `resolve_source_plane0` is the
+single answer both sides read: `from_tensor` builds the import from it, and the
+gate reads the same function through `source_import_plane0_offset`, so an
+exemption keyed on the format alone cannot wave through a shape the rebase
+declined — a 64-wide RGBA window into a tight 256-byte pitch, or a 100-wide RGB
+surface whose 320-byte stride puts a view at byte 323. Both of those reach Mali
+unaligned if the gate guesses, and both sample zeros silently; the two sides are
+held together by `the_gate_reads_the_offset_the_import_presents`, which asserts
+the resolver's answer equals the `plane0_offset` `from_tensor` actually puts in
+the import over five real DMA shapes.
+
+NV is the format that matters among the ones the rebase never covers: the
+combined-plane R8 import's pitch **is** its width (`tex_width`), so widening it
+would overlap every row with the next, and the alternative of a uniform shift
+makes the shader address luma at `y * tex_width + x + shift` — a per-texel
+integer divide and modulo, exactly what `nv_rgba_body_divfree` was written to
+avoid (3.3x on Vivante GC7000UL), and one that leaves the final chroma row's
+last bytes outside the import. NV sources at an unaligned offset keep the
+decline and upload the combined plane through the R8 shader. YUYV/VYUY are
+excluded for a different reason: their two-byte texels carry a two-pixel
+macropixel phase a texel shift would break. Every plane offset the two-plane
+NV12 import passes to EGL is still checked, not only plane 0 — a contiguous
+import derives plane 1 as `plane0_offset + pitch * height`
 (`nv12_plane1_offset`), which a `from_fd`-adopted buffer's unpadded pitch can
-leave unaligned while plane 0 is fine — chroma alone sampling zeros is a
-colour shift rather than a black frame. The R8 entry point needs plane 0
-only, binding the combined plane as one R8 texture.
+leave unaligned while plane 0 is fine, and chroma alone sampling zeros is a
+colour shift rather than a black frame. The R8 entry point needs plane 0 only,
+binding the combined plane as one R8 texture.
+
+Because the Linux import can now be wider than the logical image, the two
+`GL_TEXTURE_EXTERNAL_OES` camera programs
+(`draw_camera_texture_to_rgb_planar`, `draw_camera_texture_eglimage`) carry the
+`src_extent` clamp the `sampler2D` programs already had — the condition
+`GlPlatform::import_extent`'s contract puts on any leaf that reports a
+narrowed extent and has external-OES programs. Routing a coordinate through
+`clamp()` is also what makes its precision qualifier load-bearing: `tc`
+defaulted to `mediump`, and on Mali's fp16 ALU that quantized the sampled
+coordinate to about 0.625 texel at 1280 wide, which `LINEAR` smeared across the
+whole frame. Every shader that computes on `tc` declares it `highp`, pinned by
+`mod tc_precision` in `gl/shaders.rs`; the rule tracks the name `tc` only, so a
+sample coordinate under another name needs its own recorded decision.
 
 Mali **destinations** keep the zero-copy import, and that is measured, not
 assumed: rendering into an unaligned base at the same offsets is correct on

--- a/crates/image/src/cpu/convert.rs
+++ b/crates/image/src/cpu/convert.rs
@@ -45,9 +45,15 @@ fn luma_mapper(full_range: bool) -> fn(u8) -> u8 {
 /// `Balanced` relies on Q15 rounded-doubling multiply-accumulate (`SQRDMLAH`,
 /// Armv8.1 "rdm"). Cores without it — Cortex-A53/A35-class — emulate the op
 /// with a `vqrdmulh`+`vqadd` pair per accumulate, roughly doubling the cost of
-/// every conversion row. On those cores `Fast` (lower-precision integer
-/// approximation, error ≤ ~2/255) is 2×+ faster and visually
+/// every conversion row. On those cores `Fast` is 2×+ faster and visually
 /// indistinguishable; everywhere else `Balanced` keeps full precision.
+///
+/// `Fast`'s measured accuracy, swept over every (Y,Cb,Cr) triple on an i.MX8MP
+/// against exact BT.601 limited-range math: worst error 6/255 across the whole
+/// legal luma span 16..=235, and 2..3/255 typical. (An earlier comment here
+/// claimed ≤ ~2/255; that was never measured and is wrong.) Above the legal
+/// luma ceiling the kernel wraps outright — see [`FAST_PATH_MAX_LUMA`], which
+/// is why callers must route super-white luma through [`fast_path_luma`].
 #[inline]
 fn yuv_mode() -> yuv::YuvConversionMode {
     #[cfg(target_arch = "aarch64")]
@@ -57,6 +63,101 @@ fn yuv_mode() -> yuv::YuvConversionMode {
         }
     }
     yuv::YuvConversionMode::Balanced
+}
+
+/// Luma ceiling imposed on the `yuv` crate's `Fast` kernel in limited range:
+/// the nominal limited-range white point, chosen with margin to spare.
+///
+/// Past its real threshold the kernel silently wraps a bright pixel to its
+/// opposite. The `Fast` NV12/16/24→RGB row evaluates each channel in Q6 in a
+/// *signed 16-bit* accumulator that does not saturate (aarch64
+/// `neon_yuv_nv_to_rgba_fast_row` via `vmlal_s8`; the x86 SSE row is the same
+/// shape). Blue is `(Y - 16)·y_coef + (Cb - 128)·cb_coef`, and with the
+/// limited-range BT.601 coefficients — `y_coef` 75, `cb_coef` 129 clamped by the
+/// crate to the i8 ceiling 127 — a super-white Y = 249 with a saturated Cb = 253
+/// gives `233·75 + 125·127 = 33 350`, past `i16::MAX`. It wraps negative and the
+/// closing saturating narrow turns that into 0, so the brightest blue in the
+/// frame is emitted as black.
+///
+/// Solving `(Y - 16)·75 + 127·127 ≤ 32 767` puts the **arithmetic** ceiling at
+/// **Y = 237**: 237 gives `221·75 + 16 129 = 32 704` and fits, 238 gives
+/// `32 779` and does not. This constant is 235 rather than 237 because 235 is
+/// the limited-range white point — the value a conforming frame already
+/// respects, so the clamp is a no-op on real content — and it leaves two levels
+/// of margin against the true break point. At 235 the accumulator peaks at
+/// `219·75 + 127·127 = 32 554` against the 32 767 limit. No matrix overflows at
+/// that luma, and full range (`y_coef` 64, `bias_y` 0, `cb_coef` ≤ 120) never
+/// overflows at any luma. `fast_path_max_luma_is_below_the_kernel_wrap_point`
+/// pins both halves of that claim against the kernel itself.
+///
+/// The low end needs no guard: the kernel's saturating `y - 16` already takes
+/// sub-black luma to 0, which is what clamping to 16 would produce.
+pub(super) const FAST_PATH_MAX_LUMA: u8 = 235;
+
+/// Return a luma plane the `Fast` kernel can decode without wrapping, copying
+/// only when the frame actually carries super-white luma.
+///
+/// Borrows the caller's plane untouched on the exact path, in full range, and
+/// for any frame already within `0..=`[`FAST_PATH_MAX_LUMA`] — so the common
+/// case costs one read-only scan and output stays bit-identical. Only a frame
+/// that would otherwise wrap pays a bounded copy.
+///
+/// Clipping super-white is an approximation, and it applies to out-of-spec
+/// input only: 235 *is* limited-range white, so a conforming frame never
+/// reaches the clamp. For a frame that does, a channel that lands back in range
+/// (bright luma pulled down by strong chroma) shifts by at most
+/// `(255 - 235) · 255/219 ≈ 23`, against the 255 the unguarded kernel got wrong.
+/// `limit_to_full` above already clamps into the same span for the same reason.
+///
+/// The exact alternative is to decode super-white frames with
+/// `YuvConversionMode::Balanced`, which needs no copy and no approximation but
+/// costs ~2× on the non-`rdm` cores this path exists to serve — and, because
+/// the choice is per frame, a scene full of specular highlights would pay that
+/// 2× continuously rather than a bounded, predictable overhead. Revisit if the
+/// upstream kernel ever widens its accumulator; `yuv` 0.8.17 does not.
+///
+/// `scan` is the byte range to inspect — a caller that decodes only part of the
+/// plane passes just those rows, so an untouched region cannot force a copy.
+/// The copy, when one happens, still covers the whole plane.
+///
+/// The returned plane always has the caller's exact length. That is load-bearing,
+/// not incidental: the crate's 4:2:0 odd-last-row handling walks the luma plane
+/// with `chunks_exact(2 · stride)` and takes its `remainder()`, so a plane
+/// shortened even to the crate's own documented minimum (`stride · (height-1) +
+/// width`, which drops only the last row's padding) re-chunks the frame and
+/// corrupts its bottom rows — measured on an i.MX8MP, where trimming the pad
+/// left 63×64 and 65×64 still wrong while 64×64 came good. Callers hand over the
+/// whole plane they would otherwise pass; a caller that slices per strip clamps
+/// once, before slicing.
+pub(super) fn fast_path_luma(
+    y_plane: &[u8],
+    scan: std::ops::Range<usize>,
+    range: yuv::YuvRange,
+    mode: yuv::YuvConversionMode,
+) -> std::borrow::Cow<'_, [u8]> {
+    use std::borrow::Cow;
+    if mode != yuv::YuvConversionMode::Fast || range != yuv::YuvRange::Limited {
+        return Cow::Borrowed(y_plane);
+    }
+    let scan = scan.start.min(y_plane.len())..scan.end.min(y_plane.len());
+    // Chunked max-reduction, not `iter().any()`: the per-byte predicate carries
+    // a branch that blocks vectorization, and the common case (no super-white)
+    // has to read the whole plane before it can conclude anything — measured at
+    // ~2.5 ns/pixel on an A53, a 41% tax on the convert it guards. Folding a max
+    // over a chunk is branch-free and lowers to `umaxv`/`vmaxq_u8`, while the
+    // chunk loop still exits early on a frame that does carry super-white.
+    const SCAN_CHUNK: usize = 4096;
+    let clipping = y_plane[scan]
+        .chunks(SCAN_CHUNK)
+        .any(|c| c.iter().copied().fold(0u8, u8::max) > FAST_PATH_MAX_LUMA);
+    if !clipping {
+        return Cow::Borrowed(y_plane);
+    }
+    let mut clamped = y_plane.to_vec();
+    for l in clamped.iter_mut() {
+        *l = (*l).min(FAST_PATH_MAX_LUMA);
+    }
+    Cow::Owned(clamped)
 }
 
 /// One row of a YUYV-destination convert, split into its whole macropixels and
@@ -374,6 +475,7 @@ impl CPUProcessor {
         height: usize,
         y_stride: usize,
         uv_stride: usize,
+        range: yuv::YuvRange,
         dst: &mut Tensor<u8>,
         decode: F,
     ) -> Result<()>
@@ -384,8 +486,11 @@ impl CPUProcessor {
             u32,
         ) -> std::result::Result<(), yuv::YuvError>,
     {
+        // Super-white luma wraps to black in the `Fast` kernel; see
+        // `fast_path_luma`. Borrows unless this frame actually carries it.
+        let y_plane = fast_path_luma(y_plane, 0..y_plane.len(), range, yuv_mode());
         let src = yuv::YuvBiPlanarImage {
-            y_plane,
+            y_plane: &y_plane,
             y_stride: y_stride as u32,
             uv_plane,
             uv_stride: uv_stride as u32,
@@ -402,7 +507,12 @@ impl CPUProcessor {
     /// plane's own stride (a raw tensor whose `effective_row_stride()` has no
     /// width fallback — default to even(width)); the contiguous buffer's two
     /// planes share the one stride.
-    fn convert_nv12<F>(src: &Tensor<u8>, dst: &mut Tensor<u8>, decode: F) -> Result<()>
+    fn convert_nv12<F>(
+        src: &Tensor<u8>,
+        dst: &mut Tensor<u8>,
+        range: yuv::YuvRange,
+        decode: F,
+    ) -> Result<()>
     where
         F: FnOnce(
             &yuv::YuvBiPlanarImage<u8>,
@@ -430,6 +540,7 @@ impl CPUProcessor {
                 src_h,
                 stride,
                 uv_stride,
+                range,
                 dst,
                 decode,
             )
@@ -441,7 +552,9 @@ impl CPUProcessor {
                 src_h,
                 src.format().expect("semi-planar source has a pixel format"),
             )?;
-            Self::semi_planar_decode(y_plane, uv_plane, src_w, src_h, stride, stride, dst, decode)
+            Self::semi_planar_decode(
+                y_plane, uv_plane, src_w, src_h, stride, stride, range, dst, decode,
+            )
         }
     }
 
@@ -450,7 +563,7 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        Self::convert_nv12(src, dst, |img, out, stride| {
+        Self::convert_nv12(src, dst, cp.range, |img, out, stride| {
             yuv::yuv_nv12_to_rgb(img, out, stride, cp.range, cp.matrix, yuv_mode())
         })
     }
@@ -463,7 +576,7 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        Self::convert_nv12(src, dst, |img, out, stride| {
+        Self::convert_nv12(src, dst, cp.range, |img, out, stride| {
             yuv::yuv_nv12_to_rgba(img, out, stride, cp.range, cp.matrix, yuv_mode())
         })
     }
@@ -1313,7 +1426,12 @@ impl CPUProcessor {
     /// bytes per chroma row, i.e. the SAME pitch as luma; both planes use the
     /// buffer's (possibly even-padded) row stride (the logical width would
     /// corrupt every row past the first for an odd width where stride > width).
-    fn convert_nv16<F>(src: &Tensor<u8>, dst: &mut Tensor<u8>, decode: F) -> Result<()>
+    fn convert_nv16<F>(
+        src: &Tensor<u8>,
+        dst: &mut Tensor<u8>,
+        range: yuv::YuvRange,
+        decode: F,
+    ) -> Result<()>
     where
         F: FnOnce(
             &yuv::YuvBiPlanarImage<u8>,
@@ -1336,6 +1454,7 @@ impl CPUProcessor {
                 src_h,
                 stride,
                 stride,
+                range,
                 dst,
                 decode,
             )
@@ -1347,7 +1466,9 @@ impl CPUProcessor {
                 src_h,
                 src.format().expect("semi-planar source has a pixel format"),
             )?;
-            Self::semi_planar_decode(y_plane, uv_plane, src_w, src_h, stride, stride, dst, decode)
+            Self::semi_planar_decode(
+                y_plane, uv_plane, src_w, src_h, stride, stride, range, dst, decode,
+            )
         }
     }
 
@@ -1356,7 +1477,7 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        Self::convert_nv16(src, dst, |img, out, stride| {
+        Self::convert_nv16(src, dst, cp.range, |img, out, stride| {
             yuv::yuv_nv16_to_rgb(img, out, stride, cp.range, cp.matrix, yuv_mode())
         })
     }
@@ -1366,7 +1487,7 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        Self::convert_nv16(src, dst, |img, out, stride| {
+        Self::convert_nv16(src, dst, cp.range, |img, out, stride| {
             yuv::yuv_nv16_to_rgba(img, out, stride, cp.range, cp.matrix, yuv_mode())
         })
     }
@@ -1377,7 +1498,12 @@ impl CPUProcessor {
     /// chroma row), so the UV stride is twice the luma stride. Handles
     /// true-multiplane (separate Y / CbCr buffers) as well as the contiguous
     /// buffer so NV24 is not silently mis-sliced when chroma is its own tensor.
-    fn convert_nv24<F>(src: &Tensor<u8>, dst: &mut Tensor<u8>, decode: F) -> Result<()>
+    fn convert_nv24<F>(
+        src: &Tensor<u8>,
+        dst: &mut Tensor<u8>,
+        range: yuv::YuvRange,
+        decode: F,
+    ) -> Result<()>
     where
         F: FnOnce(
             &yuv::YuvBiPlanarImage<u8>,
@@ -1401,6 +1527,7 @@ impl CPUProcessor {
                 src_h,
                 stride,
                 uv_stride,
+                range,
                 dst,
                 decode,
             )
@@ -1413,7 +1540,7 @@ impl CPUProcessor {
                 src.format().expect("semi-planar source has a pixel format"),
             )?;
             Self::semi_planar_decode(
-                y_plane, uv_plane, src_w, src_h, stride, uv_stride, dst, decode,
+                y_plane, uv_plane, src_w, src_h, stride, uv_stride, range, dst, decode,
             )
         }
     }
@@ -1423,7 +1550,7 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        Self::convert_nv24(src, dst, |img, out, stride| {
+        Self::convert_nv24(src, dst, cp.range, |img, out, stride| {
             yuv::yuv_nv24_to_rgb(img, out, stride, cp.range, cp.matrix, yuv_mode())
         })
     }
@@ -1433,7 +1560,7 @@ impl CPUProcessor {
         dst: &mut Tensor<u8>,
         cp: ColorParams,
     ) -> Result<()> {
-        Self::convert_nv24(src, dst, |img, out, stride| {
+        Self::convert_nv24(src, dst, cp.range, |img, out, stride| {
             yuv::yuv_nv24_to_rgba(img, out, stride, cp.range, cp.matrix, yuv_mode())
         })
     }
@@ -1796,6 +1923,21 @@ impl CPUProcessor {
         let flush_bottom = region_top + out_h == src_h;
         let needs_pack =
             region_left != 0 || (src_fmt == Nv12 && !out_h.is_multiple_of(2) && !flush_bottom);
+
+        // Super-white luma wraps to black in the `Fast` kernel; see
+        // `fast_path_luma`. Clamped ONCE here, for the whole plane, rather than
+        // per strip: both arms below slice this plane by absolute row offset,
+        // and clamping a strip's slice would change the length the crate chunks
+        // over. Only this region's rows are scanned, so super-white elsewhere in
+        // a cropped source cannot force a copy. Borrows unless the frame
+        // actually carries super-white luma.
+        let y_guard = fast_path_luma(
+            y_plane,
+            region_top * y_stride..(region_top + out_h) * y_stride,
+            cp.range,
+            yuv_mode(),
+        );
+        let y_plane: &[u8] = &y_guard;
         let mut y_pack = std::mem::take(&mut self.nv_strip_y_pack);
         let mut uv_pack = std::mem::take(&mut self.nv_strip_uv_pack);
         if needs_pack {

--- a/crates/image/src/cpu/tests.rs
+++ b/crates/image/src/cpu/tests.rs
@@ -5536,4 +5536,246 @@ mod cpu_tests {
             }
         }
     }
+
+    // ---------------------------------------------------------------------
+    // Super-white luma must never decode to black (the `Fast` kernel wrap)
+    // ---------------------------------------------------------------------
+
+    /// Decode a uniform limited-range BT.601 NV12 frame and return its first
+    /// RGBA pixel. 64x64 so the `yuv` kernels take their vectorized main loop
+    /// rather than only the scalar tail.
+    fn decode_uniform_nv12(y: u8, u: u8, v: u8) -> [u8; 4] {
+        use edgefirst_tensor::{
+            ColorEncoding, ColorRange, Colorimetry, DType, PixelFormat, TensorDyn, TensorMapTrait,
+            TensorTrait,
+        };
+        let (w, h) = (64usize, 64usize);
+        let mut src = TensorDyn::image(
+            w,
+            h,
+            PixelFormat::Nv12,
+            DType::U8,
+            None,
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .unwrap();
+        {
+            let bound = src.as_typed::<u8>().unwrap();
+            let stride = bound.effective_row_stride().unwrap();
+            let mut m = bound.map().unwrap();
+            let buf = m.as_mut_slice();
+            for r in 0..h {
+                for c in 0..w {
+                    buf[r * stride + c] = y;
+                }
+            }
+            let uv = stride * h;
+            for r in 0..h / 2 {
+                for c in 0..w / 2 {
+                    buf[uv + r * stride + c * 2] = u;
+                    buf[uv + r * stride + c * 2 + 1] = v;
+                }
+            }
+        }
+        src.set_colorimetry(Some(
+            Colorimetry::default()
+                .with_encoding(ColorEncoding::Bt601)
+                .with_range(ColorRange::Limited),
+        ));
+        let mut dst = TensorDyn::image(
+            w,
+            h,
+            PixelFormat::Rgba,
+            DType::U8,
+            None,
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .unwrap();
+        CPUProcessor::new()
+            .convert(&src, &mut dst, Rotation::None, Flip::None, Crop::no_crop())
+            .unwrap();
+        let bound = dst.as_typed::<u8>().unwrap();
+        let m = bound.map().unwrap();
+        let p = m.as_slice();
+        [p[0], p[1], p[2], p[3]]
+    }
+
+    /// Exact BT.601 limited-range YUV→RGB, unclamped.
+    fn exact_bt601_limited(y: f64, u: f64, v: f64) -> [f64; 3] {
+        let l = 1.164383 * (y - 16.0);
+        [
+            l + 1.596027 * (v - 128.0),
+            l - 0.391762 * (u - 128.0) - 0.812968 * (v - 128.0),
+            l + 2.017232 * (u - 128.0),
+        ]
+    }
+
+    /// Super-white luma (Y above the 235 limited-range white point) must decode
+    /// to a bright pixel, never to its opposite.
+    ///
+    /// The `yuv` crate's `Fast` NV12→RGB kernel accumulates each channel in a
+    /// non-saturating signed 16-bit lane, so `(Y-16)*75 + (Cb-128)*127` wraps
+    /// negative past `i16::MAX` and the final saturating narrow emits 0 — the
+    /// brightest blue in a frame rendered as black. `fast_path_luma` in
+    /// `cpu/convert.rs` caps luma at the white point to keep the accumulator in
+    /// range, which clips super-white instead of inverting it.
+    ///
+    /// Clipping is deliberate and bounded: for a channel that lands back in
+    /// range the result shifts by at most `(255-235) * 255/219 ≈ 23`, hence the
+    /// tolerance below. Channels whose exact value saturates get no slack — the
+    /// bug being pinned turned exactly those into 0.
+    ///
+    /// Platform note: `yuv_mode()` selects the `Fast` kernel only on aarch64
+    /// cores without the ARMv8.1 `rdm` feature (Cortex-A53/A35-class, e.g. the
+    /// i.MX8MP). Everywhere else — x86 desktops, Cortex-A55 and newer — the
+    /// exact kernel runs and this test passes with or without the guard. It is
+    /// red only on the hardware that carries the defect.
+    #[test]
+    fn super_white_luma_never_decodes_to_black() {
+        // Saturated chroma both ways: the first overflows blue, the second is
+        // the in-range-result case that the clamp shifts rather than saves.
+        for (y, u, v) in [(255u8, 255u8, 255u8), (255, 16, 16), (249, 253, 115)] {
+            let got = decode_uniform_nv12(y, u, v);
+            let exact = exact_bt601_limited(y as f64, u as f64, v as f64);
+            for (ch, name) in ["red", "green", "blue"].iter().enumerate() {
+                let want = exact[ch].clamp(0.0, 255.0);
+                let have = got[ch] as f64;
+                if exact[ch] >= 255.0 {
+                    assert!(
+                        have >= 230.0,
+                        "Y={y} U={u} V={v}: {name} saturates to 255 in exact math \
+                         but decoded to {have} (fast-kernel wrap)"
+                    );
+                }
+                assert!(
+                    (have - want).abs() <= 25.0,
+                    "Y={y} U={u} V={v}: {name} decoded {have}, exact {want} \
+                     (delta {:.1} > 25)",
+                    (have - want).abs()
+                );
+            }
+        }
+    }
+
+    /// `fast_path_luma` borrows unless the scanned rows really carry super-white
+    /// luma, and clips the WHOLE plane when they do — the plane's length must
+    /// not change, and a partial clip would leave wrapped pixels behind.
+    ///
+    /// Runs on every platform: it drives the helper directly rather than going
+    /// through the host-dependent kernel choice.
+    #[test]
+    fn fast_path_luma_borrows_unless_it_must_clip() {
+        use crate::cpu::convert::{fast_path_luma, FAST_PATH_MAX_LUMA};
+        use std::borrow::Cow;
+        let fast = yuv::YuvConversionMode::Fast;
+        let lim = yuv::YuvRange::Limited;
+
+        // In-range frame: borrowed, byte-identical.
+        let ok = vec![FAST_PATH_MAX_LUMA; 8192];
+        assert!(matches!(
+            fast_path_luma(&ok, 0..ok.len(), lim, fast),
+            Cow::Borrowed(_)
+        ));
+
+        // Super-white: clipped to the white point, everything else untouched.
+        // Longer than one scan chunk so the chunked reduction is exercised, and
+        // the hot byte sits in the second chunk so an early exit would miss it.
+        let mut hot = vec![100u8; 8192];
+        hot[5000] = 255;
+        hot[5001] = 236;
+        let got = fast_path_luma(&hot, 0..hot.len(), lim, fast);
+        assert!(matches!(got, Cow::Owned(_)));
+        assert_eq!(got.len(), hot.len(), "the plane length must not change");
+        assert_eq!(got[5000], FAST_PATH_MAX_LUMA);
+        assert_eq!(got[5001], FAST_PATH_MAX_LUMA);
+        assert_eq!(got[4999], 100);
+
+        // Super-white outside the scanned rows must not force a copy: a cropped
+        // decode never reads those bytes.
+        assert!(matches!(
+            fast_path_luma(&hot, 0..4096, lim, fast),
+            Cow::Borrowed(_)
+        ));
+        // But a hit inside the scanned rows still clips the WHOLE plane, so no
+        // wrapped byte survives anywhere the crate might chunk over.
+        let clipped = fast_path_luma(&hot, 4096..8192, lim, fast);
+        assert!(matches!(clipped, Cow::Owned(_)));
+        assert_eq!(clipped.len(), hot.len());
+        assert_eq!(clipped[5000], FAST_PATH_MAX_LUMA);
+
+        // Full range never overflows the kernel, so it is left alone.
+        assert!(matches!(
+            fast_path_luma(&hot, 0..hot.len(), yuv::YuvRange::Full, fast),
+            Cow::Borrowed(_)
+        ));
+        // Neither does the exact kernel.
+        assert!(matches!(
+            fast_path_luma(&hot, 0..hot.len(), lim, yuv::YuvConversionMode::Balanced),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    /// [`FAST_PATH_MAX_LUMA`] must sit below the luma at which the `yuv` crate's
+    /// `Fast` kernel wraps — pinned against the kernel itself, not against our
+    /// arithmetic about it.
+    ///
+    /// This drives `yuv_nv12_to_rgba` directly with an explicit
+    /// `YuvConversionMode::Fast`, so it does not depend on what `yuv_mode()`
+    /// would pick for the host: it is red on x86 and on every CI runner, not
+    /// only on the non-`rdm` cores that select `Fast` in production. The aarch64
+    /// NEON and x86 SSE fast rows share the overflow.
+    ///
+    /// Two halves, and both matter. An unclamped super-white plane must actually
+    /// wrap — otherwise the guard is guarding nothing and this test says so. The
+    /// same plane clamped to [`FAST_PATH_MAX_LUMA`] must decode bright. If a
+    /// future `yuv` widens the accumulator the first half fails, which is the
+    /// signal to re-measure and consider dropping the guard.
+    #[test]
+    fn fast_path_max_luma_is_below_the_kernel_wrap_point() {
+        use crate::cpu::convert::FAST_PATH_MAX_LUMA;
+        const W: usize = 64;
+        const H: usize = 64;
+
+        // Uniform Y with saturated chroma: Cb = Cr = 255 drives blue hardest.
+        let decode = |luma: u8| -> [u8; 4] {
+            let y = vec![luma; W * H];
+            let uv = vec![255u8; W * (H / 2)];
+            let img = yuv::YuvBiPlanarImage {
+                y_plane: &y,
+                y_stride: W as u32,
+                uv_plane: &uv,
+                uv_stride: W as u32,
+                width: W as u32,
+                height: H as u32,
+            };
+            let mut out = vec![0u8; W * H * 4];
+            yuv::yuv_nv12_to_rgba(
+                &img,
+                &mut out,
+                (W * 4) as u32,
+                yuv::YuvRange::Limited,
+                yuv::YuvStandardMatrix::Bt601,
+                yuv::YuvConversionMode::Fast,
+            )
+            .unwrap();
+            [out[0], out[1], out[2], out[3]]
+        };
+
+        // Exact math puts blue far past 255 at Y=255, Cb=255, so anything dark
+        // is the accumulator wrapping.
+        let unguarded = decode(255);
+        assert!(
+            unguarded[2] < 64,
+            "the `Fast` kernel no longer wraps super-white luma (blue {} at Y=255, Cb=255). The guard may be removable, but re-measure before changing FAST_PATH_MAX_LUMA.",
+            unguarded[2]
+        );
+
+        // Clamped to the constant the guard applies, the same pixel is bright.
+        let guarded = decode(FAST_PATH_MAX_LUMA);
+        assert!(
+            guarded[2] >= 230,
+            "clamping luma to {FAST_PATH_MAX_LUMA} still decodes blue {}: the constant is at or above the kernel's wrap point",
+            guarded[2]
+        );
+    }
 }

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -1907,15 +1907,15 @@ mod g2d_tests {
     ///   (b) G2D output matches CPU reference within ±4 on RGB channels.
     ///       (Alpha is hardware-defined and excluded from the comparison.)
     ///
-    /// If on-target validation shows the G2D hardware has wider tolerance for
-    /// odd widths, the tolerance may be relaxed to ±6 with a justification
-    /// comment — but only after observing an actual on-target failure, not
-    /// preemptively.
+    /// On-target validation has since run: the G2D-vs-CPU residual on an
+    /// i.MX8MP is 23–24 across widths 63–81, so the ±4 tolerance only warns and
+    /// the `max_diff <= 35` assertion is what actually fails. Do not relax
+    /// either without a new measurement on the board.
     #[test]
     #[cfg(target_os = "linux")]
     fn d01_nv12_odd_w_g2d_vs_cpu() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: d01_nv12_odd_w_g2d_vs_cpu - DMA not available");
+            crate::test_support::report_skip("d01_nv12_odd_w_g2d_vs_cpu - DMA not available");
             return;
         }
         let (w, h) = (65usize, 64usize);
@@ -1974,7 +1974,9 @@ mod g2d_tests {
         let mut g2d = match G2DProcessor::new() {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: d01_nv12_odd_w_g2d_vs_cpu - G2D not available: {e}");
+                crate::test_support::report_skip(&format!(
+                    "d01_nv12_odd_w_g2d_vs_cpu - G2D not available: {e}"
+                ));
                 return;
             }
         };
@@ -1995,12 +1997,23 @@ mod g2d_tests {
         let tol = 4u32;
         let (max_diff, first_fail) = compare_g2d_vs_cpu_rgba(&g2d_dst, &cpu_dst, w, h, tol);
         eprintln!("D-01 NV12 odd-W G2D vs CPU: max_diff={max_diff}");
-        // Post-WS1 both CPU and G2D resolve this untagged odd-W NV12 source to
+        // Both CPU and G2D resolve this untagged odd-W NV12 source to
         // limited-range BT.601 (G2D is limited-range matrix-only), so the
-        // YUV-matrix delta that previously forced the loose >64 bound has
-        // closed; the residual is G2D fixed-point rounding. Warn above the tight
-        // ±tol, fail on >35 (was 64) so a real geometry/stride regression — the
-        // odd-W stride handling this test guards — still trips.
+        // YUV-matrix delta that once forced the loose >64 bound has closed. What
+        // remains is G2D's own fixed-point rounding; its exact mechanism has not
+        // been characterised, only its magnitude, measured below.
+        //
+        // Measured on an i.MX8MP (the only G2D board): max_diff 23 at 63×64,
+        // 64×64, 65×64 and 65×63, and 24 at 80×64 and 81×64. The >35 bound has
+        // ~11 of headroom over that and still trips a real geometry/stride
+        // regression — the odd-W stride handling this test guards.
+        //
+        // History: this bound was tightened 64 → 35 without a hardware run (the
+        // imx8mp lane had stopped executing), and the first run that reached it
+        // read 255. That was NOT G2D: the pattern's `% 256` ramps synthesise
+        // super-white luma, which the CPU reference's fast kernel wrapped to
+        // black. See `fast_path_luma` in `cpu/convert.rs`. The full-range
+        // pattern is deliberate — it is what caught that bug — so keep it.
         if max_diff > tol {
             eprintln!(
                 "WARNING: D-01 NV12 odd-W G2D vs CPU max_diff={max_diff} > {tol} \
@@ -2028,7 +2041,7 @@ mod g2d_tests {
     #[cfg(target_os = "linux")]
     fn d03_nv12_odd_both_g2d_vs_cpu() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: d03_nv12_odd_both_g2d_vs_cpu - DMA not available");
+            crate::test_support::report_skip("d03_nv12_odd_both_g2d_vs_cpu - DMA not available");
             return;
         }
         let (w, h) = (65usize, 63usize);
@@ -2087,7 +2100,9 @@ mod g2d_tests {
         let mut g2d = match G2DProcessor::new() {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: d03_nv12_odd_both_g2d_vs_cpu - G2D not available: {e}");
+                crate::test_support::report_skip(&format!(
+                    "d03_nv12_odd_both_g2d_vs_cpu - G2D not available: {e}"
+                ));
                 return;
             }
         };
@@ -2108,9 +2123,10 @@ mod g2d_tests {
         let tol = 4u32;
         let (max_diff, first_fail) = compare_g2d_vs_cpu_rgba(&g2d_dst, &cpu_dst, w, h, tol);
         eprintln!("D-03 NV12 odd-both G2D vs CPU: max_diff={max_diff}");
-        // Post-WS1 the YUV-matrix delta has closed — see test_d01 above. Warn
-        // above ±tol on G2D fixed-point rounding, fail only on a gross >35
-        // geometry/stride regression (was 64).
+        // The YUV-matrix delta has closed — see d01 above for the measured
+        // per-width figures behind the >35 bound, and for why this pattern's
+        // super-white luma must stay. Warn above ±tol on G2D fixed-point
+        // rounding, fail only on a gross >35 geometry/stride regression.
         if max_diff > tol {
             eprintln!(
                 "WARNING: D-03 NV12 odd-both G2D vs CPU max_diff={max_diff} > {tol} \

--- a/crates/image/src/gl/cache.rs
+++ b/crates/image/src/gl/cache.rs
@@ -126,6 +126,12 @@ pub struct ConvertStats {
 /// foreign/multi-plane byte offset (e.g. an externally-imported buffer whose data
 /// starts past the fd origin); those still key distinctly.
 ///
+/// A source rebased onto an aligned DMA-BUF base (issue #170) is keyed by its
+/// OWN `plane_offset`, not by the base it imports at, which is what keeps two
+/// views sharing one base but differing in remainder from aliasing: their
+/// imports are widened by different amounts. Keying on the base would collapse
+/// them onto one import and sample the wrong region for one of the two.
+///
 /// `width` / `height` / `row_stride` / `format` capture the geometry the
 /// EGLImage was imported with — the **parent's** for a view. A pooled buffer
 /// reused at a different size via `Tensor::configure_image` (e.g. a 128-wide pool
@@ -387,6 +393,28 @@ mod tests {
             row_stride,
             format,
         }
+    }
+
+    /// Two source views whose byte offsets share a 64-byte-aligned base but
+    /// differ in the remainder are DIFFERENT imports after issue #170 -- one
+    /// is widened by 8 texels and the other by 4 -- so their keys must not
+    /// collide. The key holds the tensor's own `plane_offset`, which is
+    /// finer than the base, so this holds by construction; it is asserted
+    /// because a future "key on the import base instead" would silently
+    /// alias two imports and sample one region for the other.
+    #[test]
+    fn source_keys_distinguish_offsets_that_share_an_aligned_base() {
+        let a = key(1, 2048, 16, 16, 256, PixelFormat::Rgba);
+        let b = key(1, 2064, 16, 16, 256, PixelFormat::Rgba);
+        let c = key(1, 2080, 16, 16, 256, PixelFormat::Rgba);
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(a, c);
+        let mut map: HashMap<BufferImportKey, u32> = HashMap::new();
+        map.insert(a, 1);
+        map.insert(b, 2);
+        map.insert(c, 3);
+        assert_eq!(map.len(), 3, "three remainders, three imports");
     }
 
     /// The two numbers Task 7 (capacity sizing) reads, and the LRU order they

--- a/crates/image/src/gl/cuda_policy.rs
+++ b/crates/image/src/gl/cuda_policy.rs
@@ -67,7 +67,7 @@ pub(crate) fn cuda_available_or_skip(what: &str) -> bool {
          list, or LD_LIBRARY_PATH does not reach the runtime)";
     let run = decide(edgefirst_tensor::is_cuda_available(), required(), what, why);
     if !run {
-        eprintln!("SKIP {what}: {why}");
+        crate::test_support::report_skip(&format!("{what}: {why}"));
     }
     run
 }
@@ -86,7 +86,7 @@ pub(crate) fn cuda_available_or_skip(what: &str) -> bool {
 pub(crate) fn require_or_skip(satisfied: bool, what: &str, why: &str) -> bool {
     let run = decide(satisfied, required(), what, why);
     if !run {
-        eprintln!("SKIP {what}: {why}");
+        crate::test_support::report_skip(&format!("{what}: {why}"));
     }
     run
 }

--- a/crates/image/src/gl/dma_import.rs
+++ b/crates/image/src/gl/dma_import.rs
@@ -15,6 +15,7 @@ use std::os::unix::io::RawFd;
 
 use super::context::egl_ext;
 use super::fourcc::pixel_format_to_drm;
+use super::processor::DMA_IMPORT_OFFSET_ALIGN;
 use crate::colorimetry::resolve_colorimetry;
 use crate::Error;
 
@@ -36,6 +37,13 @@ pub(super) struct DmaImportAttrs {
     pub plane0_fd: RawFd,
     pub plane0_pitch: usize,
     pub plane0_offset: usize,
+    /// Texels between this import's first column and the tensor's own first
+    /// pixel. Nonzero only for a SOURCE rebased onto an aligned base (issue
+    /// #170): `width` is widened by it and `plane0_offset` walked back by
+    /// `x_shift_px * bpp`, so the tensor's pixel `(x, y)` is import texel
+    /// `(x + x_shift_px, y)` at the same pitch. The engine folds it through
+    /// `GlPlatform::import_origin` into the sampling rectangle.
+    pub x_shift_px: u32,
     /// Second plane for NV12.
     pub plane1: Option<DmaPlane1Attrs>,
     pub is_yuv: bool,
@@ -53,6 +61,180 @@ pub(super) struct DmaPlane1Attrs {
     pub fd: RawFd,
     pub pitch: usize,
     pub offset: usize,
+}
+
+/// The largest byte offset at or below `offset` that is a multiple of
+/// `align` **and** a whole number of `bpp`-byte pixels away from `offset`,
+/// with that distance in pixels.
+///
+/// Mali's EGL DMA-BUF import silently samples zeros unless
+/// `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is 64-byte aligned (issue #165, measured
+/// on i.MX 95: offsets 32 and 2080 sample zeros, 0/64/256/2048 are correct).
+/// Rather than decline such a source into an upload, the import starts at
+/// this base and widens by the returned shift, so the tensor's first pixel
+/// lands on texel `x_shift_px` of the imported texture and the engine folds
+/// that shift into the sampling rectangle (issue #170).
+///
+/// The step is `lcm(align, bpp)`, not `align`: walking back by `align` alone
+/// lands mid-pixel whenever `bpp` does not divide `align` — for `Rgb`'s 3
+/// bytes a 64-byte floor of 2079 gives a 31-byte remainder, which is not a
+/// whole RGB pixel, while the 192-byte step gives 159 bytes = 53 pixels.
+///
+/// `None` when no such base exists — `offset` is not a whole number of
+/// pixels (a 128-byte padded pitch is not a multiple of 3, so an `Rgb` row
+/// offset can land mid-pixel), or a degenerate `bpp`/`align`. The caller
+/// declines the import and uploads, which is Stage F's behaviour.
+pub(super) fn aligned_source_base(offset: usize, bpp: usize, align: usize) -> Option<(usize, u32)> {
+    if bpp == 0 || align == 0 || !offset.is_multiple_of(bpp) {
+        return None;
+    }
+    // lcm(align, bpp), computed as `align / gcd * bpp` so the intermediate
+    // cannot overflow for any realistic pair.
+    let mut a = align;
+    let mut b = bpp;
+    while b != 0 {
+        let t = a % b;
+        a = b;
+        b = t;
+    }
+    let step = (align / a).checked_mul(bpp)?;
+    let base = offset - offset % step;
+    Some((base, u32::try_from((offset - base) / bpp).ok()?))
+}
+
+/// Whether a source rebased by `x_shift_px` pixels still fits the pitch it
+/// imports at: the widened row `(width_px + x_shift_px) * bpp` must not run
+/// past `plane0_pitch`.
+///
+/// A driver that derives a row from WIDTH and PITCH rejects an import whose
+/// row runs past its pitch, and the widened row is the only thing the rebase
+/// can make run past. `false` declines the rebase, and the caller imports at
+/// the original offset instead.
+///
+/// The room comes from the pitch padding. A view's `width_px` is its own
+/// while its pitch is the parent's, so a 64-padded parent pitch normally has
+/// room for every shift `aligned_source_base` can return. A pitch that is
+/// merely tight has none: a foreign DMA-BUF adopted through `from_fd` at the
+/// producer's unpadded stride, or a whole tensor at a `set_plane_offset`
+/// window whose row already fills its pitch. Overflow counts as not fitting.
+pub(super) fn rebase_fits_pitch(
+    width_px: usize,
+    x_shift_px: u32,
+    bpp: usize,
+    plane0_pitch: usize,
+) -> bool {
+    width_px
+        .checked_add(x_shift_px as usize)
+        .and_then(|w| w.checked_mul(bpp))
+        .is_some_and(|row| row <= plane0_pitch)
+}
+
+/// The bytes per pixel the aligned-base rebase uses for `src_fmt`, or `None`
+/// for the formats it does not cover.
+///
+/// Packed formats whose texel is exactly `channels()` bytes only: YUYV/VYUY
+/// carry a 2-pixel macropixel phase a texel shift would break, NV12's second
+/// plane has an offset of its own, and the R8 paths' pitch IS their width so
+/// they cannot widen at all.
+fn rebase_bpp(src_fmt: PixelFormat) -> Option<usize> {
+    matches!(
+        src_fmt,
+        PixelFormat::Rgba | PixelFormat::Bgra | PixelFormat::Rgb | PixelFormat::Grey
+    )
+    .then(|| src_fmt.channels())
+}
+
+/// The plane-0 channel count the **import** uses, which is not always
+/// `PixelFormat::channels()`: NV12's plane 0 is single-channel luma, and
+/// PlanarRgb's is one R8 plane three times as tall rather than three
+/// interleaved channels.
+///
+/// [`DmaImportAttrs::from_tensor`] derives the same number inside the branch
+/// that also resolves width, height and fourcc, and debug-asserts it against
+/// this function. [`resolved_source_plane0_offset`] calls this directly. The
+/// two must agree, because the tight pitch they fall back on when a tensor
+/// stores no row stride is what the gate and the import would otherwise
+/// disagree about.
+fn import_plane0_channels(src_fmt: PixelFormat) -> usize {
+    if src_fmt == PixelFormat::Nv12 || src_fmt.layout() == PixelLayout::Planar {
+        1
+    } else {
+        src_fmt.channels()
+    }
+}
+
+/// The tightly-packed plane-0 pitch a tensor with no stored row stride
+/// imports at.
+fn tight_plane0_pitch(src_fmt: PixelFormat, width_px: usize, channels: usize) -> usize {
+    if src_fmt == PixelFormat::Nv12 {
+        // Luma plane is 1 byte/pixel for NV12 semi-planar YUV.
+        width_px
+    } else {
+        width_px * channels
+    }
+}
+
+/// The plane-0 offset a SOURCE import of this shape presents to EGL, and the
+/// texel shift folded into the sampling rectangle to pay for it.
+///
+/// **The single source of truth for the source rebase (issue #170.)**
+/// [`DmaImportAttrs::from_tensor`] builds its import from this, and the Mali
+/// gate in `processor/mod.rs` asks it which offset EGL will actually be
+/// handed — see [`resolved_source_plane0_offset`]. Neither may
+/// reimplement the decision: the gate declines a source Mali would sample
+/// zeros from, and it can only be right about that if it is reading the very
+/// offset the import will carry.
+///
+/// Three outcomes, in order:
+///
+/// * A format the rebase does not cover, or an offset that is already
+///   64-byte aligned — returned unchanged with no shift. The aligned case
+///   is every ordinary import.
+/// * An unaligned offset the rebase can move — the aligned base below it,
+///   and the remainder in whole pixels. This is the zero-copy win.
+/// * An unaligned offset it cannot move — an offset that is not a whole
+///   number of pixels (`offset % bpp != 0`, which a 64-padded stride
+///   produces whenever `bpp` does not divide it), or a pitch with no room
+///   to widen into — returned
+///   unchanged, unaligned. The drivers that import such an offset correctly
+///   go on doing so; Mali declines it upstream and uploads instead, which is
+///   exactly what this function exists to let the gate see.
+pub(super) fn resolve_source_plane0(
+    src_fmt: PixelFormat,
+    width_px: usize,
+    plane0_pitch: usize,
+    plane_offset: usize,
+) -> (usize, u32) {
+    let Some(bpp) = rebase_bpp(src_fmt) else {
+        return (plane_offset, 0);
+    };
+    if plane_offset.is_multiple_of(DMA_IMPORT_OFFSET_ALIGN) {
+        return (plane_offset, 0);
+    }
+    aligned_source_base(plane_offset, bpp, DMA_IMPORT_OFFSET_ALIGN)
+        .filter(|&(_, shift)| rebase_fits_pitch(width_px, shift, bpp, plane0_pitch))
+        .unwrap_or((plane_offset, 0))
+}
+
+/// [`resolve_source_plane0`]'s offset for a whole tensor, resolving the
+/// width, pitch and offset the way [`DmaImportAttrs::from_tensor`] does for a
+/// source. This is what the Mali gate calls.
+///
+/// A source never collapses onto a parent import (`view_origin` is honored
+/// for destinations only), so its geometry is its own and these three
+/// accessors are the whole input. The tight-pitch fallback goes through
+/// [`import_plane0_channels`], the same rule the import applies, so the two
+/// cannot answer differently for a tensor that stores no row stride —
+/// `PixelFormat::channels()` would say three for PlanarRgb where the import
+/// says one. Unreachable while the rebase covers neither planar nor NV (the
+/// caller returns before the pitch is read), but the gate must not depend on
+/// that to be right.
+pub(super) fn resolved_source_plane0_offset(src: &Tensor<u8>, src_fmt: PixelFormat) -> usize {
+    let width = src.width().unwrap_or(0);
+    let pitch = src
+        .effective_row_stride()
+        .unwrap_or_else(|| tight_plane0_pitch(src_fmt, width, import_plane0_channels(src_fmt)));
+    resolve_source_plane0(src_fmt, width, pitch, src.plane_offset().unwrap_or(0)).0
 }
 
 impl DmaImportAttrs {
@@ -129,6 +311,12 @@ impl DmaImportAttrs {
             // tested platform (Mali G310, Vivante GC7000UL, V3D, Tegra),
             // so we keep the blanket width%4 check for those.
             //
+            // It is the TIGHT pitch this protects, and the aligned-base
+            // rebase (issue #170) never changes that pitch: the rebase
+            // widens the import and walks the offset back, both at the
+            // pitch the tensor already had, so a width that satisfies this
+            // check before the rebase still does after it.
+            //
             // 4-bpp packed formats (Rgba, Bgra) have a row pitch of
             // `width * 4` which is trivially 4-byte aligned at any width.
             // The DRM fourcc spec (ABGR8888 / ARGB8888) imposes no
@@ -149,6 +337,16 @@ impl DmaImportAttrs {
             }
             (src_w, src_h, pixel_format_to_drm(src_fmt)?, src_channels)
         };
+
+        // The branch above resolves `channels` alongside width, height and
+        // fourcc, so it cannot simply call `import_plane0_channels`; this
+        // pins the two together instead, because the gate reads the helper
+        // and both feed `tight_plane0_pitch`.
+        debug_assert_eq!(
+            channels,
+            import_plane0_channels(src_fmt),
+            "{src_fmt:?}: the import's plane-0 channel count and the gate's must agree"
+        );
 
         // `dmabuf()`, not `as_dma().fd`. Both reach the same file
         // descriptor and both are on `Tensor<T>` with the same signature on
@@ -187,14 +385,9 @@ impl DmaImportAttrs {
         // tightly-packed pitch.
         let plane0_pitch = match view_origin {
             Some(vo) => vo.parent_row_stride,
-            None => src.effective_row_stride().unwrap_or_else(|| {
-                if src_fmt == PixelFormat::Nv12 {
-                    // Luma plane is 1 byte/pixel for NV12 semi-planar YUV.
-                    width
-                } else {
-                    width * channels
-                }
-            }),
+            None => src
+                .effective_row_stride()
+                .unwrap_or_else(|| tight_plane0_pitch(src_fmt, width, channels)),
         };
 
         // A view imports its parent at offset 0 (its byte offset becomes the
@@ -204,6 +397,36 @@ impl DmaImportAttrs {
         } else {
             src.plane_offset().unwrap_or(0)
         };
+
+        // Mali's EGL DMA-BUF import silently samples zeros unless the plane
+        // offset is 64-byte aligned (issue #165: offsets 32 and 2080 on
+        // i.MX 95). Rather than decline such a SOURCE into an upload, import
+        // from an aligned base and widen by the remainder in pixels; the
+        // engine folds the shift into the sampling rectangle through
+        // `GlPlatform::import_origin` (issue #170). Applied on every driver,
+        // not only Mali: one code path, exercised wherever an unaligned
+        // source runs, rather than a Mali-only branch nothing else covers.
+        //
+        // Sources only. A destination view imports its parent at base 0 and
+        // places the tile by viewport, and the driver that does fail on an
+        // unaligned destination fails loudly (Vivante, EGL_BAD_ACCESS),
+        // which `Platform::dst_import_places` already lowers.
+        //
+        // `resolve_source_plane0` owns the whole decision, and the Mali gate
+        // in `processor/mod.rs` asks the same function what offset this
+        // import will present. That shared answer is what makes the gate
+        // safe to narrow: a source it exempts is one this call rebased onto
+        // an aligned base, never merely one whose format is usually
+        // rebasable. When the rebase cannot be applied -- an offset that is
+        // not a whole number of pixels, or a pitch with no room to widen --
+        // the import keeps its own unaligned offset, the drivers that read
+        // it correctly go on doing so, and Mali declines it upstream.
+        let (plane0_offset, x_shift_px) = if for_dst {
+            (plane0_offset, 0)
+        } else {
+            resolve_source_plane0(src_fmt, width, plane0_pitch, plane0_offset)
+        };
+        let width = width + x_shift_px as usize;
 
         // Semi-planar YUV (NV12) carries a second (interleaved CbCr) plane.
         // NV12 (4:2:0): H/2 rows, W bytes/row (W/2 CbCr pairs).
@@ -275,6 +498,7 @@ impl DmaImportAttrs {
             plane0_fd: fd,
             plane0_pitch,
             plane0_offset,
+            x_shift_px,
             plane1,
             is_yuv: src_fmt.is_yuv(),
             yuv_encoding,
@@ -363,6 +587,10 @@ impl DmaImportAttrs {
             plane0_fd: fd,
             plane0_pitch: tex_width,
             plane0_offset,
+            // The R8 import's pitch IS its width, so it cannot widen: an
+            // unaligned NV source keeps the Stage F decline and uploads
+            // (issue #170).
+            x_shift_px: 0,
             plane1: None,
             is_yuv: false, // R8 is not a multi-plane YUV fourcc; no driver hints
             // Path B applies the YUV→RGB matrix in-shader (per-tensor coeffs),
@@ -496,7 +724,7 @@ mod tests {
     #[cfg(feature = "dma_test_formats")]
     fn from_tensor_source_view_imports_own_region_dst_imports_parent() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: from_tensor_source_view... - DMA not available");
+            crate::test_support::report_skip("from_tensor_source_view... - DMA not available");
             return;
         }
         // 64x64 RGBA with a padded 320-byte stride (tight row = 64*4 = 256).
@@ -510,7 +738,7 @@ mod tests {
         ) {
             Ok(t) => t,
             Err(_) => {
-                eprintln!("SKIPPED: image_with_stride DMA unavailable");
+                crate::test_support::report_skip("image_with_stride DMA unavailable");
                 return;
             }
         };
@@ -518,17 +746,30 @@ mod tests {
             .view(edgefirst_tensor::Region::new(8, 8, 32, 16))
             .unwrap();
 
-        // SOURCE (for_dst = false): import the view's OWN region.
+        // SOURCE (for_dst = false): import the view's OWN region -- rebased
+        // onto an aligned base, because (8, 8) at a 320-byte pitch is byte
+        // 2592, which is not 64-byte aligned. The base is 2560 and the
+        // 32-byte remainder is 8 RGBA pixels of shift, so the import is 8
+        // texels wider than the view and starts it 8 texels in (issue #170).
+        // The region is deliberately left at an unaligned origin: the
+        // rebased numbers say more about what this test guards than an
+        // aligned origin that exercises nothing.
         let s = DmaImportAttrs::from_tensor(&view, PixelFormat::Rgba, false).unwrap();
         assert_eq!(
             (s.width, s.height),
-            (32, 16),
-            "source view imports its own dimensions"
+            (32 + 8, 16),
+            "source view imports its own dimensions, widened by the shift"
         );
+        assert_eq!(s.x_shift_px, 8, "32 bytes of remainder is 8 RGBA pixels");
         assert_eq!(
             s.plane0_offset,
+            8 * 320,
+            "source view imports at the aligned base below its own byte offset"
+        );
+        assert_eq!(
+            s.plane0_offset + s.x_shift_px as usize * 4,
             8 * 320 + 8 * 4,
-            "source view imports at its own byte offset"
+            "and the shift closes that base back to the view's own offset"
         );
         assert_eq!(s.plane0_pitch, 320, "source view keeps the parent pitch");
 
@@ -562,14 +803,18 @@ mod tests {
         let luma_buf = match alloc_dma(luma_bytes, "luma_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_true_multiplane_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_true_multiplane_attrs - DMA not available",
+                );
                 return;
             }
         };
         let chroma_buf = match alloc_dma(chroma_bytes, "chroma_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_true_multiplane_attrs - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_nv12_true_multiplane_attrs - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -625,7 +870,9 @@ mod tests {
         let buf = match alloc_dma(total_bytes, "shared_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_same_fd_multiplane_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_same_fd_multiplane_attrs - DMA not available",
+                );
                 return;
             }
         };
@@ -680,7 +927,9 @@ mod tests {
         let buf = match alloc_dma(total, "nv12_even_w") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_even_width_relaxed_gate - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_even_width_relaxed_gate - DMA not available",
+                );
                 return;
             }
         };
@@ -723,7 +972,9 @@ mod tests {
         let buf = match alloc_dma(total_bytes, "contiguous_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_contiguous_single_fd_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_contiguous_single_fd_attrs - DMA not available",
+                );
                 return;
             }
         };
@@ -772,7 +1023,9 @@ mod tests {
         let buf = match alloc_dma(total_bytes, "padded_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_contiguous_padded_stride_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_contiguous_padded_stride_attrs - DMA not available",
+                );
                 return;
             }
         };
@@ -810,14 +1063,16 @@ mod tests {
         let luma_buf = match alloc_dma(luma_bytes, "luma_padded") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_multiplane_padded_strides_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_multiplane_padded_strides_attrs - DMA not available",
+                );
                 return;
             }
         };
         let chroma_buf = match alloc_dma(chroma_bytes, "chroma_padded") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: DMA alloc failed");
+                crate::test_support::report_skip("DMA alloc failed");
                 return;
             }
         };
@@ -862,7 +1117,9 @@ mod tests {
         let buf = match alloc_dma(total_bytes, "offset_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_same_fd_nonzero_luma_offset - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_same_fd_nonzero_luma_offset - DMA not available",
+                );
                 return;
             }
         };
@@ -908,7 +1165,9 @@ mod tests {
         let y_buf = match alloc_dma(y_size, "y_only_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_chroma_offset_exceeds_buffer - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_chroma_offset_exceeds_buffer - DMA not available",
+                );
                 return;
             }
         };
@@ -956,6 +1215,7 @@ mod tests {
             plane0_fd: 10,
             plane0_pitch: 1920,
             plane0_offset: 0,
+            x_shift_px: 0,
             plane1: Some(DmaPlane1Attrs {
                 fd: 11, // different fd
                 pitch: 1920,
@@ -1018,6 +1278,7 @@ mod tests {
             plane0_fd: 10,
             plane0_pitch: 1920,
             plane0_offset: 0,
+            x_shift_px: 0,
             plane1: Some(DmaPlane1Attrs {
                 fd: 12, // different raw fd, same underlying buffer
                 pitch: 1920,
@@ -1053,6 +1314,7 @@ mod tests {
             plane0_fd: 10,
             plane0_pitch: pitch,
             plane0_offset: 0,
+            x_shift_px: 0,
             plane1: Some(DmaPlane1Attrs {
                 fd: 10, // SAME raw fd
                 pitch,
@@ -1088,6 +1350,7 @@ mod tests {
             plane0_fd: 10,
             plane0_pitch: 640 * 4,
             plane0_offset: 0,
+            x_shift_px: 0,
             plane1: None,
             is_yuv: false,
             yuv_encoding: ColorEncoding::Bt709,
@@ -1121,6 +1384,7 @@ mod tests {
             plane0_fd: 10,
             plane0_pitch: stride,
             plane0_offset: 0,
+            x_shift_px: 0,
             plane1: Some(DmaPlane1Attrs {
                 fd: 10,
                 pitch: stride,
@@ -1158,6 +1422,7 @@ mod tests {
             plane0_fd: 10,
             plane0_pitch: 1920,
             plane0_offset: 0,
+            x_shift_px: 0,
             plane1: Some(DmaPlane1Attrs {
                 fd: 10,
                 pitch: 1920,
@@ -1228,7 +1493,9 @@ mod tests {
     #[test]
     fn test_from_tensor_accepts_non_4_aligned_rgba() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_from_tensor_accepts_non_4_aligned_rgba — DMA not available");
+            crate::test_support::report_skip(
+                "test_from_tensor_accepts_non_4_aligned_rgba — DMA not available",
+            );
             return;
         }
         use crate::{align_pitch_bytes_to_gpu_alignment, primary_plane_bpp};
@@ -1245,7 +1512,9 @@ mod tests {
             ) {
                 Ok(t) => t,
                 Err(e) => {
-                    eprintln!("SKIPPED: image_with_stride failed at width {w}: {e}");
+                    crate::test_support::report_skip(&format!(
+                        "image_with_stride failed at width {w}: {e}"
+                    ));
                     return;
                 }
             };
@@ -1267,7 +1536,9 @@ mod tests {
     #[test]
     fn test_from_tensor_accepts_non_4_aligned_bgra() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_from_tensor_accepts_non_4_aligned_bgra — DMA not available");
+            crate::test_support::report_skip(
+                "test_from_tensor_accepts_non_4_aligned_bgra — DMA not available",
+            );
             return;
         }
         use crate::{align_pitch_bytes_to_gpu_alignment, primary_plane_bpp};
@@ -1283,7 +1554,7 @@ mod tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: image_with_stride failed: {e}");
+                crate::test_support::report_skip(&format!("image_with_stride failed: {e}"));
                 return;
             }
         };
@@ -1331,5 +1602,501 @@ mod tests {
         let err = DmaImportAttrs::from_tensor(&t, PixelFormat::Grey, false)
             .expect_err("Grey width 375 must still be rejected");
         assert!(matches!(err, crate::Error::NotSupported(_)));
+    }
+
+    // ─── aligned_source_base tests ───────────────────────────────────
+
+    /// The offsets the i.MX 95 probe classified (issue #165), at RGBA's
+    /// 4 bytes per pixel: 32 and 2080 sampled zeros, 0/64/256/2048 were fine.
+    /// `lcm(64, 4)` is 64, so the base is just the 64-byte floor and the
+    /// remainder is always a whole number of RGBA pixels.
+    #[test]
+    fn aligned_source_base_rgba_floors_to_64_and_shifts_whole_pixels() {
+        let f = |o| super::aligned_source_base(o, 4, 64);
+        // Aligned offsets are untouched: no rebase, no shift, so every
+        // driver sees exactly the import it sees today.
+        assert_eq!(f(0), Some((0, 0)));
+        assert_eq!(f(64), Some((64, 0)));
+        assert_eq!(f(256), Some((256, 0)));
+        assert_eq!(f(2048), Some((2048, 0)));
+        // The two that sampled zeros. 32 is 8 RGBA pixels past base 0;
+        // 2080 is 8 past base 2048 -- the (8, 0) and (8, 8) view origins.
+        assert_eq!(f(32), Some((0, 8)));
+        assert_eq!(f(2080), Some((2048, 8)));
+    }
+
+    /// Grey is 1 byte per pixel, so the remainder is whole by construction
+    /// and every byte of the 64-byte residue becomes a texel of shift.
+    #[test]
+    fn aligned_source_base_grey_shifts_every_residue_byte() {
+        let f = |o| super::aligned_source_base(o, 1, 64);
+        assert_eq!(f(0), Some((0, 0)));
+        assert_eq!(f(32), Some((0, 32)));
+        assert_eq!(f(2080), Some((2048, 32)));
+        assert_eq!(f(63), Some((0, 63)));
+    }
+
+    /// RGB is the case the `lcm` exists for: 3 does not divide 64, so the
+    /// step is `lcm(64, 3) = 192` and the base walks back to a multiple of
+    /// BOTH. A 64-byte floor alone would leave a fractional pixel.
+    #[test]
+    fn aligned_source_base_rgb_steps_by_lcm_192() {
+        let f = |o| super::aligned_source_base(o, 3, 64);
+        assert_eq!(f(0), Some((0, 0)));
+        assert_eq!(f(192), Some((192, 0)));
+        // 96 = 32 RGB pixels; base 0, because 96 is not a multiple of 192.
+        assert_eq!(f(96), Some((0, 32)));
+        // 2079 = 3 * 693. Base 1920 (= 10 * 192, and 1920 % 64 == 0),
+        // remainder 159 bytes = 53 whole RGB pixels.
+        assert_eq!(f(2079), Some((1920, 53)));
+        // A 64-byte floor would have given base 2048 and a 31-byte
+        // remainder, which is not a whole number of RGB pixels.
+        assert_ne!(f(2079).map(|(b, _)| b), Some(2048));
+    }
+
+    /// An offset that is not a whole number of pixels has no aligned base
+    /// with a whole-pixel remainder, and the import must decline rather
+    /// than fold half a pixel.
+    #[test]
+    fn aligned_source_base_refuses_a_fractional_pixel_offset() {
+        assert_eq!(super::aligned_source_base(2080, 3, 64), None);
+        assert_eq!(super::aligned_source_base(2081, 4, 64), None);
+        assert_eq!(super::aligned_source_base(1, 2, 64), None);
+        // Degenerate inputs are refusals, not panics or divisions by zero.
+        assert_eq!(super::aligned_source_base(64, 0, 64), None);
+        assert_eq!(super::aligned_source_base(64, 4, 0), None);
+    }
+
+    /// The two invariants every caller depends on, over a sweep rather than
+    /// a handful of points: the base is import-aligned, and the shift is an
+    /// exact whole-pixel distance from it back to the tensor's own offset.
+    #[test]
+    fn aligned_source_base_invariants_hold_across_a_sweep() {
+        for bpp in [1usize, 3, 4] {
+            for px in 0usize..4096 {
+                let offset = px * bpp;
+                let Some((base, shift)) = super::aligned_source_base(offset, bpp, 64) else {
+                    panic!("a whole-pixel offset {offset} at {bpp} bpp must have a base");
+                };
+                assert_eq!(base % 64, 0, "base {base} must be 64-byte aligned");
+                assert!(base <= offset, "base {base} must not pass offset {offset}");
+                assert_eq!(
+                    base + shift as usize * bpp,
+                    offset,
+                    "shift {shift} px at {bpp} bpp must close base {base} to {offset}"
+                );
+            }
+        }
+    }
+
+    // ─── source rebase onto an aligned base (issue #170) ─────────────
+
+    /// Allocate the DMA parent the rebase tests view into, or `None` when
+    /// this machine has no usable DMA heap (the heap is root-only on the
+    /// desk, so an unprivileged run skips) or cannot allocate this format.
+    #[cfg(feature = "dma_test_formats")]
+    fn dma_parent(width: usize, height: usize, fmt: PixelFormat) -> Option<Tensor<u8>> {
+        if !is_dma_available() {
+            return None;
+        }
+        match Tensor::<u8>::image(
+            width,
+            height,
+            fmt,
+            Some(TensorMemory::DmaBuf),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        ) {
+            Ok(t) if t.memory() == TensorMemory::DmaBuf => Some(t),
+            _ => None,
+        }
+    }
+
+    /// A source at an unaligned RGBA offset imports from the 64-byte floor,
+    /// widened by the remainder in pixels, at the SAME pitch -- so the
+    /// tensor's first pixel is texel `x_shift_px` of row 0. This is the
+    /// import Mali samples correctly where the unrebased one sampled zeros
+    /// (issue #170).
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn from_tensor_rebases_an_unaligned_rgba_source_to_an_aligned_base() {
+        let Some(parent) = dma_parent(64, 64, PixelFormat::Rgba) else {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - DMA not available",
+                function!()
+            );
+            return;
+        };
+        let pitch = parent.effective_row_stride().unwrap_or(256);
+        // (8, 8) of a 256-byte-pitched RGBA surface: offset 2080, the origin
+        // that sampled zeros on i.MX 95.
+        let view = parent
+            .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+            .unwrap();
+        assert_eq!(view.plane_offset(), Some(8 * pitch + 32));
+        let s = DmaImportAttrs::from_tensor(&view, PixelFormat::Rgba, false).unwrap();
+        assert_eq!(s.plane0_offset % 64, 0, "the import base must be aligned");
+        assert_eq!(s.plane0_offset, 8 * pitch + 32 - 32);
+        assert_eq!(s.x_shift_px, 8, "32 bytes is 8 RGBA pixels");
+        assert_eq!(s.width, 16 + 8, "the import widens by the shift");
+        assert_eq!(
+            s.plane0_pitch, pitch,
+            "the pitch is the parent's, unchanged"
+        );
+    }
+
+    /// An ALIGNED source is untouched -- no rebase, no shift, no widening --
+    /// so every driver sees exactly the import it saw before issue #170.
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn from_tensor_leaves_an_aligned_source_alone() {
+        let Some(parent) = dma_parent(64, 64, PixelFormat::Rgba) else {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - DMA not available",
+                function!()
+            );
+            return;
+        };
+        let pitch = parent.effective_row_stride().unwrap_or(256);
+        assert_eq!(pitch % 64, 0, "the premise: a 64-aligned parent pitch");
+        // (0, 8): offset 8 * pitch, aligned whenever the pitch is.
+        let view = parent
+            .view(edgefirst_tensor::Region::new(0, 8, 16, 16))
+            .unwrap();
+        let s = DmaImportAttrs::from_tensor(&view, PixelFormat::Rgba, false).unwrap();
+        assert_eq!(s.plane0_offset, 8 * pitch);
+        assert_eq!(s.x_shift_px, 0);
+        assert_eq!(s.width, 16);
+    }
+
+    /// A DESTINATION is never rebased: it imports its parent at base 0 and
+    /// places the tile by viewport, and the drivers that fail on the
+    /// destination side fail loudly rather than silently (Vivante,
+    /// EGL_BAD_ACCESS), which `dst_import_places` already lowers.
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn from_tensor_never_rebases_a_destination() {
+        let Some(parent) = dma_parent(64, 64, PixelFormat::Rgba) else {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - DMA not available",
+                function!()
+            );
+            return;
+        };
+        let view = parent
+            .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+            .unwrap();
+        let d = DmaImportAttrs::from_tensor(&view, PixelFormat::Rgba, true).unwrap();
+        assert_eq!(d.plane0_offset, 0, "a dst view imports its parent");
+        assert_eq!(d.x_shift_px, 0, "and is never shifted");
+        assert_eq!(d.width, 64, "at the parent's own width");
+    }
+    // ─── rebase_fits_pitch ───────────────────────────────────────────
+
+    /// The pitch guard is about ROOM, and the room is the pitch padding.
+    /// A pitch that is merely tight -- a foreign DMA-BUF adopted at the
+    /// producer's own stride -- has none, and the rebase must be declined
+    /// rather than handed to EGL as a row that runs past its pitch.
+    #[test]
+    fn rebase_fits_pitch_declines_a_tight_foreign_pitch() {
+        let fits = super::rebase_fits_pitch;
+        // 100 RGBA pixels at the producer's tight 400-byte stride: the row
+        // already fills the pitch, so even one pixel of shift runs past it.
+        assert!(!fits(100, 1, 4, 400));
+        assert!(!fits(100, 8, 4, 400));
+        // No shift is the unrebased import, which always fits.
+        assert!(fits(100, 0, 4, 400));
+        // The same width at the 64-padded pitch a HAL allocation gives it
+        // (448) has room for a shift, but only up to the padding: 12 pixels
+        // is 448 bytes exactly, 13 is 452 and runs past.
+        assert!(fits(100, 12, 4, 448));
+        assert!(!fits(100, 13, 4, 448));
+        // The shape the pin test exercises: a 16-pixel view shifted 8
+        // pixels inside a 256-byte parent pitch, with room to spare.
+        assert!(fits(16, 8, 4, 256));
+        // Overflow is "does not fit", never a wrap or a panic.
+        assert!(!fits(usize::MAX, 1, 4, usize::MAX));
+    }
+
+    // ─── which formats rebase (issue #170) ───────────────────────────
+
+    /// `Rgb` is 3 bytes per pixel, so its step is `lcm(64, 3) = 192` rather
+    /// than 64 and the base walks back further than a 64-byte floor would.
+    /// Asserted against the offset the view actually reports, so a board
+    /// whose pitch padding differs is still pinned rather than skipped.
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn from_tensor_rebases_an_unaligned_rgb_source_by_the_lcm_step() {
+        let Some(parent) = dma_parent(64, 64, PixelFormat::Rgb) else {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - DMA not available",
+                function!()
+            );
+            return;
+        };
+        let pitch = parent.effective_row_stride().unwrap_or(192);
+        let view = parent
+            .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+            .unwrap();
+        // (8, 8) of a 192-byte-pitched RGB surface is offset 1560: base
+        // 1536 (8 * 192), shift 8 pixels = 24 bytes.
+        let offset = view.plane_offset().unwrap_or(0);
+        assert_eq!(offset, 8 * pitch + 24);
+        let expect_base = offset - offset % 192;
+        let expect_shift = (offset - expect_base) / 3;
+        assert!(
+            expect_shift > 0,
+            "precondition: offset {offset} at pitch {pitch} must be unaligned"
+        );
+        let s = DmaImportAttrs::from_tensor(&view, PixelFormat::Rgb, false).unwrap();
+        assert_eq!(s.plane0_offset, expect_base, "base steps by lcm(64, 3)");
+        assert_eq!(s.plane0_offset % 64, 0, "and is still import-aligned");
+        assert_eq!(s.x_shift_px as usize, expect_shift);
+        assert_eq!(s.width, 16 + expect_shift, "the import widens by the shift");
+        assert_eq!(
+            s.plane0_pitch, pitch,
+            "the pitch is the parent's, unchanged"
+        );
+    }
+
+    /// `Grey` is 1 byte per pixel, so every residue byte is a texel of
+    /// shift and the step is just the 64-byte alignment.
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn from_tensor_rebases_an_unaligned_grey_source_byte_for_texel() {
+        let Some(parent) = dma_parent(64, 64, PixelFormat::Grey) else {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - DMA not available",
+                function!()
+            );
+            return;
+        };
+        let pitch = parent.effective_row_stride().unwrap_or(64);
+        let view = parent
+            .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+            .unwrap();
+        // (8, 8) of a 64-byte-pitched Grey surface is offset 520: base 512,
+        // shift 8 bytes = 8 pixels.
+        let offset = view.plane_offset().unwrap_or(0);
+        assert_eq!(offset, 8 * pitch + 8);
+        let expect_base = offset - offset % 64;
+        let expect_shift = offset - expect_base;
+        assert!(
+            expect_shift > 0,
+            "precondition: offset {offset} at pitch {pitch} must be unaligned"
+        );
+        let s = DmaImportAttrs::from_tensor(&view, PixelFormat::Grey, false).unwrap();
+        assert_eq!(s.plane0_offset, expect_base);
+        assert_eq!(s.plane0_offset % 64, 0);
+        assert_eq!(
+            s.x_shift_px as usize, expect_shift,
+            "1 bpp: a byte is a texel"
+        );
+        assert_eq!(s.width, 16 + expect_shift);
+        assert_eq!(s.plane0_pitch, pitch);
+    }
+
+    // ─── the gate and the import read the same answer ────────────────
+
+    /// The four shapes the Mali gate has to tell apart, as a pure table.
+    /// Keyed on the RESOLVED offset, so a packed format is exempt only when
+    /// the fold actually moved it -- which is the whole point of issue
+    /// #170's fix round: a format-keyed exemption waves the last two
+    /// through into a black frame on Mali.
+    #[test]
+    fn the_resolved_offset_tells_the_four_shapes_apart() {
+        // The gate's question, in the production resolver's terms.
+        let aligned = |fmt, w, pitch, off| {
+            super::resolve_source_plane0(fmt, w, pitch, off)
+                .0
+                .is_multiple_of(DMA_IMPORT_OFFSET_ALIGN)
+        };
+
+        // Rebased: a 16-pixel view 8 pixels into a 256-byte-pitched RGBA
+        // parent, at the offset i.MX 95 sampled zeros from. Room to widen
+        // ((16 + 8) * 4 = 96 <= 256), so the base is 2048 and it is exempt.
+        assert!(aligned(PixelFormat::Rgba, 16, 256, 2080));
+        // Already aligned: exempt without being touched.
+        assert!(aligned(PixelFormat::Rgba, 64, 256, 2048));
+        // Tight pitch, no room: a whole 64-wide RGBA tensor at a
+        // `set_plane_offset(32)` window. Its stride is 256 because 256 is
+        // already 64-aligned and nothing was padded on, so the widened row
+        // would be (64 + 8) * 4 = 288 > 256. NOT exempt.
+        assert!(!aligned(PixelFormat::Rgba, 64, 256, 32));
+        // Stride not a whole pixel count: a 100-wide RGB surface pads to
+        // 320 bytes, which is not a multiple of 3, so row 1 column 1 is at
+        // 323 -- unaligned and not a whole number of pixels. NOT exempt.
+        assert!(!aligned(PixelFormat::Rgb, 16, 320, 323));
+    }
+
+    /// The anti-drift pin the gate's safety rests on: for every shape, the
+    /// offset `resolved_source_plane0_offset` reports (what the gate reads)
+    /// is byte-for-byte the `plane0_offset` `from_tensor` puts in the import
+    /// (what EGL is handed). If these two ever disagree the gate is deciding
+    /// about an import that does not exist -- declining a good one, or
+    /// waving through one that comes back black.
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn the_gate_reads_the_offset_the_import_presents() {
+        if !is_dma_available() {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - DMA not available",
+                function!()
+            );
+            return;
+        }
+        // (format, parent w/h, view or whole-tensor offset)
+        let cases: [(PixelFormat, usize, usize, Option<usize>); 5] = [
+            // A rebased RGBA view: (8, 8) of 64x64, offset 2080.
+            (PixelFormat::Rgba, 64, 64, None),
+            // The tight-pitch whole tensor at a window offset.
+            (PixelFormat::Rgba, 64, 64, Some(32)),
+            // An aligned window offset, which must stay put.
+            (PixelFormat::Rgba, 64, 64, Some(64)),
+            // Rgb, whose 64-padded stride is not a multiple of 3.
+            (PixelFormat::Rgb, 100, 8, Some(323)),
+            // A format the fold never covers.
+            (PixelFormat::Nv12, 64, 64, Some(32)),
+        ];
+        // The whole test already returned above when there is no DMA heap,
+        // so on a host that reached here every case must be allocatable and
+        // every case must be compared. Counting and asserting the full total
+        // (rather than merely "more than none") is what stops this pin from
+        // going quietly vacuous if a format stops allocating.
+        let total = cases.len();
+        let mut compared = 0usize;
+        for (fmt, w, h, whole_offset) in cases {
+            let Some(mut parent) = dma_parent(w, h, fmt) else {
+                use std::io::Write;
+                let _ = writeln!(
+                    &mut std::io::stderr(),
+                    "SKIPPED: {} {fmt:?} - not allocatable here",
+                    function!()
+                );
+                continue;
+            };
+            if fmt == PixelFormat::Rgb {
+                // The premise of this row: a 100-wide RGB surface pads its
+                // 300-byte row to 320, which is not a multiple of 3, so byte
+                // 323 is row 1 column 1 and is NOT a whole number of pixels
+                // from the start. Asserted rather than assumed -- a board
+                // that padded differently would quietly turn this row into
+                // an ordinary aligned case.
+                let pitch = parent.effective_row_stride().unwrap_or(0);
+                assert_eq!(pitch, 320, "precondition: the padded Rgb stride");
+                let off = whole_offset.unwrap();
+                assert_eq!(off, pitch + 3, "precondition: row 1, column 1");
+                assert_ne!(off % 3, 0, "precondition: {off} is mid-pixel");
+                assert_ne!(off % 64, 0, "precondition: {off} is unaligned");
+            }
+            let attrs = match whole_offset {
+                Some(off) => {
+                    parent.set_plane_offset(off);
+                    DmaImportAttrs::from_tensor(&parent, fmt, false)
+                        .unwrap_or_else(|e| panic!("{fmt:?} at {off}: {e}"))
+                }
+                None => {
+                    let view = parent
+                        .view(edgefirst_tensor::Region::new(8, 8, 16, 16))
+                        .unwrap();
+                    let a = DmaImportAttrs::from_tensor(&view, fmt, false).unwrap();
+                    assert_eq!(
+                        super::resolved_source_plane0_offset(&view, fmt),
+                        a.plane0_offset,
+                        "{fmt:?} view: the gate and the import must agree"
+                    );
+                    compared += 1;
+                    continue;
+                }
+            };
+            assert_eq!(
+                super::resolved_source_plane0_offset(&parent, fmt),
+                attrs.plane0_offset,
+                "{fmt:?} at {whole_offset:?}: the gate and the import must agree"
+            );
+            compared += 1;
+        }
+        assert_eq!(
+            compared, total,
+            "a DMA heap is available, so every case must be comparable, but only \
+             {compared} of {total} were (see the SKIPPED lines above); \
+             the gate-versus-import equality went unpinned for the rest"
+        );
+    }
+
+    /// A whole 64-wide RGBA tensor at a `set_plane_offset` window is the
+    /// shape a format-keyed Mali exemption got wrong: its stride is tight at
+    /// 256 bytes (64 * 4 is already 64-aligned, so nothing was padded on),
+    /// leaving no room to widen, so the import keeps its own unaligned
+    /// offset and Mali must go on declining it.
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn from_tensor_cannot_rebase_a_window_into_a_tight_pitch() {
+        let Some(mut t) = dma_parent(64, 64, PixelFormat::Rgba) else {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - DMA not available",
+                function!()
+            );
+            return;
+        };
+        let pitch = t.effective_row_stride().unwrap_or(256);
+        assert_eq!(pitch, 64 * 4, "precondition: the pitch is tight");
+        t.set_plane_offset(32);
+        let s = DmaImportAttrs::from_tensor(&t, PixelFormat::Rgba, false).unwrap();
+        assert_eq!(s.plane0_offset, 32, "no room to widen, so no rebase");
+        assert_eq!(s.x_shift_px, 0);
+        assert_eq!(s.width, 64, "and no widening");
+        assert!(
+            !super::resolve_source_plane0(PixelFormat::Rgba, 64, pitch, 32)
+                .0
+                .is_multiple_of(DMA_IMPORT_OFFSET_ALIGN),
+            "so Mali must still decline it"
+        );
+    }
+
+    /// The formats the fold does NOT cover import at their own offset with
+    /// no shift, however unaligned that offset is: YUYV/VYUY carry a
+    /// 2-pixel macropixel phase a texel shift would break, NV12's second
+    /// plane has an offset of its own, and planar RGB stacks its planes by
+    /// row. The Mali gate in the processor must keep declining these, which
+    /// is only sound while they are not rebased here.
+    #[test]
+    #[cfg(feature = "dma_test_formats")]
+    fn from_tensor_never_rebases_the_formats_the_fold_misses() {
+        for fmt in [PixelFormat::Yuyv, PixelFormat::Nv12, PixelFormat::PlanarRgb] {
+            let Some(mut t) = dma_parent(64, 64, fmt) else {
+                use std::io::Write;
+                let _ = writeln!(
+                    &mut std::io::stderr(),
+                    "SKIPPED: {} {fmt:?} - not allocatable here",
+                    function!()
+                );
+                continue;
+            };
+            // 32 is one of the two offsets i.MX 95 sampled zeros from, and
+            // is unaligned for every one of these formats.
+            t.set_plane_offset(32);
+            let s = DmaImportAttrs::from_tensor(&t, fmt, false)
+                .unwrap_or_else(|e| panic!("{fmt:?} source import must resolve: {e}"));
+            assert_eq!(s.x_shift_px, 0, "{fmt:?} must not be rebased");
+            assert_eq!(
+                s.plane0_offset, 32,
+                "{fmt:?} keeps its own (unaligned) offset"
+            );
+            assert_eq!(s.width, 64, "{fmt:?} must not be widened");
+        }
     }
 }

--- a/crates/image/src/gl/platform/linux.rs
+++ b/crates/image/src/gl/platform/linux.rs
@@ -28,6 +28,11 @@ pub(in crate::opengl_headless) struct EglImage {
     pub(in crate::opengl_headless) egl_image: egl::Image,
     pub(in crate::opengl_headless) egl: Rc<Egl>,
     pub(in crate::opengl_headless) display: egl::Display,
+    /// Texel the logical image starts at inside this import, and the
+    /// import's own texel size — both `(0, 0)` / `None` unless a source was
+    /// rebased onto an aligned DMA-BUF offset (issue #170).
+    pub(in crate::opengl_headless) sample_origin_px: (u32, u32),
+    pub(in crate::opengl_headless) sample_extent_px: Option<(u32, u32)>,
 }
 
 impl Drop for EglImage {
@@ -87,10 +92,16 @@ impl GlPlatform for LinuxEgl {
         import.egl_image
     }
 
-    fn import_extent(_import: &EglImage) -> Option<(u32, u32)> {
-        // The DMA-BUF EGLImage is created at the tensor's logical size; the
-        // buffer's physical pitch is a separate import attribute.
-        None
+    fn import_extent(import: &EglImage) -> Option<(u32, u32)> {
+        // The DMA-BUF EGLImage is created at the tensor's logical size --
+        // the buffer's physical pitch is a separate import attribute -- so
+        // this is `None` except for a source rebased onto an aligned offset
+        // (issue #170), which imports `x_shift_px` texels wider.
+        import.sample_extent_px
+    }
+
+    fn import_origin(import: &EglImage) -> (u32, u32) {
+        import.sample_origin_px
     }
 
     unsafe fn attach_tex_image_2d(_display: &GlContext, handle: egl::Image) -> crate::Result<()> {
@@ -224,7 +235,20 @@ impl GlPlatform for LinuxEgl {
         for_dst: bool,
     ) -> crate::Result<EglImage> {
         let attrs = DmaImportAttrs::from_tensor(img, fmt, for_dst)?;
-        new_egl_image_owned(display, egl_ext::LINUX_DMA_BUF, &attrs.to_egl_attribs())
+        let mut image =
+            new_egl_image_owned(display, egl_ext::LINUX_DMA_BUF, &attrs.to_egl_attribs())?;
+        // A source rebased onto an aligned base imports wider than the
+        // logical image and starts it `x_shift_px` texels in; the engine
+        // folds both through `import_extent` / `import_origin`. Zero for
+        // every other import, which then reports the logical image as
+        // before. The extent travels WITH the origin: the fold ignores an
+        // origin whose map has no extent, which would put the shift nowhere
+        // and show up only as a black frame on the one board that rebases.
+        if attrs.x_shift_px != 0 {
+            image.sample_origin_px = (attrs.x_shift_px, 0);
+            image.sample_extent_px = Some((attrs.width as u32, attrs.height as u32));
+        }
+        Ok(image)
     }
 
     fn import_buffer_nv_r8(
@@ -271,5 +295,7 @@ pub(in crate::opengl_headless) fn new_egl_image_owned(
         egl_image: image,
         display: display.display,
         egl: Rc::clone(&display.egl),
+        sample_origin_px: (0, 0),
+        sample_extent_px: None,
     })
 }

--- a/crates/image/src/gl/platform/macos.rs
+++ b/crates/image/src/gl/platform/macos.rs
@@ -304,9 +304,9 @@ mod tests {
             .iter()
             .any(|p| std::path::Path::new(p).exists());
         if !exists_at_any {
-            eprintln!(
-                "ANGLE not installed at any default path — skipping. \
-                 Run `brew install startergo/angle/angle` to enable this test."
+            crate::test_support::report_skip(
+                "ANGLE not installed at any default path — run `brew install \
+                 startergo/angle/angle` to enable this test",
             );
             return;
         }
@@ -317,9 +317,9 @@ mod tests {
         // check above is the portable smoke-test, and the integration
         // test exercises the real load path.
         if std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
-            eprintln!(
-                "HAL_TEST_ALLOW_DLOPEN_ANGLE unset — skipping ANGLE dlopen \
-                 probe (run via scripts/test-macos.sh to exercise it)."
+            crate::test_support::report_skip(
+                "HAL_TEST_ALLOW_DLOPEN_ANGLE unset — run via \
+                 scripts/test-macos.sh to exercise the ANGLE dlopen probe",
             );
             return;
         }

--- a/crates/image/src/gl/platform/mod.rs
+++ b/crates/image/src/gl/platform/mod.rs
@@ -338,9 +338,11 @@ pub(super) trait GlPlatform {
     /// larger than the tensor's logical image; `None` when the import is
     /// always exactly the logical image.
     ///
-    /// Linux creates the DMA-BUF `EGLImage` at the logical size (the physical
-    /// pitch is a separate attribute) and macOS gives the pbuffer explicit
-    /// dimensions, so on both the import *is* the logical image.
+    /// Linux reports the logical size unless the source was rebased onto an
+    /// aligned DMA-BUF offset, where the import is `x_shift_px` texels wider
+    /// and [`Self::import_origin`] says where the image starts on it; macOS
+    /// gives the pbuffer explicit dimensions, so there the import *is* the
+    /// logical image.
     /// `EGL_ANGLE_image_d3d11_texture` has no sub-extent attribute: a pool
     /// buffer narrowed by `configure_image` keeps its texture and imports all
     /// of it, so Windows reports the texture's texel size and the engine
@@ -349,14 +351,30 @@ pub(super) trait GlPlatform {
     /// logical image ([`super::render::sample_clamp_rect`]). A leaf that
     /// returns `None` reaches both as the identity.
     ///
-    /// Not every sampling site clamps: the two `GL_TEXTURE_EXTERNAL_OES`
-    /// camera programs (`draw_camera_texture_to_rgb_planar`,
-    /// `draw_camera_texture_eglimage`) scale their source rectangle and stop
-    /// there. They exist only where [`Self::EXTERNAL_OES`] is true, which
-    /// today is only the leaf that returns `None` here, so a narrowed import
-    /// cannot reach them. A leaf that returns `Some` and has external-OES
-    /// programs must add the clamp to both.
+    /// Every sampling site clamps, the two `GL_TEXTURE_EXTERNAL_OES` camera
+    /// programs (`draw_camera_texture_to_rgb_planar`,
+    /// `draw_camera_texture_eglimage`) included: they now carry the same
+    /// `src_extent` uniform the `sampler2D` programs do, which is what lets
+    /// the Linux leaf report a narrowed extent and a nonzero
+    /// [`Self::import_origin`] and still use them.
     fn import_extent(import: &Self::Import) -> Option<(u32, u32)>;
+
+    /// Texels from the imported texture's origin to the tensor's own first
+    /// pixel, when a leaf can start the logical image partway into the
+    /// import; `(0, 0)` — the default — when the logical image always begins
+    /// at the texture's origin.
+    ///
+    /// The companion of [`Self::import_extent`]: the extent says how much
+    /// texture the import covers, this says where in it the logical image
+    /// starts, and the engine folds both through one
+    /// [`super::render::ImportMap`] at every site that turns logical-image
+    /// coordinates into texture coordinates. Linux returns a nonzero origin
+    /// for a source rebased onto a 64-byte-aligned DMA-BUF base, which the
+    /// import then widens by the same shift (issue #170); every other leaf
+    /// keeps the default.
+    fn import_origin(_import: &Self::Import) -> (u32, u32) {
+        (0, 0)
+    }
 
     /// Attach the import as the image of the CURRENTLY BOUND
     /// `GL_TEXTURE_2D` texture object. Linux:

--- a/crates/image/src/gl/platform/windows.rs
+++ b/crates/image/src/gl/platform/windows.rs
@@ -1298,11 +1298,13 @@ mod tests {
     #[test]
     fn load_egl_lib_finds_angle_or_skips() {
         let Some(dir) = std::env::var_os("EDGEFIRST_ANGLE_PATH") else {
-            eprintln!("EDGEFIRST_ANGLE_PATH unset — skipping ANGLE load probe");
+            crate::test_support::report_skip("EDGEFIRST_ANGLE_PATH unset — no ANGLE load probe");
             return;
         };
         if !Path::new(&dir).join("libEGL.dll").is_file() {
-            eprintln!("no libEGL.dll under EDGEFIRST_ANGLE_PATH — skipping ANGLE load probe");
+            crate::test_support::report_skip(
+                "no libEGL.dll under EDGEFIRST_ANGLE_PATH — no ANGLE load probe",
+            );
             return;
         }
         WindowsPlatform::load_egl_lib()
@@ -1321,11 +1323,11 @@ mod tests {
         // other tests in this binary; see `lifecycle_guard`.
         let _lifecycle = super::super::super::threaded::lifecycle_guard();
         let Ok(keeper) = AngleD3d11::init_display(None) else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         let Ok(doomed) = AngleD3d11::init_display(None) else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         // `keeper` issues the last commands, so it is the context the
@@ -1357,7 +1359,7 @@ mod tests {
         // other tests in this binary; see `lifecycle_guard`.
         let _lifecycle = super::super::super::threaded::lifecycle_guard();
         let Ok(shared) = shared_display() else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         let dev = edgefirst_tensor::d3d11::device().expect("device");
@@ -1377,7 +1379,7 @@ mod tests {
         // other tests in this binary; see `lifecycle_guard`.
         let _lifecycle = super::super::super::threaded::lifecycle_guard();
         let Ok(display) = AngleD3d11::init_display(None) else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         let t = edgefirst_tensor::Tensor::<u8>::image(
@@ -1433,7 +1435,7 @@ mod tests {
         // other tests in this binary; see `lifecycle_guard`.
         let _lifecycle = super::super::super::threaded::lifecycle_guard();
         let Ok(display) = AngleD3d11::init_display(None) else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         assert!(AngleD3d11::native_fence_sync(&display));

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -303,7 +303,11 @@ pub struct GLProcessorST {
     /// Whether the GPU is an Arm Mali core (GL_RENDERER). Used to decline a
     /// source DMA-BUF import at a plane offset Mali would sample zeros from,
     /// so the upload path takes it instead — see `mali_rejects_import_offset`
-    /// and issue #165.
+    /// and issue #165. Its reach is now the imports the aligned-base rebase
+    /// does not move: a source it rebases presents an aligned base and stays
+    /// zero-copy, so what still declines is NV12's two-plane import, the
+    /// combined-plane R8 import, YUYV's macropixel phase, planar R8, and any
+    /// packed source the rebase could not apply to (#170).
     is_mali: bool,
     /// Whether the GPU is a virtualized/paravirtual device (GL_RENDERER).
     /// Concurrent GL across contexts mis-renders on paravirtual Metal
@@ -352,6 +356,11 @@ pub struct GLProcessorST {
     /// `draw_src_texture` and `draw_src_texture_from_pbo` select between;
     /// see [`Self::texture_src_extent_loc`].
     texture_src_extent_locs: [i32; 2],
+    /// Link-time `src_extent` locations for the four external-OES programs,
+    /// in the order `[yuv, yuv_int8, planar, planar_int8]`. `-1` on a
+    /// platform without external OES, where the programs are `None` and
+    /// `glUniform4f(-1, ..)` is a defined no-op.
+    external_src_extent_locs: [i32; 4],
     /// Shader: packed RGB -> RGBA8 packing (2D texture source, pass 2).
     packed_rgba8_program_2d: GlProgram,
     /// Shader: packed RGB int8 -> RGBA8 packing with XOR 0x80 (2D texture source, pass 2).
@@ -881,7 +890,11 @@ struct RendererTraits {
     /// Arm Mali (i.MX 95 G310 and kin). Its DMA-BUF import silently samples
     /// zeros when `EGL_DMA_BUF_PLANE0_OFFSET_EXT` is not 64-byte aligned —
     /// the import succeeds and no EGL error follows — so a source at such an
-    /// offset is declined and uploaded instead (issue #165).
+    /// offset is declined and uploaded instead (issue #165). The trait
+    /// remains; the offset it is asked about is now the one the import will
+    /// present, so a packed source folded onto an aligned base keeps the
+    /// zero copy and only what the fold could not move declines (issue
+    /// #170).
     mali: bool,
     /// Software rasterizer (llvmpipe/softpipe/swrast) — rejected unless the
     /// coverage-lane override is set.
@@ -1332,7 +1345,7 @@ fn classify_renderer(renderer: &str) -> RendererTraits {
 /// Two data points bracket the Vivante rule rather than pin it — the true
 /// requirement is somewhere in `(32, 2048]` — so 64 is the tightest value
 /// consistent with both drivers rather than a documented driver constant.
-const DMA_IMPORT_OFFSET_ALIGN: usize = 64;
+pub(super) const DMA_IMPORT_OFFSET_ALIGN: usize = 64;
 
 /// Whether `plane_offset` is one of the offsets no measured embedded driver
 /// imports correctly. Pure, so the per-driver rules below are unit-testable
@@ -1347,8 +1360,39 @@ fn unaligned_import_offset(plane_offset: usize) -> bool {
 /// checked by its caller: a two-plane NV12 import hands EGL a plane-1 offset
 /// of its own, which can be unaligned while plane 0 is aligned — see
 /// [`nv12_plane1_offset`].
+///
+/// Asked of the offset the import will PRESENT, which for a source is
+/// [`source_import_plane0_offset`] rather than the tensor's own: a rebased
+/// source imports at an aligned base and is not declined, an unrebased one
+/// still carries its unaligned offset and is (issue #170).
 fn mali_rejects_import_offset(is_mali: bool, plane_offset: usize) -> bool {
     is_mali && unaligned_import_offset(plane_offset)
+}
+
+/// The plane-0 offset a SOURCE import of `img` will present to EGL.
+///
+/// Not `img.plane_offset()`: since issue #170 a source at an unaligned
+/// offset may import from the aligned base below it with the remainder
+/// folded into the sampling rectangle, and it is the base, not the tensor's
+/// own offset, that reaches `EGL_DMA_BUF_PLANE0_OFFSET_EXT`. Asking the
+/// tensor would decline a rebased source for nothing AND pass an unrebased
+/// one that comes back black, so the answer comes from the same function the
+/// import is built from — `dma_import::resolve_source_plane0`, the single
+/// source of truth.
+///
+/// Off Linux there is no DMA-BUF import to rebase, so the tensor's own
+/// offset is the answer; no non-Linux backend reports a Mali renderer
+/// anyway, which is the only thing that consults this.
+fn source_import_plane0_offset(img: &Tensor<u8>, img_fmt: PixelFormat) -> usize {
+    #[cfg(target_os = "linux")]
+    {
+        super::dma_import::resolved_source_plane0_offset(img, img_fmt)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = img_fmt;
+        img.plane_offset().unwrap_or(0)
+    }
 }
 
 /// Whether Vivante would fail to import a DESTINATION at `plane_offset`.
@@ -1637,6 +1681,24 @@ impl GLProcessorST {
             None
         };
 
+        // SAFETY: each program, when present, was linked above on this
+        // thread's current context; `GetUniformLocation` reads a linked
+        // program without needing it current, and the name is a `c"..."`
+        // literal.
+        let external_src_extent_locs = unsafe {
+            [
+                texture_program_yuv.as_ref(),
+                texture_int8_program_yuv.as_ref(),
+                texture_program_planar.as_ref(),
+                texture_program_planar_int8.as_ref(),
+            ]
+            .map(|p| {
+                p.map_or(-1, |p| {
+                    edgefirst_gl::gl::GetUniformLocation(p.id, c"src_extent".as_ptr())
+                })
+            })
+        };
+
         // Planar RGB shaders with sampler2D (for two-pass NV12→RGBA→PlanarRgb on Vivante)
         let texture_program_planar_2d =
             GlProgram::new(generate_vertex_shader(), generate_planar_rgb_shader_2d())?;
@@ -1766,6 +1828,7 @@ impl GLProcessorST {
             yuyv_program_2d,
             yuyv_2d_locs,
             texture_src_extent_locs,
+            external_src_extent_locs,
             packed_rgba8_program_2d,
             packed_rgba8_int8_program_2d,
             texture_program_planar_2d,
@@ -4022,7 +4085,8 @@ impl GLProcessorST {
             });
             // The uploaded texture is exactly the logical image, so the
             // sample clamp is the texture's own half-texel inset.
-            let [u0, v0, u1, v1] = super::render::sample_clamp_rect((src_w, src_h), None);
+            let [u0, v0, u1, v1] =
+                super::render::sample_clamp_rect((src_w, src_h), super::render::ImportMap::WHOLE);
             edgefirst_gl::gl::Uniform4f(self.texture_src_extent_loc(is_int8), u0, v0, u1, v1);
             edgefirst_gl::gl::ActiveTexture(edgefirst_gl::gl::TEXTURE0);
             edgefirst_gl::gl::BindTexture(texture_target, self.camera_normal_texture.id);
@@ -4874,13 +4938,17 @@ impl GLProcessorST {
         let src_key = BufferImportKey::from_tensor(src, src_fmt, false);
         let src_egl = self.get_or_create_egl_image(CacheKind::Src, src, src_fmt)?;
         // As in `draw_src_texture`: the import may cover more of the texture
-        // than the logical image.
-        let src_roi = self.scale_src_roi(src_roi, src, src_fmt);
+        // than the logical image, and may start it partway in. One cache
+        // lookup feeds both the source rectangle and the sampling clamp.
+        let src_map = self.cached_src_import_map(src, src_fmt);
+        let src_roi = super::render::scale_roi_to_import(src_roi, (src_w, src_h), src_map);
+        let src_extent = super::render::sample_clamp_rect((src_w, src_h), src_map);
 
         self.draw_camera_texture_to_rgb_planar(
             src_key,
             src_egl,
             src_roi,
+            src_extent,
             dst_roi,
             rotation_offset,
             flip,
@@ -5294,6 +5362,10 @@ impl GLProcessorST {
         src_key: BufferImportKey,
         egl_img: PlatformHandle,
         src_roi: RegionOfInterest,
+        // The rectangle a sample may reach on the imported texture
+        // (`render::sample_clamp_rect`), computed at the call site from the
+        // same `ImportMap` that produced `src_roi`.
+        src_extent: [f32; 4],
         mut dst_roi: RegionOfInterest,
         rotation_offset: usize,
         flip: Flip,
@@ -5322,6 +5394,8 @@ impl GLProcessorST {
         .id;
         unsafe {
             edgefirst_gl::gl::UseProgram(program_id);
+            let [e0, e1, e2, e3] = src_extent;
+            edgefirst_gl::gl::Uniform4f(self.external_src_extent_loc(int8, true), e0, e1, e2, e3);
             edgefirst_gl::gl::ActiveTexture(edgefirst_gl::gl::TEXTURE0);
             edgefirst_gl::gl::BindTexture(texture_target, self.camera_eglimage_texture.id);
             super::core::set_tex_filter(texture_target, edgefirst_gl::gl::LINEAR);
@@ -5622,20 +5696,21 @@ impl GLProcessorST {
             None
         };
         // An import can cover more of the texture than the logical image (a
-        // pool tensor narrowed by `configure_image`); sample only the logical
-        // part. `None` when the source is uploaded instead, and on every
-        // platform whose import is already the logical image.
-        let import_extent = zero_copy_attach
-            .is_some()
-            .then(|| self.cached_src_import_extent(src, src_fmt))
-            .flatten();
-        if import_extent.is_some() {
-            src_roi = super::render::scale_roi_to_import(src_roi, (src_w, src_h), import_extent);
-        }
-        // The shader clamps every sample to the logical image's half-texel-inset
-        // rectangle on the texture, so an upscale's last row or column cannot
-        // blend the texel beyond a narrowed image.
-        let [u0, v0, u1, v1] = super::render::sample_clamp_rect((src_w, src_h), import_extent);
+        // pool tensor narrowed by `configure_image`) and can start it partway
+        // in (a source rebased onto an aligned DMA-BUF base, issue #170);
+        // sample only the logical part. `WHOLE` when the source is uploaded
+        // instead, and on every platform whose import is already the logical
+        // image.
+        let import_map = if zero_copy_attach.is_some() {
+            self.cached_src_import_map(src, src_fmt)
+        } else {
+            super::render::ImportMap::WHOLE
+        };
+        src_roi = super::render::scale_roi_to_import(src_roi, (src_w, src_h), import_map);
+        // The shader clamps every sample to the logical image's
+        // half-texel-inset rectangle on the texture, so an upscale's last row
+        // or column cannot blend the texel beyond a narrowed or shifted image.
+        let [u0, v0, u1, v1] = super::render::sample_clamp_rect((src_w, src_h), import_map);
         let texture_format = match src_fmt {
             PixelFormat::Rgb => edgefirst_gl::gl::RGB,
             PixelFormat::Rgba => edgefirst_gl::gl::RGBA,
@@ -5681,8 +5756,16 @@ impl GLProcessorST {
                 // The shader rebuilds texel coordinates as `floor(tc * src_size)`,
                 // and `tc` was just scaled onto the imported texture, so this
                 // must be the texture's own texel grid — not the logical image's,
-                // which would land the pair lookup on the wrong column.
-                let (grid_w, grid_h) = import_extent
+                // which would land the pair lookup on the wrong column. A
+                // nonzero origin would break the Y/UV pair phase, so YUYV is
+                // never rebased (`DmaImportAttrs::from_tensor`).
+                debug_assert_eq!(
+                    import_map.origin,
+                    (0, 0),
+                    "YUYV must not be sampled through a shifted import"
+                );
+                let (grid_w, grid_h) = import_map
+                    .extent
                     .map_or((src_w as f32, src_h as f32), |(pw, ph)| {
                         (pw as f32, ph as f32)
                     });
@@ -5878,8 +5961,21 @@ impl GLProcessorST {
         let src_key = BufferImportKey::from_tensor(src, src_fmt, false);
         let luma_id = src_key.luma_id;
         // As in `draw_src_texture`: the import may cover more of the texture
-        // than the logical image.
+        // than the logical image, and may start it partway in.
         let src_roi = self.scale_src_roi(src_roi, src, src_fmt);
+        // The external-OES programs sample through the same mapping, so they
+        // clamp through it too: a rebased source (issue #170) has real texels
+        // in front of its first column and behind its last, and a LINEAR
+        // kernel at either edge would otherwise blend them.
+        let (src_w, src_h) = (
+            src.width().ok_or(Error::NotAnImage)?,
+            src.height().ok_or(Error::NotAnImage)?,
+        );
+        let [e0, e1, e2, e3] = super::render::sample_clamp_rect(
+            (src_w, src_h),
+            self.cached_src_import_map(src, src_fmt),
+        );
+        let extent_loc = self.external_src_extent_loc(is_int8, false);
 
         // Draw-time program selection (see draw_src_texture).
         let program_id = if is_int8 {
@@ -5895,6 +5991,7 @@ impl GLProcessorST {
         let texture_target = edgefirst_gl::gl::TEXTURE_EXTERNAL_OES;
         unsafe {
             edgefirst_gl::gl::UseProgram(program_id);
+            edgefirst_gl::gl::Uniform4f(extent_loc, e0, e1, e2, e3);
             edgefirst_gl::gl::ActiveTexture(edgefirst_gl::gl::TEXTURE0);
             edgefirst_gl::gl::BindTexture(texture_target, self.camera_eglimage_texture.id);
             super::core::set_tex_filter_clamp(texture_target, edgefirst_gl::gl::LINEAR);
@@ -6290,6 +6387,20 @@ impl GLProcessorST {
         // shader addresses the chroma bytes inside it by texel arithmetic, so
         // EGL is never handed a second plane offset. The two-plane import in
         // `get_or_create_egl_image` is the one that needs plane 1 checked too.
+        //
+        // The aligned-base rebase that keeps packed sources zero-copy (issue
+        // #170) does not apply here, and cannot: this import's pitch IS its
+        // width (`tex_width`), so widening it by the shift would overlap
+        // every row with the next, and the alternative -- a uniform shift
+        // with the width unchanged -- makes the shader address luma at
+        // `y * tex_width + x + shift`, which wraps rows and so needs a
+        // per-texel integer divide and modulo. That is exactly the
+        // arithmetic `nv_rgba_body_divfree` exists to avoid (3.3x on
+        // Vivante), and it would also leave the last `shift` bytes of the
+        // final chroma row outside the import, which for NV24 are pixels.
+        // So the NV path keeps the decline and uploads the combined plane,
+        // which issue #166's routing already sends to the R8 upload rather
+        // than the CPU.
         let offset = img.plane_offset().unwrap_or(0);
         if mali_rejects_import_offset(self.is_mali, offset) {
             return Err(crate::Error::NotSupported(format!(
@@ -6345,8 +6456,22 @@ impl GLProcessorST {
             },
         )?;
         // Mali samples zeros from a source imported at a plane offset that is
-        // not 64-byte aligned, with no EGL error to notice (issue #165). Refuse
-        // it so the caller's failure arm uploads the window through `map()`.
+        // not 64-byte aligned, with no EGL error to notice (issue #165). The
+        // question is asked of the offset the import will actually PRESENT,
+        // not of the tensor's own: since issue #170 a packed source at an
+        // unaligned offset imports from the aligned base below it with the
+        // remainder folded into the sampling rectangle, so it is exempt --
+        // but only when that rebase really applied. An offset that is not a
+        // whole number of pixels (`offset % bpp != 0`: a 64-padded RGB row
+        // stride of 320 is not a multiple of 3, so row 1 column 1 is byte
+        // 323) or a pitch with no room to widen (a whole 64-wide RGBA tensor
+        // at a `set_plane_offset` window has a tight 256-byte pitch) leaves
+        // the import unaligned, and keying the exemption on the FORMAT would
+        // wave exactly those through into a black frame. NV12's two-plane
+        // import, YUYV's macropixel phase and planar R8 are never rebased
+        // and so never exempt. The caller's failure arm uploads the window
+        // through `map()`.
+        //
         // Destinations are untouched: a destination view imports its parent at
         // offset 0 and is rendered into by viewport, never sampled at an
         // offset.
@@ -6362,7 +6487,12 @@ impl GLProcessorST {
             // would then sample zeros for chroma alone — silently
             // colour-shifted output rather than a black frame, which is harder
             // to notice than the luma case.
-            let offset = img.plane_offset().unwrap_or(0);
+            // The offset EGL will be handed, which is the tensor's own
+            // unless the rebase moved it.
+            let offset = source_import_plane0_offset(img, img_fmt);
+            // Plane 1 is derived from that same value, which for NV12 is
+            // the tensor's own offset unchanged: the rebase never covers a
+            // semi-planar format, so there is nothing for it to have moved.
             let chroma_offset = (img_fmt == PixelFormat::Nv12).then(|| {
                 if img.is_multiplane() {
                     // A separate chroma DMA-BUF imports at its own offset.
@@ -6463,24 +6593,50 @@ impl GLProcessorST {
         Ok(handle)
     }
 
-    /// The texel extent of the cached source import for `img`, when the
-    /// platform's import can cover more than the logical image
-    /// ([`GlPlatform::import_extent`]). Read after the import so the entry
-    /// exists; `None` on every platform whose import is the logical image, and
-    /// when the source was fed by upload instead.
-    fn cached_src_import_extent(&self, img: &Tensor<u8>, fmt: PixelFormat) -> Option<(u32, u32)> {
+    /// Where the cached source import puts `img`'s logical image on the
+    /// texture it covers ([`GlPlatform::import_extent`] +
+    /// [`GlPlatform::import_origin`]). ONE cache lookup for both, because
+    /// this runs on every convert. Read after the import so the entry
+    /// exists; [`ImportMap::WHOLE`](super::render::ImportMap::WHOLE) on every
+    /// platform whose import is the logical image, and when the source was
+    /// fed by upload instead.
+    fn cached_src_import_map(
+        &self,
+        img: &Tensor<u8>,
+        fmt: PixelFormat,
+    ) -> super::render::ImportMap {
         let id = BufferImportKey::from_tensor(img, fmt, false);
         self.src_egl_cache
             .entries
             .get(&id)
-            .and_then(|entry| Platform::import_extent(&entry.import))
+            .map(|entry| {
+                let map = super::render::ImportMap {
+                    extent: Platform::import_extent(&entry.import),
+                    origin: Platform::import_origin(&entry.import),
+                };
+                // The origin is only meaningful against an extent: every fold
+                // helper takes the map as the identity when `extent` is
+                // `None`, so a leaf that shifted the image without saying how
+                // big the texture is would drop the shift silently and show
+                // up as a black or torn frame on that board alone, with
+                // nothing to see locally. The two travel together.
+                debug_assert!(
+                    map.origin == (0, 0) || map.extent.is_some(),
+                    "an import origin {:?} without an extent is dropped by the fold",
+                    map.origin,
+                );
+                map
+            })
+            .unwrap_or(super::render::ImportMap::WHOLE)
     }
 
-    /// [`Self::cached_src_import_extent`] applied to a source rectangle: the
+    /// [`Self::cached_src_import_map`] applied to a source rectangle: the
     /// single site that turns logical-image coordinates into texture
     /// coordinates for the uv-sampling paths. The NV combined-plane path does
     /// not use it — its shader indexes texels absolutely from `img_size`, so a
-    /// narrowed plane already reads the right texels.
+    /// narrowed plane already reads the right texels, which is also why the NV
+    /// R8 import is never rebased to an aligned base (issue #170); it keeps
+    /// the Stage F decline.
     fn scale_src_roi(
         &self,
         roi: RegionOfInterest,
@@ -6490,7 +6646,7 @@ impl GLProcessorST {
         let (Some(w), Some(h)) = (img.width(), img.height()) else {
             return roi;
         };
-        super::render::scale_roi_to_import(roi, (w, h), self.cached_src_import_extent(img, fmt))
+        super::render::scale_roi_to_import(roi, (w, h), self.cached_src_import_map(img, fmt))
     }
 
     /// The `src_extent` location of the `sampler2D` source program
@@ -6502,6 +6658,18 @@ impl GLProcessorST {
             int8
         } else {
             plain
+        }
+    }
+
+    /// The `src_extent` location of the external-OES program the two camera
+    /// draws select for `is_int8` and `planar`.
+    fn external_src_extent_loc(&self, is_int8: bool, planar: bool) -> i32 {
+        let [yuv, yuv_int8, pl, pl_int8] = self.external_src_extent_locs;
+        match (planar, is_int8) {
+            (false, false) => yuv,
+            (false, true) => yuv_int8,
+            (true, false) => pl,
+            (true, true) => pl_int8,
         }
     }
 
@@ -6522,12 +6690,14 @@ impl GLProcessorST {
         src_w: usize,
         src_h: usize,
     ) -> ([f32; 4], [f32; 4]) {
-        let extent = (feed == float::FloatSrcFeed::Import)
-            .then(|| self.cached_src_import_extent(src_u8, PixelFormat::Rgba))
-            .flatten();
+        let map = if feed == float::FloatSrcFeed::Import {
+            self.cached_src_import_map(src_u8, PixelFormat::Rgba)
+        } else {
+            super::render::ImportMap::WHOLE
+        };
         (
-            super::render::scale_uv_rect_to_import(src_rect_uv, (src_w, src_h), extent),
-            super::render::sample_clamp_rect((src_w, src_h), extent),
+            super::render::scale_uv_rect_to_import(src_rect_uv, (src_w, src_h), map),
+            super::render::sample_clamp_rect((src_w, src_h), map),
         )
     }
 
@@ -8109,7 +8279,8 @@ impl GLProcessorST {
         let (src_rect_uv, dst_rect_px, pad_color) =
             super::core::float_crop_uniforms(&ResolvedCrop::no_crop(), dst_w, dst_h, dst_w, dst_h)?;
         // The intermediate texture is exactly the pass-1 destination.
-        let src_extent = super::render::sample_clamp_rect((dst_w, dst_h), None);
+        let src_extent =
+            super::render::sample_clamp_rect((dst_w, dst_h), super::render::ImportMap::WHOLE);
         self.render_float_to_zero_copy_tail(
             self.packed_rgb_intermediate_tex.id,
             src_rect_uv,
@@ -8469,6 +8640,9 @@ mod tests {
     // imported or uploaded. The offsets are the ones measured on i.MX 95
     // (issue #165): 32 and 2080 sampled zeros; 64, 256 and 2048 sampled
     // correctly, and offset 0 is the whole-image control, not a window.
+    // The offset rule itself is unchanged by issue #170: these are still the
+    // offsets Mali samples zeros from, and `mali_rejects_import_offset` is
+    // still the predicate. What changed is which formats are asked.
     #[test]
     fn mali_declines_only_unaligned_source_offsets() {
         use super::mali_rejects_import_offset as rejects;
@@ -8485,6 +8659,59 @@ mod tests {
         assert!(!rejects(false, 2080));
         // 256 was measured too, and is the RGBA test's `(0, 1)` origin.
         assert!(!rejects(true, 256));
+    }
+
+    // Which imports still reach that rule. A packed source the fold rebases
+    // presents an aligned base and must NOT be declined -- declining it is
+    // one regression this test exists to catch, because it costs the zero
+    // copy silently and every pixel still comes out right through the
+    // upload. Exempting one the fold could NOT move is the other, and that
+    // one comes back black, which is why the exemption is keyed on the
+    // resolved offset rather than on the format.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mali_declines_the_imports_the_fold_could_not_move() {
+        use super::super::dma_import::resolve_source_plane0;
+        use super::{PixelFormat, DMA_IMPORT_OFFSET_ALIGN};
+
+        // Exactly the question the gate asks, through the same resolver
+        // the import is built from -- not a mirror of it.
+        let aligned = |fmt, w, pitch, off| {
+            resolve_source_plane0(fmt, w, pitch, off)
+                .0
+                .is_multiple_of(DMA_IMPORT_OFFSET_ALIGN)
+        };
+
+        // Rebased onto an aligned base: exempt. A 16-pixel view 8 pixels
+        // into a 256-byte-pitched RGBA parent, at the offset i.MX 95
+        // sampled zeros from.
+        assert!(aligned(PixelFormat::Rgba, 16, 256, 2080));
+        assert!(aligned(PixelFormat::Bgra, 16, 256, 32));
+        // Already aligned: exempt, and untouched.
+        assert!(aligned(PixelFormat::Rgba, 64, 256, 2048));
+        assert!(aligned(PixelFormat::Nv12, 64, 64, 0));
+        // Packed, but the fold cannot move it -- these are the two shapes
+        // that would come back black if the exemption were keyed on the
+        // format. A whole 64-wide RGBA tensor at a `set_plane_offset`
+        // window has a tight 256-byte pitch with no room to widen; a
+        // 100-wide RGB surface has a 64-padded 320-byte stride that is not
+        // a multiple of 3, so row 1 does not start on a whole pixel.
+        assert!(!aligned(PixelFormat::Rgba, 64, 256, 32));
+        assert!(!aligned(PixelFormat::Rgb, 16, 320, 323));
+        // Never rebased, so still declined at an unaligned offset: NV12's
+        // second plane carries an offset of its own and the R8 import's
+        // pitch is its width; YUYV/VYUY carry a macropixel phase a texel
+        // shift would break; planar RGB stacks its planes by row.
+        for fmt in [
+            PixelFormat::Nv12,
+            PixelFormat::Nv16,
+            PixelFormat::Nv24,
+            PixelFormat::Yuyv,
+            PixelFormat::Vyuy,
+            PixelFormat::PlanarRgb,
+        ] {
+            assert!(!aligned(fmt, 64, 256, 32), "{fmt:?} must not be exempt");
+        }
     }
 
     // The destination-side rule, which is Vivante's and NOT Mali's: Mali was

--- a/crates/image/src/gl/render.rs
+++ b/crates/image/src/gl/render.rs
@@ -258,11 +258,39 @@ pub(super) fn plan_batch(n_tiles: usize, rows_per_tile: usize, max_rows: usize) 
     }
 }
 
+/// Where a tensor's logical image sits on the texture its import covers.
+///
+/// Two independent reasons the two can differ, both folded the same way:
+/// a pool buffer narrowed by `configure_image` keeps its whole texture and
+/// reports a larger [`extent`](Self::extent) (Windows/D3D11), and a source
+/// rebased to an aligned DMA-BUF offset starts the logical image partway
+/// into the import and reports a nonzero [`origin`](Self::origin) (Linux,
+/// issue #170). A platform whose import IS the logical image reports
+/// [`ImportMap::WHOLE`], which every helper here treats as the identity.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct ImportMap {
+    /// Texel size of the imported texture when it can exceed the logical
+    /// image ([`super::platform::GlPlatform::import_extent`]); `None` when
+    /// the import is exactly the logical image.
+    pub(super) extent: Option<(u32, u32)>,
+    /// Texels from the texture's origin to the logical image's first pixel
+    /// ([`super::platform::GlPlatform::import_origin`]).
+    pub(super) origin: (u32, u32),
+}
+
+impl ImportMap {
+    /// The import is exactly the logical image: no scale, no shift.
+    pub(super) const WHOLE: Self = Self {
+        extent: None,
+        origin: (0, 0),
+    };
+}
+
 /// How one axis of a logical image maps onto the texture an import covers:
-/// `(scale, limit)` — the factor that places the logical image over its share
-/// of the texture, and the normalized coordinate of its far edge. An axis that
-/// is not narrowed (and a degenerate or contradictory extent) maps as the
-/// identity.
+/// `(origin, scale, limit)` — the normalized coordinate the logical image
+/// starts at, the factor that places it over its share of the texture, and the
+/// normalized coordinate of its far edge. An axis that is not narrowed or
+/// shifted (and a degenerate or contradictory map) maps as the identity.
 ///
 /// The far edge is not pulled half a physical texel inside here. These
 /// coordinates are the endpoints of the quad's texcoord attribute, so moving
@@ -277,56 +305,68 @@ pub(super) fn plan_batch(n_tiles: usize, rows_per_tile: usize, max_rows: usize) 
 /// RTX 3070 and on WARP, the last row and column of an upscaled narrowed
 /// source then match a fresh buffer of the same geometry byte for byte
 /// (492-762 bytes differed by up to 48 without the clamp).
-fn axis_map(logical: usize, extent: u32) -> (f32, f32) {
-    if extent == 0 || logical == 0 || logical as u64 >= extent as u64 {
-        return (1.0, 1.0);
+///
+/// The origin is an ADDITIVE offset and the logical size a MULTIPLICATIVE
+/// scale, in that order: a coordinate `t` over the logical image lands at
+/// `(origin + t * logical) / extent`. A map whose shifted image would run
+/// past the texture is contradictory and maps as the identity, same as a
+/// degenerate one.
+fn axis_map(logical: usize, origin: u32, extent: u32) -> (f32, f32, f32) {
+    let span = (origin as u64).saturating_add(logical as u64);
+    if extent == 0 || logical == 0 || span > extent as u64 {
+        return (0.0, 1.0, 1.0);
     }
-    let scale = logical as f32 / extent as f32;
-    (scale, scale)
+    let texture = extent as f32;
+    (
+        origin as f32 / texture,
+        logical as f32 / texture,
+        span as f32 / texture,
+    )
 }
 
 /// Map a source rectangle from the tensor's logical image onto the larger
 /// texture its import covers.
 ///
-/// `roi` is normalized over the logical image; `extent` is
-/// `GlPlatform::import_extent`. The logical image occupies the texture's own
-/// texels from its origin, so mapping one onto the other is one multiply per
-/// axis — the half-texel inset the crop math already applied scales with it —
-/// held inside the logical edge by [`axis_map`]. `None` and an extent no
-/// larger than the logical image leave `roi` untouched.
+/// `roi` is normalized over the logical image; `map` is where that image sits
+/// on the texture. The logical image occupies a contiguous block of the
+/// texture's own texels starting at the map's origin, so mapping one onto the
+/// other is one shift and one multiply per axis — the half-texel inset the
+/// crop math already applied scales with it — held inside the logical edge by
+/// [`axis_map`]. [`ImportMap::WHOLE`] and an extent no larger than the logical
+/// image leave `roi` untouched.
 pub(super) fn scale_roi_to_import(
     roi: super::RegionOfInterest,
     logical: (usize, usize),
-    extent: Option<(u32, u32)>,
+    map: ImportMap,
 ) -> super::RegionOfInterest {
-    let Some((pw, ph)) = extent else {
+    let Some((pw, ph)) = map.extent else {
         return roi;
     };
-    let (sx, lx) = axis_map(logical.0, pw);
-    let (sy, ly) = axis_map(logical.1, ph);
+    let (ox, sx, lx) = axis_map(logical.0, map.origin.0, pw);
+    let (oy, sy, ly) = axis_map(logical.1, map.origin.1, ph);
     super::RegionOfInterest {
-        left: (roi.left * sx).min(lx),
-        top: (roi.top * sy).min(ly),
-        right: (roi.right * sx).min(lx),
-        bottom: (roi.bottom * sy).min(ly),
+        left: (ox + roi.left * sx).min(lx),
+        top: (oy + roi.top * sy).min(ly),
+        right: (ox + roi.right * sx).min(lx),
+        bottom: (oy + roi.bottom * sy).min(ly),
     }
 }
 
 /// [`scale_roi_to_import`] for the float paths' `src_rect_uv`, which is an
-/// origin and a size rather than two corners: the origin scales, and the size
-/// is trimmed to keep the far edge inside the same limit.
+/// origin and a size rather than two corners: the origin shifts and scales,
+/// and the size is trimmed to keep the far edge inside the same limit.
 pub(super) fn scale_uv_rect_to_import(
     rect: [f32; 4],
     logical: (usize, usize),
-    extent: Option<(u32, u32)>,
+    map: ImportMap,
 ) -> [f32; 4] {
-    let Some((pw, ph)) = extent else {
+    let Some((pw, ph)) = map.extent else {
         return rect;
     };
-    let (sx, lx) = axis_map(logical.0, pw);
-    let (sy, ly) = axis_map(logical.1, ph);
-    let left = (rect[0] * sx).min(lx);
-    let top = (rect[1] * sy).min(ly);
+    let (ox, sx, lx) = axis_map(logical.0, map.origin.0, pw);
+    let (oy, sy, ly) = axis_map(logical.1, map.origin.1, ph);
+    let left = (ox + rect[0] * sx).min(lx);
+    let top = (oy + rect[1] * sy).min(ly);
     [
         left,
         top,
@@ -342,27 +382,35 @@ pub(super) fn scale_uv_rect_to_import(
 ///
 /// A `LINEAR` sample at those bounds is centred on the logical image's edge
 /// texel, so the kernel cannot reach the texel beyond it. On a texture that
-/// is exactly the logical image (`extent` is `None`, or no larger than
-/// `logical`) that texel does not exist and `CLAMP_TO_EDGE` already returns
-/// the edge value, so the clamp changes nothing there. On an import that
-/// covers more of the texture than the logical image the texel beyond the
-/// edge holds the pool buffer's previous content, which an upscale would
-/// otherwise blend into the last row or column.
+/// is exactly the logical image ([`ImportMap::WHOLE`], or an extent no larger
+/// than `logical`) that texel does not exist and `CLAMP_TO_EDGE` already
+/// returns the edge value, so the clamp changes nothing there. On an import
+/// that covers more of the texture than the logical image the texels outside
+/// the image hold the pool buffer's previous content, or — when the map has a
+/// nonzero origin — the bytes the rebase walked back over and the pitch
+/// padding behind the last column, which an upscale would otherwise blend
+/// into the first or last row or column.
 ///
 /// A degenerate logical size yields the whole texture, `[0, 0, 1, 1]`.
-pub(super) fn sample_clamp_rect(logical: (usize, usize), extent: Option<(u32, u32)>) -> [f32; 4] {
-    fn axis(logical: usize, extent: Option<u32>) -> (f32, f32) {
+pub(super) fn sample_clamp_rect(logical: (usize, usize), map: ImportMap) -> [f32; 4] {
+    fn axis(logical: usize, origin: u32, extent: Option<u32>) -> (f32, f32) {
         if logical == 0 {
             return (0.0, 1.0);
         }
-        let texture = match extent {
-            Some(e) if e as u64 > logical as u64 => e as f32,
-            _ => logical as f32,
+        let span = (origin as u64).saturating_add(logical as u64);
+        let (texture, first) = match extent {
+            Some(e) if e as u64 > logical as u64 && e as u64 >= span => (e as f32, origin as f32),
+            // No extent, an extent no larger than the image, or a
+            // contradictory shift: the texture is the image at its origin.
+            _ => (logical as f32, 0.0),
         };
-        (0.5 / texture, (logical as f32 - 0.5) / texture)
+        (
+            (first + 0.5) / texture,
+            (first + logical as f32 - 0.5) / texture,
+        )
     }
-    let (u_min, u_max) = axis(logical.0, extent.map(|e| e.0));
-    let (v_min, v_max) = axis(logical.1, extent.map(|e| e.1));
+    let (u_min, u_max) = axis(logical.0, map.origin.0, map.extent.map(|e| e.0));
+    let (v_min, v_max) = axis(logical.1, map.origin.1, map.extent.map(|e| e.1));
     [u_min, v_min, u_max, v_max]
 }
 
@@ -603,6 +651,14 @@ mod tests {
 mod import_extent_tests {
     use super::*;
 
+    /// The pre-origin shape of every fold call: an extent, at origin `(0, 0)`.
+    fn narrowed(extent: (u32, u32)) -> ImportMap {
+        ImportMap {
+            extent: Some(extent),
+            origin: (0, 0),
+        }
+    }
+
     fn roi() -> super::super::RegionOfInterest {
         super::super::RegionOfInterest {
             left: 0.0,
@@ -616,7 +672,7 @@ mod import_extent_tests {
     /// is not narrowed), v is scaled to the logical image's share.
     #[test]
     fn a_narrowed_logical_image_scales_by_its_share_of_the_texture() {
-        let r = scale_roi_to_import(roi(), (128, 96), Some((128, 128)));
+        let r = scale_roi_to_import(roi(), (128, 96), narrowed((128, 128)));
         assert_eq!(r.left, 0.0);
         assert_eq!(r.right, 1.0);
         assert_eq!(r.top, 0.75);
@@ -631,16 +687,16 @@ mod import_extent_tests {
             right: 0.5,
             bottom: 0.25,
         };
-        let r = scale_roi_to_import(src, (64, 100), Some((128, 200)));
+        let r = scale_roi_to_import(src, (64, 100), narrowed((128, 200)));
         assert_eq!((r.left, r.right), (0.125, 0.25));
         assert_eq!((r.top, r.bottom), (0.375, 0.125));
     }
 
     #[test]
     fn equal_extents_and_no_extent_leave_the_rectangle_alone() {
-        let r = scale_roi_to_import(roi(), (128, 96), Some((128, 96)));
+        let r = scale_roi_to_import(roi(), (128, 96), narrowed((128, 96)));
         assert_eq!((r.left, r.top, r.right, r.bottom), (0.0, 1.0, 1.0, 0.0));
-        let r = scale_roi_to_import(roi(), (128, 96), None);
+        let r = scale_roi_to_import(roi(), (128, 96), ImportMap::WHOLE);
         assert_eq!((r.left, r.top, r.right, r.bottom), (0.0, 1.0, 1.0, 0.0));
     }
 
@@ -648,13 +704,13 @@ mod import_extent_tests {
     /// rectangle is left alone rather than magnified past the texture.
     #[test]
     fn a_logical_image_larger_than_the_extent_is_not_magnified() {
-        let r = scale_roi_to_import(roi(), (256, 256), Some((128, 128)));
+        let r = scale_roi_to_import(roi(), (256, 256), narrowed((128, 128)));
         assert_eq!((r.left, r.top, r.right, r.bottom), (0.0, 1.0, 1.0, 0.0));
     }
 
     #[test]
     fn a_degenerate_extent_leaves_the_rectangle_alone() {
-        let r = scale_roi_to_import(roi(), (128, 96), Some((0, 0)));
+        let r = scale_roi_to_import(roi(), (128, 96), narrowed((0, 0)));
         assert_eq!((r.left, r.top, r.right, r.bottom), (0.0, 1.0, 1.0, 0.0));
     }
 
@@ -662,7 +718,7 @@ mod import_extent_tests {
     /// is trimmed so the far edge lands where a corner would.
     #[test]
     fn a_uv_rect_scales_its_origin_and_trims_its_size() {
-        let r = scale_uv_rect_to_import([0.0, 0.0, 1.0, 1.0], (128, 96), Some((128, 128)));
+        let r = scale_uv_rect_to_import([0.0, 0.0, 1.0, 1.0], (128, 96), narrowed((128, 128)));
         assert_eq!([r[0], r[1]], [0.0, 0.0]);
         assert_eq!(r[2], 1.0);
         assert_eq!(r[3], 0.75);
@@ -672,10 +728,10 @@ mod import_extent_tests {
     fn a_uv_rect_keeps_an_interior_crop_and_passes_no_extent_through() {
         // Half the width starting a quarter in, on an axis narrowed to 3/4:
         // both scale, and the far edge (0.25 + 0.5) * 0.75 stays interior.
-        let r = scale_uv_rect_to_import([0.25, 0.25, 0.5, 0.5], (96, 96), Some((128, 128)));
+        let r = scale_uv_rect_to_import([0.25, 0.25, 0.5, 0.5], (96, 96), narrowed((128, 128)));
         assert_eq!([r[0], r[1]], [0.1875, 0.1875]);
         assert_eq!([r[2], r[3]], [0.375, 0.375]);
-        let r = scale_uv_rect_to_import([0.25, 0.25, 0.5, 0.5], (96, 96), None);
+        let r = scale_uv_rect_to_import([0.25, 0.25, 0.5, 0.5], (96, 96), ImportMap::WHOLE);
         assert_eq!(r, [0.25, 0.25, 0.5, 0.5]);
     }
 
@@ -683,7 +739,7 @@ mod import_extent_tests {
     /// a texel, v stops half a texel short of row 96.
     #[test]
     fn a_narrowed_image_clamps_samples_half_a_texel_inside_its_edge() {
-        let r = sample_clamp_rect((128, 96), Some((128, 128)));
+        let r = sample_clamp_rect((128, 96), narrowed((128, 128)));
         assert_eq!(r, [0.5 / 128.0, 0.5 / 128.0, 127.5 / 128.0, 95.5 / 128.0]);
     }
 
@@ -691,9 +747,9 @@ mod import_extent_tests {
     /// the half-texel inset of the whole texture on both axes.
     #[test]
     fn no_extent_clamps_to_the_textures_own_edge_texels() {
-        let r = sample_clamp_rect((128, 96), None);
+        let r = sample_clamp_rect((128, 96), ImportMap::WHOLE);
         assert_eq!(r, [0.5 / 128.0, 0.5 / 96.0, 127.5 / 128.0, 95.5 / 96.0]);
-        assert_eq!(sample_clamp_rect((128, 96), Some((128, 96))), r);
+        assert_eq!(sample_clamp_rect((128, 96), narrowed((128, 96))), r);
     }
 
     /// An extent smaller than the logical image is a contradiction; the
@@ -701,19 +757,19 @@ mod import_extent_tests {
     #[test]
     fn an_extent_smaller_than_the_image_is_ignored() {
         assert_eq!(
-            sample_clamp_rect((256, 256), Some((128, 128))),
-            sample_clamp_rect((256, 256), None)
+            sample_clamp_rect((256, 256), narrowed((128, 128))),
+            sample_clamp_rect((256, 256), ImportMap::WHOLE)
         );
     }
 
     #[test]
     fn a_degenerate_logical_size_leaves_the_whole_texture_reachable() {
         assert_eq!(
-            sample_clamp_rect((0, 0), Some((128, 128))),
+            sample_clamp_rect((0, 0), narrowed((128, 128))),
             [0.0, 0.0, 1.0, 1.0]
         );
         assert_eq!(
-            sample_clamp_rect((0, 96), None),
+            sample_clamp_rect((0, 96), ImportMap::WHOLE),
             [0.0, 0.5 / 96.0, 1.0, 95.5 / 96.0]
         );
     }
@@ -723,9 +779,167 @@ mod import_extent_tests {
     #[test]
     fn a_one_texel_image_clamps_to_its_single_texel_centre() {
         assert_eq!(
-            sample_clamp_rect((1, 1), Some((128, 128))),
+            sample_clamp_rect((1, 1), narrowed((128, 128))),
             [0.5 / 128.0; 4]
         );
-        assert_eq!(sample_clamp_rect((1, 1), None), [0.5; 4]);
+        assert_eq!(sample_clamp_rect((1, 1), ImportMap::WHOLE), [0.5; 4]);
+    }
+
+    /// A shifted import: the logical 16-wide image sits at texel 8 of a
+    /// 24-wide texture. The ROI must land on `[8/24, 24/24]`, not `[0, 16/24]`
+    /// -- the whole point of the origin. This is the (8, 0) view of issue
+    /// #165's probe at RGBA, whose 32-byte offset rebases to 0 with a
+    /// 8-texel shift.
+    #[test]
+    fn scale_roi_to_import_offsets_by_the_origin() {
+        let roi = super::super::RegionOfInterest {
+            left: 0.0,
+            top: 0.0,
+            right: 1.0,
+            bottom: 1.0,
+        };
+        let map = ImportMap {
+            extent: Some((24, 16)),
+            origin: (8, 0),
+        };
+        let got = scale_roi_to_import(roi, (16, 16), map);
+        assert!((got.left - 8.0 / 24.0).abs() < 1e-6, "left {}", got.left);
+        assert!((got.right - 1.0).abs() < 1e-6, "right {}", got.right);
+        // The unshifted axis is untouched.
+        assert!((got.top - 0.0).abs() < 1e-6, "top {}", got.top);
+        assert!((got.bottom - 1.0).abs() < 1e-6, "bottom {}", got.bottom);
+    }
+
+    /// A half-width ROI on a shifted import: the origin is an ADDITIVE
+    /// offset and the logical size is the MULTIPLICATIVE scale, so the
+    /// midpoint lands at `(8 + 8) / 24`, not at `8 / 24 * 0.5` or `0.5`.
+    #[test]
+    fn scale_roi_to_import_composes_origin_and_scale() {
+        let roi = super::super::RegionOfInterest {
+            left: 0.0,
+            top: 0.25,
+            right: 0.5,
+            bottom: 0.75,
+        };
+        let map = ImportMap {
+            extent: Some((24, 16)),
+            origin: (8, 0),
+        };
+        let got = scale_roi_to_import(roi, (16, 16), map);
+        assert!((got.left - 8.0 / 24.0).abs() < 1e-6, "left {}", got.left);
+        assert!(
+            (got.right - 16.0 / 24.0).abs() < 1e-6,
+            "right {}",
+            got.right
+        );
+        assert!((got.top - 0.25).abs() < 1e-6, "top {}", got.top);
+        assert!((got.bottom - 0.75).abs() < 1e-6, "bottom {}", got.bottom);
+    }
+
+    /// `ImportMap::WHOLE` is the identity on all three helpers -- the state
+    /// every platform whose import IS the logical image reports, and the
+    /// state every call site had before the origin existed.
+    #[test]
+    fn whole_import_map_is_the_identity() {
+        let roi = super::super::RegionOfInterest {
+            left: 0.1,
+            top: 0.2,
+            right: 0.8,
+            bottom: 0.9,
+        };
+        let got = scale_roi_to_import(roi, (64, 64), ImportMap::WHOLE);
+        assert_eq!(
+            (got.left, got.top, got.right, got.bottom),
+            (0.1, 0.2, 0.8, 0.9)
+        );
+        assert_eq!(
+            scale_uv_rect_to_import([0.1, 0.2, 0.3, 0.4], (64, 64), ImportMap::WHOLE),
+            [0.1, 0.2, 0.3, 0.4]
+        );
+        assert_eq!(ImportMap::default(), ImportMap::WHOLE);
+        let [u0, v0, u1, v1] = sample_clamp_rect((64, 64), ImportMap::WHOLE);
+        assert!((u0 - 0.5 / 64.0).abs() < 1e-9 && (v0 - 0.5 / 64.0).abs() < 1e-9);
+        assert!((u1 - 63.5 / 64.0).abs() < 1e-9 && (v1 - 63.5 / 64.0).abs() < 1e-9);
+    }
+
+    /// The clamp rectangle must bracket the LOGICAL image's texels on a
+    /// shifted texture, so a LINEAR kernel at the left edge cannot blend
+    /// the rebase padding in front of it and one at the right edge cannot
+    /// reach the pitch padding behind it.
+    #[test]
+    fn sample_clamp_rect_brackets_a_shifted_image() {
+        let map = ImportMap {
+            extent: Some((24, 16)),
+            origin: (8, 0),
+        };
+        let [u0, v0, u1, v1] = sample_clamp_rect((16, 16), map);
+        assert!((u0 - 8.5 / 24.0).abs() < 1e-6, "u0 {u0}");
+        assert!((u1 - 23.5 / 24.0).abs() < 1e-6, "u1 {u1}");
+        assert!((v0 - 0.5 / 16.0).abs() < 1e-6, "v0 {v0}");
+        assert!((v1 - 15.5 / 16.0).abs() < 1e-6, "v1 {v1}");
+    }
+
+    /// A contradictory map -- the shifted image would run past the texture
+    /// -- falls back to the identity rather than sampling outside it.
+    #[test]
+    fn a_shifted_image_that_overruns_the_extent_maps_as_the_identity() {
+        let roi = super::super::RegionOfInterest {
+            left: 0.0,
+            top: 0.0,
+            right: 1.0,
+            bottom: 1.0,
+        };
+        let map = ImportMap {
+            extent: Some((20, 16)),
+            origin: (8, 0),
+        };
+        let got = scale_roi_to_import(roi, (16, 16), map);
+        assert_eq!((got.left, got.right), (0.0, 1.0));
+        let [u0, _, u1, _] = sample_clamp_rect((16, 16), map);
+        assert!((u0 - 0.5 / 16.0).abs() < 1e-6, "u0 {u0}");
+        assert!((u1 - 15.5 / 16.0).abs() < 1e-6, "u1 {u1}");
+    }
+
+    /// An origin with NO extent is DROPPED by every helper -- the map is the
+    /// identity, and the shift silently goes nowhere. This is why a leaf that
+    /// reports a nonzero origin must report the widened extent alongside it
+    /// (`GLProcessorST::cached_src_import_map` asserts the pairing): the
+    /// failure mode is a wrongly-sampled frame on the one board that rebases,
+    /// with nothing to see anywhere else.
+    #[test]
+    fn an_origin_without_an_extent_is_dropped_by_every_helper() {
+        let map = ImportMap {
+            extent: None,
+            origin: (8, 0),
+        };
+        let r = roi();
+        let got = scale_roi_to_import(r, (16, 16), map);
+        assert_eq!(
+            (got.left, got.top, got.right, got.bottom),
+            (r.left, r.top, r.right, r.bottom)
+        );
+        assert_eq!(
+            scale_uv_rect_to_import([0.1, 0.2, 0.3, 0.4], (16, 16), map),
+            [0.1, 0.2, 0.3, 0.4]
+        );
+        assert_eq!(
+            sample_clamp_rect((16, 16), map),
+            sample_clamp_rect((16, 16), ImportMap::WHOLE)
+        );
+    }
+
+    /// The float paths' origin-and-size rect: the origin shifts and the
+    /// size stays trimmed inside the same limit.
+    #[test]
+    fn scale_uv_rect_to_import_offsets_by_the_origin() {
+        let map = ImportMap {
+            extent: Some((24, 16)),
+            origin: (8, 0),
+        };
+        let got = scale_uv_rect_to_import([0.0, 0.0, 1.0, 1.0], (16, 16), map);
+        assert!((got[0] - 8.0 / 24.0).abs() < 1e-6, "x {}", got[0]);
+        assert!((got[2] - 16.0 / 24.0).abs() < 1e-6, "w {}", got[2]);
+        assert!((got[1] - 0.0).abs() < 1e-6, "y {}", got[1]);
+        assert!((got[3] - 1.0).abs() < 1e-6, "h {}", got[3]);
     }
 }

--- a/crates/image/src/gl/shaders.rs
+++ b/crates/image/src/gl/shaders.rs
@@ -80,6 +80,31 @@ pub(super) fn generate_vertex_shader() -> &'static str {
 /// last column's sample in by up to half a texel. At `highp` the bound is
 /// exact, so clamping to it reproduces `CLAMP_TO_EDGE` wherever the texture
 /// is the logical image.
+///
+/// `tc` is `highp` for a second, sharper reason: the SAMPLED COORDINATE must
+/// not go through a `mediump` ALU. Passing a varying straight to `texture()`
+/// lets a driver hand the interpolator's own coordinate to the texture unit,
+/// but `clamp()` is arithmetic, and at `mediump` it rounds the result to fp16
+/// — a step of 2^-11 near 1.0, which is 0.625 texel on a 1280-wide source.
+/// `LINEAR` then blends the neighbour in by that fraction. Measured on
+/// Mali-G310 (i.MX 95) with a 1280x720 RGBA identity blit: 96% of the frame
+/// differed from the CPU reference, worst 50/255 mid-frame at an implied
+/// blend fraction of 0.40 texel, and the error was flat across the width
+/// rather than confined to the edges — so it was the coordinate, not the
+/// bound. Clamping to the full texture `[0,0,1,1]` reproduced the corruption
+/// byte for byte; declaring `tc` `highp` removed it. Vivante GC7000UL and
+/// V3D did not show it (issue #170).
+///
+/// Only the CONSUMER's qualifier matters here. The vertex stage still writes
+/// `out vec2 tc;` under a `mediump` default (`shaders_common::VERTEX_SHADER`,
+/// byte-pinned by `golden/vertex.glsl`) and is deliberately left alone:
+/// GLSL ES 3.00 does not match precision across stages, so the fragment
+/// shader's own qualifier governs the interpolation and the ALU it feeds.
+/// Two independent facts confirm it. Removing only the `clamp()` while
+/// leaving that same vertex shader in place made the Mali case pass, so the
+/// vertex write was never the limiting step; and the `highp` shaders that
+/// have always sampled correctly on Mali — `YUYV_RGBA_2D_FRAGMENT` and
+/// `NV_RGBA_FRAGMENT` — are fed by this very vertex shader.
 pub(super) fn generate_texture_fragment_shader() -> &'static str {
     "\
 #version 300 es
@@ -88,7 +113,7 @@ precision mediump float;
 uniform sampler2D tex;
 uniform highp vec4 src_extent;
 in vec3 fragPos;
-in vec2 tc;
+in highp vec2 tc;
 
 out vec4 color;
 
@@ -98,19 +123,28 @@ void main(){
 "
 }
 
+/// `src_extent` is the rectangle a sample may reach
+/// (`render::sample_clamp_rect`), the same uniform and the same reason as
+/// [`generate_texture_fragment_shader`]: an EGLImage import can cover more
+/// texture than the logical image — a narrowed pool buffer, or a source
+/// rebased onto an aligned DMA-BUF offset (issue #170) — and a `LINEAR`
+/// kernel at the edge must not blend the texels outside it. `highp` although
+/// this shader's default is `mediump`, because a `mediump` bound rounds near
+/// 1.0 and would pull the last column's sample in.
 pub(super) fn generate_texture_fragment_shader_yuv() -> &'static str {
     "\
 #version 300 es
 #extension GL_OES_EGL_image_external_essl3 : require
 precision mediump float;
 uniform samplerExternalOES tex;
+uniform highp vec4 src_extent;
 in vec3 fragPos;
-in vec2 tc;
+in highp vec2 tc;
 
 out vec4 color;
 
 void main(){
-    color = texture(tex, tc);
+    color = texture(tex, clamp(tc, src_extent.xy, src_extent.zw));
 }
 "
 }
@@ -127,13 +161,14 @@ pub(super) fn generate_planar_rgb_shader() -> &'static str {
 #extension GL_OES_EGL_image_external_essl3 : require
 precision mediump float;
 uniform samplerExternalOES tex;
+uniform highp vec4 src_extent;
 in vec3 fragPos;
-in vec2 tc;
+in highp vec2 tc;
 
 out vec4 color;
 
 void main(){
-    color = texture(tex, tc);
+    color = texture(tex, clamp(tc, src_extent.xy, src_extent.zw));
 }
 "
 }
@@ -171,12 +206,14 @@ void main(){
 /// Int8 variant of [`generate_texture_fragment_shader_yuv`]. Applies XOR 0x80 bias
 /// to each RGB channel (uint8 → int8 conversion).
 /// Used for single-pass int8 output with external OES sources (YUV EGLImage).
+/// Carries the same `src_extent` clamp, for the same reason.
 pub(super) fn generate_texture_int8_shader_yuv() -> &'static str {
     "\
 #version 300 es
 #extension GL_OES_EGL_image_external_essl3 : require
 precision highp float;
 uniform samplerExternalOES tex;
+uniform highp vec4 src_extent;
 in vec3 fragPos;
 in vec2 tc;
 
@@ -188,7 +225,7 @@ vec3 int8_bias(vec3 v) {
 }
 
 void main(){
-    vec4 c = texture(tex, tc);
+    vec4 c = texture(tex, clamp(tc, src_extent.xy, src_extent.zw));
     color = vec4(int8_bias(c.rgb), c.a);
 }
 "
@@ -197,12 +234,14 @@ void main(){
 /// Int8 variant of [`generate_planar_rgb_shader`]. Applies XOR 0x80 bias
 /// to each RGB channel (uint8 → int8 conversion) using the bit-exact
 /// quantize+mod approach: `floor(v * 255 + 0.5) + 128 mod 256 / 255`.
+/// Carries the same `src_extent` clamp, for the same reason.
 pub(super) fn generate_planar_rgb_int8_shader() -> &'static str {
     "\
 #version 300 es
 #extension GL_OES_EGL_image_external_essl3 : require
 precision highp float;
 uniform samplerExternalOES tex;
+uniform highp vec4 src_extent;
 in vec3 fragPos;
 in vec2 tc;
 
@@ -214,7 +253,7 @@ vec3 int8_bias(vec3 v) {
 }
 
 void main(){
-    vec4 c = texture(tex, tc);
+    vec4 c = texture(tex, clamp(tc, src_extent.xy, src_extent.zw));
     color = vec4(int8_bias(c.rgb), c.a);
 }
 "
@@ -278,7 +317,7 @@ uniform int background_index;
 uniform float opacity;
 
 in vec3 fragPos;
-in vec2 tc;
+in highp vec2 tc;
 in vec4 fragColor;
 
 out vec4 color;
@@ -903,4 +942,419 @@ void main() {
     }
 }
 "
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tc_precision {
+    /// Every shader this module can link, paired with its source: each
+    /// generator here, plus the `shaders_common` fragment constants that
+    /// carry a `tc` and are linked directly rather than through a generator
+    /// (`YUYV_RGBA_2D_FRAGMENT` is, at `processor/mod.rs`'s
+    /// `yuyv_program_2d`).
+    ///
+    /// The list is written out by hand rather than discovered, so a new
+    /// shader has to be added here deliberately —
+    /// [`the_list_names_every_shader`] fails until it is. Add new shaders to
+    /// this list.
+    fn all_shaders() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("generate_vertex_shader", super::generate_vertex_shader()),
+            (
+                "generate_texture_fragment_shader",
+                super::generate_texture_fragment_shader(),
+            ),
+            (
+                "generate_texture_fragment_shader_yuv",
+                super::generate_texture_fragment_shader_yuv(),
+            ),
+            (
+                "generate_planar_rgb_shader",
+                super::generate_planar_rgb_shader(),
+            ),
+            (
+                "generate_texture_int8_shader",
+                super::generate_texture_int8_shader(),
+            ),
+            (
+                "generate_texture_int8_shader_yuv",
+                super::generate_texture_int8_shader_yuv(),
+            ),
+            (
+                "generate_planar_rgb_int8_shader",
+                super::generate_planar_rgb_int8_shader(),
+            ),
+            (
+                "generate_planar_rgb_shader_2d",
+                super::generate_planar_rgb_shader_2d(),
+            ),
+            (
+                "generate_planar_rgb_int8_shader_2d",
+                super::generate_planar_rgb_int8_shader_2d(),
+            ),
+            (
+                "generate_segmentation_shader",
+                super::generate_segmentation_shader(),
+            ),
+            (
+                "generate_instanced_segmentation_shader",
+                super::generate_instanced_segmentation_shader(),
+            ),
+            (
+                "generate_proto_segmentation_shader",
+                super::generate_proto_segmentation_shader(),
+            ),
+            (
+                "generate_proto_segmentation_shader_int8_nearest",
+                super::generate_proto_segmentation_shader_int8_nearest(),
+            ),
+            (
+                "generate_proto_segmentation_shader_int8_bilinear",
+                super::generate_proto_segmentation_shader_int8_bilinear(),
+            ),
+            (
+                "generate_proto_dequant_shader_int8",
+                super::generate_proto_dequant_shader_int8(),
+            ),
+            (
+                "generate_proto_segmentation_shader_f32",
+                super::generate_proto_segmentation_shader_f32(),
+            ),
+            (
+                "generate_packed_f32_nhwc_shader",
+                super::generate_packed_f32_nhwc_shader(),
+            ),
+            (
+                "generate_planar_rgb_f16_packed_shader",
+                super::generate_planar_rgb_f16_packed_shader(),
+            ),
+            (
+                "generate_float_nhwc_packed_shader",
+                super::generate_float_nhwc_packed_shader(),
+            ),
+            (
+                "generate_float_rgba_shader",
+                super::generate_float_rgba_shader(),
+            ),
+            ("generate_color_shader", super::generate_color_shader()),
+            (
+                "generate_packed_rgba8_shader_2d",
+                super::generate_packed_rgba8_shader_2d(),
+            ),
+            (
+                "generate_packed_rgba8_int8_shader_2d",
+                super::generate_packed_rgba8_int8_shader_2d(),
+            ),
+            (
+                "generate_nv_to_rgba_shader_2d",
+                super::generate_nv_to_rgba_shader_2d(),
+            ),
+            (
+                "generate_nv_to_rgba_int8_shader_2d",
+                super::generate_nv_to_rgba_int8_shader_2d(),
+            ),
+            (
+                "generate_proto_repack_compute_shader",
+                super::generate_proto_repack_compute_shader(),
+            ),
+            // Linked straight from the constant, with no generator wrapper.
+            (
+                "YUYV_RGBA_2D_FRAGMENT",
+                super::super::shaders_common::YUYV_RGBA_2D_FRAGMENT,
+            ),
+            (
+                "NV_RGBA_FRAGMENT",
+                super::super::shaders_common::NV_RGBA_FRAGMENT,
+            ),
+        ]
+    }
+
+    /// `//` and `/* */` stripped, so a commented-out sample cannot be counted
+    /// as a real one. Without this a commented `texture(tex, tc)` would raise
+    /// the verbatim-fetch tally and mask a genuine arithmetic use beside it.
+    fn strip_comments(src: &str) -> String {
+        let b = src.as_bytes();
+        let mut out = String::with_capacity(src.len());
+        let mut i = 0;
+        while i < b.len() {
+            if b[i] == b'/' && i + 1 < b.len() && b[i + 1] == b'/' {
+                while i < b.len() && b[i] != b'\n' {
+                    i += 1;
+                }
+            } else if b[i] == b'/' && i + 1 < b.len() && b[i + 1] == b'*' {
+                i += 2;
+                while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(b.len());
+            } else {
+                out.push(b[i] as char);
+                i += 1;
+            }
+        }
+        out
+    }
+
+    /// Byte offsets of every occurrence of the identifier `tc` — `tc` with a
+    /// non-identifier character (or nothing) on each side, so `tc.x` counts
+    /// and `tcoord` does not.
+    fn tc_identifier_offsets(src: &str) -> Vec<usize> {
+        let b = src.as_bytes();
+        let ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+        let mut out = Vec::new();
+        let mut i = 0;
+        while let Some(k) = src[i..].find("tc") {
+            let at = i + k;
+            let before_ok = at == 0 || !ident(b[at - 1]);
+            let after_ok = at + 2 >= b.len() || !ident(b[at + 2]);
+            if before_ok && after_ok {
+                out.push(at);
+            }
+            i = at + 2;
+        }
+        out
+    }
+
+    /// How many of those occurrences are `tc` handed VERBATIM to a texture
+    /// fetch — the exact shape `texture(<sampler>, tc)`, the one use that
+    /// needs no arithmetic and so needs no precision promise.
+    fn verbatim_fetch_count(src: &str) -> usize {
+        let mut n = 0;
+        let mut i = 0;
+        while let Some(k) = src[i..].find("texture(") {
+            let at = i + k + "texture(".len();
+            let rest = &src[at..];
+            let name_len = rest
+                .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+                .unwrap_or(0);
+            if name_len > 0 && rest[name_len..].starts_with(", tc)") {
+                n += 1;
+            }
+            i = at;
+        }
+        n
+    }
+
+    /// The effective precision of the `in ... vec2 tc;` declaration, and
+    /// whether the shader does anything with `tc` beyond handing it straight
+    /// to a texture fetch. `None` when the shader has no `tc` input.
+    fn tc_precision_and_use(src: &str) -> Option<(&'static str, bool)> {
+        let src = &strip_comments(src);
+        let decl = src
+            .lines()
+            .find(|l| l.trim_start().starts_with("in ") && l.trim_end().ends_with("vec2 tc;"))?;
+        let declared = if decl.contains("highp") {
+            Some("highp")
+        } else if decl.contains("mediump") {
+            Some("mediump")
+        } else if decl.contains("lowp") {
+            Some("lowp")
+        } else {
+            None
+        };
+        let file_default = src
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("precision ")?.strip_suffix(" float;"))
+            .map(|p| match p {
+                "highp" => "highp",
+                "mediump" => "mediump",
+                "lowp" => "lowp",
+                _ => "unknown",
+            })
+            .unwrap_or("unknown");
+        let effective = declared.unwrap_or(file_default);
+        // Every `tc` outside the declaration line, minus the ones that are a
+        // verbatim `texture(sampler, tc)` argument.
+        let in_decl = tc_identifier_offsets(decl).len();
+        let total = tc_identifier_offsets(src).len() - in_decl;
+        Some((effective, total > verbatim_fetch_count(src)))
+    }
+
+    /// A shader that does ARITHMETIC on `tc` must declare it `highp`.
+    ///
+    /// Handing a varying straight to `texture()` lets a driver give the
+    /// interpolator's own coordinate to the texture unit, but any operation
+    /// on it — `clamp()`, a `vec3(tc, i)` constructor, a multiply — runs on
+    /// the ALU, and a `mediump` ALU is fp16 on Mali: a 2^-11 step, which is
+    /// 0.625 texel on a 1280-wide source, and `LINEAR` blends the neighbour
+    /// in by that fraction (the measurement is in the comment above
+    /// [`super::generate_texture_fragment_shader`]). No other lane can catch
+    /// it — Vivante, V3D and every desktop GL evaluate `mediump` at fp32, and
+    /// the desktop cannot import a DMA-BUF at all — so this test is the only
+    /// guard, and it is textual on purpose.
+    ///
+    /// The rule: count the `tc` identifiers outside the declaration line; a
+    /// shader is doing arithmetic if any of them is not the second argument
+    /// of a verbatim `texture(<sampler>, tc)`.
+    #[test]
+    fn shaders_that_compute_on_tc_declare_it_highp() {
+        let mut offenders = Vec::new();
+        let mut checked = 0;
+        for (name, src) in all_shaders() {
+            let Some((precision, computes)) = tc_precision_and_use(src) else {
+                continue;
+            };
+            checked += 1;
+            if computes && precision != "highp" {
+                offenders.push(format!("{name} (tc is {precision})"));
+            }
+        }
+        // Cross-check the line parser against a dumb substring test: if the
+        // parser silently stops matching a declaration, the two disagree.
+        let expected = all_shaders()
+            .iter()
+            .filter(|(_, src)| {
+                [
+                    "in vec2 tc;",
+                    "in highp vec2 tc;",
+                    "in mediump vec2 tc;",
+                    "in lowp vec2 tc;",
+                ]
+                .iter()
+                .any(|d| src.contains(d))
+            })
+            .count();
+        assert_eq!(
+            checked, expected,
+            "the declaration parser matched {checked} shaders but {expected} contain an \
+             `in ... vec2 tc;` declaration — the parser stopped matching one"
+        );
+        assert!(
+            offenders.is_empty(),
+            "these shaders do arithmetic on a `tc` that is not `highp`; on Mali the \
+             fp16 ALU quantizes the sampled coordinate to a 2^-11 step, which is \
+             0.625 texel on a 1280-wide source, and the measured shift was 0.40 \
+             texel -- a truncation, not a rounding, so the error does not halve: \
+             {offenders:?}"
+        );
+    }
+
+    /// Every shader name the sources declare: each function in this file
+    /// whose name starts with `generate_`, at ANY visibility, plus each
+    /// `shaders_common` constant ending `_FRAGMENT` whose body carries a
+    /// `tc`. Textual on purpose — it must not share the parser it checks.
+    fn shader_names_in_source() -> Vec<String> {
+        let mut names = Vec::new();
+        let this = include_str!("shaders.rs");
+        let mut i = 0;
+        // A definition, not a call: the marker is the `fn ` keyword, which
+        // `super::generate_x()` in the list above does not have.
+        while let Some(k) = this[i..].find("fn generate_") {
+            let at = i + k + "fn ".len();
+            let rest = &this[at..];
+            let n = rest.find('(').unwrap_or(0);
+            if n > 0
+                && rest[..n]
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                names.push(rest[..n].to_string());
+            }
+            i = at;
+        }
+        let common = include_str!("shaders_common.rs");
+        let mut i = 0;
+        while let Some(k) = common[i..].find("const ") {
+            let at = i + k + "const ".len();
+            let rest = &common[at..];
+            let n = rest
+                .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+                .unwrap_or(0);
+            let name = &rest[..n];
+            // `_FRAGMENT` also filters out GLSL's own `const` declarations.
+            if n > 0 && name.ends_with("_FRAGMENT") {
+                let body = &common[at + n..];
+                let end = body.find("\npub(crate) const ").unwrap_or(body.len());
+                if body[..end].contains("vec2 tc;") {
+                    names.push(name.to_string());
+                }
+            }
+            i = at;
+        }
+        names
+    }
+
+    /// [`all_shaders`] is hand-written, so it can fall behind the sources.
+    /// This pins it by NAME rather than by count, so an omission, a
+    /// duplicate and a shader declared at a different visibility all fail,
+    /// each naming what is wrong. A count alone would let an omission and an
+    /// accidental duplicate cancel out.
+    #[test]
+    fn the_list_names_every_shader() {
+        let listed: Vec<String> = all_shaders().iter().map(|(n, _)| n.to_string()).collect();
+        let mut unique = listed.clone();
+        unique.sort();
+        let dup_len = unique.len();
+        unique.dedup();
+        let duplicates: Vec<&String> = if unique.len() == dup_len {
+            Vec::new()
+        } else {
+            listed
+                .iter()
+                .filter(|n| listed.iter().filter(|m| m == n).count() > 1)
+                .collect()
+        };
+        assert!(
+            duplicates.is_empty(),
+            "`all_shaders` lists these names more than once: {duplicates:?}"
+        );
+
+        let mut declared = shader_names_in_source();
+        declared.sort();
+        declared.dedup();
+        let missing: Vec<&String> = declared.iter().filter(|n| !unique.contains(n)).collect();
+        let extra: Vec<&String> = unique.iter().filter(|n| !declared.contains(n)).collect();
+        assert!(
+            missing.is_empty() && extra.is_empty(),
+            "`all_shaders` is out of step with the sources. Declared but not listed \
+             (add them, so they are precision-checked): {missing:?}. Listed but not \
+             declared (renamed or removed): {extra:?}"
+        );
+    }
+
+    /// The `tc` identifier scan must not match a longer identifier, or the
+    /// rule would fire on unrelated names.
+    #[test]
+    fn tc_scan_matches_the_identifier_only() {
+        assert_eq!(tc_identifier_offsets("tc").len(), 1);
+        assert_eq!(tc_identifier_offsets("tc.x * 2.0").len(), 1);
+        assert_eq!(tc_identifier_offsets("vec3(tc, i)").len(), 1);
+        assert_eq!(tc_identifier_offsets("tcoord + stc + tc_2").len(), 0);
+        assert_eq!(verbatim_fetch_count("texture(tex, tc)"), 1);
+        assert_eq!(verbatim_fetch_count("texture(tex, clamp(tc, a, b))"), 0);
+        assert_eq!(verbatim_fetch_count("texture(tex, vec3(tc, i))"), 0);
+    }
+
+    /// A commented-out verbatim sample must not be counted, or it would
+    /// cancel a real arithmetic use sitting beside it and let an offender
+    /// through.
+    #[test]
+    fn a_commented_out_sample_does_not_mask_an_arithmetic_use() {
+        let src = "\
+#version 300 es
+precision mediump float;
+uniform sampler2D tex;
+in vec2 tc;
+out vec4 color;
+void main(){
+    // color = texture(tex, tc);
+    color = texture(tex, clamp(tc, vec2(0.0), vec2(1.0)));
+}
+";
+        assert_eq!(verbatim_fetch_count(&strip_comments(src)), 0);
+        assert_eq!(
+            tc_precision_and_use(src),
+            Some(("mediump", true)),
+            "the commented sample must not hide the clamp"
+        );
+
+        // The block-comment form, and a comment that is the ONLY use.
+        let only_comment = "\
+#version 300 es
+precision mediump float;
+in vec2 tc;
+void main(){ /* texture(tex, tc) */ color = vec4(0.0); }
+";
+        assert_eq!(tc_precision_and_use(only_comment), Some(("mediump", false)));
+    }
 }

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -22,7 +22,7 @@ mod gl_tests {
         use edgefirst_tensor::Segmentation;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -64,7 +64,7 @@ mod gl_tests {
         use edgefirst_tensor::Segmentation;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -107,7 +107,7 @@ mod gl_tests {
         use ndarray::Array3;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -190,7 +190,7 @@ mod gl_tests {
         use edgefirst_tensor::DetectBox;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -464,13 +464,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_pool_steady_state_zero_imports() {
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -558,13 +564,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn reimported_buffer_hits_the_cache() {
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -690,13 +702,16 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn convert_with_fence_blocking_fallback_matches() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - GL not available", function!());
+            crate::test_support::report_skip(&format!("{} - GL not available", function!()));
             return;
         }
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -760,16 +775,43 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn float_dma_src_import_matches_upload() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers or GL", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or GL",
+                function!()
+            ));
             return;
         }
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
+        // The F16 destinations below are a render target, and Vivante has no
+        // float color buffer at all (`float_render_support` returns
+        // `{f32: false, f16: false}` for it), so `convert` refuses the
+        // destination outright. Gated the way
+        // `convert_f16_gl_cpu_parity_identity` and the F16 cache tests in
+        // `lib.rs` already gate, on the capability the processor reports
+        // rather than on a driver name.
+        //
+        // Direct stderr, not eprintln!: libtest captures println!/eprintln!
+        // and replays it only for FAILING tests, so a skip would print
+        // "... ok" with its reason discarded and be indistinguishable from
+        // having run. See TESTING.md.
+        if !gl.supported_render_dtypes().f16 {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - this GPU has no F16 render target",
+                function!()
+            );
+            return;
+        }
         let (sw, sh, dw) = (96usize, 72usize, 64usize);
         let bytes = rgba_gradient(sw, sh, 0);
         let src_dma = load_raw_image(
@@ -856,16 +898,43 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn float_src_feed_alternating_frames() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers or GL", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or GL",
+                function!()
+            ));
             return;
         }
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
+        // The F16 destinations below are a render target, and Vivante has no
+        // float color buffer at all (`float_render_support` returns
+        // `{f32: false, f16: false}` for it), so `convert` refuses the
+        // destination outright. Gated the way
+        // `convert_f16_gl_cpu_parity_identity` and the F16 cache tests in
+        // `lib.rs` already gate, on the capability the processor reports
+        // rather than on a driver name.
+        //
+        // Direct stderr, not eprintln!: libtest captures println!/eprintln!
+        // and replays it only for FAILING tests, so a skip would print
+        // "... ok" with its reason discarded and be indistinguishable from
+        // having run. See TESTING.md.
+        if !gl.supported_render_dtypes().f16 {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - this GPU has no F16 render target",
+                function!()
+            );
+            return;
+        }
         let (sw, sh, dw) = (96usize, 72usize, 64usize);
         let content_a = rgba_gradient(sw, sh, 0x00);
         let content_b = rgba_gradient(sw, sh, 0x5A);
@@ -964,16 +1033,43 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn float_dma_src_pool_steady_state() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers or GL", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or GL",
+                function!()
+            ));
             return;
         }
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
+        // The F16 destinations below are a render target, and Vivante has no
+        // float color buffer at all (`float_render_support` returns
+        // `{f32: false, f16: false}` for it), so `convert` refuses the
+        // destination outright. Gated the way
+        // `convert_f16_gl_cpu_parity_identity` and the F16 cache tests in
+        // `lib.rs` already gate, on the capability the processor reports
+        // rather than on a driver name.
+        //
+        // Direct stderr, not eprintln!: libtest captures println!/eprintln!
+        // and replays it only for FAILING tests, so a skip would print
+        // "... ok" with its reason discarded and be indistinguishable from
+        // having run. See TESTING.md.
+        if !gl.supported_render_dtypes().f16 {
+            use std::io::Write;
+            let _ = writeln!(
+                &mut std::io::stderr(),
+                "SKIPPED: {} - this GPU has no F16 render target",
+                function!()
+            );
+            return;
+        }
         let (sw, sh, dw) = (128usize, 96usize, 64usize);
         const FRAMES: usize = 100;
         let pool: Vec<TensorDyn> = (0..2)
@@ -1062,13 +1158,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn repeat_convert_rgba_mem_to_rgb_dma() {
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -1105,7 +1207,9 @@ mod gl_tests {
             ) {
                 Ok(d) => d,
                 Err(e) => {
-                    eprintln!("SKIPPED cell {dtype:?}: DMA RGB dst unavailable: {e}");
+                    crate::test_support::report_skip(&format!(
+                        "cell {dtype:?}: DMA RGB dst unavailable: {e}"
+                    ));
                     continue;
                 }
             };
@@ -1160,13 +1264,16 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn int8_mem_convert_is_xor_biased_u8() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -1209,7 +1316,9 @@ mod gl_tests {
                     if fmt == PixelFormat::Rgba {
                         panic!("nv12@mem -> rgba.{dtype:?}@mem must be supported: {e}");
                     }
-                    eprintln!("SKIPPED cell nv12@mem -> {fmt}.{dtype:?}@mem: {e}");
+                    crate::test_support::report_skip(&format!(
+                        "cell nv12@mem -> {fmt}.{dtype:?}@mem: {e}"
+                    ));
                     continue 'fmt;
                 }
                 out[slot] = match dtype {
@@ -1260,10 +1369,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn test_opengl_nv12_to_rgba_reference() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         // Load PixelFormat::Nv12 source with DMA
@@ -1337,10 +1446,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn test_opengl_yuyv_to_rgba_reference() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         // Load PixelFormat::Yuyv source with DMA
@@ -1424,10 +1533,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn opengl_render_into_dma_subviews_no_aliasing() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1636,10 +1745,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_grey_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1659,10 +1768,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_nv12_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1679,10 +1788,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_nv16_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1702,10 +1811,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_pool_recycle_all_frames_match_oracle() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1806,10 +1915,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_geometry_change_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         // Oversized pool (like the profiler's pool_w x 3*max_h R8 surface),
@@ -1894,10 +2003,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_pool_geometry_interleaved_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = [
@@ -1984,10 +2093,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_single_shot_grey_matches_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -2045,13 +2154,19 @@ mod gl_tests {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("SKIPPED: {} - EGL not available: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - EGL not available: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if displays.is_empty() {
-            eprintln!("SKIPPED: {} - No EGL displays available", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - No EGL displays available",
+                function!()
+            ));
             return;
         }
 
@@ -2088,13 +2203,19 @@ mod gl_tests {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("SKIPPED: {} - EGL not available: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - EGL not available: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if displays.is_empty() {
-            eprintln!("SKIPPED: {} - No EGL displays available", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - No EGL displays available",
+                function!()
+            ));
             return;
         }
 
@@ -2107,10 +2228,10 @@ mod gl_tests {
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} - GLProcessorThreaded failed: {e:?}",
+                crate::test_support::report_skip(&format!(
+                    "{} - GLProcessorThreaded failed: {e:?}",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -2157,13 +2278,19 @@ mod gl_tests {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("SKIPPED: {} - EGL not available: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - EGL not available: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if displays.is_empty() {
-            eprintln!("SKIPPED: {} - No EGL displays available", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - No EGL displays available",
+                function!()
+            ));
             return;
         }
 
@@ -2218,7 +2345,10 @@ mod gl_tests {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("SKIPPED: {} - EGL not available: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - EGL not available: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -2243,10 +2373,10 @@ mod gl_tests {
             );
             eprintln!("  Correctly returned error: {:?}", result.unwrap_err());
         } else {
-            eprintln!(
-                "SKIPPED: {} - All three display kinds are available",
+            crate::test_support::report_skip(&format!(
+                "{} - All three display kinds are available",
                 function!()
-            );
+            ));
         }
     }
 
@@ -2256,7 +2386,7 @@ mod gl_tests {
     #[cfg(target_os = "linux")] // Linux display probing
     fn test_auto_detect_display() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -2454,7 +2584,10 @@ mod gl_tests {
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -2583,7 +2716,9 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn test_opengl_nv12_to_bgra() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: test_opengl_nv12_to_bgra - no zero-copy GPU buffers or OpenGL");
+            crate::test_support::report_skip(
+                "test_opengl_nv12_to_bgra - no zero-copy GPU buffers or OpenGL",
+            );
             return;
         }
 
@@ -2670,7 +2805,9 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn test_opengl_yuyv_to_bgra() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: test_opengl_yuyv_to_bgra - no zero-copy GPU buffers or OpenGL");
+            crate::test_support::report_skip(
+                "test_opengl_yuyv_to_bgra - no zero-copy GPU buffers or OpenGL",
+            );
             return;
         }
 
@@ -2755,7 +2892,7 @@ mod gl_tests {
         use edgefirst_tensor::Segmentation;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_draw_decoded_masks_bgra - OpenGL not available");
+            crate::test_support::report_skip("test_draw_decoded_masks_bgra - OpenGL not available");
             return;
         }
 
@@ -2853,7 +2990,9 @@ mod gl_tests {
         use edgefirst_tensor::DetectBox;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_draw_decoded_masks_bgra_mem - OpenGL not available");
+            crate::test_support::report_skip(
+                "test_draw_decoded_masks_bgra_mem - OpenGL not available",
+            );
             return;
         }
 
@@ -2941,7 +3080,7 @@ mod gl_tests {
     #[test]
     fn test_gl_mask_render_smoke() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -2973,7 +3112,7 @@ mod gl_tests {
     #[cfg(any(target_os = "linux", target_os = "windows"))] // PBO destinations: Linux + Windows
     fn test_gl_pbo_destination_smoke() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -2987,7 +3126,10 @@ mod gl_tests {
             }
             Err(e) => {
                 // PBO may not be supported on all GL implementations
-                eprintln!("SKIPPED: {} - PBO not supported: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - PBO not supported: {e:?}",
+                    function!()
+                ));
             }
         }
     }
@@ -3007,7 +3149,7 @@ mod gl_tests {
     #[cfg(any(target_os = "linux", target_os = "windows"))] // PBO destinations: Linux + Windows
     fn test_gl_convert_any_to_pbo_no_deadlock() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -3015,7 +3157,10 @@ mod gl_tests {
         let pbo_dst = match gl.create_pbo_image(64, 64, PixelFormat::Rgba) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} - PBO not supported: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - PBO not supported: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3065,7 +3210,10 @@ mod gl_tests {
                     !msg.contains("GL converter thread exited"),
                     "PBO destination convert deadlocked: {msg}"
                 );
-                eprintln!("SKIPPED: {} - convert failed unrelated: {msg}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - convert failed unrelated: {msg}",
+                    function!()
+                ));
             }
         }
     }
@@ -3077,7 +3225,7 @@ mod gl_tests {
     #[cfg(any(target_os = "linux", target_os = "windows"))] // PBO destinations: Linux + Windows
     fn test_gl_convert_pbo_to_pbo_no_deadlock() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -3085,14 +3233,20 @@ mod gl_tests {
         let pbo_src = match gl.create_pbo_image(64, 64, PixelFormat::Rgba) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} - PBO not supported: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - PBO not supported: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
         let pbo_dst = match gl.create_pbo_image(64, 64, PixelFormat::Rgba) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} - PBO dst not supported: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - PBO dst not supported: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3115,7 +3269,10 @@ mod gl_tests {
                     !msg.contains("GL converter thread exited"),
                     "PBO→PBO convert deadlocked: {msg}"
                 );
-                eprintln!("SKIPPED: {} - convert failed unrelated: {msg}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - convert failed unrelated: {msg}",
+                    function!()
+                ));
             }
         }
     }
@@ -3153,7 +3310,7 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_multiplane_nv12_to_rgba_opengl() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -3249,11 +3406,11 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -3275,7 +3432,7 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: {} - DMA alloc failed", function!());
+                crate::test_support::report_skip(&format!("{} - DMA alloc failed", function!()));
                 return;
             }
         };
@@ -3375,7 +3532,7 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_multiplane_nv12_to_rgb_letterbox_opengl() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -3452,7 +3609,7 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_multiplane_nv12_to_rgb_int8_letterbox_opengl() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -3555,7 +3712,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut proc = match ImageProcessor::with_config(ImageProcessorConfig {
@@ -3564,7 +3721,10 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3674,7 +3834,7 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn letterbox_nv12_to_planar_matches_rgba_reference() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -3758,7 +3918,7 @@ mod gl_tests {
     #[test]
     fn gl_planar_heap_matches_cpu() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (sw, sh) = (1280usize, 720usize);
@@ -3770,7 +3930,10 @@ mod gl_tests {
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3818,15 +3981,15 @@ mod gl_tests {
         use crate::ImageProcessor;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut proc = ImageProcessor::new().unwrap();
         if proc.opengl.is_none() {
-            eprintln!(
-                "SKIPPED: {} - ImageProcessor resolved no GL backend",
+            crate::test_support::report_skip(&format!(
+                "{} - ImageProcessor resolved no GL backend",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -3870,7 +4033,7 @@ mod gl_tests {
     #[test]
     fn gl_planar_heap_rgba_src_matches_cpu() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let src = crate::load_image_test_helper(
@@ -3886,7 +4049,10 @@ mod gl_tests {
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3925,15 +4091,15 @@ mod gl_tests {
         use crate::ImageProcessor;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut proc = ImageProcessor::new().unwrap();
         if proc.opengl.is_none() {
-            eprintln!(
-                "SKIPPED: {} - ImageProcessor resolved no GL backend",
+            crate::test_support::report_skip(&format!(
+                "{} - ImageProcessor resolved no GL backend",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -3978,7 +4144,7 @@ mod gl_tests {
     #[test]
     fn test_proto_fused_vs_hybrid_ssim() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4285,7 +4451,7 @@ mod gl_tests {
     #[test]
     fn proto_float_dtypes_match_int8_reference() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4308,7 +4474,7 @@ mod gl_tests {
     #[test]
     fn proto_f32_no_float_linear_fallback_matches() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4336,7 +4502,7 @@ mod gl_tests {
     #[test]
     fn proto_compute_repack_matches_cpu_repack() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4367,7 +4533,7 @@ mod gl_tests {
         use crate::Int8InterpolationMode;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4410,7 +4576,7 @@ mod gl_tests {
     #[test]
     fn proto_dims_and_format_churn_uploads_correctly() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4470,11 +4636,11 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_opengl_dst_offset_zero_regression() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4545,11 +4711,11 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4627,11 +4793,11 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4717,11 +4883,11 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4812,18 +4978,18 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !is_neutron_available() {
-            eprintln!(
-                "SKIPPED: {} - Neutron not available (/dev/neutron0 not found)",
+            crate::test_support::report_skip(&format!(
+                "{} - Neutron not available (/dev/neutron0 not found)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -4834,11 +5000,11 @@ mod gl_tests {
         let large_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!(
-                    "SKIPPED: {} - cannot allocate {} MB DMA buffer",
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate {} MB DMA buffer",
                     function!(),
                     total_size / 1_048_576
-                );
+                ));
                 return;
             }
         };
@@ -4891,18 +5057,18 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !is_neutron_available() {
-            eprintln!(
-                "SKIPPED: {} - Neutron not available (/dev/neutron0 not found)",
+            crate::test_support::report_skip(&format!(
+                "{} - Neutron not available (/dev/neutron0 not found)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -4922,7 +5088,10 @@ mod gl_tests {
         let rgba_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!("SKIPPED: {} - cannot allocate DMA buffer", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate DMA buffer",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4953,10 +5122,10 @@ mod gl_tests {
         let rgb_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!(
-                    "SKIPPED: {} - cannot allocate second DMA buffer",
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate second DMA buffer",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -4992,18 +5161,18 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !is_neutron_available() {
-            eprintln!(
-                "SKIPPED: {} - Neutron not available (/dev/neutron0 not found)",
+            crate::test_support::report_skip(&format!(
+                "{} - Neutron not available (/dev/neutron0 not found)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -5026,7 +5195,10 @@ mod gl_tests {
         let u8_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!("SKIPPED: {} - cannot allocate DMA buffer", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate DMA buffer",
+                    function!()
+                ));
                 return;
             }
         };
@@ -5055,10 +5227,10 @@ mod gl_tests {
         let i8_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!(
-                    "SKIPPED: {} - cannot allocate second DMA buffer",
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate second DMA buffer",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -5094,18 +5266,18 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !is_neutron_available() {
-            eprintln!(
-                "SKIPPED: {} - Neutron not available (/dev/neutron0 not found)",
+            crate::test_support::report_skip(&format!(
+                "{} - Neutron not available (/dev/neutron0 not found)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -5129,7 +5301,10 @@ mod gl_tests {
         let aligned_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!("SKIPPED: {} - cannot allocate DMA buffer", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate DMA buffer",
+                    function!()
+                ));
                 return;
             }
         };
@@ -5162,10 +5337,10 @@ mod gl_tests {
         {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!(
-                    "SKIPPED: {} - cannot allocate second DMA buffer",
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate second DMA buffer",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -5208,7 +5383,9 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_import_image_rgba_with_stride - DMA not available");
+            crate::test_support::report_skip(
+                "test_import_image_rgba_with_stride - DMA not available",
+            );
             return;
         }
 
@@ -5226,7 +5403,9 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: test_import_image_rgba_with_stride - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_import_image_rgba_with_stride - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -5262,7 +5441,9 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_import_image_rgba_padded_stride - DMA not available");
+            crate::test_support::report_skip(
+                "test_import_image_rgba_padded_stride - DMA not available",
+            );
             return;
         }
 
@@ -5285,7 +5466,9 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: test_import_image_rgba_padded_stride - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_import_image_rgba_padded_stride - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -5322,7 +5505,9 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_import_image_nv12_with_offset - DMA not available");
+            crate::test_support::report_skip(
+                "test_import_image_nv12_with_offset - DMA not available",
+            );
             return;
         }
 
@@ -5343,7 +5528,9 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: test_import_image_nv12_with_offset - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_import_image_nv12_with_offset - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -5386,11 +5573,11 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5414,7 +5601,10 @@ mod gl_tests {
         let luma_buf = match luma_buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: {} - luma DMA alloc failed", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - luma DMA alloc failed",
+                    function!()
+                ));
                 return;
             }
         };
@@ -5428,7 +5618,10 @@ mod gl_tests {
         let chroma_buf = match chroma_buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: {} - chroma DMA alloc failed", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - chroma DMA alloc failed",
+                    function!()
+                ));
                 return;
             }
         };
@@ -5519,11 +5712,11 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5542,7 +5735,7 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: {} - DMA alloc failed", function!());
+                crate::test_support::report_skip(&format!("{} - DMA alloc failed", function!()));
                 return;
             }
         };
@@ -5633,7 +5826,9 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_import_image_stride_too_small - DMA not available");
+            crate::test_support::report_skip(
+                "test_import_image_stride_too_small - DMA not available",
+            );
             return;
         }
 
@@ -5650,7 +5845,9 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: test_import_image_stride_too_small - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_import_image_stride_too_small - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -5724,7 +5921,9 @@ mod gl_tests {
     #[test]
     fn test_src_rect_crop_no_bleed_gl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_src_rect_crop_no_bleed_gl - OpenGL not available");
+            crate::test_support::report_skip(
+                "test_src_rect_crop_no_bleed_gl - OpenGL not available",
+            );
             return;
         }
 
@@ -5759,7 +5958,7 @@ mod gl_tests {
             // logic is still covered on RGBA-capable drivers (e.g. Mesa); Vivante
             // RGB-source support is tracked for separate investigation.
             if e.to_string().contains("RGB source") {
-                eprintln!("SKIPPED: {} - {e}", function!());
+                crate::test_support::report_skip(&format!("{} - {e}", function!()));
                 return;
             }
             panic!("{e}");
@@ -5794,7 +5993,9 @@ mod gl_tests {
     #[test]
     fn test_src_rect_boundary_crop_no_bleed_gl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_src_rect_boundary_crop_no_bleed_gl - OpenGL not available");
+            crate::test_support::report_skip(
+                "test_src_rect_boundary_crop_no_bleed_gl - OpenGL not available",
+            );
             return;
         }
 
@@ -5826,7 +6027,7 @@ mod gl_tests {
             // logic is still covered on RGBA-capable drivers (e.g. Mesa); Vivante
             // RGB-source support is tracked for separate investigation.
             if e.to_string().contains("RGB source") {
-                eprintln!("SKIPPED: {} - {e}", function!());
+                crate::test_support::report_skip(&format!("{} - {e}", function!()));
                 return;
             }
             panic!("{e}");
@@ -5850,7 +6051,9 @@ mod gl_tests {
     #[test]
     fn test_src_rect_crop_left_half_no_bleed_gl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_src_rect_crop_left_half_no_bleed_gl - OpenGL not available");
+            crate::test_support::report_skip(
+                "test_src_rect_crop_left_half_no_bleed_gl - OpenGL not available",
+            );
             return;
         }
 
@@ -5880,7 +6083,7 @@ mod gl_tests {
             // logic is still covered on RGBA-capable drivers (e.g. Mesa); Vivante
             // RGB-source support is tracked for separate investigation.
             if e.to_string().contains("RGB source") {
-                eprintln!("SKIPPED: {} - {e}", function!());
+                crate::test_support::report_skip(&format!("{} - {e}", function!()));
                 return;
             }
             panic!("{e}");
@@ -6176,7 +6379,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut proc = match ImageProcessor::with_config(ImageProcessorConfig {
@@ -6185,7 +6388,10 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -6202,10 +6408,10 @@ mod gl_tests {
             )
             .unwrap();
         if probe.memory() != TensorMemory::Pbo {
-            eprintln!(
-                "SKIPPED: {} - target does not allocate PBO images",
+            crate::test_support::report_skip(&format!(
+                "{} - target does not allocate PBO images",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -6314,7 +6520,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6326,13 +6532,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f32 {
-            eprintln!("SKIPPED: {} - F32 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F32 render not supported",
+                function!()
+            ));
             return;
         }
 
@@ -6351,7 +6563,10 @@ mod gl_tests {
             )
             .unwrap();
         if src.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - RGBA8 src not PBO-backed", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - RGBA8 src not PBO-backed",
+                function!()
+            ));
             return;
         }
         {
@@ -6379,7 +6594,7 @@ mod gl_tests {
             )
             .unwrap();
         if dst.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - F32 dst not PBO-backed", function!());
+            crate::test_support::report_skip(&format!("{} - F32 dst not PBO-backed", function!()));
             return;
         }
 
@@ -6441,7 +6656,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6451,13 +6666,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f32 {
-            eprintln!("SKIPPED: {} - F32 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F32 render not supported",
+                function!()
+            ));
             return;
         }
 
@@ -6478,7 +6699,10 @@ mod gl_tests {
             )
             .unwrap();
         if src.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - RGBA8 src not PBO-backed", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - RGBA8 src not PBO-backed",
+                function!()
+            ));
             return;
         }
         {
@@ -6506,7 +6730,7 @@ mod gl_tests {
             )
             .unwrap();
         if dst.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - F32 dst not PBO-backed", function!());
+            crate::test_support::report_skip(&format!("{} - F32 dst not PBO-backed", function!()));
             return;
         }
 
@@ -6566,7 +6790,7 @@ mod gl_tests {
         use half::f16;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6576,13 +6800,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f16 {
-            eprintln!("SKIPPED: {} - F16 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F16 render not supported",
+                function!()
+            ));
             return;
         }
 
@@ -6600,7 +6830,10 @@ mod gl_tests {
             )
             .unwrap();
         if src.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - RGBA8 src not PBO-backed", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - RGBA8 src not PBO-backed",
+                function!()
+            ));
             return;
         }
         {
@@ -6628,7 +6861,7 @@ mod gl_tests {
             )
             .unwrap();
         if dst.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - F16 dst not PBO-backed", function!());
+            crate::test_support::report_skip(&format!("{} - F16 dst not PBO-backed", function!()));
             return;
         }
 
@@ -6700,7 +6933,7 @@ mod gl_tests {
         use half::f16;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6713,16 +6946,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f16 {
-            eprintln!(
-                "SKIPPED: {} - F16 render not supported (Vivante?)",
+            crate::test_support::report_skip(&format!(
+                "{} - F16 render not supported (Vivante?)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -6770,10 +7006,10 @@ mod gl_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} - F16 DMA tensor alloc failed (no dma-heap?): {e}",
+                crate::test_support::report_skip(&format!(
+                    "{} - F16 DMA tensor alloc failed (no dma-heap?): {e}",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -6781,11 +7017,11 @@ mod gl_tests {
         // Confirm the tensor is genuinely DMA-backed — skip if the allocator
         // fell back to a different memory type.
         if dst.memory() != TensorMemory::DmaBuf {
-            eprintln!(
-                "SKIPPED: {} - F16 dst memory is {:?}, not Dma; DMA path not exercised",
+            crate::test_support::report_skip(&format!(
+                "{} - F16 dst memory is {:?}, not Dma; DMA path not exercised",
                 function!(),
                 dst.memory()
-            );
+            ));
             return;
         }
 
@@ -6858,7 +7094,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6868,13 +7104,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f32 {
-            eprintln!("SKIPPED: {} - F32 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F32 render not supported",
+                function!()
+            ));
             return;
         }
 
@@ -6895,7 +7137,10 @@ mod gl_tests {
             )
             .unwrap();
         if src.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - RGBA8 src not PBO-backed", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - RGBA8 src not PBO-backed",
+                function!()
+            ));
             return;
         }
         {
@@ -6920,7 +7165,7 @@ mod gl_tests {
             )
             .unwrap();
         if dst.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - F32 dst not PBO-backed", function!());
+            crate::test_support::report_skip(&format!("{} - F32 dst not PBO-backed", function!()));
             return;
         }
 
@@ -7490,7 +7735,10 @@ mod gl_tests {
     fn test_gpu_nv16_to_rgba_path_b() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
 
@@ -7528,7 +7776,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -7614,13 +7865,16 @@ mod gl_tests {
         use edgefirst_tensor::{ColorEncoding, ColorRange, Colorimetry};
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -7750,7 +8004,7 @@ mod gl_tests {
     fn test_nv12_path_env_override() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize); // width % 4 == 0 so the sampler import is accepted
@@ -7771,7 +8025,10 @@ mod gl_tests {
             let mut gl = match gl {
                 Ok(g) => g,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                    crate::test_support::report_skip(&format!(
+                        "{} - GL not available: {e}",
+                        function!()
+                    ));
                     return None;
                 }
             };
@@ -7841,7 +8098,7 @@ mod gl_tests {
     fn test_nv12_nondma_upload_uses_shader() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -7857,7 +8114,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -7926,7 +8186,7 @@ mod gl_tests {
     fn test_nv12_to_planar_rgb_uses_shader_path() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -7955,7 +8215,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8017,14 +8280,17 @@ mod gl_tests {
     fn test_nv16_nv24_nondma_upload_uses_shader() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize);
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8108,7 +8374,7 @@ mod gl_tests {
     fn probe_nv12_sampler_vs_shader_divergence() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize); // width % 4 == 0 for the sampler import
@@ -8137,7 +8403,10 @@ mod gl_tests {
             let mut gl = match gl {
                 Ok(g) => g,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                    crate::test_support::report_skip(&format!(
+                        "{} - GL not available: {e}",
+                        function!()
+                    ));
                     return None;
                 }
             };
@@ -8238,7 +8507,7 @@ mod gl_tests {
         use crate::opengl_headless::processor::GLProcessorST;
         use crate::{Fit, Region};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         // 16:9 source so fitting into a square model produces top/bottom bars.
@@ -8284,7 +8553,7 @@ mod gl_tests {
             let mut g = match g {
                 Ok(x) => x,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - GL: {e}", function!());
+                    crate::test_support::report_skip(&format!("{} - GL: {e}", function!()));
                     return None;
                 }
             };
@@ -8408,7 +8677,10 @@ mod gl_tests {
     fn test_gpu_nv24_to_rgba_path_b() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
 
@@ -8445,7 +8717,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8488,7 +8763,10 @@ mod gl_tests {
     fn test_gpu_nv16_matches_cpu_reference() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
 
@@ -8545,7 +8823,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8586,7 +8867,10 @@ mod gl_tests {
     fn test_gpu_nv24_matches_cpu_reference() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
 
@@ -8643,7 +8927,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8685,7 +8972,7 @@ mod gl_tests {
     fn test_nv12_dma_gpu_path_no_cpu_fallback() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -8709,7 +8996,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8739,7 +9029,7 @@ mod gl_tests {
     fn test_gpu_nv16_path_b_int8_output() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -8804,7 +9094,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9036,7 +9329,10 @@ mod gl_tests {
     fn g03_nv16_odd_w_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -9073,7 +9369,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9111,7 +9410,10 @@ mod gl_tests {
     fn g04_nv24_odd_w_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -9148,7 +9450,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9190,7 +9495,10 @@ mod gl_tests {
     fn g05_nv16_odd_both_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 241usize); // QVGA-scale odd both (Mali rejects sub-minimum textures)
@@ -9227,7 +9535,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9269,7 +9580,10 @@ mod gl_tests {
     fn g06_nv24_odd_both_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 241usize); // QVGA-scale odd both (Mali rejects sub-minimum textures)
@@ -9306,7 +9620,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9356,7 +9673,7 @@ mod gl_tests {
     fn g09_odd_dst_unaligned_stride_guarded() {
         use crate::opengl_headless::processor::GLProcessorST;
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (321usize, 240usize);
@@ -9383,7 +9700,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9422,7 +9742,10 @@ mod gl_tests {
     fn g01_nv12_odd_w_path_b_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -9459,7 +9782,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9508,7 +9834,10 @@ mod gl_tests {
     fn g02_nv12_odd_h_path_b_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         // Even width, odd height — exercises odd-H chroma row boundary.
@@ -9546,7 +9875,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9608,7 +9940,10 @@ mod gl_tests {
         use crate::opengl_headless::processor::GLProcessorST;
         use edgefirst_codec::{ImageDecoder, ImageLoad};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let jpeg: &[u8] = &edgefirst_bench::testdata::read("coco_grey_odd.jpg");
@@ -9630,7 +9965,10 @@ mod gl_tests {
                 TensorDyn::from(t)
             }
             Err(e) => {
-                eprintln!("SKIPPED: {} - DMA Grey alloc failed: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - DMA Grey alloc failed: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9681,7 +10019,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9727,7 +10068,7 @@ mod gl_tests {
     fn g07_nv12_odd_w_i8_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -9766,7 +10107,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9816,7 +10160,7 @@ mod gl_tests {
     fn g08_nv16_odd_both_i8_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (321usize, 241usize); // QVGA-scale odd both (Mali rejects sub-minimum textures)
@@ -9855,7 +10199,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9897,7 +10244,10 @@ mod gl_tests {
     fn g_even_nv16_64x64_regression() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -9934,7 +10284,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9966,7 +10319,10 @@ mod gl_tests {
     fn g_even_nv24_64x64_regression() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -10003,7 +10359,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -10116,10 +10475,10 @@ mod gl_tests {
     #[test]
     fn recycled_narrowed_destination_matches_a_fresh_one() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let src = match crate::load_image_test_helper(
@@ -10129,7 +10488,10 @@ mod gl_tests {
         ) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("SKIPPED: {} - source decode failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - source decode failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -10145,10 +10507,10 @@ mod gl_tests {
             )
         };
         let Ok(mut pool) = rgba_dst(256, 192) else {
-            eprintln!(
-                "SKIPPED: {} - texture destination alloc failed",
+            crate::test_support::report_skip(&format!(
+                "{} - texture destination alloc failed",
                 function!()
-            );
+            ));
             return;
         };
         // Seed the whole texture, so anything the narrowed convert fails to
@@ -10307,10 +10669,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_source_resized_matches_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = seeded_grey_pool();
@@ -10358,10 +10720,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_source_upscaled_edges_match_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = seeded_grey_pool();
@@ -10413,10 +10775,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_source_cropped_and_rotated_edges_match_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = seeded_grey_pool();
@@ -10475,10 +10837,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_yuyv_source_matches_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = TensorDyn::image(
@@ -10571,10 +10933,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_source_into_float_dst_matches_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         // `ComputeBackend::OpenGl` selects the GL backend but does NOT disable
@@ -10589,12 +10951,18 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
         if !proc.supported_render_dtypes().f32 {
-            eprintln!("SKIPPED: {} - F32 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F32 render not supported",
+                function!()
+            ));
             return;
         }
         let mut pool = TensorDyn::image(
@@ -10628,7 +10996,10 @@ mod gl_tests {
                     .create_pbo_image_dtype(dw, dh, PixelFormat::Rgb, DType::F32)
             };
             let Ok(mut recycled) = float_dst(&proc) else {
-                eprintln!("SKIPPED: {} - no F32 PBO destination", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - no F32 PBO destination",
+                    function!()
+                ));
                 return;
             };
             let fallbacks_before = proc.convert_fallback_count();
@@ -10709,17 +11080,17 @@ mod gl_tests {
                 )
             };
             let (Ok(mut zc_recycled), Ok(mut zc_oracle)) = (planar_dst(), planar_dst()) else {
-                eprintln!(
-                    "SKIPPED (zero-copy float dst): {} - no F32 PlanarRgb texture",
+                crate::test_support::report_skip(&format!(
+                    "(zero-copy float dst): {} - no F32 PlanarRgb texture",
                     function!()
-                );
+                ));
                 continue;
             };
             if zc_recycled.memory() != TensorMemory::DmaBuf {
-                eprintln!(
-                    "SKIPPED (zero-copy float dst): {} - F32 PlanarRgb dst is not zero-copy",
+                crate::test_support::report_skip(&format!(
+                    "(zero-copy float dst): {} - F32 PlanarRgb dst is not zero-copy",
                     function!()
-                );
+                ));
                 continue;
             }
             // Both sides are read through `copy_to_flat`: a Windows texture
@@ -10799,16 +11170,16 @@ mod gl_tests {
         const TOLERANCE: u8 = 8;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
         #[cfg(target_os = "macos")]
         if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
-            eprintln!(
-                "SKIPPED: {} - ANGLE dlopen gate closed (coverage pass 1)",
+            crate::test_support::report_skip(&format!(
+                "{} - ANGLE dlopen gate closed (coverage pass 1)",
                 function!()
-            );
+            ));
             return;
         }
         // Two rows taller than the logical frame, so a window starting a row
@@ -10837,10 +11208,10 @@ mod gl_tests {
                     "HAL_TEST_REQUIRE_GL=1 and this host reports a zero-copy \
                      buffer backing, but the NV12 zero-copy allocation {what}"
                 );
-                eprintln!(
-                    "SKIPPED: {} - no zero-copy NV12 image here ({what})",
+                crate::test_support::report_skip(&format!(
+                    "{} - no zero-copy NV12 image here ({what})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -11013,16 +11384,16 @@ mod gl_tests {
         const BLANK: u8 = 0x55;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
         #[cfg(target_os = "macos")]
         if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
-            eprintln!(
-                "SKIPPED: {} - ANGLE dlopen gate closed (coverage pass 1)",
+            crate::test_support::report_skip(&format!(
+                "{} - ANGLE dlopen gate closed (coverage pass 1)",
                 function!()
-            );
+            ));
             return;
         }
         let dma_rgba = |w: usize, h: usize| {
@@ -11047,10 +11418,10 @@ mod gl_tests {
                     "HAL_TEST_REQUIRE_GL=1 and this host reports a zero-copy buffer \
                      backing, but the RGBA zero-copy allocation {what}"
                 );
-                eprintln!(
-                    "SKIPPED: {} - no zero-copy RGBA image here ({what})",
+                crate::test_support::report_skip(&format!(
+                    "{} - no zero-copy RGBA image here ({what})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -11113,12 +11484,12 @@ mod gl_tests {
         // cannot run the subject. This desktop is one: its EGL cannot import a
         // DMA-BUF, so the backend falls back to PBO.
         if control == 0 {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy destination import on this host, so a \
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy destination import on this host, so a \
                  view() destination is declined by the engine and there is nothing \
                  to measure",
                 function!()
-            );
+            ));
             log::info!(
                 "{}: pitch {pitch} offset {offset} -> control_dst_imports=0, skipped",
                 function!()

--- a/crates/image/src/gl/threaded.rs
+++ b/crates/image/src/gl/threaded.rs
@@ -1485,20 +1485,20 @@ mod tests {
         let gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: concurrent_maps_from_two_independent_handles... - \
+                crate::test_support::report_skip(&format!(
+                    "concurrent_maps_from_two_independent_handles... - \
                      OpenGL not available: {e:?}"
-                );
+                ));
                 return;
             }
         };
         let tensor_a = match gl.create_pbo_image(64, 64, PixelFormat::Rgba) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: concurrent_maps_from_two_independent_handles... - \
+                crate::test_support::report_skip(&format!(
+                    "concurrent_maps_from_two_independent_handles... - \
                      PBO not supported: {e:?}"
-                );
+                ));
                 return;
             }
         };

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -410,6 +410,8 @@ mod error;
 mod g2d;
 #[path = "gl/mod.rs"]
 mod opengl_headless;
+#[cfg(test)]
+mod test_support;
 mod tiling;
 pub use tiling::{tile_grid, TilePlacement, TileSpec, TilingConfig};
 
@@ -3771,10 +3773,10 @@ mod image_tests {
         let mut proc = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — ImageProcessor init failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} — ImageProcessor init failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -3797,10 +3799,10 @@ mod image_tests {
         ) {
             Ok(d) => d,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — tall DMA destination alloc failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} — tall DMA destination alloc failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -3894,7 +3896,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3976,7 +3981,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4044,10 +4052,10 @@ mod image_tests {
         let mut proc = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — ImageProcessor init failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} — ImageProcessor init failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -4066,10 +4074,10 @@ mod image_tests {
         ) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — tall DMA parent alloc failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} — tall DMA parent alloc failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -4125,7 +4133,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4158,7 +4169,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4184,7 +4198,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4707,7 +4724,9 @@ mod image_tests {
             }
             Err(e) => {
                 // Skip cleanly on hosts without a dma-heap.
-                eprintln!("SKIPPED: create_image NV12 DMA non-aligned width: {e}");
+                crate::test_support::report_skip(&format!(
+                    "create_image NV12 DMA non-aligned width: {e}"
+                ));
             }
         }
     }
@@ -4825,18 +4844,18 @@ mod image_tests {
     fn gl_backend_available_canary() {
         let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
         if !require_gl {
-            eprintln!(
-                "SKIPPED: {} — HAL_TEST_REQUIRE_GL is not set to 1",
+            crate::test_support::report_skip(&format!(
+                "{} — HAL_TEST_REQUIRE_GL is not set to 1",
                 function!()
-            );
+            ));
             return;
         }
         #[cfg(target_os = "macos")]
         if std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
-            eprintln!(
-                "SKIPPED: {} — ANGLE dlopen gate closed (coverage pass 1)",
+            crate::test_support::report_skip(&format!(
+                "{} — ANGLE dlopen gate closed (coverage pass 1)",
                 function!()
-            );
+            ));
             return;
         }
         GLProcessorThreaded::new(None).expect(
@@ -5032,8 +5051,8 @@ mod image_tests {
     fn test_convert_rgba_non_4_aligned_width_end_to_end() {
         use edgefirst_tensor::is_dma_available;
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_convert_rgba_non_4_aligned_width_end_to_end — DMA not available"
+            crate::test_support::report_skip(
+                "test_convert_rgba_non_4_aligned_width_end_to_end — DMA not available",
             );
             return;
         }
@@ -5117,8 +5136,8 @@ mod image_tests {
     fn test_load_jpeg_rgba_non_aligned_pitch_padded_dma() {
         use edgefirst_tensor::is_dma_available;
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_load_jpeg_rgba_non_aligned_pitch_padded_dma — DMA not available"
+            crate::test_support::report_skip(
+                "test_load_jpeg_rgba_non_aligned_pitch_padded_dma — DMA not available",
             );
             return;
         }
@@ -5242,7 +5261,9 @@ mod image_tests {
     fn test_load_png_grey_misaligned_width_dma() {
         use edgefirst_tensor::is_dma_available;
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_load_png_grey_misaligned_width_dma — DMA not available");
+            crate::test_support::report_skip(
+                "test_load_png_grey_misaligned_width_dma — DMA not available",
+            );
             return;
         }
         let png = make_grey_png(612, 388);
@@ -5323,13 +5344,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_resize() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_resize - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_resize - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_resize - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_resize - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -5402,7 +5423,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_resize() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5470,7 +5491,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_10_threads() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5500,7 +5521,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_grey() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5560,13 +5581,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_src_crop() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_src_crop - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_src_crop - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_src_crop - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_src_crop - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -5628,13 +5649,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_dst_crop() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_dst_crop - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_dst_crop - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_dst_crop - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_dst_crop - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -5696,13 +5717,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_all_rgba() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_all_rgba - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_all_rgba - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_all_rgba - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_all_rgba - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -5797,7 +5818,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_src_crop() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5861,7 +5882,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_dst_crop() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6059,7 +6080,7 @@ mod image_tests {
     #[cfg(all(target_os = "windows", feature = "opengl"))]
     fn windows_padded_float_pbo_rows_land_at_the_declared_stride() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         const W: usize = 64;
@@ -6090,18 +6111,24 @@ mod image_tests {
 
         for (fmt, dtype, supported, strides) in cases {
             if !supported {
-                eprintln!("SKIPPED: {} - {fmt:?}/{dtype:?} not reported", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - {fmt:?}/{dtype:?} not reported",
+                    function!()
+                ));
                 continue;
             }
             let Some(gl) = gpu.opengl.as_ref() else {
-                eprintln!("SKIPPED: {} - no GL processor", function!());
+                crate::test_support::report_skip(&format!("{} - no GL processor", function!()));
                 return;
             };
             // The oracle: a tight PBO of the target geometry, same route.
             let mut reference = match gl.create_pbo_image_dtype(W, H, fmt, dtype) {
                 Ok(t) => t,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - no float PBO images: {e:?}", function!());
+                    crate::test_support::report_skip(&format!(
+                        "{} - no float PBO images: {e:?}",
+                        function!()
+                    ));
                     return;
                 }
             };
@@ -6177,11 +6204,14 @@ mod image_tests {
     #[cfg(all(target_os = "windows", feature = "opengl"))]
     fn windows_float_destinations_match_the_cpu_converter_for_every_layout() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut gpu = ImageProcessor::new().unwrap();
@@ -6284,16 +6314,19 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} - ImageProcessor init failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} - ImageProcessor init failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -6306,7 +6339,10 @@ mod image_tests {
             })
             .collect();
         if dsts[0].memory() != TensorMemory::DmaBuf {
-            eprintln!("SKIPPED: {} - destinations are not textures", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - destinations are not textures",
+                function!()
+            ));
             return;
         }
         for dst in &mut dsts {
@@ -6385,7 +6421,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let src = synthetic_rgba(320, 240);
@@ -6393,7 +6432,10 @@ mod image_tests {
             let mut p = match ImageProcessor::new() {
                 Ok(p) => p,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - init failed ({e:?})", function!());
+                    crate::test_support::report_skip(&format!(
+                        "{} - init failed ({e:?})",
+                        function!()
+                    ));
                     return;
                 }
             };
@@ -6408,7 +6450,10 @@ mod image_tests {
                 )
                 .unwrap();
             if dst.memory() != TensorMemory::DmaBuf {
-                eprintln!("SKIPPED: {} - destination is not a texture", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - destination is not a texture",
+                    function!()
+                ));
                 return;
             }
             p.convert_deferred(&src, &mut dst, Rotation::None, Flip::None, Crop::default())
@@ -6443,7 +6488,10 @@ mod image_tests {
         use std::os::windows::io::AsRawHandle;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = ImageProcessor::new().unwrap();
@@ -6464,11 +6512,11 @@ mod image_tests {
         if dst.memory() != TensorMemory::DmaBuf
             && !std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1")
         {
-            eprintln!(
-                "SKIPPED: {} - create_image gave {:?}, not a texture (no GL backend)",
+            crate::test_support::report_skip(&format!(
+                "{} - create_image gave {:?}, not a texture (no GL backend)",
                 function!(),
                 dst.memory()
-            );
+            ));
             return;
         }
         assert_eq!(
@@ -6562,10 +6610,10 @@ mod image_tests {
                 t.memory()
             );
         }
-        eprintln!(
-            "SKIPPED: {test} - create_image gave {:?}, not a texture (no GL backend)",
+        crate::test_support::report_skip(&format!(
+            "{test} - create_image gave {:?}, not a texture (no GL backend)",
             t.memory()
-        );
+        ));
         false
     }
 
@@ -6581,7 +6629,10 @@ mod image_tests {
         use ndarray::Array3;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = ImageProcessor::new().unwrap();
@@ -6645,7 +6696,10 @@ mod image_tests {
         use edgefirst_tensor::{CpuAccess, Tensor};
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         // Forcing OpenGL fails outright without a GL backend (CI's no-ANGLE
@@ -6654,7 +6708,10 @@ mod image_tests {
         let mut p = match with_force_backend(Some("opengl"), ImageProcessor::new) {
             Ok(p) => p,
             Err(e) if !std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1") => {
-                eprintln!("SKIPPED: {} - no OpenGL backend: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - no OpenGL backend: {e}",
+                    function!()
+                ));
                 return;
             }
             Err(e) => panic!("forced OpenGL backend unavailable: {e}"),
@@ -6702,7 +6759,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = ImageProcessor::new().unwrap();
@@ -6727,7 +6787,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = ImageProcessor::new().unwrap();
@@ -6767,7 +6830,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (32usize, 64usize);
@@ -6842,7 +6908,10 @@ mod image_tests {
         use ndarray::Array3;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         const CUSTOM: [u8; 4] = [7, 200, 13, 255];
@@ -6872,11 +6941,11 @@ mod image_tests {
         if parent.memory() != TensorMemory::DmaBuf
             && !std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1")
         {
-            eprintln!(
-                "SKIPPED: {} - create_image gave {:?}, not a texture (no GL backend)",
+            crate::test_support::report_skip(&format!(
+                "{} - create_image gave {:?}, not a texture (no GL backend)",
                 function!(),
                 parent.memory()
-            );
+            ));
             return;
         }
         p.set_class_colors(&[CUSTOM]).unwrap();
@@ -6930,7 +6999,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut a = ImageProcessor::new().unwrap();
@@ -7029,7 +7101,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_all_rgba() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -7228,7 +7300,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_rotate() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -7325,13 +7397,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_rotate() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_rotate - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_rotate - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_rotate - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_rotate - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -7499,15 +7571,15 @@ mod image_tests {
     #[ignore = "opengl doesn't support rendering to PixelFormat::Yuyv texture"]
     fn test_rgba_to_yuyv_resize_opengl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!(
-                "SKIPPED: {} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
+            crate::test_support::report_skip(&format!(
+                "{} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -7575,15 +7647,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_rgba_to_yuyv_resize_g2d() {
         if !is_g2d_available() {
-            eprintln!(
-                "SKIPPED: test_rgba_to_yuyv_resize_g2d - G2D library (libg2d.so.2) not available"
+            crate::test_support::report_skip(
+                "test_rgba_to_yuyv_resize_g2d - G2D library (libg2d.so.2) not available",
             );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_rgba_to_yuyv_resize_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_rgba_to_yuyv_resize_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -7795,13 +7865,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_yuyv_to_rgba_g2d() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_yuyv_to_rgba_g2d - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_yuyv_to_rgba_g2d - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_yuyv_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -7869,16 +7939,16 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_yuyv_to_rgba_opengl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         // Zero-copy YUYV source: DMA-BUF on Linux, IOSurface on macOS, a
         // D3D11 texture on Windows; skips where no such backing exists.
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!(
-                "SKIPPED: {} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
+            crate::test_support::report_skip(&format!(
+                "{} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -7913,7 +7983,7 @@ mod image_tests {
         // Desktop NVIDIA cannot sample YUYV as a GL texture; i.MX/Vivante can.
         // Production ImageProcessor falls back to CPU; this oracle skips.
         if let Err(crate::Error::NotSupported(msg)) = &result {
-            eprintln!("SKIPPED: {} — {msg}", function!());
+            crate::test_support::report_skip(&format!("{} — {msg}", function!()));
             return;
         }
         result.unwrap();
@@ -7957,7 +8027,10 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8049,7 +8122,7 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!("{} — init failed ({e:?})", function!()));
                 return;
             }
         };
@@ -8064,7 +8137,10 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — NV12 IOSurface alloc: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — NV12 IOSurface alloc: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8085,7 +8161,10 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — F16 PlanarRgb IOSurface: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — F16 PlanarRgb IOSurface: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8102,10 +8181,10 @@ mod image_tests {
             // GL_EXT_color_buffer_half_float may be absent on some configs; the
             // RGBA8 pass-1 + F16 pass-2 path then can't render. Skip rather than
             // fail on a capability gap (the same policy as the F16 path tests).
-            eprintln!(
-                "SKIPPED: {} — NV12→PlanarRgb F16 not available ({e:?})",
+            crate::test_support::report_skip(&format!(
+                "{} — NV12→PlanarRgb F16 not available ({e:?})",
                 function!()
-            );
+            ));
             return;
         }
         let dt = dst.as_typed::<half::f16>().expect("dst is F16 PlanarRgb");
@@ -8142,7 +8221,7 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!("{} — init failed ({e:?})", function!()));
                 return;
             }
         };
@@ -8161,7 +8240,10 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — R8 pool alloc: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — R8 pool alloc: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8189,7 +8271,10 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — F16 PlanarRgb dst: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — F16 PlanarRgb dst: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8204,10 +8289,10 @@ mod image_tests {
         if let Err(e) =
             ImageProcessorTrait::convert(&mut gpu, &src, &mut dst, Rotation::None, Flip::None, crop)
         {
-            eprintln!(
-                "SKIPPED: {} — NV12→PlanarRgb F16 unavailable ({e:?})",
+            crate::test_support::report_skip(&format!(
+                "{} — NV12→PlanarRgb F16 unavailable ({e:?})",
                 function!()
-            );
+            ));
             return;
         }
         let _ = stride;
@@ -8237,7 +8322,7 @@ mod image_tests {
         let mut proc = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!("{} — init failed ({e:?})", function!()));
                 return;
             }
         };
@@ -8252,7 +8337,7 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — pool: {e:?}", function!());
+                crate::test_support::report_skip(&format!("{} — pool: {e:?}", function!()));
                 return;
             }
         };
@@ -8273,7 +8358,7 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — dst: {e:?}", function!());
+                crate::test_support::report_skip(&format!("{} — dst: {e:?}", function!()));
                 return;
             }
         };
@@ -8314,7 +8399,7 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!("{} — init failed ({e:?})", function!()));
                 return;
             }
         };
@@ -8336,7 +8421,7 @@ mod image_tests {
                 ) {
                     Ok(t) => t,
                     Err(e) => {
-                        eprintln!("SKIPPED: {} — pool: {e:?}", function!());
+                        crate::test_support::report_skip(&format!("{} — pool: {e:?}", function!()));
                         return;
                     }
                 },
@@ -8352,7 +8437,7 @@ mod image_tests {
                 ) {
                     Ok(t) => t,
                     Err(e) => {
-                        eprintln!("SKIPPED: {} — dst: {e:?}", function!());
+                        crate::test_support::report_skip(&format!("{} — dst: {e:?}", function!()));
                         return;
                     }
                 },
@@ -8415,7 +8500,10 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8585,7 +8673,10 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8682,7 +8773,10 @@ mod image_tests {
                 ) {
                     Ok(t) => t,
                     Err(e) => {
-                        eprintln!("SKIPPED: {} — R8 pool IOSurface alloc: {e:?}", function!());
+                        crate::test_support::report_skip(&format!(
+                            "{} — R8 pool IOSurface alloc: {e:?}",
+                            function!()
+                        ));
                         return;
                     }
                 };
@@ -8766,13 +8860,13 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — GL engine init failed ({e:?}). \
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?}). \
                      Install ANGLE via `brew install startergo/angle/angle` \
                      and re-sign per README.md § macOS GPU Acceleration to \
                      run this test.",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -8855,7 +8949,10 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8933,7 +9030,10 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9010,7 +9110,10 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9079,14 +9182,14 @@ mod image_tests {
     fn test_macos_gl_f16_planar_is_gl_backed() {
         let mut proc = ImageProcessor::new().expect("ImageProcessor");
         let Some(ref gl) = proc.opengl else {
-            eprintln!("SKIPPED: {} — GL backend unavailable", function!());
+            crate::test_support::report_skip(&format!("{} — GL backend unavailable", function!()));
             return;
         };
         if !gl.supported_render_dtypes().f16 {
-            eprintln!(
-                "SKIPPED: {} — configuration lacks F16 color-buffer support",
+            crate::test_support::report_skip(&format!(
+                "{} — configuration lacks F16 color-buffer support",
                 function!()
-            );
+            ));
             return;
         }
         let stats_before = gl.egl_cache_stats().expect("cache stats");
@@ -9159,7 +9262,10 @@ mod image_tests {
         }) {
             Ok(p) if p.opengl.is_some() => p,
             _ => {
-                eprintln!("SKIPPED: {} — GL backend unavailable", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL backend unavailable",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9169,13 +9275,13 @@ mod image_tests {
             .map(|g| g.supported_render_dtypes().f16)
             .unwrap_or(false)
         {
-            eprintln!("SKIPPED: {} — no F16 render support", function!());
+            crate::test_support::report_skip(&format!("{} — no F16 render support", function!()));
             return;
         }
         let mem = if edgefirst_tensor::is_gpu_buffer_available() {
             TensorMemory::DmaBuf
         } else {
-            eprintln!("SKIPPED: {} — no zero-copy buffers", function!());
+            crate::test_support::report_skip(&format!("{} — no zero-copy buffers", function!()));
             return;
         };
 
@@ -9236,7 +9342,7 @@ mod image_tests {
         ) {
             Ok(()) => {}
             Err(crate::Error::NotSupported(msg)) => {
-                eprintln!("SKIPPED: {} — {msg}", function!());
+                crate::test_support::report_skip(&format!("{} — {msg}", function!()));
                 return;
             }
             Err(e) => panic!("fused NV12→PlanarF16 GL convert: {e}"),
@@ -9315,12 +9421,15 @@ mod image_tests {
         let mut proc = match ImageProcessor::new() {
             Ok(p) if p.opengl.is_some() => p,
             _ => {
-                eprintln!("SKIPPED: {} — GL backend unavailable", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL backend unavailable",
+                    function!()
+                ));
                 return;
             }
         };
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} — no zero-copy buffers", function!());
+            crate::test_support::report_skip(&format!("{} — no zero-copy buffers", function!()));
             return;
         }
 
@@ -9417,13 +9526,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_yuyv_to_rgb_g2d() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_yuyv_to_rgb_g2d - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_yuyv_to_rgb_g2d - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_yuyv_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -9490,15 +9599,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_yuyv_to_yuyv_resize_g2d() {
         if !is_g2d_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_yuyv_resize_g2d - G2D library (libg2d.so.2) not available"
+            crate::test_support::report_skip(
+                "test_yuyv_to_yuyv_resize_g2d - G2D library (libg2d.so.2) not available",
             );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_yuyv_resize_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_yuyv_to_yuyv_resize_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -9636,15 +9743,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_yuyv_to_rgba_crop_flip_g2d() {
         if !is_g2d_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_rgba_crop_flip_g2d - G2D library (libg2d.so.2) not available"
+            crate::test_support::report_skip(
+                "test_yuyv_to_rgba_crop_flip_g2d - G2D library (libg2d.so.2) not available",
             );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_rgba_crop_flip_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_yuyv_to_rgba_crop_flip_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -9720,15 +9825,15 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_yuyv_to_rgba_crop_flip_opengl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!(
-                "SKIPPED: {} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
+            crate::test_support::report_skip(&format!(
+                "{} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -9765,7 +9870,7 @@ mod image_tests {
         );
         // Desktop NVIDIA cannot sample YUYV as a GL texture; i.MX/Vivante can.
         if let Err(crate::Error::NotSupported(msg)) = &result {
-            eprintln!("SKIPPED: {} — {msg}", function!());
+            crate::test_support::report_skip(&format!("{} — {msg}", function!()));
             return;
         }
         result.unwrap();
@@ -9934,13 +10039,13 @@ mod image_tests {
     #[ignore = "G2D does not support VYUY; re-enable when hardware support is added"]
     fn test_vyuy_to_rgba_g2d() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_vyuy_to_rgba_g2d - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_vyuy_to_rgba_g2d - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_vyuy_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_vyuy_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -9974,7 +10079,9 @@ mod image_tests {
         );
         match result {
             Err(Error::G2D(_)) => {
-                eprintln!("SKIPPED: test_vyuy_to_rgba_g2d - G2D does not support PixelFormat::Vyuy format");
+                crate::test_support::report_skip(
+                    "test_vyuy_to_rgba_g2d - G2D does not support PixelFormat::Vyuy format",
+                );
                 return;
             }
             r => r.unwrap(),
@@ -10008,13 +10115,13 @@ mod image_tests {
     #[ignore = "G2D does not support VYUY; re-enable when hardware support is added"]
     fn test_vyuy_to_rgb_g2d() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_vyuy_to_rgb_g2d - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_vyuy_to_rgb_g2d - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_vyuy_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_vyuy_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -10048,8 +10155,8 @@ mod image_tests {
         );
         match result {
             Err(Error::G2D(_)) => {
-                eprintln!(
-                    "SKIPPED: test_vyuy_to_rgb_g2d - G2D does not support PixelFormat::Vyuy format"
+                crate::test_support::report_skip(
+                    "test_vyuy_to_rgb_g2d - G2D does not support PixelFormat::Vyuy format",
                 );
                 return;
             }
@@ -10096,14 +10203,14 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_vyuy_to_rgba_opengl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!(
-                "SKIPPED: {} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
+            crate::test_support::report_skip(&format!(
+                "{} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -10119,10 +10226,10 @@ mod image_tests {
         ) {
             Ok(src) => src,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} - zero-copy VYUY source not allocatable on this platform ({e})",
+                crate::test_support::report_skip(&format!(
+                    "{} - zero-copy VYUY source not allocatable on this platform ({e})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -10148,10 +10255,10 @@ mod image_tests {
         );
         match result {
             Err(Error::NotSupported(_)) => {
-                eprintln!(
-                    "SKIPPED: {} - OpenGL does not support PixelFormat::Vyuy DMA format",
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL does not support PixelFormat::Vyuy DMA format",
                     function!()
-                );
+                ));
                 return;
             }
             r => r.unwrap(),
@@ -11767,14 +11874,14 @@ mod image_tests {
         require_dma_for_bg: bool,
     ) {
         if require_dma_for_bg && !edgefirst_tensor::is_dma_available() {
-            eprintln!("SKIPPED: {case} — DMA not available on this host");
+            crate::test_support::report_skip(&format!("{case} — DMA not available on this host"));
             return;
         }
         let processor_result = with_force_backend(force_backend, ImageProcessor::new);
         let mut processor = match processor_result {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {case} — backend init failed: {e:?}");
+                crate::test_support::report_skip(&format!("{case} — backend init failed: {e:?}"));
                 return;
             }
         };
@@ -11815,14 +11922,14 @@ mod image_tests {
     #[test]
     fn test_draw_masks_zero_detection_g2d_forced() {
         if !edgefirst_tensor::is_dma_available() {
-            eprintln!("SKIPPED: g2d forced — DMA not available on this host");
+            crate::test_support::report_skip("g2d forced — DMA not available on this host");
             return;
         }
         let processor_result = with_force_backend(Some("g2d"), ImageProcessor::new);
         let mut processor = match processor_result {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: g2d forced — init failed: {e:?}");
+                crate::test_support::report_skip(&format!("g2d forced — init failed: {e:?}"));
                 return;
             }
         };
@@ -12006,10 +12113,10 @@ mod image_tests {
         // a regression appears. (Skip, not #[ignore]: the platform is decided
         // at runtime, not compile time.)
         if std::env::var_os("EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS").is_some() {
-            eprintln!(
-                "SKIPPED: test_multiple_image_processors_separate_threads — known Vivante \
+            crate::test_support::report_skip(
+                "test_multiple_image_processors_separate_threads — known Vivante \
                  GC7000UL concurrent-EGL-teardown double-free \
-                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)"
+                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)",
             );
             return;
         }
@@ -12188,10 +12295,10 @@ mod image_tests {
         const TIMEOUT: Duration = Duration::from_secs(60);
 
         if std::env::var_os("EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS").is_some() {
-            eprintln!(
-                "SKIPPED: test_parallel_processors_unique_outputs — known Vivante \
+            crate::test_support::report_skip(
+                "test_parallel_processors_unique_outputs — known Vivante \
                  GC7000UL concurrent-multi-processor driver abort \
-                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)"
+                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)",
             );
             return;
         }
@@ -12667,7 +12774,9 @@ mod image_tests {
     ))]
     fn convert_f16_gl_cpu_parity_identity() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: convert_f16_gl_cpu_parity_identity - OpenGL not available");
+            crate::test_support::report_skip(
+                "convert_f16_gl_cpu_parity_identity - OpenGL not available",
+            );
             return;
         }
 
@@ -12707,15 +12816,17 @@ mod image_tests {
             }) {
                 Ok(p) => p,
                 Err(e) => {
-                    eprintln!(
-                        "SKIPPED: convert_f16_gl_cpu_parity_identity - GL backend unavailable: {e}"
-                    );
+                    crate::test_support::report_skip(&format!(
+                        "convert_f16_gl_cpu_parity_identity - GL backend unavailable: {e}"
+                    ));
                     return;
                 }
             };
 
             if !gl_proc.supported_render_dtypes().f16 {
-                eprintln!("SKIPPED: convert_f16_gl_cpu_parity_identity - F16 render not supported");
+                crate::test_support::report_skip(
+                    "convert_f16_gl_cpu_parity_identity - F16 render not supported",
+                );
                 return;
             }
 
@@ -12731,9 +12842,9 @@ mod image_tests {
             match gl_proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default()) {
                 Ok(()) => dst,
                 Err(e) => {
-                    eprintln!(
-                        "SKIPPED: convert_f16_gl_cpu_parity_identity - GL convert failed: {e}"
-                    );
+                    crate::test_support::report_skip(&format!(
+                        "convert_f16_gl_cpu_parity_identity - GL convert failed: {e}"
+                    ));
                     return;
                 }
             }
@@ -12801,12 +12912,16 @@ mod image_tests {
         let proc = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: supported_render_dtypes_linux_smoke — ImageProcessor::new() failed: {e}");
+                crate::test_support::report_skip(&format!(
+                    "supported_render_dtypes_linux_smoke — ImageProcessor::new() failed: {e}"
+                ));
                 return;
             }
         };
         if proc.opengl.is_none() {
-            eprintln!("SKIPPED: supported_render_dtypes_linux_smoke — no GL backend on this host");
+            crate::test_support::report_skip(
+                "supported_render_dtypes_linux_smoke — no GL backend on this host",
+            );
             return;
         }
         // The call must complete without panicking or deadlocking.
@@ -13118,7 +13233,7 @@ mod image_tests {
                 Some(expected),
                 "set_colorimetry must round-trip"
             );
-            eprintln!("SKIPPED import_image_carries_colorimetry (DMA unavailable); storage contract verified via TensorDyn");
+            crate::test_support::report_skip("import_image_carries_colorimetry (DMA unavailable); storage contract verified via TensorDyn");
             return;
         }
 

--- a/crates/image/src/test_support.rs
+++ b/crates/image/src/test_support.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test-only helper for reporting a skipped test so the report
+//! survives libtest's output capture.
+//!
+//! `eprintln!`/`println!` route through `std::io::_eprint`/`_print`, which
+//! libtest hooks to capture per-test output and replay it only for a
+//! *failing* test. A hardware-gated test that returns early after printing
+//! its reason with `eprintln!` therefore reports `ok` with the reason
+//! silently discarded -- indistinguishable from having actually exercised
+//! the code, both locally (`cargo test` without `--nocapture`) and in CI.
+//! Writing directly to `std::io::stderr()` bypasses that hook, so the
+//! `SKIPPED: ...` line survives capture in both directions; `scripts/
+//! on-target-test.sh` greps captured logs for the literal string
+//! `SKIPPED` to report a skip count per board.
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it.
+#[cfg(test)]
+pub(crate) fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}

--- a/crates/image/tests/crop_golden.rs
+++ b/crates/image/tests/crop_golden.rs
@@ -39,6 +39,17 @@ use serde::{Deserialize, Serialize};
 const SRC_W: usize = 640;
 const SRC_H: usize = 480;
 
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it -- see `edgefirst_image`'s (crate-internal) `test_support` module
+/// for the same mechanism in the library's own `#[cfg(test)]` code; this
+/// integration test binary is a separate compilation unit and cannot reach
+/// that `pub(crate)` helper, so it carries a local copy.
+fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}
+
 /// One golden-fixture entry: the case parameters plus the CRC32 of the CPU
 /// backend's converted output bytes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -165,10 +176,10 @@ fn generate_cases() -> Vec<Case> {
                 for &(dst_w, dst_h) in &dst_sizes() {
                     let Some(crc32) = run_case(&mut proc_, &src, dst_fmt, crop_rect, dst_w, dst_h)
                     else {
-                        eprintln!(
-                            "crop_golden: skipping rejected case {src_fmt:?} -> {dst_fmt:?} \
+                        report_skip(&format!(
+                            "crop_golden: rejected case {src_fmt:?} -> {dst_fmt:?} \
                              crop={crop_rect:?} dst={dst_w}x{dst_h}"
-                        );
+                        ));
                         continue;
                     };
                     cases.push(Case {
@@ -234,12 +245,12 @@ fn generate_golden() {
 #[test]
 fn cropped_convert_matches_golden() {
     if !cpu_matches_fixture_kernel_path() {
-        eprintln!(
-            "crop_golden: SKIP — this CPU selects a different (equally correct) \
+        report_skip(
+            "crop_golden: this CPU selects a different (equally correct) \
              yuv-crate kernel path than the one the frozen fixtures were \
              generated under; byte comparison is unmatchable by construction. \
              Cropped-convert correctness here is covered by the oracle-based \
-             tests in the edgefirst-image lib suite."
+             tests in the edgefirst-image lib suite.",
         );
         return;
     }

--- a/crates/image/tests/offset_source_view_alignment.rs
+++ b/crates/image/tests/offset_source_view_alignment.rs
@@ -10,8 +10,11 @@
 //! the import succeeds -- so a 16x16 view at (8, 8) of a 256-byte-pitched RGBA
 //! surface (offset 2080) came back all `[0, 0, 0, 255]` while (0, 8) (offset
 //! 2048) and (16, 0) (offset 64) were fine; V3D converts all of them. The
-//! engine now declines a Mali source import at an unaligned offset so the
-//! upload path, which reads through `map()`, takes it.
+//! engine imports such a source from the 64-byte-aligned base below its
+//! offset, widened by the remainder in pixels, and folds that shift into the
+//! sampling rectangle -- so the view stays zero-copy on Mali (issue #170).
+//! The NV12 case below still declines and uploads: its combined-plane R8
+//! import has no room to widen, its pitch being its width.
 //!
 //! The NV12 case also pins #166: a declined NV source must reach the R8
 //! *upload*, not the CPU converter -- `GLProcessorThreaded` is driven
@@ -152,6 +155,7 @@ fn rgba_source_views_convert_their_own_tile_at_every_origin() {
             }
         }
     }
+    let before = gl.convert_stats().expect("convert stats");
     let mut failures = Vec::new();
     for (x0, y0) in ORIGINS {
         let view = src.view(Region::new(x0, y0, SIDE, SIDE)).expect("view");
@@ -187,6 +191,175 @@ fn rgba_source_views_convert_their_own_tile_at_every_origin() {
     assert!(
         failures.is_empty(),
         "pitch {pitch}:\n{}",
+        failures.join("\n")
+    );
+
+    let after = gl.convert_stats().expect("convert stats");
+    let imports = after.src_imports - before.src_imports;
+    let uploads = after.src_uploads - before.src_uploads;
+    let pbo = after.src_pbo_uploads - before.src_pbo_uploads;
+    // A driver with no DMA-BUF import at all feeds every one of them by
+    // copy and there is no route to assert -- the desktop NVIDIA GPU is
+    // exactly that: it has a DMA heap, so the allocation above is a real
+    // DMA-BUF and the file does not skip, but its EGL has no working
+    // DMA-BUF import. The copy is a `map()` upload on some drivers and a
+    // PBO on others, so both count here; leaving PBO out let a PBO-fed
+    // desktop fall past this guard into the assertions below. The pixels
+    // above are the whole assertion on such a driver.
+    if imports == 0 && (uploads + pbo) as usize == ORIGINS.len() {
+        skip("this GL driver cannot import DMA-BUF at all; the pixels above are the assertion");
+        return;
+    }
+    // Issue #170: an unaligned source is no longer declined into an upload.
+    // It imports from a 64-byte-aligned base widened by the remainder in
+    // pixels, and the engine folds the shift into the sampling rectangle --
+    // so every one of these origins is a zero-copy import on every driver
+    // with a DMA-BUF import, Mali included, where offsets 32 and 2080 used
+    // to take the upload path.
+    //
+    // Asserted alongside the pixels, not instead of them: an engine that
+    // silently uploaded would still produce the right tile and pass the
+    // loop above, which is exactly how #170 could regress unnoticed.
+    assert_eq!(
+        uploads + pbo,
+        0,
+        "{uploads} of {} source views were uploaded and {pbo} went by PBO, \
+         not imported (issue #170: the aligned-base rebase must keep them \
+         zero-copy); imports={imports}",
+        ORIGINS.len()
+    );
+    assert_eq!(
+        imports as usize,
+        ORIGINS.len(),
+        "every origin must be fed by import; uploads={uploads} pbo={pbo}"
+    );
+    assert_eq!(
+        after.zero_copy_declines, before.zero_copy_declines,
+        "no source import may be declined at any of these origins"
+    );
+}
+
+/// A whole RGBA frame at a byte offset inside a bigger DMA-BUF -- the shape a
+/// pool slot or an `interop::apply_plane_offset` window arrives in -- on a
+/// surface whose pitch has no room to widen.
+///
+/// This is the case a Mali decline keyed on the FORMAT gets wrong. 64 RGBA
+/// pixels is a 256-byte row, already 64-byte aligned, so nothing is padded on
+/// and the pitch is tight; folding a 32-byte offset would need the import
+/// widened to 72 pixels (288 bytes), which runs past that pitch, so
+/// `from_tensor` keeps the frame's own unaligned offset and Mali must go on
+/// declining it into the upload. Exempt it because "RGBA is a format the fold
+/// covers" and it imports unaligned and comes back black (issue #170).
+///
+/// The pixels are the assertion that separates the drivers, and they have to
+/// be: nothing here can name the renderer. On Mali a wrongly-exempted import
+/// samples zeros and this fails; on V3D and Vivante the same import is read
+/// correctly and it passes, which is the behaviour those two must keep. The
+/// counters pin the other half -- exactly one source feed per convert, so a
+/// silent CPU fallback cannot pass either.
+#[test]
+fn rgba_offset_frames_convert_at_a_pitch_with_no_room_to_rebase() {
+    let Some(mut gl) = gl_or_skip() else { return };
+    // Three frames' worth of rows so a window can start past the first frame
+    // and still be fully backed, then re-tagged to one frame's geometry at an
+    // offset, which keeps the surface pitch -- as in the NV12 case below.
+    let Some(mut src) = dmabuf_image_or_skip(W, H * 3, PixelFormat::Rgba) else {
+        return;
+    };
+    let pitch = src.effective_row_stride().unwrap_or(W * BPP);
+    assert_eq!(
+        pitch,
+        W * BPP,
+        "precondition: {W} RGBA pixels is {} bytes, already 64-aligned, so the \
+         surface pitch is tight and the rebase has no room to widen into",
+        W * BPP
+    );
+    // A pattern whose period (31) is coprime with both the pitch and 64, so a
+    // window read at the wrong offset cannot coincide with the right one.
+    // Written BEFORE the re-tag, while the map still covers every row.
+    {
+        let mut m = src.map_bytes(CpuAccess::Write).expect("map src");
+        let s = m.as_mut_slice();
+        for (i, b) in s.iter_mut().enumerate() {
+            *b = 112 + (i % 31) as u8;
+        }
+    }
+    src.set_logical_shape(&[H, W, BPP])
+        .expect("one frame's geometry");
+    assert_eq!(src.height(), Some(H), "precondition: one frame is {H} rows");
+    assert_eq!(
+        src.effective_row_stride(),
+        Some(pitch),
+        "precondition: the re-tag kept the surface pitch"
+    );
+
+    let frame = pitch * H;
+    let aligned = frame.next_multiple_of(MALI_ALIGN);
+    let unaligned = aligned + MALI_ALIGN / 2;
+    assert_ne!(
+        unaligned % MALI_ALIGN,
+        0,
+        "precondition: {unaligned} is not aligned"
+    );
+
+    let mut failures = Vec::new();
+    for offset in [aligned, unaligned] {
+        src.set_plane_offset(offset);
+        assert_eq!(
+            src.plane_offset(),
+            Some(offset),
+            "precondition: the offset stuck"
+        );
+        let mut reference = rgba_dst(W, H);
+        CPUProcessor::new()
+            .convert(
+                &src,
+                &mut reference,
+                Rotation::None,
+                Flip::None,
+                Crop::default(),
+            )
+            .expect("CPU reference");
+        let want = bytes(&reference);
+
+        let before = gl.convert_stats().expect("convert stats");
+        let mut dst = rgba_dst(W, H);
+        let outcome = gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default());
+        let after = gl.convert_stats().expect("convert stats");
+        let imports = after.src_imports - before.src_imports;
+        let uploads = after.src_uploads - before.src_uploads;
+        let pbo = after.src_pbo_uploads - before.src_pbo_uploads;
+
+        match outcome {
+            Err(e) => failures.push(format!("offset {offset}: GL refused the source: {e}")),
+            Ok(()) => {
+                let got = bytes(&dst);
+                if got != want {
+                    let kind = if got.chunks(BPP).all(|p| p == [0, 0, 0, 255]) {
+                        "ZEROS (issue #170: an unrebased offset was imported anyway)"
+                    } else {
+                        "wrong pixels"
+                    };
+                    failures.push(format!(
+                        "offset {offset}: {kind}; first={:?} expected={:?} \
+                         (imports={imports} uploads={uploads} pbo={pbo})",
+                        &got[..BPP],
+                        &want[..BPP]
+                    ));
+                }
+            }
+        }
+        if imports + uploads + pbo != 1 {
+            failures.push(format!(
+                "offset {offset}: the source must be fed exactly once, not \
+                 imports={imports} uploads={uploads} pbo={pbo} -- a silent CPU \
+                 fallback would pass the pixels above"
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "pitch {pitch}, aligned {aligned}, unaligned {unaligned}:\n{}",
         failures.join("\n")
     );
 }

--- a/crates/tensor/build.rs
+++ b/crates/tensor/build.rs
@@ -15,18 +15,43 @@ fn main() {
     // deliberately declares with no `#[link]` attribute of its own
     // (linking is normally the *consumer's* decision, and this crate has no
     // other consumer to make that decision on its behalf for its own
-    // tests). `../../target/debug`, relative to this crate's manifest dir,
-    // is where `crates/tensor-capi` lands when built with `--target-dir
-    // target` from the workspace root -- the same directory `cargo
-    // test -p edgefirst-tensor` itself builds into, so no extra
-    // search-path configuration is needed beyond building `tensor-capi`
-    // first. A stale or missing `.so` here is a link error, not a silent
+    // tests). A stale or missing `.so` here is a link error, not a silent
     // pass, the same "build the producer first" precondition
     // `tensor-capi`'s own `EF_REQUIRE_FRESH_ARTIFACTS`-gated tests document.
     if std::env::var_os("CARGO_FEATURE_DYNAMIC_TEST_LINK").is_some() {
-        let manifest_dir =
-            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is always set");
-        let lib_dir = std::path::Path::new(&manifest_dir).join("../../target/debug");
+        // `EDGEFIRST_TENSOR_LIB_DIR` wins when set -- cross-compiling this
+        // lane for a board (`cargo zigbuild ... --target
+        // aarch64-unknown-linux-gnu.2.35`) needs to point at a cross-built
+        // `libedgefirst_tensor.so` under `target/aarch64-unknown-linux-gnu/
+        // debug/`, which nothing below can derive on its own: there is no
+        // env var that names the *producer* crate's (`tensor-capi`) output
+        // directory, only this crate's own.
+        println!("cargo::rerun-if-env-changed=EDGEFIRST_TENSOR_LIB_DIR");
+        let lib_dir =
+            match std::env::var_os("EDGEFIRST_TENSOR_LIB_DIR").filter(|dir| !dir.is_empty()) {
+                Some(dir) => std::path::PathBuf::from(dir),
+                None => {
+                    // Cargo always lays `OUT_DIR` out as
+                    // `<profile-dir>/build/<pkg>-<hash>/out`, where
+                    // `<profile-dir>` is `target/<profile>` for a native build
+                    // and `target/<target-triple>/<profile>` for any `--target`
+                    // build (cross or not) -- exactly the directory sibling
+                    // crates' compiled dylibs land in, including `tensor-capi`'s
+                    // when built with `--target-dir target` from the workspace
+                    // root. Walking up from `OUT_DIR` finds it without assuming
+                    // a fixed `../../target/debug` relative to this crate's
+                    // manifest dir (wrong for any `--target` build, cross or
+                    // not) or a fixed `--target-dir` (wrong for a custom one --
+                    // see `scripts/on-target-test.sh`'s own comment on exactly
+                    // this class of bug in `build_libs_for`).
+                    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR is always set");
+                    std::path::Path::new(&out_dir)
+                        .ancestors()
+                        .nth(3)
+                        .expect("OUT_DIR is nested at least 3 levels under target/<profile>")
+                        .to_path_buf()
+                }
+            };
         println!("cargo::rustc-link-search=native={}", lib_dir.display());
         println!("cargo::rustc-link-lib=dylib=edgefirst_tensor");
     }

--- a/crates/tensor/src/d3d11/adapter.rs
+++ b/crates/tensor/src/d3d11/adapter.rs
@@ -343,7 +343,7 @@ mod tests {
             match DxgiAdapter::fake(description, luid_low, vram, software) {
                 Ok(a) => adapters.push(a),
                 Err(e) => {
-                    eprintln!("DXGI enumeration unavailable — skipping: {e}");
+                    crate::test_support::report_skip(&format!("DXGI enumeration unavailable: {e}"));
                     return;
                 }
             }
@@ -383,7 +383,9 @@ mod tests {
                     assert!(!a.description.is_empty());
                 }
             }
-            Err(e) => eprintln!("DXGI enumeration unavailable — skipping: {e}"),
+            Err(e) => {
+                crate::test_support::report_skip(&format!("DXGI enumeration unavailable: {e}"))
+            }
         }
     }
 

--- a/crates/tensor/src/dma.rs
+++ b/crates/tensor/src/dma.rs
@@ -707,7 +707,7 @@ mod tests {
         let large_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!("SKIPPED: DMA not available");
+                crate::test_support::report_skip("DMA not available");
                 return;
             }
         };

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -133,6 +133,8 @@ pub mod protocol;
 #[cfg(all(unix, feature = "static"))]
 mod shm;
 mod tensor_dyn;
+#[cfg(test)]
+mod test_support;
 pub mod view;
 mod vocabulary;
 pub use colorimetry::{
@@ -6574,7 +6576,7 @@ mod image_tests {
         let _lock = crate::tests::fd_lock_shared();
         // Skip if DMA not available (e.g. sandboxed CI lacking dma_heap access).
         if !is_dma_available() {
-            eprintln!("SKIPPED: DMA heap not available");
+            crate::test_support::report_skip("DMA heap not available");
             return;
         }
         // 3004×1688 RGBA8: natural pitch 12016, padded to 12032 (64-aligned).
@@ -6657,7 +6659,7 @@ mod image_tests {
         // it needs both Linux and a dma-heap: it skips on macOS and on Orin
         // (nvmap, no CONFIG_DMABUF_HEAPS).
         if !is_dma_available() {
-            eprintln!("SKIPPED: DMA heap not available");
+            crate::test_support::report_skip("DMA heap not available");
             return;
         }
         let backing =
@@ -6710,7 +6712,7 @@ mod image_tests {
         // returning a slice larger than the backing mmap (that would be UB
         // in `DmaMap::as_slice`).
         if !is_dma_available() {
-            eprintln!("SKIPPED: DMA heap not available");
+            crate::test_support::report_skip("DMA heap not available");
             return;
         }
         // Allocate a 640×480 RGBA8 padded canvas (stride = 3072 = 768 px).
@@ -7040,7 +7042,7 @@ mod cpu_access_tests {
         // Declares this test as an fd-opener; see FD_LOCK.
         let _lock = crate::tests::fd_lock_shared();
         let Ok(t) = Tensor::<u8>::new(&[64], Some(TensorMemory::DmaBuf), None) else {
-            eprintln!("SKIPPED: IOSurface unavailable");
+            crate::test_support::report_skip("IOSurface unavailable");
             return;
         };
         {
@@ -7664,7 +7666,7 @@ mod tests {
         // and 4 must share the segment (zero-copy, via cloned fd) and be
         // independently writable — view 0 owns [0,4), view 1 owns [4,8).
         if !crate::is_shm_available() {
-            eprintln!("SKIPPED: shm not available");
+            crate::test_support::report_skip("shm not available");
             return;
         }
         let parent = Tensor::<u8>::new(&[2, 4], Some(TensorMemory::Shm), None).unwrap();
@@ -7700,7 +7702,7 @@ mod tests {
         // Declares this test as an fd-opener; see FD_LOCK.
         let _lock = crate::tests::fd_lock_shared();
         if !crate::is_shm_available() {
-            eprintln!("SKIPPED: shm not available");
+            crate::test_support::report_skip("shm not available");
             return;
         }
         // f32 align 4: a 2-byte offset cannot back a valid `*const f32`.
@@ -7723,7 +7725,7 @@ mod tests {
         let dma = match Tensor::<u8>::new(&[8], Some(TensorMemory::DmaBuf), None) {
             Ok(t) => t,
             Err(_) => {
-                eprintln!("SKIPPED: DMA not available");
+                crate::test_support::report_skip("DMA not available");
                 return;
             }
         };
@@ -7756,7 +7758,7 @@ mod tests {
         let parent = match Tensor::<u8>::new(&[2048], Some(TensorMemory::DmaBuf), None) {
             Ok(t) => t,
             Err(_) => {
-                eprintln!("SKIPPED: DMA not available");
+                crate::test_support::report_skip("DMA not available");
                 return;
             }
         };
@@ -7802,7 +7804,7 @@ mod tests {
         ) {
             Ok(t) => t,
             Err(_) => {
-                eprintln!("SKIPPED: DMA not available");
+                crate::test_support::report_skip("DMA not available");
                 return;
             }
         };

--- a/crates/tensor/src/test_support.rs
+++ b/crates/tensor/src/test_support.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test-only helper for reporting a skipped test so the report
+//! survives libtest's output capture.
+//!
+//! `eprintln!`/`println!` route through `std::io::_eprint`/`_print`, which
+//! libtest hooks to capture per-test output and replay it only for a
+//! *failing* test. A hardware-gated test that returns early after printing
+//! its reason with `eprintln!` therefore reports `ok` with the reason
+//! silently discarded -- indistinguishable from having actually exercised
+//! the code, both locally (`cargo test` without `--nocapture`) and in CI.
+//! Writing directly to `std::io::stderr()` bypasses that hook, so the
+//! `SKIPPED: ...` line survives capture in both directions; `scripts/
+//! on-target-test.sh` greps captured logs for the literal string
+//! `SKIPPED` to report a skip count per board.
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it.
+///
+/// Plain `cfg(test)`, not `cfg(all(test, unix))`: this crate's Unix-only
+/// call sites (`dma.rs`'s `target_os = "linux"` tests, `lib.rs`'s IOSurface
+/// tests under `target_os = "macos"`, its shm tests under plain `unix`)
+/// once left this dead code on Windows, but `d3d11/adapter.rs`'s tests
+/// (that whole module is `#[cfg(target_os = "windows")]`, see `lib.rs`)
+/// are a real Windows-only caller now, so every platform this crate builds
+/// for has at least one caller and the narrower gate is no longer needed.
+/// `crates/tensor/tests/d3d11_tensor.rs` still carries its own local copy
+/// rather than reaching this one -- it's a separate integration-test
+/// compilation unit and can't reach a `pub(crate)` item in the lib crate.
+#[cfg(test)]
+pub(crate) fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}

--- a/crates/tensor/tests/d3d11_tensor.rs
+++ b/crates/tensor/tests/d3d11_tensor.rs
@@ -14,8 +14,9 @@ use std::os::windows::io::AsRawHandle;
 #[path = "support/cuda_require.rs"]
 mod cuda_require;
 
-/// The WARP exclusion for the three CUDA interop tests, printing
-/// `SKIP {what}: ...` and returning `true` when the caller must return early.
+/// The WARP exclusion for the three CUDA interop tests, reporting
+/// `SKIPPED: {what}: ...` through `report_skip` and returning `true` when the
+/// caller must return early.
 ///
 /// `cudaD3D11GetDevice` has no ordinal for the WARP adapter, so no amount of
 /// working CUDA runtime can give a WARP device a CUDA import: the skip is a
@@ -31,15 +32,26 @@ mod cuda_require;
 fn warp_has_no_cuda_device(what: &str) -> bool {
     let warp = edgefirst_tensor::d3d11::device().is_ok_and(|d| d.is_warp());
     if warp {
-        eprintln!("SKIP {what}: WARP adapter has no CUDA device");
+        report_skip(&format!("{what}: WARP adapter has no CUDA device"));
     }
     warp
+}
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it -- see `edgefirst_tensor`'s (crate-internal) `test_support` module
+/// for the same mechanism in the library's own `#[cfg(test)]` code; this
+/// integration test binary is a separate compilation unit and cannot reach
+/// that `pub(crate)` helper, so it carries a local copy.
+fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
 }
 
 #[test]
 fn image_with_dmabuf_on_windows_is_a_texture_tensor() {
     if !edgefirst_tensor::is_gpu_buffer_available() {
-        eprintln!("no D3D11 device on this box -- skipping");
+        report_skip("no D3D11 device on this box");
         return;
     }
     let t = Tensor::<u8>::image(
@@ -848,7 +860,7 @@ fn child_imports_the_exported_blob(path: &str) {
                 !m.device_ptr().is_null(),
                 "the CUDA map has a device pointer"
             ),
-            None => eprintln!("no CUDA registration on the imported texture -- skipping"),
+            None => report_skip("no CUDA registration on the imported texture"),
         }
     }
 }

--- a/crates/tensor/tests/dynamic_primitives.rs
+++ b/crates/tensor/tests/dynamic_primitives.rs
@@ -47,6 +47,17 @@ use edgefirst_tensor::{
     TensorMemory, TensorTrait,
 };
 
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it -- see `edgefirst_tensor`'s (crate-internal) `test_support` module
+/// for the same mechanism in the library's own `#[cfg(test)]` code; this
+/// integration test binary is a separate compilation unit and cannot reach
+/// that `pub(crate)` helper, so it carries a local copy.
+fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}
+
 /// Allocate a bare (formatless) `TensorDyn` of the given shape/dtype code,
 /// the same way `ef_tensor_new` does -- the smallest live handle every test
 /// below builds on before attaching format/quantization metadata.
@@ -351,9 +362,9 @@ fn family5_from_planes_is_genuinely_multiplane_and_chroma_is_independently_writa
 #[test]
 fn dma_multiplane_from_planes_makes_is_multiplane_and_chroma_honest() {
     if !edgefirst_tensor::is_dma_available() {
-        eprintln!(
-            "SKIPPED: dma_multiplane_from_planes_makes_is_multiplane_and_chroma_honest - \
-                    DMA not available"
+        report_skip(
+            "dma_multiplane_from_planes_makes_is_multiplane_and_chroma_honest - \
+                    DMA not available",
         );
         return;
     }
@@ -409,9 +420,9 @@ fn dma_multiplane_from_planes_makes_is_multiplane_and_chroma_honest() {
 #[test]
 fn dma_buffer_identity_is_derived_from_the_inode_not_the_handle_address() {
     if !edgefirst_tensor::is_dma_available() {
-        eprintln!(
-            "SKIPPED: dma_buffer_identity_is_derived_from_the_inode_not_the_handle_address \
-                    - DMA not available"
+        report_skip(
+            "dma_buffer_identity_is_derived_from_the_inode_not_the_handle_address \
+                    - DMA not available",
         );
         return;
     }
@@ -478,12 +489,11 @@ fn a_texture_handles_identity_names_its_texture_not_its_recyclable_handle_addres
         ) {
             Ok(t) if t.d3d11_texture().is_some() => drop(t),
             other => {
-                eprintln!(
-                    "SKIPPED: \
+                report_skip(&format!("\
                      a_texture_handles_identity_names_its_texture_not_its_recyclable_handle_address \
                      - no D3D11 {format:?} texture tensors on this host ({:?})",
                     other.map(|t| t.memory())
-                );
+                ));
                 return;
             }
         }
@@ -560,7 +570,7 @@ fn two_distinct_views_of_one_dma_parent_share_one_identity_and_do_not_collide_wi
     // sharing an identity with something that is not actually the same
     // buffer would be the ABA hazard this fix closes).
     if !edgefirst_tensor::is_dma_available() {
-        eprintln!("SKIPPED: two_distinct_views_of_one_dma_parent... - DMA not available");
+        report_skip("two_distinct_views_of_one_dma_parent... - DMA not available");
         return;
     }
     let (w, h) = (64usize, 32usize);

--- a/crates/tensor/tests/no_global_state.rs
+++ b/crates/tensor/tests/no_global_state.rs
@@ -14,6 +14,17 @@
 
 use std::path::{Path, PathBuf};
 
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it -- see `edgefirst_tensor`'s (crate-internal) `test_support` module
+/// for the same mechanism in the library's own `#[cfg(test)]` code; this
+/// integration test binary is a separate compilation unit and cannot reach
+/// that `pub(crate)` helper, so it carries a local copy.
+fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}
+
 const ALLOWED: &[(&str, &str)] = &[
     (
         "SHARED_DRM_FD",
@@ -244,11 +255,11 @@ fn edgefirst_tensor_declares_no_new_global_state() {
     // board, which is the exact failure mode this gate exists to catch.
     let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     if !src.is_dir() {
-        eprintln!(
-            "SKIP: {} - source tree not present at {} (deployed test binary)",
+        report_skip(&format!(
+            "{} - source tree not present at {} (deployed test binary)",
             module_path!(),
             src.display()
-        );
+        ));
         return;
     }
 

--- a/scripts/on-target-test.sh
+++ b/scripts/on-target-test.sh
@@ -28,6 +28,16 @@
 #                      workspace, see each crate's own Cargo.toml comment)
 #   GLIBC              glibc floor for the build (default: the project floor,
 #                      see README "Toolchain and Platform Floors")
+#   FEATURES           cargo features for the TEST build, space- or
+#                      comma-separated (default: none, so the crates build
+#                      with their own defaults). Use it to reach tests that
+#                      are behind a feature and would otherwise never run on
+#                      a board -- `FEATURES=dma_test_formats` is the DMA-BUF
+#                      import suite, which CI's hardware lane builds and this
+#                      script did not. With more than one package selected,
+#                      cargo wants a feature that is not shared spelled
+#                      `<pkg>/<feature>`. Applied to the test build only, not
+#                      to the C-API leaves.
 #   FILTER             test-name filter passed to each binary
 #   REMOTE_DIR         remote scratch dir      (default: /tmp/hal-ontarget)
 #   SYNC_TESTDATA      1 to rsync testdata/    (default: 1)
@@ -55,6 +65,7 @@ CAPI_CRATES="${CAPI_CRATES:-tensor-capi image-capi codec-capi decoder-capi track
 # against it so one set runs on every supported target. Declared alongside the
 # MSRV in the README -- change it there and here together.
 GLIBC="${GLIBC:-2.35}"
+FEATURES="${FEATURES:-}"
 FILTER="${FILTER:-}"
 REMOTE_DIR="${REMOTE_DIR:-/tmp/hal-ontarget}"
 SYNC_TESTDATA="${SYNC_TESTDATA:-1}"
@@ -132,10 +143,18 @@ build_for() {
   local pkgs=() c
   for c in ${CRATES}; do pkgs+=(-p "$c"); done
 
+  # Empty FEATURES must not become a bare `--features ''`, which cargo reads
+  # as a request for a feature named "" and rejects.
+  local feats=()
+  if [ -n "${FEATURES}" ]; then
+    feats=(--features "${FEATURES}")
+    echo "==> test build features: ${FEATURES}"
+  fi
+
   echo "==> building tests for ${triple}"
   local json="${RESULTS}/build-${triple//[.\/]/_}.json"
   if ! cargo-zigbuild test --no-run --release --target "${triple}" \
-        "${pkgs[@]}" --message-format=json > "${json}" 2>"${json}.err"; then
+        "${pkgs[@]}" ${feats[@]+"${feats[@]}"} --message-format=json > "${json}" 2>"${json}.err"; then
     echo "BUILD FAILED for ${triple}; last lines of stderr:" >&2
     tail -30 "${json}.err" >&2
     return 1
@@ -308,9 +327,46 @@ for i in "${!OK_HOSTS[@]}"; do
     echo "SKIP: binary sync failed"; SUMMARY+=("${target}|SYNCFAIL|${arch}|-"); continue; }
 
   if [[ "${SYNC_TESTDATA}" == "1" && -d "${ROOT}/testdata" ]]; then
+    # Per-crate testdata (e.g. `crates/decoder/testdata/infer/`) merges into
+    # the SAME remote testdata/ tree below, not a separate location: every
+    # `EDGEFIRST_TESTDATA_DIR`-aware fixture loader resolves relative to one
+    # deploy root (see e.g. `infer.rs`'s `infer_fixture_dir()`), so a second
+    # root here would just be a place fixtures are never looked for.
+    #
+    # The root sync below runs with `--delete` (to prune fixtures this repo
+    # no longer ships), which would otherwise delete every merged crate
+    # subtree on every single invocation -- it isn't present in the LOCAL
+    # `${ROOT}/testdata/` source, so `--delete` reads it as removed on the
+    # remote, immediately undone by the per-crate merge that follows. Excludes
+    # derived from this same `crates/*/testdata` loop keep `--delete` from
+    # ever touching what the merge owns, so a run that doesn't change any
+    # crate's fixtures doesn't re-transfer them either.
+    crate_testdata_excludes=()
+    for crate_testdata in "${ROOT}"/crates/*/testdata; do
+      [[ -d "${crate_testdata}" ]] || continue
+      for entry in "${crate_testdata}"/*; do
+        [[ -e "${entry}" ]] || continue
+        crate_testdata_excludes+=(--exclude "$(basename "${entry}")")
+      done
+    done
+
     echo "    syncing testdata"
-    rsync -az --delete --info=none "${ROOT}/testdata/" "${target}:${REMOTE_DIR}/testdata/" || {
+    rsync -az --delete --info=none "${crate_testdata_excludes[@]}"         "${ROOT}/testdata/" "${target}:${REMOTE_DIR}/testdata/" || {
       echo "SKIP: testdata sync failed"; SUMMARY+=("${target}|SYNCFAIL|${arch}|-"); continue; }
+
+    # No `--delete` here: each crate contributes a disjoint subtree of the
+    # merged tree, so a stale file left by a DIFFERENT crate's sync must not
+    # be pruned by this one.
+    crate_testdata_sync_failed=0
+    for crate_testdata in "${ROOT}"/crates/*/testdata; do
+      [[ -d "${crate_testdata}" ]] || continue
+      echo "    syncing $(basename "$(dirname "${crate_testdata}")")'s testdata"
+      rsync -az --info=none "${crate_testdata}/" "${target}:${REMOTE_DIR}/testdata/" || {
+        crate_testdata_sync_failed=1; break; }
+    done
+    if [[ "${crate_testdata_sync_failed}" == "1" ]]; then
+      echo "SKIP: per-crate testdata sync failed"; SUMMARY+=("${target}|SYNCFAIL|${arch}|-"); continue
+    fi
   fi
 
   # Deploy the five C-API libraries + their `.so.0` symlinks + the G3


### PR DESCRIPTION
Keeps an unaligned-offset packed source (RGBA, BGRA, RGB, Grey) zero-copy on Mali by importing from the 64-byte-aligned base below the offset and folding the remainder into the sampling rectangle, fixes a Mali precision defect the change exposed, and makes the imx8mp CI hardware lane execute the tests it ships. Closes #170 (close by hand after merge; auto-close only fires on `main`). Includes the CI-lane work previously opened as #182.

## Zero-copy fold (#170)

- `aligned_source_base` (lcm(64, bpp) step) and `rebase_fits_pitch` in `dma_import.rs`; `from_tensor`'s source arm rebases the four packed formats and widens the import by the shift; the render path folds an origin, not only an extent, onto the import (`ImportMap`, `GlPlatform::import_origin`), and the external-OES shaders clamp `src_extent` so a rebased import never samples past the logical image.
- The Mali decline is import-aware: `resolve_source_plane0` is the single place that decides the offset the import will present, read by both `from_tensor` and the gate, pinned by a table test. A format-keyed exemption was tried first and reopened silent zeros for a 64-wide RGBA window with a tight pitch and for a 100-wide RGB surface whose stride is not a whole pixel count (imx95 red run: `offset 16416: ZEROS imports=1`); the import-aware gate declines those and uploads.
- NV12/NV16/NV24 combined-plane, YUYV and planar sources keep the decline-and-upload path: the NV R8 import's pitch is its width, so it cannot widen, and a uniform shift would put a per-texel divide back into the hot shader.

## Mali precision fix

The clamp routed the sampled coordinate through a `mediump` varying; Mali-G310 evaluates that at fp16, a 2^-11 step (0.625 texel at 1280 wide) that `LINEAR` blends in, giving a flat whole-frame error (max_diff 50). Four fragment shaders that compute on `tc` now declare it `highp` (one is the pre-existing `sampler2D` blit, one the segmentation shader). `mod tc_precision` pins the rule by name-set equality over every shader generator and constant, with comment stripping; it tracks the coordinate `tc` only, so a sample coordinate under another name needs a recorded decision.

## imx8mp CI hardware lane (from #182)

Since `a87ae59c` (2026-05-14) the lane `chmod`ed a directory the artifact never delivers, so `[[ -x ]]` skipped all 76 binaries silently and the junit read `tests="0"` while the job stayed green. Now: the `chmod` targets the delivered directory with no error suppression; a zero-tests guard and a junit floor counted from the per-binary summary lines (`--min-tests` 643 on imx8mp from the first real run's 757 executed tests, 1000 on the aarch64 runner); 15 GL and tensor integration binaries run on the board instead of being skipped as "CPU-only"; test skips go through a stderr helper so output capture cannot hide them (over 340 sites across image, tensor, codec and decoder); every crate's `testdata` ships to the boards and CI (the decoder's infer tests resolved a compile-time path); the dynamic test lane cross-links via `EDGEFIRST_TENSOR_LIB_DIR`; `scripts/on-target-test.sh` gains a `FEATURES` passthrough. The three float tests that `unwrap`ed on Vivante's missing F16 render skip on the capability probe.

## CPU conversion on Cortex-A53

The first real lane run exposed that the fast YUV kernel selected on aarch64 without the `rdm` feature (Cortex-A53, the i.MX 8M Plus) accumulates in a non-saturating 16-bit lane: super-white luma with strong chroma wrapped to black, so the two G2D parity tests read max_diff=255 with G2D being right. Luma is now capped at the limited-range white point (235; the arithmetic ceiling is 237) before that kernel, with a vectorized scan and a copy only when a frame carries super-white. In-range output is byte-identical; the common path costs 8% more on the i.MX 8M Plus (6.06 → 6.56 ns/pixel), an affected frame 26%. The accurate kernel would cost ~2x. A desktop-runnable test pins the cap against the kernel's wrap point (the x86 SSE kernel has the same overflow).

## Verification

- Boards (`scripts/on-target-test.sh`, default and `FEATURES=dma_test_formats`): imx95-frdm, imx8mp-frdm, rpi5-hailo all green (460 default / 548 gated lib tests each; the offset-alignment pin file 4/4). On imx95 the route assertion shows every unaligned RGBA view imported, zero uploads.
- Desktop: image lib 458/2 (the two known NVIDIA `src_rect_crop` failures), 526/22 with `dma_test_formats` (NVIDIA cannot import DMA-BUF); clippy `-D warnings`; macOS and Windows target checks.
- CI: the imx8mp lane now executes 757 tests.

## Notes for the reader

- The GIL-release test's gap floor is lowered from 20% to 10% (x86_64 runner headroom measured at 17–19% on three runs with a 53% control; a GIL-holding mutation measures −3%). The same commit is on #180; it drops out on rebase.
- 16 `eprintln!` skip sites remain in the C-API test harnesses (image-capi, tensor-capi).
