### PR TITLE
Make the imx8mp hardware lane actually run its tests

### DIFF
--- a/.github/scripts/generate_junit_xml.py
+++ b/.github/scripts/generate_junit_xml.py
@@ -40,7 +40,7 @@ def generate_junit_xml(results_dir: str, output_file: str, min_tests: int = 0) -
         with open(output_file, 'w') as f:
             f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
             f.write('<testsuites name="rust-hardware" tests="0" failures="0" errors="0"></testsuites>\n')
-        if 0 < min_tests:
+        if min_tests > 0:
             print(f"::error::junit has 0 tests, floor is {min_tests}")
             return 1
         return 0

--- a/.github/scripts/generate_junit_xml.py
+++ b/.github/scripts/generate_junit_xml.py
@@ -8,6 +8,7 @@ Usage:
     python scripts/generate_junit_xml.py build/rust-test-results build/rust_hardware_results.xml
 """
 
+import argparse
 import glob
 import os
 import re
@@ -15,12 +16,19 @@ import sys
 from datetime import datetime
 
 
-def generate_junit_xml(results_dir: str, output_file: str) -> None:
+def generate_junit_xml(results_dir: str, output_file: str, min_tests: int = 0) -> int:
     """Parse Rust test output files and generate JUnit XML.
 
     Args:
         results_dir: Directory containing test output .txt files
         output_file: Path to write the JUnit XML output
+        min_tests: Minimum number of tests the generated XML must contain.
+            When the parsed test count is below this floor, an
+            `::error::` is printed and a non-zero status is returned,
+            after the XML has still been written.
+
+    Returns:
+        0 on success, 1 if the test count is below `min_tests`.
     """
     tests = []
     total_passed = 0
@@ -32,7 +40,10 @@ def generate_junit_xml(results_dir: str, output_file: str) -> None:
         with open(output_file, 'w') as f:
             f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
             f.write('<testsuites name="rust-hardware" tests="0" failures="0" errors="0"></testsuites>\n')
-        return
+        if 0 < min_tests:
+            print(f"::error::junit has 0 tests, floor is {min_tests}")
+            return 1
+        return 0
 
     for txt_file in glob.glob(f"{results_dir}/*.txt"):
         test_binary = os.path.basename(txt_file).replace('.txt', '')
@@ -87,17 +98,28 @@ def generate_junit_xml(results_dir: str, output_file: str) -> None:
     print(f"Generated {output_file} with {len(tests)} tests "
           f"({total_passed} passed, {total_failed} failed)")
 
+    if len(tests) < min_tests:
+        print(f"::error::junit has {len(tests)} tests, floor is {min_tests}")
+        return 1
+    return 0
+
 
 def main() -> int:
-    if len(sys.argv) < 3:
-        print("Usage: generate_junit_xml.py <results_dir> <output_file>")
-        return 1
+    parser = argparse.ArgumentParser(
+        description="Generate JUnit XML from Rust test output files."
+    )
+    parser.add_argument("results_dir", help="Directory containing test output .txt files")
+    parser.add_argument("output_file", help="Path to write the JUnit XML output")
+    parser.add_argument(
+        "--min-tests",
+        type=int,
+        default=0,
+        help="Minimum number of tests the generated XML must contain "
+             "(default: 0, i.e. no floor)",
+    )
+    args = parser.parse_args()
 
-    results_dir = sys.argv[1]
-    output_file = sys.argv[2]
-
-    generate_junit_xml(results_dir, output_file)
-    return 0
+    return generate_junit_xml(args.results_dir, args.output_file, args.min_tests)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2097,9 +2097,14 @@ jobs:
       - name: Generate JUnit XML from Rust results
         if: always()
         run: |
+          # Floor set from the lane's first real run after the chmod fix
+          # (run 34472605256, job 102858670856): the junit parsed 574 tests,
+          # so the floor is 574 - 15% rounded down. Raise it deliberately when
+          # the suite grows; it exists to catch a silent collapse to zero, not
+          # to track the exact count.
           python3 .github/scripts/generate_junit_xml.py \
             build/rust-test-results build/rust_hardware_results.xml \
-            --min-tests 40
+            --min-tests 487
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,27 @@ jobs:
       - name: Checkout LFS objects
         run: git lfs checkout
 
+      - name: Merge per-crate testdata into the shared testdata/ tree
+        run: |
+          # Every `crates/<name>/testdata/` (currently only
+          # `crates/decoder/testdata/infer/`) merges into the top-level
+          # `testdata/` tree uploaded below, so every job that downloads the
+          # `testdata-lfs` artifact -- rather than doing its own full LFS
+          # checkout -- gets crate-local fixtures too, at the same relative
+          # path `EDGEFIRST_TESTDATA_DIR`-aware fixture loaders resolve
+          # against (see e.g. `infer.rs`'s `infer_fixture_dir()`, and
+          # `scripts/on-target-test.sh`'s testdata sync, which merges the
+          # same way). A second `path:` entry on the upload step below would
+          # do this too, but `upload-artifact` strips only the paths' least
+          # common ancestor, which for `testdata/` and
+          # `crates/decoder/testdata/` is the repo root -- every job that
+          # downloads this artifact expecting a bare `testdata/` layout
+          # would break.
+          for dir in crates/*/testdata; do
+            [ -d "${dir}" ] || continue
+            cp -a "${dir}/." testdata/
+          done
+
       - name: Upload testdata as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1949,6 +1949,31 @@ jobs:
             fi
           }
 
+          run_unfiltered() {
+            # Same as run_filtered but without a substring filter: used for
+            # the crates/image/tests/*.rs integration binaries below, which
+            # are each a single dedicated whole-binary GL test rather than a
+            # multi-category lib test binary split by g2d/opengl/dma filter.
+            local test_bin="$1" label="$2"
+            local test_name
+            test_name=$(basename "$test_bin")
+            echo "=== Running $test_name ($label) ==="
+            EXIT_CODE=0
+            local logfile="build/rust-test-results/${test_name}-${label// /-}.txt"
+            "$test_bin" --test-threads=1 2>&1 | tee "$logfile" || EXIT_CODE=$?
+            if [ $EXIT_CODE -ne 0 ]; then
+              # Check if all tests actually passed but process crashed on
+              # exit (Vivante GPU driver SIGABRT during library unload)
+              if grep -q 'test result: ok' "$logfile" && \
+                 ! grep -q 'FAILED' "$logfile"; then
+                echo "::warning::$test_name ($label) exited with code $EXIT_CODE (likely GPU driver crash during shutdown) but all tests passed"
+              else
+                echo "FAILED: $test_name ($label)"
+                TEST_FAILED=1
+              fi
+            fi
+          }
+
           for test_bin in hardware-test-binaries-stripped/*; do
             [[ -x "$test_bin" && -f "$test_bin" ]] || continue
             [[ "$test_bin" == *.so ]] && continue
@@ -1962,7 +1987,30 @@ jobs:
             elif [[ "$test_name" == edgefirst_tensor-* ]]; then
               # DMA-heap tensor tests only
               run_filtered "$test_bin" dma "DMA tests"
+            elif [[ "$test_name" == dst_view_stride-* || "$test_name" == offset_nv_source_upload-* || \
+                    "$test_name" == offset_source_view_alignment-* || "$test_name" == gl_concurrent_stress-* || \
+                    "$test_name" == reconstructed_view_convert-* || "$test_name" == reconstructed_view_draw-* || \
+                    "$test_name" == reconstructed_planar_dst-* || "$test_name" == pin_convert-* || \
+                    "$test_name" == crop_golden-* || "$test_name" == mask_golden-* || "$test_name" == odd_dim_cpu-* ]]; then
+              # crates/image/tests/*.rs GL integration binaries: whole-binary
+              # GPU/EGL tests, run unfiltered (no g2d/opengl/dma split).
+              run_unfiltered "$test_bin" "GL integration test"
             else
+              # CPU-only, covered by aarch64 runner: edgefirst-image benches
+              # (image_benchmark, pipeline_benchmark, nv_path_benchmark,
+              # mask_benchmark, parallel_processors_benchmark,
+              # mask_decode_benchmark, sanity_check, decode_pipeline_benchmark,
+              # nvjpeg_benchmark, convert_matrix_benchmark,
+              # cpu_preprocess_benchmark, batch_convert_benchmark,
+              # tiled_convert_benchmark, opencv_benchmark), and any decoder/
+              # tracker/capi binaries that end up in this artifact.
+              #
+              # NOTE: crates/tensor/tests/*.rs integration binaries also land
+              # here (d3d11_tensor, dynamic_primitives, identity,
+              # logical_shape, map_access, no_global_state, pin, protocol,
+              # protocol_roundtrip, scenarios, vocabulary). This is scoped
+              # out of the current fix -- see the task report for whether
+              # any of these need DMA-heap routing like edgefirst_tensor-*.
               echo "=== Skipping $test_name (CPU-only, covered by aarch64 runner) ==="
             fi
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2016,6 +2016,19 @@ jobs:
               # crates/image/tests/*.rs GL integration binaries: whole-binary
               # GPU/EGL tests, run unfiltered (no g2d/opengl/dma split).
               run_unfiltered "$test_bin" "GL integration test"
+            elif [[ "$test_name" == pin-* || "$test_name" == protocol-* || \
+                    "$test_name" == protocol_roundtrip-* || "$test_name" == dynamic_primitives-* || \
+                    "$test_name" == identity-* || "$test_name" == vocabulary-* ]]; then
+              # crates/tensor/tests/*.rs DMA-BUF-touching integration
+              # binaries: whole-binary tests, run unfiltered, same reasoning
+              # as the crates/image/tests/*.rs branch above. `dynamic_
+              # primitives-*` is `#![cfg(feature = "dynamic")]`-gated and
+              # this artifact is built with default features only (no
+              # `dynamic`), so it currently runs zero tests here -- routed
+              # anyway rather than silently left in the skip branch, so it
+              # picks up coverage for free the day this crate's hardware
+              # build gains that feature.
+              run_unfiltered "$test_bin" "tensor integration test"
             else
               # CPU-only, covered by aarch64 runner: edgefirst-image benches
               # (image_benchmark, pipeline_benchmark, nv_path_benchmark,
@@ -2026,12 +2039,11 @@ jobs:
               # tiled_convert_benchmark, opencv_benchmark), and any decoder/
               # tracker/capi binaries that end up in this artifact.
               #
-              # NOTE: crates/tensor/tests/*.rs integration binaries also land
-              # here (d3d11_tensor, dynamic_primitives, identity,
-              # logical_shape, map_access, no_global_state, pin, protocol,
-              # protocol_roundtrip, scenarios, vocabulary). This is scoped
-              # out of the current fix -- see the task report for whether
-              # any of these need DMA-heap routing like edgefirst_tensor-*.
+              # crates/tensor/tests/*.rs binaries that do NOT touch DMA-BUF
+              # stay here: logical_shape, map_access, no_global_state,
+              # scenarios. `d3d11_tensor` also lands here -- it is
+              # `#![cfg(target_os = "windows")]`-gated and compiles to an
+              # empty binary on this Linux runner regardless of routing.
               echo "=== Skipping $test_name (CPU-only, covered by aarch64 runner) ==="
             fi
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1729,7 +1729,10 @@ jobs:
 
       - name: Generate JUnit XML from Rust results
         if: always()
-        run: python3 .github/scripts/generate_junit_xml.py build/rust-test-results build/rust_runner_results.xml
+        run: |
+          python3 .github/scripts/generate_junit_xml.py \
+            build/rust-test-results build/rust_runner_results.xml \
+            --min-tests 1000
 
       - name: Process Rust coverage
         if: always()
@@ -1919,7 +1922,10 @@ jobs:
           # Only run tests that exercise hardware (G2D, OpenGL/EGL, DMA).
           # CPU-only tests already run on the ubuntu-22.04-arm-xlarge runner.
           mkdir -p build/rust-test-results build/profraw
-          chmod +x hardware-test-binaries/* 2>/dev/null || true
+          # The artifact round trip does not preserve the executable bit, so
+          # every binary arrives 0644 and the `[[ -x ]]` guard below skips it.
+          # This MUST name the same directory the loop iterates.
+          chmod +x hardware-test-binaries-stripped/*
           TEST_FAILED=0
 
           run_filtered() {
@@ -1960,11 +1966,19 @@ jobs:
               echo "=== Skipping $test_name (CPU-only, covered by aarch64 runner) ==="
             fi
           done
+          ran=$(find build/rust-test-results -name '*.txt' | wc -l)
+          if [ "$ran" -eq 0 ]; then
+            echo "::error::imx8mp hardware lane executed 0 test binaries"
+            exit 1
+          fi
           [ $TEST_FAILED -eq 0 ] || exit 1
 
       - name: Generate JUnit XML from Rust results
         if: always()
-        run: python3 .github/scripts/generate_junit_xml.py build/rust-test-results build/rust_hardware_results.xml
+        run: |
+          python3 .github/scripts/generate_junit_xml.py \
+            build/rust-test-results build/rust_hardware_results.xml \
+            --min-tests 40
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,18 @@ jobs:
           # would break.
           for dir in crates/*/testdata; do
             [ -d "${dir}" ] || continue
+            # `cp -a` silently overwrites on a name collision (with the
+            # root testdata/ tree, or with an earlier crate merged this
+            # same loop) -- checked file by file before copying so a
+            # collision fails the step loudly, naming the exact path,
+            # instead of one crate's fixture silently replacing another's.
+            while IFS= read -r -d '' f; do
+              rel="${f#"${dir}"/}"
+              if [ -e "testdata/${rel}" ]; then
+                echo "::error::${dir}/${rel} collides with an existing testdata/${rel}"
+                exit 1
+              fi
+            done < <(find "${dir}" -type f -print0)
             cp -a "${dir}/." testdata/
           done
 
@@ -2010,8 +2022,7 @@ jobs:
               run_filtered "$test_bin" dma "DMA tests"
             elif [[ "$test_name" == dst_view_stride-* || "$test_name" == offset_nv_source_upload-* || \
                     "$test_name" == offset_source_view_alignment-* || "$test_name" == gl_concurrent_stress-* || \
-                    "$test_name" == reconstructed_view_convert-* || "$test_name" == reconstructed_view_draw-* || \
-                    "$test_name" == reconstructed_planar_dst-* || "$test_name" == pin_convert-* || \
+                    "$test_name" == reconstructed_view_convert-* || "$test_name" == pin_convert-* || \
                     "$test_name" == crop_golden-* || "$test_name" == mask_golden-* || "$test_name" == odd_dim_cpu-* ]]; then
               # crates/image/tests/*.rs GL integration binaries: whole-binary
               # GPU/EGL tests, run unfiltered (no g2d/opengl/dma split).
@@ -2029,25 +2040,54 @@ jobs:
               # picks up coverage for free the day this crate's hardware
               # build gains that feature.
               run_unfiltered "$test_bin" "tensor integration test"
+            elif [[ "$test_name" == reconstructed_planar_dst-* || "$test_name" == reconstructed_view_draw-* ]]; then
+              # These two compile to a zero-test binary on this Linux
+              # runner: `reconstructed_planar_dst.rs` is
+              # `#![cfg(all(any(target_os = "macos", target_os = "ios"),
+              # feature = "opengl"))]` and `reconstructed_view_draw.rs` is
+              # `#![cfg(all(any(target_os = "macos", target_os = "ios",
+              # target_os = "windows"), feature = "opengl"))]` -- neither
+              # cfg includes linux, so running them here is a guaranteed
+              # "0 tests" no-op, not coverage. Every other routed binary in
+              # the branches above was checked the same way and has no such
+              # gate (or, for `offset_nv_source_upload`/
+              # `offset_source_view_alignment`, includes linux).
+              echo "=== Skipping $test_name (compiles to 0 tests on linux: macOS/iOS/Windows-only) ==="
             else
-              # CPU-only, covered by aarch64 runner: edgefirst-image benches
-              # (image_benchmark, pipeline_benchmark, nv_path_benchmark,
-              # mask_benchmark, parallel_processors_benchmark,
-              # mask_decode_benchmark, sanity_check, decode_pipeline_benchmark,
-              # nvjpeg_benchmark, convert_matrix_benchmark,
-              # cpu_preprocess_benchmark, batch_convert_benchmark,
-              # tiled_convert_benchmark, opencv_benchmark), and any decoder/
-              # tracker/capi binaries that end up in this artifact.
-              #
-              # crates/tensor/tests/*.rs binaries that do NOT touch DMA-BUF
-              # stay here: logical_shape, map_access, no_global_state,
-              # scenarios. `d3d11_tensor` also lands here -- it is
-              # `#![cfg(target_os = "windows")]`-gated and compiles to an
-              # empty binary on this Linux runner regardless of routing.
+              # What actually lands in hardware-test-binaries-stripped/ is
+              # NOT scoped to edgefirst-image/edgefirst-tensor: this job's
+              # earlier "Build runner test binaries" step (`cargo nextest
+              # run --no-run --workspace --exclude <the six python-*
+              # crates>`) and this step both run under the SAME
+              # `CARGO_TARGET_DIR=target/llvm-cov-target` (`source
+              # /tmp/coverage-env.sh` in both), so the `find
+              # target/llvm-cov-target/profiling/deps/ -type f -executable`
+              # above -- which has no package filter -- copies every
+              # lib-test and integration-test binary the workspace build
+              # produced, not just the two packages this step explicitly
+              # names. So this branch actually sees: edgefirst-codec,
+              # edgefirst-decoder, edgefirst-tracker, edgefirst-bench,
+              # edgefirst-egl, edgefirst-gl, edgefirst-gpu-probe,
+              # edgefirst-tensor-abi, edgefirst-decoder-abi,
+              # edgefirst-tensor-ffi, and the five -capi crates' own
+              # lib-test binaries (and edgefirst-tensor's non-DMA
+              # `crates/tensor/tests/*.rs`: logical_shape, map_access,
+              # no_global_state, scenarios, plus `d3d11_tensor` --
+              # `#![cfg(target_os = "windows")]`-gated, empty here
+              # regardless of routing). None of these exercise the GPU/DMA
+              # hardware this lane exists for; they are already covered by
+              # `Test (aarch64)`, which runs the full `--workspace` set on
+              # real hardware. The fourteen `edgefirst-image`
+              # `[[bench]]` targets (image_benchmark, ...) are NOT here:
+              # every one is `harness = false` with no explicit
+              # `test = true`, so cargo's default (`test = false` for a
+              # bench target) means nextest never builds them as test
+              # binaries in the first place -- there is nothing from them
+              # to skip.
               echo "=== Skipping $test_name (CPU-only, covered by aarch64 runner) ==="
             fi
           done
-          ran=$(find build/rust-test-results -name '*.txt' | wc -l)
+          ran=$(find build/rust-test-results -maxdepth 1 -name '*.txt' | wc -l)
           if [ "$ran" -eq 0 ]; then
             echo "::error::imx8mp hardware lane executed 0 test binaries"
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `HAL_TEST_REQUIRE_CUDA=1` (set by `make test-cuda` whenever it located a
   runtime) makes such a skip a failure rather than a silent pass.
 
+- **The imx8mp hardware lane executed zero Rust tests, silently, since
+  2026-05-14 (`a87ae59c`).** The artifact-restoring `chmod +x` named
+  `hardware-test-binaries/`, a directory the artifact stopped shipping the
+  day that commit switched to `hardware-test-binaries-stripped/`; the glob
+  matched nothing, the error was swallowed by `2>/dev/null || true`, and
+  every binary then failed the loop's `[[ -x ]]` guard in complete silence
+  -- no `=== Running`, no `=== Skipping`, and the JUnit generator reported
+  `tests="0"` with nothing downstream asserting a floor. Four months of a
+  green-but-empty gate. Fixed by naming the directory the loop actually
+  iterates, dropping the error suppression so a real mismatch fails loudly
+  instead of vanishing, and adding a zero-tests guard plus a `--min-tests`
+  floor on the generated JUnit XML (also applied to the aarch64 runner's
+  identical step). The lane now also runs 15 integration binaries
+  (`crates/image/tests/*.rs`'s GL binaries and `crates/tensor/tests/*.rs`'s
+  DMA-BUF-touching ones) that previously fell into a CPU-only skip branch
+  unconditionally, and every crate's `testdata/` (not just the repository
+  root's) is shipped to the boards and to CI's own testdata artifact, so
+  fixtures under a crate-local `testdata/` directory reach on-target runs
+  the same way root-level fixtures already did.
+- **A hardware-gated test that returned early after `eprintln!`-ing its
+  skip reason reported bare `ok`, indistinguishable from having actually
+  run.** libtest captures `println!`/`eprintln!` and replays it only for a
+  *failing* test, so the reason was silently discarded on every passing
+  skip -- both locally and on the boards. Every such site across
+  `edgefirst-image`, `edgefirst-tensor`, `edgefirst-codec`, and
+  `edgefirst-decoder` now writes `SKIPPED: <reason>` directly to stderr,
+  bypassing libtest's capture hook, so `scripts/on-target-test.sh`'s
+  per-board skip count (and a human reading captured CI logs) can actually
+  see it.
+- **Cross-building `edgefirst-tensor`'s `dynamic` backend test lane for a
+  board needed a hand-rolled `RUSTFLAGS`.** `crates/tensor/build.rs`'s
+  `dynamic-test-link` feature hardcoded a link-search path relative to this
+  crate's own manifest directory, which is wrong for any cross (`--target`)
+  build. It now honours `EDGEFIRST_TENSOR_LIB_DIR` when set and otherwise
+  derives the search path from `OUT_DIR`, matching whatever `target/
+  <profile>` or `target/<target-triple>/<profile>` layout the actual build
+  used.
+- **`test_merge_tiled_detections_releases_the_gil`'s 20% gap floor failed
+  on a two-vCPU hosted CI runner** that measured a real, repeatable ~17-19%
+  gap for a short CPU-bound op -- a headroom shortfall on that runner, not
+  a regression (a GIL-holding mutation still measures a gap near 0% under
+  the same harness). Lowered to 10%, which still discriminates a genuine
+  hold from a genuine release by roughly an order of magnitude.
+
 ### Changed
 
 - A malformed quantization descriptor in a tensor capsule is now reported

--- a/TESTING.md
+++ b/TESTING.md
@@ -709,6 +709,29 @@ ssh imx95-frdm 'cd /tmp/hal-tests && EDGEFIRST_TESTDATA_DIR=$(pwd)/testdata ./<b
 The `python-*` crates are excluded from cross-builds — PyO3 requires a
 target Python installation.
 
+**Cross-compiling the `dynamic` backend's tests** (`dynamic_primitives`,
+`protocol_roundtrip`, and the rest of `make test-tensor-dynamic`'s
+`DYNAMIC_TEST_TARGETS`) needs one more step: these link against
+`libedgefirst_tensor.so`, cross-built from `crates/tensor-capi`, not the
+plain `edgefirst-tensor` rlib. `crates/tensor/build.rs`'s
+`dynamic-test-link` feature honours `EDGEFIRST_TENSOR_LIB_DIR` when set,
+otherwise it derives the search path from `OUT_DIR` (the
+`target/<target-triple>/<profile>` layout `cargo-zigbuild` itself produces)
+— so cross-building this lane no longer needs a hand-rolled `RUSTFLAGS`:
+
+```bash
+cargo-zigbuild build --target aarch64-unknown-linux-gnu.2.35 \
+  --manifest-path crates/tensor-capi/Cargo.toml --target-dir target
+cargo-zigbuild test --target aarch64-unknown-linux-gnu.2.35 --no-run \
+  -p edgefirst-tensor --no-default-features --features dynamic,dynamic-test-link,ndarray \
+  --test dynamic_primitives
+```
+
+Set `EDGEFIRST_TENSOR_LIB_DIR` to the directory containing
+`libedgefirst_tensor.so` only when the producer build landed somewhere the
+derived path can't find on its own (a different `--target-dir`, or a `.so`
+fetched from elsewhere).
+
 CI automates this flow in
 [`.github/workflows/test.yml`](https://github.com/EdgeFirstAI/hal/blob/main/.github/workflows/test.yml).
 Binaries are stripped on the build host (split debuginfo preserved for

--- a/crates/codec/src/jpeg/idct/avx2.rs
+++ b/crates/codec/src/jpeg/idct/avx2.rs
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_random_strided() {
         if !is_x86_feature_detected!("avx2") {
-            eprintln!("AVX2 not available, skipping");
+            crate::test_support::report_skip("AVX2 not available");
             return;
         }
         const STRIDE: usize = 24;

--- a/crates/codec/src/jpeg/idct/fast.rs
+++ b/crates/codec/src/jpeg/idct/fast.rs
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn fast_neon_matches_fast_scalar_exactly() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut quant = [0u16; 64];

--- a/crates/codec/src/jpeg/idct/neon.rs
+++ b/crates/codec/src/jpeg/idct/neon.rs
@@ -693,7 +693,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         // Default coefficients live in rows 0–3 / cols 0–3: exercises both
@@ -705,7 +705,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_row0_only() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = [0i16; 64];
@@ -724,7 +724,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_left_dc_right_ac() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = [0i16; 64];
@@ -740,7 +740,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_right_half_coeffs() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = make_test_coeffs();
@@ -755,7 +755,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_bottom_row_coeffs() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = make_test_coeffs();
@@ -769,7 +769,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_dense() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut coeffs = make_test_coeffs();
@@ -783,7 +783,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_with_quant() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut quant = [0u16; 64];
@@ -802,7 +802,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_zero_block() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         assert_parity(&[0i16; 64], &UNIT_QUANT, "zero-block");
@@ -811,7 +811,7 @@ mod tests {
     #[test]
     fn idct_8x8_parity_strided() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
 
@@ -845,7 +845,7 @@ mod tests {
     #[test]
     fn idct_8x8_k_tiers_match_scalar() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
         let mut quant = [0u16; 64];
@@ -893,7 +893,7 @@ mod tests {
     #[test]
     fn idct_dc_only_parity() {
         if !std::arch::is_aarch64_feature_detected!("neon") {
-            eprintln!("SIMD feature not available, skipping");
+            crate::test_support::report_skip("SIMD feature not available");
             return;
         }
 

--- a/crates/codec/src/jpeg/v4l2/mod.rs
+++ b/crates/codec/src/jpeg/v4l2/mod.rs
@@ -2013,7 +2013,7 @@ mod tests {
         // SAFETY: mplane variant.
         let cap_fmt = *unsafe { gfmt.pix_mp() };
         if cap_fmt.num_planes != 1 {
-            eprintln!("  capture is not single-plane; skipping");
+            crate::test_support::report_skip("capture is not single-plane");
             return None;
         }
         let sizeimage = cap_fmt.plane_fmt[0].sizeimage as usize;

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -54,6 +54,8 @@ mod options;
 mod pixel;
 #[cfg(feature = "png")]
 mod png;
+#[cfg(test)]
+mod test_support;
 mod traits;
 
 pub use decoder::{peek_info, ChromaUpsample, DctMethod, ImageDecoder};

--- a/crates/codec/src/test_support.rs
+++ b/crates/codec/src/test_support.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test-only helper for reporting a skipped test so the report
+//! survives libtest's output capture.
+//!
+//! `eprintln!`/`println!` route through `std::io::_eprint`/`_print`, which
+//! libtest hooks to capture per-test output and replay it only for a
+//! *failing* test. A hardware- or CPU-feature-gated test that returns
+//! early after printing its reason with `eprintln!` therefore reports `ok`
+//! with the reason silently discarded -- indistinguishable from having
+//! actually exercised the code, both locally (`cargo test` without
+//! `--nocapture`) and in CI. Writing directly to `std::io::stderr()`
+//! bypasses that hook, so the `SKIPPED: ...` line survives capture in both
+//! directions; `scripts/on-target-test.sh` greps captured logs for the
+//! literal string `SKIPPED` to report a skip count per board.
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it.
+#[cfg(test)]
+pub(crate) fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}

--- a/crates/decoder/src/infer.rs
+++ b/crates/decoder/src/infer.rs
@@ -1047,6 +1047,26 @@ pub fn infer_ultralytics_schema(signals: &ModelSignals) -> Result<InferredSchema
 mod tests {
     use super::*;
 
+    /// Root of the `testdata/infer` fixture directory.
+    ///
+    /// `EDGEFIRST_TESTDATA_DIR` wins when set -- `scripts/on-target-test.sh`
+    /// and CI both mirror `crates/decoder/testdata/infer` into
+    /// `$EDGEFIRST_TESTDATA_DIR/infer` (see `on-target-test.sh`'s testdata
+    /// sync and `.github/workflows/test.yml`'s "Upload testdata as
+    /// artifact" step). The manifest-relative fallback is baked in at
+    /// **compile** time, so a cross-compiled binary carries the build
+    /// host's absolute path and can never find fixtures on a different
+    /// target -- same reasoning as `decoder_from_edgefirst_json.rs`'s
+    /// `testdata_root()`.
+    fn infer_fixture_dir() -> std::path::PathBuf {
+        std::env::var("EDGEFIRST_TESTDATA_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata")
+            })
+            .join("infer")
+    }
+
     #[test]
     fn parse_names_python_dict_repr() {
         let s = "{0: 'person', 1: 'bicycle', 2: \"fire hydrant\"}";
@@ -1152,12 +1172,9 @@ mod tests {
     /// regardless of whether the source was ONNX (flat props) or TFLite
     /// (single `metadata.json` envelope entry).
     fn load_fixture_metadata(name: &str) -> BTreeMap<String, String> {
-        let path = format!(
-            "{}/testdata/infer/{name}.signals.json",
-            env!("CARGO_MANIFEST_DIR")
-        );
+        let path = infer_fixture_dir().join(format!("{name}.signals.json"));
         let content = std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"));
+            .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
         let json: serde_json::Value =
             serde_json::from_str(&content).expect("fixture is valid JSON");
         json["metadata"]
@@ -1199,12 +1216,9 @@ mod tests {
     /// inference runtime would report it: tensor names/shapes/dtypes plus
     /// the raw metadata map.
     fn signals_from_fixture(name: &str) -> ModelSignals {
-        let path = format!(
-            "{}/testdata/infer/{name}.signals.json",
-            env!("CARGO_MANIFEST_DIR")
-        );
+        let path = infer_fixture_dir().join(format!("{name}.signals.json"));
         let content = std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"));
+            .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
         let json: serde_json::Value =
             serde_json::from_str(&content).expect("fixture is valid JSON");
 
@@ -2162,9 +2176,9 @@ mod tests {
         // Without this, a fixture can be added (or renamed) and silently
         // never asserted on -- which is exactly how `yolo11n-seg` and
         // `yolov8n-seg_int8` ended up with no field-level coverage.
-        let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/testdata/infer");
-        let mut on_disk: Vec<String> = std::fs::read_dir(dir)
-            .expect("testdata/infer exists")
+        let dir = infer_fixture_dir();
+        let mut on_disk: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("{} exists: {e}", dir.display()))
             .filter_map(|e| {
                 let name = e.ok()?.file_name().into_string().ok()?;
                 name.strip_suffix(".signals.json").map(str::to_string)

--- a/crates/decoder/src/lib.rs
+++ b/crates/decoder/src/lib.rs
@@ -85,6 +85,8 @@ pub use infer::{
 
 mod decoder;
 pub use decoder::*;
+#[cfg(test)]
+mod test_support;
 
 // The detection vocabulary lives in edgefirst-tensor so edgefirst-image can
 // render from it without depending on this crate. Re-exported here so the

--- a/crates/decoder/src/per_scale/kernels/neon_baseline.rs
+++ b/crates/decoder/src/per_scale/kernels/neon_baseline.rs
@@ -2097,7 +2097,9 @@ mod tests {
     #[test]
     fn expf_neon_f32x8_via_f16_matches_libm_relative() {
         if !fp16_supported() {
-            eprintln!("fp16 not supported on this CPU; skipping FP16 expf parity test");
+            crate::test_support::report_skip(
+                "fp16 not supported on this CPU (FP16 expf parity test)",
+            );
             return;
         }
         // f16 polynomial expf has ~1% relative error in exp(r) — wider
@@ -2142,7 +2144,7 @@ mod tests {
     #[test]
     fn sigmoid_slice_f32_neon_fp16_matches_scalar() {
         if !fp16_supported() {
-            eprintln!("fp16 not supported; skipping");
+            crate::test_support::report_skip("fp16 not supported");
             return;
         }
         // 32 elements: 4 chunks of 8, no tail.
@@ -2168,7 +2170,7 @@ mod tests {
     #[test]
     fn softmax_neon_fp16_matches_scalar() {
         if !fp16_supported() {
-            eprintln!("fp16 not supported; skipping");
+            crate::test_support::report_skip("fp16 not supported");
             return;
         }
         // 16 elements: 2 chunks of 8, exact reg_max boundary.

--- a/crates/decoder/src/test_support.rs
+++ b/crates/decoder/src/test_support.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test-only helper for reporting a skipped test so the report
+//! survives libtest's output capture.
+//!
+//! `eprintln!`/`println!` route through `std::io::_eprint`/`_print`, which
+//! libtest hooks to capture per-test output and replay it only for a
+//! *failing* test. A hardware- or CPU-feature-gated test that returns
+//! early after printing its reason with `eprintln!` therefore reports `ok`
+//! with the reason silently discarded -- indistinguishable from having
+//! actually exercised the code, both locally (`cargo test` without
+//! `--nocapture`) and in CI. Writing directly to `std::io::stderr()`
+//! bypasses that hook, so the `SKIPPED: ...` line survives capture in both
+//! directions; `scripts/on-target-test.sh` greps captured logs for the
+//! literal string `SKIPPED` to report a skip count per board.
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it.
+///
+/// `cfg(target_arch = "aarch64")`, not just `cfg(test)`: this crate's only
+/// call site today is `per_scale/kernels/neon_baseline.rs`, whose whole
+/// file is `#![cfg(target_arch = "aarch64")]` (NEON kernels have no other
+/// target). An unconditional `pub(crate) fn` here would be dead code on
+/// x86_64 and fail a `-D warnings` build there. Widen this if a
+/// non-aarch64 caller is ever added.
+#[cfg(all(test, target_arch = "aarch64"))]
+pub(crate) fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}

--- a/crates/decoder/src/test_support.rs
+++ b/crates/decoder/src/test_support.rs
@@ -20,11 +20,12 @@
 /// it.
 ///
 /// `cfg(target_arch = "aarch64")`, not just `cfg(test)`: this crate's only
-/// call site today is `per_scale/kernels/neon_baseline.rs`, whose whole
-/// file is `#![cfg(target_arch = "aarch64")]` (NEON kernels have no other
-/// target). An unconditional `pub(crate) fn` here would be dead code on
-/// x86_64 and fail a `-D warnings` build there. Widen this if a
-/// non-aarch64 caller is ever added.
+/// call site today is `per_scale/kernels/neon_baseline.rs`, whose module
+/// declaration in `per_scale/kernels/mod.rs` carries an outer
+/// `#[cfg(target_arch = "aarch64")]` (NEON kernels have no other target),
+/// so the file compiles only on aarch64. An unconditional `pub(crate) fn`
+/// here would be dead code on x86_64 and fail a `-D warnings` build there.
+/// Widen this if a non-aarch64 caller is ever added.
 #[cfg(all(test, target_arch = "aarch64"))]
 pub(crate) fn report_skip(reason: &str) {
     use std::io::Write;

--- a/crates/decoder/tests/infer_builder.rs
+++ b/crates/decoder/tests/infer_builder.rs
@@ -15,21 +15,35 @@ use edgefirst_decoder::schema::{DType, SchemaV2};
 use edgefirst_decoder::DecoderBuilder;
 use edgefirst_tensor::{Tensor, TensorDyn, TensorMapTrait, TensorMemory, TensorTrait};
 
-/// Loads a captured Task-0 fixture into `ModelSignals`, exactly as the
-/// inference runtime would report it: tensor names/shapes/dtypes plus the
-/// raw metadata map.
+/// Root of the `testdata/infer` fixture directory.
+///
+/// `EDGEFIRST_TESTDATA_DIR` wins when set -- `scripts/on-target-test.sh`
+/// and CI both mirror `crates/decoder/testdata/infer` into
+/// `$EDGEFIRST_TESTDATA_DIR/infer` (see `on-target-test.sh`'s testdata sync
+/// and `.github/workflows/test.yml`'s "Upload testdata as artifact" step).
+/// The manifest-relative fallback is baked in at **compile** time, so a
+/// cross-compiled binary carries the build host's absolute path and can
+/// never find fixtures on a different target -- same reasoning as
+/// `decoder_from_edgefirst_json.rs`'s `testdata_root()`.
 ///
 /// Copied from `infer.rs`'s unit-test module rather than shared: this is a
 /// separate integration-test crate, and reusing a `#[cfg(test)]`-only
 /// helper across crates would force a public (non-test) API just for test
 /// convenience.
+fn infer_fixture_dir() -> std::path::PathBuf {
+    std::env::var("EDGEFIRST_TESTDATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("testdata"))
+        .join("infer")
+}
+
+/// Loads a captured Task-0 fixture into `ModelSignals`, exactly as the
+/// inference runtime would report it: tensor names/shapes/dtypes plus the
+/// raw metadata map.
 fn signals_from_fixture(name: &str) -> ModelSignals {
-    let path = format!(
-        "{}/testdata/infer/{name}.signals.json",
-        env!("CARGO_MANIFEST_DIR")
-    );
+    let path = infer_fixture_dir().join(format!("{name}.signals.json"));
     let content = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"));
+        .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
     let json: serde_json::Value = serde_json::from_str(&content).expect("fixture is valid JSON");
 
     let source = match json["source"]

--- a/crates/decoder/tests/per_scale_parity.rs
+++ b/crates/decoder/tests/per_scale_parity.rs
@@ -682,9 +682,8 @@ fn parity_yolov8n_seg_per_scale_int8() {
         .join("per_scale")
         .join("yolov8n_seg_per_scale_int8.tflite");
     if !model.exists() {
-        eprintln!(
-            "skipping: real-model fixture not present at {model:?} — \
-                   contact validator team for the binary"
+        skip_note!(
+            "real-model fixture not present at {model:?} — contact validator team for the binary"
         );
         return;
     }

--- a/crates/image/src/g2d.rs
+++ b/crates/image/src/g2d.rs
@@ -1915,7 +1915,7 @@ mod g2d_tests {
     #[cfg(target_os = "linux")]
     fn d01_nv12_odd_w_g2d_vs_cpu() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: d01_nv12_odd_w_g2d_vs_cpu - DMA not available");
+            crate::test_support::report_skip("d01_nv12_odd_w_g2d_vs_cpu - DMA not available");
             return;
         }
         let (w, h) = (65usize, 64usize);
@@ -1974,7 +1974,9 @@ mod g2d_tests {
         let mut g2d = match G2DProcessor::new() {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: d01_nv12_odd_w_g2d_vs_cpu - G2D not available: {e}");
+                crate::test_support::report_skip(&format!(
+                    "d01_nv12_odd_w_g2d_vs_cpu - G2D not available: {e}"
+                ));
                 return;
             }
         };
@@ -2028,7 +2030,7 @@ mod g2d_tests {
     #[cfg(target_os = "linux")]
     fn d03_nv12_odd_both_g2d_vs_cpu() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: d03_nv12_odd_both_g2d_vs_cpu - DMA not available");
+            crate::test_support::report_skip("d03_nv12_odd_both_g2d_vs_cpu - DMA not available");
             return;
         }
         let (w, h) = (65usize, 63usize);
@@ -2087,7 +2089,9 @@ mod g2d_tests {
         let mut g2d = match G2DProcessor::new() {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: d03_nv12_odd_both_g2d_vs_cpu - G2D not available: {e}");
+                crate::test_support::report_skip(&format!(
+                    "d03_nv12_odd_both_g2d_vs_cpu - G2D not available: {e}"
+                ));
                 return;
             }
         };

--- a/crates/image/src/gl/cuda_policy.rs
+++ b/crates/image/src/gl/cuda_policy.rs
@@ -67,7 +67,7 @@ pub(crate) fn cuda_available_or_skip(what: &str) -> bool {
          list, or LD_LIBRARY_PATH does not reach the runtime)";
     let run = decide(edgefirst_tensor::is_cuda_available(), required(), what, why);
     if !run {
-        eprintln!("SKIP {what}: {why}");
+        crate::test_support::report_skip(&format!("{what}: {why}"));
     }
     run
 }
@@ -86,7 +86,7 @@ pub(crate) fn cuda_available_or_skip(what: &str) -> bool {
 pub(crate) fn require_or_skip(satisfied: bool, what: &str, why: &str) -> bool {
     let run = decide(satisfied, required(), what, why);
     if !run {
-        eprintln!("SKIP {what}: {why}");
+        crate::test_support::report_skip(&format!("{what}: {why}"));
     }
     run
 }

--- a/crates/image/src/gl/dma_import.rs
+++ b/crates/image/src/gl/dma_import.rs
@@ -496,7 +496,7 @@ mod tests {
     #[cfg(feature = "dma_test_formats")]
     fn from_tensor_source_view_imports_own_region_dst_imports_parent() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: from_tensor_source_view... - DMA not available");
+            crate::test_support::report_skip("from_tensor_source_view... - DMA not available");
             return;
         }
         // 64x64 RGBA with a padded 320-byte stride (tight row = 64*4 = 256).
@@ -510,7 +510,7 @@ mod tests {
         ) {
             Ok(t) => t,
             Err(_) => {
-                eprintln!("SKIPPED: image_with_stride DMA unavailable");
+                crate::test_support::report_skip("image_with_stride DMA unavailable");
                 return;
             }
         };
@@ -562,14 +562,18 @@ mod tests {
         let luma_buf = match alloc_dma(luma_bytes, "luma_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_true_multiplane_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_true_multiplane_attrs - DMA not available",
+                );
                 return;
             }
         };
         let chroma_buf = match alloc_dma(chroma_bytes, "chroma_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_true_multiplane_attrs - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_nv12_true_multiplane_attrs - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -625,7 +629,9 @@ mod tests {
         let buf = match alloc_dma(total_bytes, "shared_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_same_fd_multiplane_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_same_fd_multiplane_attrs - DMA not available",
+                );
                 return;
             }
         };
@@ -680,7 +686,9 @@ mod tests {
         let buf = match alloc_dma(total, "nv12_even_w") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_even_width_relaxed_gate - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_even_width_relaxed_gate - DMA not available",
+                );
                 return;
             }
         };
@@ -723,7 +731,9 @@ mod tests {
         let buf = match alloc_dma(total_bytes, "contiguous_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_contiguous_single_fd_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_contiguous_single_fd_attrs - DMA not available",
+                );
                 return;
             }
         };
@@ -772,7 +782,9 @@ mod tests {
         let buf = match alloc_dma(total_bytes, "padded_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_contiguous_padded_stride_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_contiguous_padded_stride_attrs - DMA not available",
+                );
                 return;
             }
         };
@@ -810,14 +822,16 @@ mod tests {
         let luma_buf = match alloc_dma(luma_bytes, "luma_padded") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_multiplane_padded_strides_attrs - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_multiplane_padded_strides_attrs - DMA not available",
+                );
                 return;
             }
         };
         let chroma_buf = match alloc_dma(chroma_bytes, "chroma_padded") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: DMA alloc failed");
+                crate::test_support::report_skip("DMA alloc failed");
                 return;
             }
         };
@@ -862,7 +876,9 @@ mod tests {
         let buf = match alloc_dma(total_bytes, "offset_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_same_fd_nonzero_luma_offset - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_same_fd_nonzero_luma_offset - DMA not available",
+                );
                 return;
             }
         };
@@ -908,7 +924,9 @@ mod tests {
         let y_buf = match alloc_dma(y_size, "y_only_buf") {
             Some(t) => t,
             None => {
-                eprintln!("SKIPPED: test_nv12_chroma_offset_exceeds_buffer - DMA not available");
+                crate::test_support::report_skip(
+                    "test_nv12_chroma_offset_exceeds_buffer - DMA not available",
+                );
                 return;
             }
         };
@@ -1228,7 +1246,9 @@ mod tests {
     #[test]
     fn test_from_tensor_accepts_non_4_aligned_rgba() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_from_tensor_accepts_non_4_aligned_rgba — DMA not available");
+            crate::test_support::report_skip(
+                "test_from_tensor_accepts_non_4_aligned_rgba — DMA not available",
+            );
             return;
         }
         use crate::{align_pitch_bytes_to_gpu_alignment, primary_plane_bpp};
@@ -1245,7 +1265,9 @@ mod tests {
             ) {
                 Ok(t) => t,
                 Err(e) => {
-                    eprintln!("SKIPPED: image_with_stride failed at width {w}: {e}");
+                    crate::test_support::report_skip(&format!(
+                        "image_with_stride failed at width {w}: {e}"
+                    ));
                     return;
                 }
             };
@@ -1267,7 +1289,9 @@ mod tests {
     #[test]
     fn test_from_tensor_accepts_non_4_aligned_bgra() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_from_tensor_accepts_non_4_aligned_bgra — DMA not available");
+            crate::test_support::report_skip(
+                "test_from_tensor_accepts_non_4_aligned_bgra — DMA not available",
+            );
             return;
         }
         use crate::{align_pitch_bytes_to_gpu_alignment, primary_plane_bpp};
@@ -1283,7 +1307,7 @@ mod tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: image_with_stride failed: {e}");
+                crate::test_support::report_skip(&format!("image_with_stride failed: {e}"));
                 return;
             }
         };

--- a/crates/image/src/gl/platform/macos.rs
+++ b/crates/image/src/gl/platform/macos.rs
@@ -304,9 +304,9 @@ mod tests {
             .iter()
             .any(|p| std::path::Path::new(p).exists());
         if !exists_at_any {
-            eprintln!(
-                "ANGLE not installed at any default path — skipping. \
-                 Run `brew install startergo/angle/angle` to enable this test."
+            crate::test_support::report_skip(
+                "ANGLE not installed at any default path — run `brew install \
+                 startergo/angle/angle` to enable this test",
             );
             return;
         }
@@ -317,9 +317,9 @@ mod tests {
         // check above is the portable smoke-test, and the integration
         // test exercises the real load path.
         if std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
-            eprintln!(
-                "HAL_TEST_ALLOW_DLOPEN_ANGLE unset — skipping ANGLE dlopen \
-                 probe (run via scripts/test-macos.sh to exercise it)."
+            crate::test_support::report_skip(
+                "HAL_TEST_ALLOW_DLOPEN_ANGLE unset — run via \
+                 scripts/test-macos.sh to exercise the ANGLE dlopen probe",
             );
             return;
         }

--- a/crates/image/src/gl/platform/windows.rs
+++ b/crates/image/src/gl/platform/windows.rs
@@ -1321,11 +1321,11 @@ mod tests {
         // other tests in this binary; see `lifecycle_guard`.
         let _lifecycle = super::super::super::threaded::lifecycle_guard();
         let Ok(keeper) = AngleD3d11::init_display(None) else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         let Ok(doomed) = AngleD3d11::init_display(None) else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         // `keeper` issues the last commands, so it is the context the
@@ -1357,7 +1357,7 @@ mod tests {
         // other tests in this binary; see `lifecycle_guard`.
         let _lifecycle = super::super::super::threaded::lifecycle_guard();
         let Ok(shared) = shared_display() else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         let dev = edgefirst_tensor::d3d11::device().expect("device");
@@ -1377,7 +1377,7 @@ mod tests {
         // other tests in this binary; see `lifecycle_guard`.
         let _lifecycle = super::super::super::threaded::lifecycle_guard();
         let Ok(display) = AngleD3d11::init_display(None) else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         let t = edgefirst_tensor::Tensor::<u8>::image(
@@ -1433,7 +1433,7 @@ mod tests {
         // other tests in this binary; see `lifecycle_guard`.
         let _lifecycle = super::super::super::threaded::lifecycle_guard();
         let Ok(display) = AngleD3d11::init_display(None) else {
-            eprintln!("SKIP: no ANGLE");
+            crate::test_support::report_skip("no ANGLE");
             return;
         };
         assert!(AngleD3d11::native_fence_sync(&display));

--- a/crates/image/src/gl/platform/windows.rs
+++ b/crates/image/src/gl/platform/windows.rs
@@ -1298,11 +1298,13 @@ mod tests {
     #[test]
     fn load_egl_lib_finds_angle_or_skips() {
         let Some(dir) = std::env::var_os("EDGEFIRST_ANGLE_PATH") else {
-            eprintln!("EDGEFIRST_ANGLE_PATH unset — skipping ANGLE load probe");
+            crate::test_support::report_skip("EDGEFIRST_ANGLE_PATH unset — no ANGLE load probe");
             return;
         };
         if !Path::new(&dir).join("libEGL.dll").is_file() {
-            eprintln!("no libEGL.dll under EDGEFIRST_ANGLE_PATH — skipping ANGLE load probe");
+            crate::test_support::report_skip(
+                "no libEGL.dll under EDGEFIRST_ANGLE_PATH — no ANGLE load probe",
+            );
             return;
         }
         WindowsPlatform::load_egl_lib()

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -22,7 +22,7 @@ mod gl_tests {
         use edgefirst_tensor::Segmentation;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -64,7 +64,7 @@ mod gl_tests {
         use edgefirst_tensor::Segmentation;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -107,7 +107,7 @@ mod gl_tests {
         use ndarray::Array3;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -190,7 +190,7 @@ mod gl_tests {
         use edgefirst_tensor::DetectBox;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -464,13 +464,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_pool_steady_state_zero_imports() {
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -558,13 +564,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn reimported_buffer_hits_the_cache() {
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -690,13 +702,16 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn convert_with_fence_blocking_fallback_matches() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - GL not available", function!());
+            crate::test_support::report_skip(&format!("{} - GL not available", function!()));
             return;
         }
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -760,13 +775,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn float_dma_src_import_matches_upload() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers or GL", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or GL",
+                function!()
+            ));
             return;
         }
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -856,13 +877,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn float_src_feed_alternating_frames() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers or GL", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or GL",
+                function!()
+            ));
             return;
         }
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -964,13 +991,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn float_dma_src_pool_steady_state() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers or GL", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or GL",
+                function!()
+            ));
             return;
         }
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -1062,13 +1095,19 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn repeat_convert_rgba_mem_to_rgb_dma() {
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -1105,7 +1144,9 @@ mod gl_tests {
             ) {
                 Ok(d) => d,
                 Err(e) => {
-                    eprintln!("SKIPPED cell {dtype:?}: DMA RGB dst unavailable: {e}");
+                    crate::test_support::report_skip(&format!(
+                        "cell {dtype:?}: DMA RGB dst unavailable: {e}"
+                    ));
                     continue;
                 }
             };
@@ -1160,13 +1201,16 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn int8_mem_convert_is_xor_biased_u8() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut renderer = match GLProcessorThreaded::new(None) {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -1209,7 +1253,9 @@ mod gl_tests {
                     if fmt == PixelFormat::Rgba {
                         panic!("nv12@mem -> rgba.{dtype:?}@mem must be supported: {e}");
                     }
-                    eprintln!("SKIPPED cell nv12@mem -> {fmt}.{dtype:?}@mem: {e}");
+                    crate::test_support::report_skip(&format!(
+                        "cell nv12@mem -> {fmt}.{dtype:?}@mem: {e}"
+                    ));
                     continue 'fmt;
                 }
                 out[slot] = match dtype {
@@ -1260,10 +1306,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn test_opengl_nv12_to_rgba_reference() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         // Load PixelFormat::Nv12 source with DMA
@@ -1337,10 +1383,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn test_opengl_yuyv_to_rgba_reference() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         // Load PixelFormat::Yuyv source with DMA
@@ -1424,10 +1470,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn opengl_render_into_dma_subviews_no_aliasing() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1636,10 +1682,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_grey_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1659,10 +1705,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_nv12_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1679,10 +1725,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_nv16_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1702,10 +1748,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_pool_recycle_all_frames_match_oracle() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -1806,10 +1852,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_geometry_change_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         // Oversized pool (like the profiler's pool_w x 3*max_h R8 surface),
@@ -1894,10 +1940,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_pool_geometry_interleaved_stale_read() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = [
@@ -1984,10 +2030,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_single_shot_grey_matches_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -2045,13 +2091,19 @@ mod gl_tests {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("SKIPPED: {} - EGL not available: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - EGL not available: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if displays.is_empty() {
-            eprintln!("SKIPPED: {} - No EGL displays available", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - No EGL displays available",
+                function!()
+            ));
             return;
         }
 
@@ -2088,13 +2140,19 @@ mod gl_tests {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("SKIPPED: {} - EGL not available: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - EGL not available: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if displays.is_empty() {
-            eprintln!("SKIPPED: {} - No EGL displays available", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - No EGL displays available",
+                function!()
+            ));
             return;
         }
 
@@ -2107,10 +2165,10 @@ mod gl_tests {
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} - GLProcessorThreaded failed: {e:?}",
+                crate::test_support::report_skip(&format!(
+                    "{} - GLProcessorThreaded failed: {e:?}",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -2157,13 +2215,19 @@ mod gl_tests {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("SKIPPED: {} - EGL not available: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - EGL not available: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if displays.is_empty() {
-            eprintln!("SKIPPED: {} - No EGL displays available", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - No EGL displays available",
+                function!()
+            ));
             return;
         }
 
@@ -2218,7 +2282,10 @@ mod gl_tests {
         let displays = match probe_egl_displays() {
             Ok(d) => d,
             Err(e) => {
-                eprintln!("SKIPPED: {} - EGL not available: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - EGL not available: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -2243,10 +2310,10 @@ mod gl_tests {
             );
             eprintln!("  Correctly returned error: {:?}", result.unwrap_err());
         } else {
-            eprintln!(
-                "SKIPPED: {} - All three display kinds are available",
+            crate::test_support::report_skip(&format!(
+                "{} - All three display kinds are available",
                 function!()
-            );
+            ));
         }
     }
 
@@ -2256,7 +2323,7 @@ mod gl_tests {
     #[cfg(target_os = "linux")] // Linux display probing
     fn test_auto_detect_display() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -2454,7 +2521,10 @@ mod gl_tests {
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -2583,7 +2653,9 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn test_opengl_nv12_to_bgra() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: test_opengl_nv12_to_bgra - no zero-copy GPU buffers or OpenGL");
+            crate::test_support::report_skip(
+                "test_opengl_nv12_to_bgra - no zero-copy GPU buffers or OpenGL",
+            );
             return;
         }
 
@@ -2670,7 +2742,9 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn test_opengl_yuyv_to_bgra() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!("SKIPPED: test_opengl_yuyv_to_bgra - no zero-copy GPU buffers or OpenGL");
+            crate::test_support::report_skip(
+                "test_opengl_yuyv_to_bgra - no zero-copy GPU buffers or OpenGL",
+            );
             return;
         }
 
@@ -2755,7 +2829,7 @@ mod gl_tests {
         use edgefirst_tensor::Segmentation;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_draw_decoded_masks_bgra - OpenGL not available");
+            crate::test_support::report_skip("test_draw_decoded_masks_bgra - OpenGL not available");
             return;
         }
 
@@ -2853,7 +2927,9 @@ mod gl_tests {
         use edgefirst_tensor::DetectBox;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_draw_decoded_masks_bgra_mem - OpenGL not available");
+            crate::test_support::report_skip(
+                "test_draw_decoded_masks_bgra_mem - OpenGL not available",
+            );
             return;
         }
 
@@ -2941,7 +3017,7 @@ mod gl_tests {
     #[test]
     fn test_gl_mask_render_smoke() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -2973,7 +3049,7 @@ mod gl_tests {
     #[cfg(any(target_os = "linux", target_os = "windows"))] // PBO destinations: Linux + Windows
     fn test_gl_pbo_destination_smoke() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -2987,7 +3063,10 @@ mod gl_tests {
             }
             Err(e) => {
                 // PBO may not be supported on all GL implementations
-                eprintln!("SKIPPED: {} - PBO not supported: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - PBO not supported: {e:?}",
+                    function!()
+                ));
             }
         }
     }
@@ -3007,7 +3086,7 @@ mod gl_tests {
     #[cfg(any(target_os = "linux", target_os = "windows"))] // PBO destinations: Linux + Windows
     fn test_gl_convert_any_to_pbo_no_deadlock() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -3015,7 +3094,10 @@ mod gl_tests {
         let pbo_dst = match gl.create_pbo_image(64, 64, PixelFormat::Rgba) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} - PBO not supported: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - PBO not supported: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3065,7 +3147,10 @@ mod gl_tests {
                     !msg.contains("GL converter thread exited"),
                     "PBO destination convert deadlocked: {msg}"
                 );
-                eprintln!("SKIPPED: {} - convert failed unrelated: {msg}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - convert failed unrelated: {msg}",
+                    function!()
+                ));
             }
         }
     }
@@ -3077,7 +3162,7 @@ mod gl_tests {
     #[cfg(any(target_os = "linux", target_os = "windows"))] // PBO destinations: Linux + Windows
     fn test_gl_convert_pbo_to_pbo_no_deadlock() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -3085,14 +3170,20 @@ mod gl_tests {
         let pbo_src = match gl.create_pbo_image(64, 64, PixelFormat::Rgba) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} - PBO not supported: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - PBO not supported: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
         let pbo_dst = match gl.create_pbo_image(64, 64, PixelFormat::Rgba) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} - PBO dst not supported: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - PBO dst not supported: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3115,7 +3206,10 @@ mod gl_tests {
                     !msg.contains("GL converter thread exited"),
                     "PBO→PBO convert deadlocked: {msg}"
                 );
-                eprintln!("SKIPPED: {} - convert failed unrelated: {msg}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - convert failed unrelated: {msg}",
+                    function!()
+                ));
             }
         }
     }
@@ -3153,7 +3247,7 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_multiplane_nv12_to_rgba_opengl() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -3249,11 +3343,11 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -3275,7 +3369,7 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: {} - DMA alloc failed", function!());
+                crate::test_support::report_skip(&format!("{} - DMA alloc failed", function!()));
                 return;
             }
         };
@@ -3375,7 +3469,7 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_multiplane_nv12_to_rgb_letterbox_opengl() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -3452,7 +3546,7 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_multiplane_nv12_to_rgb_int8_letterbox_opengl() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -3555,7 +3649,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut proc = match ImageProcessor::with_config(ImageProcessorConfig {
@@ -3564,7 +3658,10 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3674,7 +3771,7 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn letterbox_nv12_to_planar_matches_rgba_reference() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -3758,7 +3855,7 @@ mod gl_tests {
     #[test]
     fn gl_planar_heap_matches_cpu() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (sw, sh) = (1280usize, 720usize);
@@ -3770,7 +3867,10 @@ mod gl_tests {
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3818,15 +3918,15 @@ mod gl_tests {
         use crate::ImageProcessor;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut proc = ImageProcessor::new().unwrap();
         if proc.opengl.is_none() {
-            eprintln!(
-                "SKIPPED: {} - ImageProcessor resolved no GL backend",
+            crate::test_support::report_skip(&format!(
+                "{} - ImageProcessor resolved no GL backend",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -3870,7 +3970,7 @@ mod gl_tests {
     #[test]
     fn gl_planar_heap_rgba_src_matches_cpu() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let src = crate::load_image_test_helper(
@@ -3886,7 +3986,10 @@ mod gl_tests {
         let mut gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3925,15 +4028,15 @@ mod gl_tests {
         use crate::ImageProcessor;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut proc = ImageProcessor::new().unwrap();
         if proc.opengl.is_none() {
-            eprintln!(
-                "SKIPPED: {} - ImageProcessor resolved no GL backend",
+            crate::test_support::report_skip(&format!(
+                "{} - ImageProcessor resolved no GL backend",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -3978,7 +4081,7 @@ mod gl_tests {
     #[test]
     fn test_proto_fused_vs_hybrid_ssim() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4285,7 +4388,7 @@ mod gl_tests {
     #[test]
     fn proto_float_dtypes_match_int8_reference() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4308,7 +4411,7 @@ mod gl_tests {
     #[test]
     fn proto_f32_no_float_linear_fallback_matches() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4336,7 +4439,7 @@ mod gl_tests {
     #[test]
     fn proto_compute_repack_matches_cpu_repack() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4367,7 +4470,7 @@ mod gl_tests {
         use crate::Int8InterpolationMode;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4410,7 +4513,7 @@ mod gl_tests {
     #[test]
     fn proto_dims_and_format_churn_uploads_correctly() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (boxes, proto_i8) = decode_yolov8_proto_fixture();
@@ -4470,11 +4573,11 @@ mod gl_tests {
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn test_opengl_dst_offset_zero_regression() {
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4545,11 +4648,11 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4627,11 +4730,11 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4717,11 +4820,11 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -4812,18 +4915,18 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !is_neutron_available() {
-            eprintln!(
-                "SKIPPED: {} - Neutron not available (/dev/neutron0 not found)",
+            crate::test_support::report_skip(&format!(
+                "{} - Neutron not available (/dev/neutron0 not found)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -4834,11 +4937,11 @@ mod gl_tests {
         let large_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!(
-                    "SKIPPED: {} - cannot allocate {} MB DMA buffer",
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate {} MB DMA buffer",
                     function!(),
                     total_size / 1_048_576
-                );
+                ));
                 return;
             }
         };
@@ -4891,18 +4994,18 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !is_neutron_available() {
-            eprintln!(
-                "SKIPPED: {} - Neutron not available (/dev/neutron0 not found)",
+            crate::test_support::report_skip(&format!(
+                "{} - Neutron not available (/dev/neutron0 not found)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -4922,7 +5025,10 @@ mod gl_tests {
         let rgba_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!("SKIPPED: {} - cannot allocate DMA buffer", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate DMA buffer",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4953,10 +5059,10 @@ mod gl_tests {
         let rgb_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!(
-                    "SKIPPED: {} - cannot allocate second DMA buffer",
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate second DMA buffer",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -4992,18 +5098,18 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !is_neutron_available() {
-            eprintln!(
-                "SKIPPED: {} - Neutron not available (/dev/neutron0 not found)",
+            crate::test_support::report_skip(&format!(
+                "{} - Neutron not available (/dev/neutron0 not found)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -5026,7 +5132,10 @@ mod gl_tests {
         let u8_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!("SKIPPED: {} - cannot allocate DMA buffer", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate DMA buffer",
+                    function!()
+                ));
                 return;
             }
         };
@@ -5055,10 +5164,10 @@ mod gl_tests {
         let i8_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!(
-                    "SKIPPED: {} - cannot allocate second DMA buffer",
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate second DMA buffer",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -5094,18 +5203,18 @@ mod gl_tests {
         use std::os::fd::AsFd;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !is_neutron_available() {
-            eprintln!(
-                "SKIPPED: {} - Neutron not available (/dev/neutron0 not found)",
+            crate::test_support::report_skip(&format!(
+                "{} - Neutron not available (/dev/neutron0 not found)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -5129,7 +5238,10 @@ mod gl_tests {
         let aligned_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!("SKIPPED: {} - cannot allocate DMA buffer", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate DMA buffer",
+                    function!()
+                ));
                 return;
             }
         };
@@ -5162,10 +5274,10 @@ mod gl_tests {
         {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!(
-                    "SKIPPED: {} - cannot allocate second DMA buffer",
+                crate::test_support::report_skip(&format!(
+                    "{} - cannot allocate second DMA buffer",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -5208,7 +5320,9 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_import_image_rgba_with_stride - DMA not available");
+            crate::test_support::report_skip(
+                "test_import_image_rgba_with_stride - DMA not available",
+            );
             return;
         }
 
@@ -5226,7 +5340,9 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: test_import_image_rgba_with_stride - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_import_image_rgba_with_stride - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -5262,7 +5378,9 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_import_image_rgba_padded_stride - DMA not available");
+            crate::test_support::report_skip(
+                "test_import_image_rgba_padded_stride - DMA not available",
+            );
             return;
         }
 
@@ -5285,7 +5403,9 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: test_import_image_rgba_padded_stride - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_import_image_rgba_padded_stride - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -5322,7 +5442,9 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_import_image_nv12_with_offset - DMA not available");
+            crate::test_support::report_skip(
+                "test_import_image_nv12_with_offset - DMA not available",
+            );
             return;
         }
 
@@ -5343,7 +5465,9 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: test_import_image_nv12_with_offset - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_import_image_nv12_with_offset - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -5386,11 +5510,11 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5414,7 +5538,10 @@ mod gl_tests {
         let luma_buf = match luma_buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: {} - luma DMA alloc failed", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - luma DMA alloc failed",
+                    function!()
+                ));
                 return;
             }
         };
@@ -5428,7 +5555,10 @@ mod gl_tests {
         let chroma_buf = match chroma_buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: {} - chroma DMA alloc failed", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - chroma DMA alloc failed",
+                    function!()
+                ));
                 return;
             }
         };
@@ -5519,11 +5649,11 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5542,7 +5672,7 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: {} - DMA alloc failed", function!());
+                crate::test_support::report_skip(&format!("{} - DMA alloc failed", function!()));
                 return;
             }
         };
@@ -5633,7 +5763,9 @@ mod gl_tests {
         use edgefirst_tensor::PlaneDescriptor;
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_import_image_stride_too_small - DMA not available");
+            crate::test_support::report_skip(
+                "test_import_image_stride_too_small - DMA not available",
+            );
             return;
         }
 
@@ -5650,7 +5782,9 @@ mod gl_tests {
         let buf = match buf {
             Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
             _ => {
-                eprintln!("SKIPPED: test_import_image_stride_too_small - DMA alloc failed");
+                crate::test_support::report_skip(
+                    "test_import_image_stride_too_small - DMA alloc failed",
+                );
                 return;
             }
         };
@@ -5724,7 +5858,9 @@ mod gl_tests {
     #[test]
     fn test_src_rect_crop_no_bleed_gl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_src_rect_crop_no_bleed_gl - OpenGL not available");
+            crate::test_support::report_skip(
+                "test_src_rect_crop_no_bleed_gl - OpenGL not available",
+            );
             return;
         }
 
@@ -5759,7 +5895,7 @@ mod gl_tests {
             // logic is still covered on RGBA-capable drivers (e.g. Mesa); Vivante
             // RGB-source support is tracked for separate investigation.
             if e.to_string().contains("RGB source") {
-                eprintln!("SKIPPED: {} - {e}", function!());
+                crate::test_support::report_skip(&format!("{} - {e}", function!()));
                 return;
             }
             panic!("{e}");
@@ -5794,7 +5930,9 @@ mod gl_tests {
     #[test]
     fn test_src_rect_boundary_crop_no_bleed_gl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_src_rect_boundary_crop_no_bleed_gl - OpenGL not available");
+            crate::test_support::report_skip(
+                "test_src_rect_boundary_crop_no_bleed_gl - OpenGL not available",
+            );
             return;
         }
 
@@ -5826,7 +5964,7 @@ mod gl_tests {
             // logic is still covered on RGBA-capable drivers (e.g. Mesa); Vivante
             // RGB-source support is tracked for separate investigation.
             if e.to_string().contains("RGB source") {
-                eprintln!("SKIPPED: {} - {e}", function!());
+                crate::test_support::report_skip(&format!("{} - {e}", function!()));
                 return;
             }
             panic!("{e}");
@@ -5850,7 +5988,9 @@ mod gl_tests {
     #[test]
     fn test_src_rect_crop_left_half_no_bleed_gl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: test_src_rect_crop_left_half_no_bleed_gl - OpenGL not available");
+            crate::test_support::report_skip(
+                "test_src_rect_crop_left_half_no_bleed_gl - OpenGL not available",
+            );
             return;
         }
 
@@ -5880,7 +6020,7 @@ mod gl_tests {
             // logic is still covered on RGBA-capable drivers (e.g. Mesa); Vivante
             // RGB-source support is tracked for separate investigation.
             if e.to_string().contains("RGB source") {
-                eprintln!("SKIPPED: {} - {e}", function!());
+                crate::test_support::report_skip(&format!("{} - {e}", function!()));
                 return;
             }
             panic!("{e}");
@@ -6176,7 +6316,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let mut proc = match ImageProcessor::with_config(ImageProcessorConfig {
@@ -6185,7 +6325,10 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -6202,10 +6345,10 @@ mod gl_tests {
             )
             .unwrap();
         if probe.memory() != TensorMemory::Pbo {
-            eprintln!(
-                "SKIPPED: {} - target does not allocate PBO images",
+            crate::test_support::report_skip(&format!(
+                "{} - target does not allocate PBO images",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -6295,7 +6438,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6307,13 +6450,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f32 {
-            eprintln!("SKIPPED: {} - F32 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F32 render not supported",
+                function!()
+            ));
             return;
         }
 
@@ -6332,7 +6481,10 @@ mod gl_tests {
             )
             .unwrap();
         if src.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - RGBA8 src not PBO-backed", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - RGBA8 src not PBO-backed",
+                function!()
+            ));
             return;
         }
         {
@@ -6360,7 +6512,7 @@ mod gl_tests {
             )
             .unwrap();
         if dst.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - F32 dst not PBO-backed", function!());
+            crate::test_support::report_skip(&format!("{} - F32 dst not PBO-backed", function!()));
             return;
         }
 
@@ -6411,7 +6563,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6421,13 +6573,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f32 {
-            eprintln!("SKIPPED: {} - F32 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F32 render not supported",
+                function!()
+            ));
             return;
         }
 
@@ -6448,7 +6606,10 @@ mod gl_tests {
             )
             .unwrap();
         if src.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - RGBA8 src not PBO-backed", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - RGBA8 src not PBO-backed",
+                function!()
+            ));
             return;
         }
         {
@@ -6476,7 +6637,7 @@ mod gl_tests {
             )
             .unwrap();
         if dst.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - F32 dst not PBO-backed", function!());
+            crate::test_support::report_skip(&format!("{} - F32 dst not PBO-backed", function!()));
             return;
         }
 
@@ -6522,7 +6683,7 @@ mod gl_tests {
         use half::f16;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6532,13 +6693,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f16 {
-            eprintln!("SKIPPED: {} - F16 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F16 render not supported",
+                function!()
+            ));
             return;
         }
 
@@ -6556,7 +6723,10 @@ mod gl_tests {
             )
             .unwrap();
         if src.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - RGBA8 src not PBO-backed", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - RGBA8 src not PBO-backed",
+                function!()
+            ));
             return;
         }
         {
@@ -6584,7 +6754,7 @@ mod gl_tests {
             )
             .unwrap();
         if dst.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - F16 dst not PBO-backed", function!());
+            crate::test_support::report_skip(&format!("{} - F16 dst not PBO-backed", function!()));
             return;
         }
 
@@ -6639,7 +6809,7 @@ mod gl_tests {
         use half::f16;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6652,16 +6822,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f16 {
-            eprintln!(
-                "SKIPPED: {} - F16 render not supported (Vivante?)",
+            crate::test_support::report_skip(&format!(
+                "{} - F16 render not supported (Vivante?)",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -6709,10 +6882,10 @@ mod gl_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} - F16 DMA tensor alloc failed (no dma-heap?): {e}",
+                crate::test_support::report_skip(&format!(
+                    "{} - F16 DMA tensor alloc failed (no dma-heap?): {e}",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -6720,11 +6893,11 @@ mod gl_tests {
         // Confirm the tensor is genuinely DMA-backed — skip if the allocator
         // fell back to a different memory type.
         if dst.memory() != TensorMemory::DmaBuf {
-            eprintln!(
-                "SKIPPED: {} - F16 dst memory is {:?}, not Dma; DMA path not exercised",
+            crate::test_support::report_skip(&format!(
+                "{} - F16 dst memory is {:?}, not Dma; DMA path not exercised",
                 function!(),
                 dst.memory()
-            );
+            ));
             return;
         }
 
@@ -6779,7 +6952,7 @@ mod gl_tests {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6789,13 +6962,19 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
 
         if !proc.supported_render_dtypes().f32 {
-            eprintln!("SKIPPED: {} - F32 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F32 render not supported",
+                function!()
+            ));
             return;
         }
 
@@ -6816,7 +6995,10 @@ mod gl_tests {
             )
             .unwrap();
         if src.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - RGBA8 src not PBO-backed", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - RGBA8 src not PBO-backed",
+                function!()
+            ));
             return;
         }
         {
@@ -6841,7 +7023,7 @@ mod gl_tests {
             )
             .unwrap();
         if dst.memory() != TensorMemory::Pbo {
-            eprintln!("SKIPPED: {} - F32 dst not PBO-backed", function!());
+            crate::test_support::report_skip(&format!("{} - F32 dst not PBO-backed", function!()));
             return;
         }
 
@@ -7371,7 +7553,10 @@ mod gl_tests {
     fn test_gpu_nv16_to_rgba_path_b() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
 
@@ -7409,7 +7594,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -7495,13 +7683,16 @@ mod gl_tests {
         use edgefirst_tensor::{ColorEncoding, ColorRange, Colorimetry};
 
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -7631,7 +7822,7 @@ mod gl_tests {
     fn test_nv12_path_env_override() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize); // width % 4 == 0 so the sampler import is accepted
@@ -7652,7 +7843,10 @@ mod gl_tests {
             let mut gl = match gl {
                 Ok(g) => g,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                    crate::test_support::report_skip(&format!(
+                        "{} - GL not available: {e}",
+                        function!()
+                    ));
                     return None;
                 }
             };
@@ -7722,7 +7916,7 @@ mod gl_tests {
     fn test_nv12_nondma_upload_uses_shader() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -7738,7 +7932,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -7807,7 +8004,7 @@ mod gl_tests {
     fn test_nv12_to_planar_rgb_uses_shader_path() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -7836,7 +8033,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -7898,14 +8098,17 @@ mod gl_tests {
     fn test_nv16_nv24_nondma_upload_uses_shader() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize);
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -7989,7 +8192,7 @@ mod gl_tests {
     fn probe_nv12_sampler_vs_shader_divergence() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (64usize, 64usize); // width % 4 == 0 for the sampler import
@@ -8018,7 +8221,10 @@ mod gl_tests {
             let mut gl = match gl {
                 Ok(g) => g,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                    crate::test_support::report_skip(&format!(
+                        "{} - GL not available: {e}",
+                        function!()
+                    ));
                     return None;
                 }
             };
@@ -8119,7 +8325,7 @@ mod gl_tests {
         use crate::opengl_headless::processor::GLProcessorST;
         use crate::{Fit, Region};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         // 16:9 source so fitting into a square model produces top/bottom bars.
@@ -8165,7 +8371,7 @@ mod gl_tests {
             let mut g = match g {
                 Ok(x) => x,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - GL: {e}", function!());
+                    crate::test_support::report_skip(&format!("{} - GL: {e}", function!()));
                     return None;
                 }
             };
@@ -8289,7 +8495,10 @@ mod gl_tests {
     fn test_gpu_nv24_to_rgba_path_b() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
 
@@ -8326,7 +8535,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8369,7 +8581,10 @@ mod gl_tests {
     fn test_gpu_nv16_matches_cpu_reference() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
 
@@ -8426,7 +8641,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8467,7 +8685,10 @@ mod gl_tests {
     fn test_gpu_nv24_matches_cpu_reference() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
 
@@ -8524,7 +8745,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8566,7 +8790,7 @@ mod gl_tests {
     fn test_nv12_dma_gpu_path_no_cpu_fallback() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -8590,7 +8814,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8620,7 +8847,7 @@ mod gl_tests {
     fn test_gpu_nv16_path_b_int8_output() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
 
@@ -8685,7 +8912,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8917,7 +9147,10 @@ mod gl_tests {
     fn g03_nv16_odd_w_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -8954,7 +9187,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8992,7 +9228,10 @@ mod gl_tests {
     fn g04_nv24_odd_w_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -9029,7 +9268,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9071,7 +9313,10 @@ mod gl_tests {
     fn g05_nv16_odd_both_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 241usize); // QVGA-scale odd both (Mali rejects sub-minimum textures)
@@ -9108,7 +9353,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9150,7 +9398,10 @@ mod gl_tests {
     fn g06_nv24_odd_both_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 241usize); // QVGA-scale odd both (Mali rejects sub-minimum textures)
@@ -9187,7 +9438,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9237,7 +9491,7 @@ mod gl_tests {
     fn g09_odd_dst_unaligned_stride_guarded() {
         use crate::opengl_headless::processor::GLProcessorST;
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (321usize, 240usize);
@@ -9264,7 +9518,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9303,7 +9560,10 @@ mod gl_tests {
     fn g01_nv12_odd_w_path_b_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -9340,7 +9600,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9389,7 +9652,10 @@ mod gl_tests {
     fn g02_nv12_odd_h_path_b_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         // Even width, odd height — exercises odd-H chroma row boundary.
@@ -9427,7 +9693,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9489,7 +9758,10 @@ mod gl_tests {
         use crate::opengl_headless::processor::GLProcessorST;
         use edgefirst_codec::{ImageDecoder, ImageLoad};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let jpeg: &[u8] = &edgefirst_bench::testdata::read("coco_grey_odd.jpg");
@@ -9511,7 +9783,10 @@ mod gl_tests {
                 TensorDyn::from(t)
             }
             Err(e) => {
-                eprintln!("SKIPPED: {} - DMA Grey alloc failed: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - DMA Grey alloc failed: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9562,7 +9837,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9608,7 +9886,7 @@ mod gl_tests {
     fn g07_nv12_odd_w_i8_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (321usize, 240usize); // QVGA-scale odd width (Mali rejects sub-minimum textures)
@@ -9647,7 +9925,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9697,7 +9978,7 @@ mod gl_tests {
     fn g08_nv16_odd_both_i8_vs_cpu() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_dma_available() {
-            eprintln!("SKIPPED: {} - DMA not available", function!());
+            crate::test_support::report_skip(&format!("{} - DMA not available", function!()));
             return;
         }
         let (w, h) = (321usize, 241usize); // QVGA-scale odd both (Mali rejects sub-minimum textures)
@@ -9736,7 +10017,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9778,7 +10062,10 @@ mod gl_tests {
     fn g_even_nv16_64x64_regression() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -9815,7 +10102,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9847,7 +10137,10 @@ mod gl_tests {
     fn g_even_nv24_64x64_regression() {
         use crate::opengl_headless::processor::{GLProcessorST, NvConvertPath};
         if !is_gpu_image_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (64usize, 64usize);
@@ -9884,7 +10177,10 @@ mod gl_tests {
         let mut gl = match GLProcessorST::new(None, None) {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("SKIPPED: {} - GL not available: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - GL not available: {e}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9997,10 +10293,10 @@ mod gl_tests {
     #[test]
     fn recycled_narrowed_destination_matches_a_fresh_one() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let src = match crate::load_image_test_helper(
@@ -10010,7 +10306,10 @@ mod gl_tests {
         ) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("SKIPPED: {} - source decode failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - source decode failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -10026,10 +10325,10 @@ mod gl_tests {
             )
         };
         let Ok(mut pool) = rgba_dst(256, 192) else {
-            eprintln!(
-                "SKIPPED: {} - texture destination alloc failed",
+            crate::test_support::report_skip(&format!(
+                "{} - texture destination alloc failed",
                 function!()
-            );
+            ));
             return;
         };
         // Seed the whole texture, so anything the narrowed convert fails to
@@ -10188,10 +10487,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_source_resized_matches_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = seeded_grey_pool();
@@ -10239,10 +10538,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_source_upscaled_edges_match_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = seeded_grey_pool();
@@ -10294,10 +10593,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_source_cropped_and_rotated_edges_match_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = seeded_grey_pool();
@@ -10356,10 +10655,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_yuyv_source_matches_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         let mut pool = TensorDyn::image(
@@ -10452,10 +10751,10 @@ mod gl_tests {
     #[cfg(feature = "dma_test_formats")]
     fn dma_recycle_narrowed_source_into_float_dst_matches_fresh() {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy GPU buffers or OpenGL",
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers or OpenGL",
                 function!()
-            );
+            ));
             return;
         }
         // Force the GL backend so a declined float path is a hard error rather
@@ -10466,12 +10765,18 @@ mod gl_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} - OpenGL backend unavailable: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL backend unavailable: {e}",
+                    function!()
+                ));
                 return;
             }
         };
         if !proc.supported_render_dtypes().f32 {
-            eprintln!("SKIPPED: {} - F32 render not supported", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - F32 render not supported",
+                function!()
+            ));
             return;
         }
         let mut pool = TensorDyn::image(
@@ -10505,7 +10810,10 @@ mod gl_tests {
                     .create_pbo_image_dtype(dw, dh, PixelFormat::Rgb, DType::F32)
             };
             let Ok(mut recycled) = float_dst(&proc) else {
-                eprintln!("SKIPPED: {} - no F32 PBO destination", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - no F32 PBO destination",
+                    function!()
+                ));
                 return;
             };
             proc.convert(
@@ -10572,17 +10880,17 @@ mod gl_tests {
                 )
             };
             let (Ok(mut zc_recycled), Ok(mut zc_oracle)) = (planar_dst(), planar_dst()) else {
-                eprintln!(
-                    "SKIPPED (zero-copy float dst): {} - no F32 PlanarRgb texture",
+                crate::test_support::report_skip(&format!(
+                    "(zero-copy float dst): {} - no F32 PlanarRgb texture",
                     function!()
-                );
+                ));
                 continue;
             };
             if zc_recycled.memory() != TensorMemory::DmaBuf {
-                eprintln!(
-                    "SKIPPED (zero-copy float dst): {} - F32 PlanarRgb dst is not zero-copy",
+                crate::test_support::report_skip(&format!(
+                    "(zero-copy float dst): {} - F32 PlanarRgb dst is not zero-copy",
                     function!()
-                );
+                ));
                 continue;
             }
             // Both sides are read through `copy_to_flat`: a Windows texture
@@ -10655,16 +10963,16 @@ mod gl_tests {
         const TOLERANCE: u8 = 8;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
         #[cfg(target_os = "macos")]
         if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
-            eprintln!(
-                "SKIPPED: {} - ANGLE dlopen gate closed (coverage pass 1)",
+            crate::test_support::report_skip(&format!(
+                "{} - ANGLE dlopen gate closed (coverage pass 1)",
                 function!()
-            );
+            ));
             return;
         }
         // Two rows taller than the logical frame, so a window starting a row
@@ -10693,10 +11001,10 @@ mod gl_tests {
                     "HAL_TEST_REQUIRE_GL=1 and this host reports a zero-copy \
                      buffer backing, but the NV12 zero-copy allocation {what}"
                 );
-                eprintln!(
-                    "SKIPPED: {} - no zero-copy NV12 image here ({what})",
+                crate::test_support::report_skip(&format!(
+                    "{} - no zero-copy NV12 image here ({what})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -10869,16 +11177,16 @@ mod gl_tests {
         const BLANK: u8 = 0x55;
 
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
         #[cfg(target_os = "macos")]
         if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
-            eprintln!(
-                "SKIPPED: {} - ANGLE dlopen gate closed (coverage pass 1)",
+            crate::test_support::report_skip(&format!(
+                "{} - ANGLE dlopen gate closed (coverage pass 1)",
                 function!()
-            );
+            ));
             return;
         }
         let dma_rgba = |w: usize, h: usize| {
@@ -10903,10 +11211,10 @@ mod gl_tests {
                     "HAL_TEST_REQUIRE_GL=1 and this host reports a zero-copy buffer \
                      backing, but the RGBA zero-copy allocation {what}"
                 );
-                eprintln!(
-                    "SKIPPED: {} - no zero-copy RGBA image here ({what})",
+                crate::test_support::report_skip(&format!(
+                    "{} - no zero-copy RGBA image here ({what})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -10969,12 +11277,12 @@ mod gl_tests {
         // cannot run the subject. This desktop is one: its EGL cannot import a
         // DMA-BUF, so the backend falls back to PBO.
         if control == 0 {
-            eprintln!(
-                "SKIPPED: {} - no zero-copy destination import on this host, so a \
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy destination import on this host, so a \
                  view() destination is declined by the engine and there is nothing \
                  to measure",
                 function!()
-            );
+            ));
             log::info!(
                 "{}: pitch {pitch} offset {offset} -> control_dst_imports=0, skipped",
                 function!()

--- a/crates/image/src/gl/threaded.rs
+++ b/crates/image/src/gl/threaded.rs
@@ -1485,20 +1485,20 @@ mod tests {
         let gl = match GLProcessorThreaded::new(None) {
             Ok(gl) => gl,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: concurrent_maps_from_two_independent_handles... - \
+                crate::test_support::report_skip(&format!(
+                    "concurrent_maps_from_two_independent_handles... - \
                      OpenGL not available: {e:?}"
-                );
+                ));
                 return;
             }
         };
         let tensor_a = match gl.create_pbo_image(64, 64, PixelFormat::Rgba) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: concurrent_maps_from_two_independent_handles... - \
+                crate::test_support::report_skip(&format!(
+                    "concurrent_maps_from_two_independent_handles... - \
                      PBO not supported: {e:?}"
-                );
+                ));
                 return;
             }
         };

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -410,6 +410,8 @@ mod error;
 mod g2d;
 #[path = "gl/mod.rs"]
 mod opengl_headless;
+#[cfg(test)]
+mod test_support;
 mod tiling;
 pub use tiling::{tile_grid, TilePlacement, TileSpec, TilingConfig};
 
@@ -3771,10 +3773,10 @@ mod image_tests {
         let mut proc = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — ImageProcessor init failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} — ImageProcessor init failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -3797,10 +3799,10 @@ mod image_tests {
         ) {
             Ok(d) => d,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — tall DMA destination alloc failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} — tall DMA destination alloc failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -3894,7 +3896,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -3976,7 +3981,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4044,10 +4052,10 @@ mod image_tests {
         let mut proc = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — ImageProcessor init failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} — ImageProcessor init failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -4066,10 +4074,10 @@ mod image_tests {
         ) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — tall DMA parent alloc failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} — tall DMA parent alloc failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -4125,7 +4133,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4158,7 +4169,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4184,7 +4198,10 @@ mod image_tests {
         }) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — CPU init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — CPU init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -4707,7 +4724,9 @@ mod image_tests {
             }
             Err(e) => {
                 // Skip cleanly on hosts without a dma-heap.
-                eprintln!("SKIPPED: create_image NV12 DMA non-aligned width: {e}");
+                crate::test_support::report_skip(&format!(
+                    "create_image NV12 DMA non-aligned width: {e}"
+                ));
             }
         }
     }
@@ -4825,18 +4844,18 @@ mod image_tests {
     fn gl_backend_available_canary() {
         let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
         if !require_gl {
-            eprintln!(
-                "SKIPPED: {} — HAL_TEST_REQUIRE_GL is not set to 1",
+            crate::test_support::report_skip(&format!(
+                "{} — HAL_TEST_REQUIRE_GL is not set to 1",
                 function!()
-            );
+            ));
             return;
         }
         #[cfg(target_os = "macos")]
         if std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
-            eprintln!(
-                "SKIPPED: {} — ANGLE dlopen gate closed (coverage pass 1)",
+            crate::test_support::report_skip(&format!(
+                "{} — ANGLE dlopen gate closed (coverage pass 1)",
                 function!()
-            );
+            ));
             return;
         }
         GLProcessorThreaded::new(None).expect(
@@ -5032,8 +5051,8 @@ mod image_tests {
     fn test_convert_rgba_non_4_aligned_width_end_to_end() {
         use edgefirst_tensor::is_dma_available;
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_convert_rgba_non_4_aligned_width_end_to_end — DMA not available"
+            crate::test_support::report_skip(
+                "test_convert_rgba_non_4_aligned_width_end_to_end — DMA not available",
             );
             return;
         }
@@ -5117,8 +5136,8 @@ mod image_tests {
     fn test_load_jpeg_rgba_non_aligned_pitch_padded_dma() {
         use edgefirst_tensor::is_dma_available;
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_load_jpeg_rgba_non_aligned_pitch_padded_dma — DMA not available"
+            crate::test_support::report_skip(
+                "test_load_jpeg_rgba_non_aligned_pitch_padded_dma — DMA not available",
             );
             return;
         }
@@ -5242,7 +5261,9 @@ mod image_tests {
     fn test_load_png_grey_misaligned_width_dma() {
         use edgefirst_tensor::is_dma_available;
         if !is_dma_available() {
-            eprintln!("SKIPPED: test_load_png_grey_misaligned_width_dma — DMA not available");
+            crate::test_support::report_skip(
+                "test_load_png_grey_misaligned_width_dma — DMA not available",
+            );
             return;
         }
         let png = make_grey_png(612, 388);
@@ -5323,13 +5344,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_resize() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_resize - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_resize - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_resize - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_resize - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -5402,7 +5423,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_resize() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5470,7 +5491,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_10_threads() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5500,7 +5521,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_grey() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5560,13 +5581,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_src_crop() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_src_crop - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_src_crop - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_src_crop - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_src_crop - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -5628,13 +5649,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_dst_crop() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_dst_crop - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_dst_crop - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_dst_crop - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_dst_crop - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -5696,13 +5717,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_all_rgba() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_all_rgba - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_all_rgba - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_all_rgba - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_all_rgba - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -5797,7 +5818,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_src_crop() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -5861,7 +5882,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_dst_crop() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -6059,7 +6080,7 @@ mod image_tests {
     #[cfg(all(target_os = "windows", feature = "opengl"))]
     fn windows_padded_float_pbo_rows_land_at_the_declared_stride() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         const W: usize = 64;
@@ -6090,18 +6111,24 @@ mod image_tests {
 
         for (fmt, dtype, supported, strides) in cases {
             if !supported {
-                eprintln!("SKIPPED: {} - {fmt:?}/{dtype:?} not reported", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - {fmt:?}/{dtype:?} not reported",
+                    function!()
+                ));
                 continue;
             }
             let Some(gl) = gpu.opengl.as_ref() else {
-                eprintln!("SKIPPED: {} - no GL processor", function!());
+                crate::test_support::report_skip(&format!("{} - no GL processor", function!()));
                 return;
             };
             // The oracle: a tight PBO of the target geometry, same route.
             let mut reference = match gl.create_pbo_image_dtype(W, H, fmt, dtype) {
                 Ok(t) => t,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - no float PBO images: {e:?}", function!());
+                    crate::test_support::report_skip(&format!(
+                        "{} - no float PBO images: {e:?}",
+                        function!()
+                    ));
                     return;
                 }
             };
@@ -6177,11 +6204,14 @@ mod image_tests {
     #[cfg(all(target_os = "windows", feature = "opengl"))]
     fn windows_float_destinations_match_the_cpu_converter_for_every_layout() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut gpu = ImageProcessor::new().unwrap();
@@ -6284,16 +6314,19 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} - ImageProcessor init failed ({e:?})",
+                crate::test_support::report_skip(&format!(
+                    "{} - ImageProcessor init failed ({e:?})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -6306,7 +6339,10 @@ mod image_tests {
             })
             .collect();
         if dsts[0].memory() != TensorMemory::DmaBuf {
-            eprintln!("SKIPPED: {} - destinations are not textures", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - destinations are not textures",
+                function!()
+            ));
             return;
         }
         for dst in &mut dsts {
@@ -6385,7 +6421,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let src = synthetic_rgba(320, 240);
@@ -6393,7 +6432,10 @@ mod image_tests {
             let mut p = match ImageProcessor::new() {
                 Ok(p) => p,
                 Err(e) => {
-                    eprintln!("SKIPPED: {} - init failed ({e:?})", function!());
+                    crate::test_support::report_skip(&format!(
+                        "{} - init failed ({e:?})",
+                        function!()
+                    ));
                     return;
                 }
             };
@@ -6408,7 +6450,10 @@ mod image_tests {
                 )
                 .unwrap();
             if dst.memory() != TensorMemory::DmaBuf {
-                eprintln!("SKIPPED: {} - destination is not a texture", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - destination is not a texture",
+                    function!()
+                ));
                 return;
             }
             p.convert_deferred(&src, &mut dst, Rotation::None, Flip::None, Crop::default())
@@ -6443,7 +6488,10 @@ mod image_tests {
         use std::os::windows::io::AsRawHandle;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = ImageProcessor::new().unwrap();
@@ -6464,11 +6512,11 @@ mod image_tests {
         if dst.memory() != TensorMemory::DmaBuf
             && !std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1")
         {
-            eprintln!(
-                "SKIPPED: {} - create_image gave {:?}, not a texture (no GL backend)",
+            crate::test_support::report_skip(&format!(
+                "{} - create_image gave {:?}, not a texture (no GL backend)",
                 function!(),
                 dst.memory()
-            );
+            ));
             return;
         }
         assert_eq!(
@@ -6562,10 +6610,10 @@ mod image_tests {
                 t.memory()
             );
         }
-        eprintln!(
-            "SKIPPED: {test} - create_image gave {:?}, not a texture (no GL backend)",
+        crate::test_support::report_skip(&format!(
+            "{test} - create_image gave {:?}, not a texture (no GL backend)",
             t.memory()
-        );
+        ));
         false
     }
 
@@ -6581,7 +6629,10 @@ mod image_tests {
         use ndarray::Array3;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = ImageProcessor::new().unwrap();
@@ -6645,7 +6696,10 @@ mod image_tests {
         use edgefirst_tensor::{CpuAccess, Tensor};
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         // Forcing OpenGL fails outright without a GL backend (CI's no-ANGLE
@@ -6654,7 +6708,10 @@ mod image_tests {
         let mut p = match with_force_backend(Some("opengl"), ImageProcessor::new) {
             Ok(p) => p,
             Err(e) if !std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1") => {
-                eprintln!("SKIPPED: {} - no OpenGL backend: {e}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} - no OpenGL backend: {e}",
+                    function!()
+                ));
                 return;
             }
             Err(e) => panic!("forced OpenGL backend unavailable: {e}"),
@@ -6702,7 +6759,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = ImageProcessor::new().unwrap();
@@ -6727,7 +6787,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut p = ImageProcessor::new().unwrap();
@@ -6767,7 +6830,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let (w, h) = (32usize, 64usize);
@@ -6842,7 +6908,10 @@ mod image_tests {
         use ndarray::Array3;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         const CUSTOM: [u8; 4] = [7, 200, 13, 255];
@@ -6872,11 +6941,11 @@ mod image_tests {
         if parent.memory() != TensorMemory::DmaBuf
             && !std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1")
         {
-            eprintln!(
-                "SKIPPED: {} - create_image gave {:?}, not a texture (no GL backend)",
+            crate::test_support::report_skip(&format!(
+                "{} - create_image gave {:?}, not a texture (no GL backend)",
                 function!(),
                 parent.memory()
-            );
+            ));
             return;
         }
         p.set_class_colors(&[CUSTOM]).unwrap();
@@ -6930,7 +6999,10 @@ mod image_tests {
         use edgefirst_tensor::CpuAccess;
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} - no zero-copy GPU buffers", function!());
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy GPU buffers",
+                function!()
+            ));
             return;
         }
         let mut a = ImageProcessor::new().unwrap();
@@ -7029,7 +7101,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_all_rgba() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -7228,7 +7300,7 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_opengl_rotate() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
@@ -7325,13 +7397,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_g2d_rotate() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_g2d_rotate - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_g2d_rotate - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_g2d_rotate - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_g2d_rotate - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -7499,15 +7571,15 @@ mod image_tests {
     #[ignore = "opengl doesn't support rendering to PixelFormat::Yuyv texture"]
     fn test_rgba_to_yuyv_resize_opengl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!(
-                "SKIPPED: {} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
+            crate::test_support::report_skip(&format!(
+                "{} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -7575,15 +7647,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_rgba_to_yuyv_resize_g2d() {
         if !is_g2d_available() {
-            eprintln!(
-                "SKIPPED: test_rgba_to_yuyv_resize_g2d - G2D library (libg2d.so.2) not available"
+            crate::test_support::report_skip(
+                "test_rgba_to_yuyv_resize_g2d - G2D library (libg2d.so.2) not available",
             );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_rgba_to_yuyv_resize_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_rgba_to_yuyv_resize_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -7795,13 +7865,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_yuyv_to_rgba_g2d() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_yuyv_to_rgba_g2d - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_yuyv_to_rgba_g2d - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_yuyv_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -7869,16 +7939,16 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_yuyv_to_rgba_opengl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         // Zero-copy YUYV source: DMA-BUF on Linux, IOSurface on macOS, a
         // D3D11 texture on Windows; skips where no such backing exists.
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!(
-                "SKIPPED: {} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
+            crate::test_support::report_skip(&format!(
+                "{} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -7913,7 +7983,7 @@ mod image_tests {
         // Desktop NVIDIA cannot sample YUYV as a GL texture; i.MX/Vivante can.
         // Production ImageProcessor falls back to CPU; this oracle skips.
         if let Err(crate::Error::NotSupported(msg)) = &result {
-            eprintln!("SKIPPED: {} — {msg}", function!());
+            crate::test_support::report_skip(&format!("{} — {msg}", function!()));
             return;
         }
         result.unwrap();
@@ -7957,7 +8027,10 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8049,7 +8122,7 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!("{} — init failed ({e:?})", function!()));
                 return;
             }
         };
@@ -8064,7 +8137,10 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — NV12 IOSurface alloc: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — NV12 IOSurface alloc: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8085,7 +8161,10 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — F16 PlanarRgb IOSurface: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — F16 PlanarRgb IOSurface: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8102,10 +8181,10 @@ mod image_tests {
             // GL_EXT_color_buffer_half_float may be absent on some configs; the
             // RGBA8 pass-1 + F16 pass-2 path then can't render. Skip rather than
             // fail on a capability gap (the same policy as the F16 path tests).
-            eprintln!(
-                "SKIPPED: {} — NV12→PlanarRgb F16 not available ({e:?})",
+            crate::test_support::report_skip(&format!(
+                "{} — NV12→PlanarRgb F16 not available ({e:?})",
                 function!()
-            );
+            ));
             return;
         }
         let dt = dst.as_typed::<half::f16>().expect("dst is F16 PlanarRgb");
@@ -8142,7 +8221,7 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!("{} — init failed ({e:?})", function!()));
                 return;
             }
         };
@@ -8161,7 +8240,10 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — R8 pool alloc: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — R8 pool alloc: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8189,7 +8271,10 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — F16 PlanarRgb dst: {e:?}", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — F16 PlanarRgb dst: {e:?}",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8204,10 +8289,10 @@ mod image_tests {
         if let Err(e) =
             ImageProcessorTrait::convert(&mut gpu, &src, &mut dst, Rotation::None, Flip::None, crop)
         {
-            eprintln!(
-                "SKIPPED: {} — NV12→PlanarRgb F16 unavailable ({e:?})",
+            crate::test_support::report_skip(&format!(
+                "{} — NV12→PlanarRgb F16 unavailable ({e:?})",
                 function!()
-            );
+            ));
             return;
         }
         let _ = stride;
@@ -8237,7 +8322,7 @@ mod image_tests {
         let mut proc = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!("{} — init failed ({e:?})", function!()));
                 return;
             }
         };
@@ -8252,7 +8337,7 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — pool: {e:?}", function!());
+                crate::test_support::report_skip(&format!("{} — pool: {e:?}", function!()));
                 return;
             }
         };
@@ -8273,7 +8358,7 @@ mod image_tests {
         ) {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("SKIPPED: {} — dst: {e:?}", function!());
+                crate::test_support::report_skip(&format!("{} — dst: {e:?}", function!()));
                 return;
             }
         };
@@ -8314,7 +8399,7 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!("{} — init failed ({e:?})", function!()));
                 return;
             }
         };
@@ -8336,7 +8421,7 @@ mod image_tests {
                 ) {
                     Ok(t) => t,
                     Err(e) => {
-                        eprintln!("SKIPPED: {} — pool: {e:?}", function!());
+                        crate::test_support::report_skip(&format!("{} — pool: {e:?}", function!()));
                         return;
                     }
                 },
@@ -8352,7 +8437,7 @@ mod image_tests {
                 ) {
                     Ok(t) => t,
                     Err(e) => {
-                        eprintln!("SKIPPED: {} — dst: {e:?}", function!());
+                        crate::test_support::report_skip(&format!("{} — dst: {e:?}", function!()));
                         return;
                     }
                 },
@@ -8415,7 +8500,10 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8585,7 +8673,10 @@ mod image_tests {
         let mut gpu = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8682,7 +8773,10 @@ mod image_tests {
                 ) {
                     Ok(t) => t,
                     Err(e) => {
-                        eprintln!("SKIPPED: {} — R8 pool IOSurface alloc: {e:?}", function!());
+                        crate::test_support::report_skip(&format!(
+                            "{} — R8 pool IOSurface alloc: {e:?}",
+                            function!()
+                        ));
                         return;
                     }
                 };
@@ -8766,13 +8860,13 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} — GL engine init failed ({e:?}). \
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?}). \
                      Install ANGLE via `brew install startergo/angle/angle` \
                      and re-sign per README.md § macOS GPU Acceleration to \
                      run this test.",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -8855,7 +8949,10 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -8933,7 +9030,10 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9010,7 +9110,10 @@ mod image_tests {
         let mut proc = match GLProcessorThreaded::new(None) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {} — GL engine init failed ({e:?})", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL engine init failed ({e:?})",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9079,14 +9182,14 @@ mod image_tests {
     fn test_macos_gl_f16_planar_is_gl_backed() {
         let mut proc = ImageProcessor::new().expect("ImageProcessor");
         let Some(ref gl) = proc.opengl else {
-            eprintln!("SKIPPED: {} — GL backend unavailable", function!());
+            crate::test_support::report_skip(&format!("{} — GL backend unavailable", function!()));
             return;
         };
         if !gl.supported_render_dtypes().f16 {
-            eprintln!(
-                "SKIPPED: {} — configuration lacks F16 color-buffer support",
+            crate::test_support::report_skip(&format!(
+                "{} — configuration lacks F16 color-buffer support",
                 function!()
-            );
+            ));
             return;
         }
         let stats_before = gl.egl_cache_stats().expect("cache stats");
@@ -9159,7 +9262,10 @@ mod image_tests {
         }) {
             Ok(p) if p.opengl.is_some() => p,
             _ => {
-                eprintln!("SKIPPED: {} — GL backend unavailable", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL backend unavailable",
+                    function!()
+                ));
                 return;
             }
         };
@@ -9169,13 +9275,13 @@ mod image_tests {
             .map(|g| g.supported_render_dtypes().f16)
             .unwrap_or(false)
         {
-            eprintln!("SKIPPED: {} — no F16 render support", function!());
+            crate::test_support::report_skip(&format!("{} — no F16 render support", function!()));
             return;
         }
         let mem = if edgefirst_tensor::is_gpu_buffer_available() {
             TensorMemory::DmaBuf
         } else {
-            eprintln!("SKIPPED: {} — no zero-copy buffers", function!());
+            crate::test_support::report_skip(&format!("{} — no zero-copy buffers", function!()));
             return;
         };
 
@@ -9236,7 +9342,7 @@ mod image_tests {
         ) {
             Ok(()) => {}
             Err(crate::Error::NotSupported(msg)) => {
-                eprintln!("SKIPPED: {} — {msg}", function!());
+                crate::test_support::report_skip(&format!("{} — {msg}", function!()));
                 return;
             }
             Err(e) => panic!("fused NV12→PlanarF16 GL convert: {e}"),
@@ -9315,12 +9421,15 @@ mod image_tests {
         let mut proc = match ImageProcessor::new() {
             Ok(p) if p.opengl.is_some() => p,
             _ => {
-                eprintln!("SKIPPED: {} — GL backend unavailable", function!());
+                crate::test_support::report_skip(&format!(
+                    "{} — GL backend unavailable",
+                    function!()
+                ));
                 return;
             }
         };
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIPPED: {} — no zero-copy buffers", function!());
+            crate::test_support::report_skip(&format!("{} — no zero-copy buffers", function!()));
             return;
         }
 
@@ -9417,13 +9526,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_yuyv_to_rgb_g2d() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_yuyv_to_rgb_g2d - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_yuyv_to_rgb_g2d - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_yuyv_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -9490,15 +9599,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_yuyv_to_yuyv_resize_g2d() {
         if !is_g2d_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_yuyv_resize_g2d - G2D library (libg2d.so.2) not available"
+            crate::test_support::report_skip(
+                "test_yuyv_to_yuyv_resize_g2d - G2D library (libg2d.so.2) not available",
             );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_yuyv_resize_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_yuyv_to_yuyv_resize_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -9636,15 +9743,13 @@ mod image_tests {
     #[cfg(target_os = "linux")]
     fn test_yuyv_to_rgba_crop_flip_g2d() {
         if !is_g2d_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_rgba_crop_flip_g2d - G2D library (libg2d.so.2) not available"
+            crate::test_support::report_skip(
+                "test_yuyv_to_rgba_crop_flip_g2d - G2D library (libg2d.so.2) not available",
             );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_yuyv_to_rgba_crop_flip_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_yuyv_to_rgba_crop_flip_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -9720,15 +9825,15 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_yuyv_to_rgba_crop_flip_opengl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
 
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!(
-                "SKIPPED: {} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
+            crate::test_support::report_skip(&format!(
+                "{} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -9765,7 +9870,7 @@ mod image_tests {
         );
         // Desktop NVIDIA cannot sample YUYV as a GL texture; i.MX/Vivante can.
         if let Err(crate::Error::NotSupported(msg)) = &result {
-            eprintln!("SKIPPED: {} — {msg}", function!());
+            crate::test_support::report_skip(&format!("{} — {msg}", function!()));
             return;
         }
         result.unwrap();
@@ -9934,13 +10039,13 @@ mod image_tests {
     #[ignore = "G2D does not support VYUY; re-enable when hardware support is added"]
     fn test_vyuy_to_rgba_g2d() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_vyuy_to_rgba_g2d - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_vyuy_to_rgba_g2d - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_vyuy_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_vyuy_to_rgba_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -9974,7 +10079,9 @@ mod image_tests {
         );
         match result {
             Err(Error::G2D(_)) => {
-                eprintln!("SKIPPED: test_vyuy_to_rgba_g2d - G2D does not support PixelFormat::Vyuy format");
+                crate::test_support::report_skip(
+                    "test_vyuy_to_rgba_g2d - G2D does not support PixelFormat::Vyuy format",
+                );
                 return;
             }
             r => r.unwrap(),
@@ -10008,13 +10115,13 @@ mod image_tests {
     #[ignore = "G2D does not support VYUY; re-enable when hardware support is added"]
     fn test_vyuy_to_rgb_g2d() {
         if !is_g2d_available() {
-            eprintln!("SKIPPED: test_vyuy_to_rgb_g2d - G2D library (libg2d.so.2) not available");
+            crate::test_support::report_skip(
+                "test_vyuy_to_rgb_g2d - G2D library (libg2d.so.2) not available",
+            );
             return;
         }
         if !is_dma_available() {
-            eprintln!(
-                "SKIPPED: test_vyuy_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)"
-            );
+            crate::test_support::report_skip("test_vyuy_to_rgb_g2d - DMA memory allocation not available (permission denied or no DMA-BUF support)");
             return;
         }
 
@@ -10048,8 +10155,8 @@ mod image_tests {
         );
         match result {
             Err(Error::G2D(_)) => {
-                eprintln!(
-                    "SKIPPED: test_vyuy_to_rgb_g2d - G2D does not support PixelFormat::Vyuy format"
+                crate::test_support::report_skip(
+                    "test_vyuy_to_rgb_g2d - G2D does not support PixelFormat::Vyuy format",
                 );
                 return;
             }
@@ -10096,14 +10203,14 @@ mod image_tests {
     #[cfg(feature = "opengl")]
     fn test_vyuy_to_rgba_opengl() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: {} - OpenGL not available", function!());
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
             return;
         }
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!(
-                "SKIPPED: {} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
+            crate::test_support::report_skip(&format!(
+                "{} - zero-copy GPU buffer (DMA-BUF / IOSurface) not available on this host",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -10119,10 +10226,10 @@ mod image_tests {
         ) {
             Ok(src) => src,
             Err(e) => {
-                eprintln!(
-                    "SKIPPED: {} - zero-copy VYUY source not allocatable on this platform ({e})",
+                crate::test_support::report_skip(&format!(
+                    "{} - zero-copy VYUY source not allocatable on this platform ({e})",
                     function!()
-                );
+                ));
                 return;
             }
         };
@@ -10148,10 +10255,10 @@ mod image_tests {
         );
         match result {
             Err(Error::NotSupported(_)) => {
-                eprintln!(
-                    "SKIPPED: {} - OpenGL does not support PixelFormat::Vyuy DMA format",
+                crate::test_support::report_skip(&format!(
+                    "{} - OpenGL does not support PixelFormat::Vyuy DMA format",
                     function!()
-                );
+                ));
                 return;
             }
             r => r.unwrap(),
@@ -11767,14 +11874,14 @@ mod image_tests {
         require_dma_for_bg: bool,
     ) {
         if require_dma_for_bg && !edgefirst_tensor::is_dma_available() {
-            eprintln!("SKIPPED: {case} — DMA not available on this host");
+            crate::test_support::report_skip(&format!("{case} — DMA not available on this host"));
             return;
         }
         let processor_result = with_force_backend(force_backend, ImageProcessor::new);
         let mut processor = match processor_result {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: {case} — backend init failed: {e:?}");
+                crate::test_support::report_skip(&format!("{case} — backend init failed: {e:?}"));
                 return;
             }
         };
@@ -11815,14 +11922,14 @@ mod image_tests {
     #[test]
     fn test_draw_masks_zero_detection_g2d_forced() {
         if !edgefirst_tensor::is_dma_available() {
-            eprintln!("SKIPPED: g2d forced — DMA not available on this host");
+            crate::test_support::report_skip("g2d forced — DMA not available on this host");
             return;
         }
         let processor_result = with_force_backend(Some("g2d"), ImageProcessor::new);
         let mut processor = match processor_result {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: g2d forced — init failed: {e:?}");
+                crate::test_support::report_skip(&format!("g2d forced — init failed: {e:?}"));
                 return;
             }
         };
@@ -12006,10 +12113,10 @@ mod image_tests {
         // a regression appears. (Skip, not #[ignore]: the platform is decided
         // at runtime, not compile time.)
         if std::env::var_os("EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS").is_some() {
-            eprintln!(
-                "SKIPPED: test_multiple_image_processors_separate_threads — known Vivante \
+            crate::test_support::report_skip(
+                "test_multiple_image_processors_separate_threads — known Vivante \
                  GC7000UL concurrent-EGL-teardown double-free \
-                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)"
+                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)",
             );
             return;
         }
@@ -12188,10 +12295,10 @@ mod image_tests {
         const TIMEOUT: Duration = Duration::from_secs(60);
 
         if std::env::var_os("EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS").is_some() {
-            eprintln!(
-                "SKIPPED: test_parallel_processors_unique_outputs — known Vivante \
+            crate::test_support::report_skip(
+                "test_parallel_processors_unique_outputs — known Vivante \
                  GC7000UL concurrent-multi-processor driver abort \
-                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)"
+                 (EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS set)",
             );
             return;
         }
@@ -12667,7 +12774,9 @@ mod image_tests {
     ))]
     fn convert_f16_gl_cpu_parity_identity() {
         if !is_opengl_available() {
-            eprintln!("SKIPPED: convert_f16_gl_cpu_parity_identity - OpenGL not available");
+            crate::test_support::report_skip(
+                "convert_f16_gl_cpu_parity_identity - OpenGL not available",
+            );
             return;
         }
 
@@ -12707,15 +12816,17 @@ mod image_tests {
             }) {
                 Ok(p) => p,
                 Err(e) => {
-                    eprintln!(
-                        "SKIPPED: convert_f16_gl_cpu_parity_identity - GL backend unavailable: {e}"
-                    );
+                    crate::test_support::report_skip(&format!(
+                        "convert_f16_gl_cpu_parity_identity - GL backend unavailable: {e}"
+                    ));
                     return;
                 }
             };
 
             if !gl_proc.supported_render_dtypes().f16 {
-                eprintln!("SKIPPED: convert_f16_gl_cpu_parity_identity - F16 render not supported");
+                crate::test_support::report_skip(
+                    "convert_f16_gl_cpu_parity_identity - F16 render not supported",
+                );
                 return;
             }
 
@@ -12731,9 +12842,9 @@ mod image_tests {
             match gl_proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default()) {
                 Ok(()) => dst,
                 Err(e) => {
-                    eprintln!(
-                        "SKIPPED: convert_f16_gl_cpu_parity_identity - GL convert failed: {e}"
-                    );
+                    crate::test_support::report_skip(&format!(
+                        "convert_f16_gl_cpu_parity_identity - GL convert failed: {e}"
+                    ));
                     return;
                 }
             }
@@ -12801,12 +12912,16 @@ mod image_tests {
         let proc = match ImageProcessor::new() {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("SKIPPED: supported_render_dtypes_linux_smoke — ImageProcessor::new() failed: {e}");
+                crate::test_support::report_skip(&format!(
+                    "supported_render_dtypes_linux_smoke — ImageProcessor::new() failed: {e}"
+                ));
                 return;
             }
         };
         if proc.opengl.is_none() {
-            eprintln!("SKIPPED: supported_render_dtypes_linux_smoke — no GL backend on this host");
+            crate::test_support::report_skip(
+                "supported_render_dtypes_linux_smoke — no GL backend on this host",
+            );
             return;
         }
         // The call must complete without panicking or deadlocking.
@@ -13118,7 +13233,7 @@ mod image_tests {
                 Some(expected),
                 "set_colorimetry must round-trip"
             );
-            eprintln!("SKIPPED import_image_carries_colorimetry (DMA unavailable); storage contract verified via TensorDyn");
+            crate::test_support::report_skip("import_image_carries_colorimetry (DMA unavailable); storage contract verified via TensorDyn");
             return;
         }
 

--- a/crates/image/src/test_support.rs
+++ b/crates/image/src/test_support.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test-only helper for reporting a skipped test so the report
+//! survives libtest's output capture.
+//!
+//! `eprintln!`/`println!` route through `std::io::_eprint`/`_print`, which
+//! libtest hooks to capture per-test output and replay it only for a
+//! *failing* test. A hardware-gated test that returns early after printing
+//! its reason with `eprintln!` therefore reports `ok` with the reason
+//! silently discarded -- indistinguishable from having actually exercised
+//! the code, both locally (`cargo test` without `--nocapture`) and in CI.
+//! Writing directly to `std::io::stderr()` bypasses that hook, so the
+//! `SKIPPED: ...` line survives capture in both directions; `scripts/
+//! on-target-test.sh` greps captured logs for the literal string
+//! `SKIPPED` to report a skip count per board.
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it.
+#[cfg(test)]
+pub(crate) fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}

--- a/crates/image/tests/crop_golden.rs
+++ b/crates/image/tests/crop_golden.rs
@@ -39,6 +39,17 @@ use serde::{Deserialize, Serialize};
 const SRC_W: usize = 640;
 const SRC_H: usize = 480;
 
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it -- see `edgefirst_image`'s (crate-internal) `test_support` module
+/// for the same mechanism in the library's own `#[cfg(test)]` code; this
+/// integration test binary is a separate compilation unit and cannot reach
+/// that `pub(crate)` helper, so it carries a local copy.
+fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}
+
 /// One golden-fixture entry: the case parameters plus the CRC32 of the CPU
 /// backend's converted output bytes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -165,10 +176,10 @@ fn generate_cases() -> Vec<Case> {
                 for &(dst_w, dst_h) in &dst_sizes() {
                     let Some(crc32) = run_case(&mut proc_, &src, dst_fmt, crop_rect, dst_w, dst_h)
                     else {
-                        eprintln!(
-                            "crop_golden: skipping rejected case {src_fmt:?} -> {dst_fmt:?} \
+                        report_skip(&format!(
+                            "crop_golden: rejected case {src_fmt:?} -> {dst_fmt:?} \
                              crop={crop_rect:?} dst={dst_w}x{dst_h}"
-                        );
+                        ));
                         continue;
                     };
                     cases.push(Case {
@@ -234,12 +245,12 @@ fn generate_golden() {
 #[test]
 fn cropped_convert_matches_golden() {
     if !cpu_matches_fixture_kernel_path() {
-        eprintln!(
-            "crop_golden: SKIP — this CPU selects a different (equally correct) \
+        report_skip(
+            "crop_golden: this CPU selects a different (equally correct) \
              yuv-crate kernel path than the one the frozen fixtures were \
              generated under; byte comparison is unmatchable by construction. \
              Cropped-convert correctness here is covered by the oracle-based \
-             tests in the edgefirst-image lib suite."
+             tests in the edgefirst-image lib suite.",
         );
         return;
     }

--- a/crates/tensor/build.rs
+++ b/crates/tensor/build.rs
@@ -15,18 +15,43 @@ fn main() {
     // deliberately declares with no `#[link]` attribute of its own
     // (linking is normally the *consumer's* decision, and this crate has no
     // other consumer to make that decision on its behalf for its own
-    // tests). `../../target/debug`, relative to this crate's manifest dir,
-    // is where `crates/tensor-capi` lands when built with `--target-dir
-    // target` from the workspace root -- the same directory `cargo
-    // test -p edgefirst-tensor` itself builds into, so no extra
-    // search-path configuration is needed beyond building `tensor-capi`
-    // first. A stale or missing `.so` here is a link error, not a silent
+    // tests). A stale or missing `.so` here is a link error, not a silent
     // pass, the same "build the producer first" precondition
     // `tensor-capi`'s own `EF_REQUIRE_FRESH_ARTIFACTS`-gated tests document.
     if std::env::var_os("CARGO_FEATURE_DYNAMIC_TEST_LINK").is_some() {
-        let manifest_dir =
-            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is always set");
-        let lib_dir = std::path::Path::new(&manifest_dir).join("../../target/debug");
+        // `EDGEFIRST_TENSOR_LIB_DIR` wins when set -- cross-compiling this
+        // lane for a board (`cargo zigbuild ... --target
+        // aarch64-unknown-linux-gnu.2.35`) needs to point at a cross-built
+        // `libedgefirst_tensor.so` under `target/aarch64-unknown-linux-gnu/
+        // debug/`, which nothing below can derive on its own: there is no
+        // env var that names the *producer* crate's (`tensor-capi`) output
+        // directory, only this crate's own.
+        println!("cargo::rerun-if-env-changed=EDGEFIRST_TENSOR_LIB_DIR");
+        let lib_dir =
+            match std::env::var_os("EDGEFIRST_TENSOR_LIB_DIR").filter(|dir| !dir.is_empty()) {
+                Some(dir) => std::path::PathBuf::from(dir),
+                None => {
+                    // Cargo always lays `OUT_DIR` out as
+                    // `<profile-dir>/build/<pkg>-<hash>/out`, where
+                    // `<profile-dir>` is `target/<profile>` for a native build
+                    // and `target/<target-triple>/<profile>` for any `--target`
+                    // build (cross or not) -- exactly the directory sibling
+                    // crates' compiled dylibs land in, including `tensor-capi`'s
+                    // when built with `--target-dir target` from the workspace
+                    // root. Walking up from `OUT_DIR` finds it without assuming
+                    // a fixed `../../target/debug` relative to this crate's
+                    // manifest dir (wrong for any `--target` build, cross or
+                    // not) or a fixed `--target-dir` (wrong for a custom one --
+                    // see `scripts/on-target-test.sh`'s own comment on exactly
+                    // this class of bug in `build_libs_for`).
+                    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR is always set");
+                    std::path::Path::new(&out_dir)
+                        .ancestors()
+                        .nth(3)
+                        .expect("OUT_DIR is nested at least 3 levels under target/<profile>")
+                        .to_path_buf()
+                }
+            };
         println!("cargo::rustc-link-search=native={}", lib_dir.display());
         println!("cargo::rustc-link-lib=dylib=edgefirst_tensor");
     }

--- a/crates/tensor/src/d3d11/adapter.rs
+++ b/crates/tensor/src/d3d11/adapter.rs
@@ -343,7 +343,7 @@ mod tests {
             match DxgiAdapter::fake(description, luid_low, vram, software) {
                 Ok(a) => adapters.push(a),
                 Err(e) => {
-                    eprintln!("DXGI enumeration unavailable — skipping: {e}");
+                    crate::test_support::report_skip(&format!("DXGI enumeration unavailable: {e}"));
                     return;
                 }
             }
@@ -383,7 +383,9 @@ mod tests {
                     assert!(!a.description.is_empty());
                 }
             }
-            Err(e) => eprintln!("DXGI enumeration unavailable — skipping: {e}"),
+            Err(e) => {
+                crate::test_support::report_skip(&format!("DXGI enumeration unavailable: {e}"))
+            }
         }
     }
 

--- a/crates/tensor/src/dma.rs
+++ b/crates/tensor/src/dma.rs
@@ -707,7 +707,7 @@ mod tests {
         let large_buf = match Tensor::<u8>::new(&[total_size], Some(TensorMemory::DmaBuf), None) {
             Ok(buf) => buf,
             Err(_) => {
-                eprintln!("SKIPPED: DMA not available");
+                crate::test_support::report_skip("DMA not available");
                 return;
             }
         };

--- a/crates/tensor/src/lib.rs
+++ b/crates/tensor/src/lib.rs
@@ -133,6 +133,8 @@ pub mod protocol;
 #[cfg(all(unix, feature = "static"))]
 mod shm;
 mod tensor_dyn;
+#[cfg(test)]
+mod test_support;
 pub mod view;
 mod vocabulary;
 pub use colorimetry::{
@@ -6493,7 +6495,7 @@ mod image_tests {
         let _lock = crate::tests::fd_lock_shared();
         // Skip if DMA not available (e.g. sandboxed CI lacking dma_heap access).
         if !is_dma_available() {
-            eprintln!("SKIPPED: DMA heap not available");
+            crate::test_support::report_skip("DMA heap not available");
             return;
         }
         // 3004×1688 RGBA8: natural pitch 12016, padded to 12032 (64-aligned).
@@ -6576,7 +6578,7 @@ mod image_tests {
         // it needs both Linux and a dma-heap: it skips on macOS and on Orin
         // (nvmap, no CONFIG_DMABUF_HEAPS).
         if !is_dma_available() {
-            eprintln!("SKIPPED: DMA heap not available");
+            crate::test_support::report_skip("DMA heap not available");
             return;
         }
         let backing =
@@ -6629,7 +6631,7 @@ mod image_tests {
         // returning a slice larger than the backing mmap (that would be UB
         // in `DmaMap::as_slice`).
         if !is_dma_available() {
-            eprintln!("SKIPPED: DMA heap not available");
+            crate::test_support::report_skip("DMA heap not available");
             return;
         }
         // Allocate a 640×480 RGBA8 padded canvas (stride = 3072 = 768 px).
@@ -6959,7 +6961,7 @@ mod cpu_access_tests {
         // Declares this test as an fd-opener; see FD_LOCK.
         let _lock = crate::tests::fd_lock_shared();
         let Ok(t) = Tensor::<u8>::new(&[64], Some(TensorMemory::DmaBuf), None) else {
-            eprintln!("SKIPPED: IOSurface unavailable");
+            crate::test_support::report_skip("IOSurface unavailable");
             return;
         };
         {
@@ -7583,7 +7585,7 @@ mod tests {
         // and 4 must share the segment (zero-copy, via cloned fd) and be
         // independently writable — view 0 owns [0,4), view 1 owns [4,8).
         if !crate::is_shm_available() {
-            eprintln!("SKIPPED: shm not available");
+            crate::test_support::report_skip("shm not available");
             return;
         }
         let parent = Tensor::<u8>::new(&[2, 4], Some(TensorMemory::Shm), None).unwrap();
@@ -7619,7 +7621,7 @@ mod tests {
         // Declares this test as an fd-opener; see FD_LOCK.
         let _lock = crate::tests::fd_lock_shared();
         if !crate::is_shm_available() {
-            eprintln!("SKIPPED: shm not available");
+            crate::test_support::report_skip("shm not available");
             return;
         }
         // f32 align 4: a 2-byte offset cannot back a valid `*const f32`.
@@ -7642,7 +7644,7 @@ mod tests {
         let dma = match Tensor::<u8>::new(&[8], Some(TensorMemory::DmaBuf), None) {
             Ok(t) => t,
             Err(_) => {
-                eprintln!("SKIPPED: DMA not available");
+                crate::test_support::report_skip("DMA not available");
                 return;
             }
         };
@@ -7675,7 +7677,7 @@ mod tests {
         let parent = match Tensor::<u8>::new(&[2048], Some(TensorMemory::DmaBuf), None) {
             Ok(t) => t,
             Err(_) => {
-                eprintln!("SKIPPED: DMA not available");
+                crate::test_support::report_skip("DMA not available");
                 return;
             }
         };
@@ -7721,7 +7723,7 @@ mod tests {
         ) {
             Ok(t) => t,
             Err(_) => {
-                eprintln!("SKIPPED: DMA not available");
+                crate::test_support::report_skip("DMA not available");
                 return;
             }
         };

--- a/crates/tensor/src/test_support.rs
+++ b/crates/tensor/src/test_support.rs
@@ -18,7 +18,18 @@
 /// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
 /// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
 /// it.
-#[cfg(test)]
+///
+/// `cfg(unix)`, not just `cfg(test)`: every current call site
+/// (`dma.rs`'s `target_os = "linux"` tests, `lib.rs`'s IOSurface tests
+/// under `target_os = "macos"`, and its shm tests under plain `unix`) is
+/// reachable only on Unix, so an unconditional `pub(crate) fn` here is
+/// dead code on Windows and fails a `-D warnings` build there. Widen this
+/// (or add a Windows-specific caller with its own cfg) if a Windows test
+/// inside this crate's `src/` ever needs it directly --
+/// `crates/tensor/tests/d3d11_tensor.rs` already carries its own local
+/// copy for exactly that reason, since an integration-test binary can't
+/// reach this `pub(crate)` item anyway.
+#[cfg(all(test, unix))]
 pub(crate) fn report_skip(reason: &str) {
     use std::io::Write;
     let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");

--- a/crates/tensor/src/test_support.rs
+++ b/crates/tensor/src/test_support.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared test-only helper for reporting a skipped test so the report
+//! survives libtest's output capture.
+//!
+//! `eprintln!`/`println!` route through `std::io::_eprint`/`_print`, which
+//! libtest hooks to capture per-test output and replay it only for a
+//! *failing* test. A hardware-gated test that returns early after printing
+//! its reason with `eprintln!` therefore reports `ok` with the reason
+//! silently discarded -- indistinguishable from having actually exercised
+//! the code, both locally (`cargo test` without `--nocapture`) and in CI.
+//! Writing directly to `std::io::stderr()` bypasses that hook, so the
+//! `SKIPPED: ...` line survives capture in both directions; `scripts/
+//! on-target-test.sh` greps captured logs for the literal string
+//! `SKIPPED` to report a skip count per board.
+
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it.
+#[cfg(test)]
+pub(crate) fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}

--- a/crates/tensor/src/test_support.rs
+++ b/crates/tensor/src/test_support.rs
@@ -19,17 +19,17 @@
 /// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
 /// it.
 ///
-/// `cfg(unix)`, not just `cfg(test)`: every current call site
-/// (`dma.rs`'s `target_os = "linux"` tests, `lib.rs`'s IOSurface tests
-/// under `target_os = "macos"`, and its shm tests under plain `unix`) is
-/// reachable only on Unix, so an unconditional `pub(crate) fn` here is
-/// dead code on Windows and fails a `-D warnings` build there. Widen this
-/// (or add a Windows-specific caller with its own cfg) if a Windows test
-/// inside this crate's `src/` ever needs it directly --
-/// `crates/tensor/tests/d3d11_tensor.rs` already carries its own local
-/// copy for exactly that reason, since an integration-test binary can't
-/// reach this `pub(crate)` item anyway.
-#[cfg(all(test, unix))]
+/// Plain `cfg(test)`, not `cfg(all(test, unix))`: this crate's Unix-only
+/// call sites (`dma.rs`'s `target_os = "linux"` tests, `lib.rs`'s IOSurface
+/// tests under `target_os = "macos"`, its shm tests under plain `unix`)
+/// once left this dead code on Windows, but `d3d11/adapter.rs`'s tests
+/// (that whole module is `#[cfg(target_os = "windows")]`, see `lib.rs`)
+/// are a real Windows-only caller now, so every platform this crate builds
+/// for has at least one caller and the narrower gate is no longer needed.
+/// `crates/tensor/tests/d3d11_tensor.rs` still carries its own local copy
+/// rather than reaching this one -- it's a separate integration-test
+/// compilation unit and can't reach a `pub(crate)` item in the lib crate.
+#[cfg(test)]
 pub(crate) fn report_skip(reason: &str) {
     use std::io::Write;
     let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");

--- a/crates/tensor/tests/d3d11_tensor.rs
+++ b/crates/tensor/tests/d3d11_tensor.rs
@@ -11,6 +11,17 @@ use edgefirst_tensor::{
 };
 use std::os::windows::io::AsRawHandle;
 
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it -- see `edgefirst_tensor`'s (crate-internal) `test_support` module
+/// for the same mechanism in the library's own `#[cfg(test)]` code; this
+/// integration test binary is a separate compilation unit and cannot reach
+/// that `pub(crate)` helper, so it carries a local copy.
+fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}
+
 #[test]
 fn image_with_dmabuf_on_windows_is_a_texture_tensor() {
     if !edgefirst_tensor::is_gpu_buffer_available() {
@@ -432,14 +443,14 @@ fn copy_rows(dst: &mut [u8], src: &[u8], row_bytes: usize, dst_stride: usize) {
 #[test]
 fn cuda_map_matches_the_cpu_map_and_map_mut_writes_back() {
     if !edgefirst_tensor::is_cuda_available() {
-        eprintln!("SKIP: no CUDA runtime");
+        report_skip("no CUDA runtime");
         return;
     }
     let device = edgefirst_tensor::d3d11::device().unwrap();
     if device.is_warp() {
         // `cudaD3D11GetDevice` has no ordinal for the WARP adapter, so the
         // import fails and the tensor is CUDA-less by design.
-        eprintln!("SKIP: WARP adapter has no CUDA device");
+        report_skip("WARP adapter has no CUDA device");
         return;
     }
     let t = Tensor::<u8>::image(
@@ -510,11 +521,11 @@ fn cuda_map_matches_the_cpu_map_and_map_mut_writes_back() {
 #[test]
 fn cuda_map_covers_a_texture_whose_allocation_the_driver_padded() {
     if !edgefirst_tensor::is_cuda_available() {
-        eprintln!("SKIP: no CUDA runtime");
+        report_skip("no CUDA runtime");
         return;
     }
     if edgefirst_tensor::d3d11::device().unwrap().is_warp() {
-        eprintln!("SKIP: WARP adapter has no CUDA device");
+        report_skip("WARP adapter has no CUDA device");
         return;
     }
     let (w, h) = (640usize, 480usize);
@@ -557,11 +568,11 @@ fn cuda_map_covers_a_texture_whose_allocation_the_driver_padded() {
 #[test]
 fn cuda_map_reads_the_nv12_combined_plane() {
     if !edgefirst_tensor::is_cuda_available() {
-        eprintln!("SKIP: no CUDA runtime");
+        report_skip("no CUDA runtime");
         return;
     }
     if edgefirst_tensor::d3d11::device().unwrap().is_warp() {
-        eprintln!("SKIP: WARP adapter has no CUDA device");
+        report_skip("WARP adapter has no CUDA device");
         return;
     }
     let (w, h) = (640usize, 480usize);

--- a/crates/tensor/tests/d3d11_tensor.rs
+++ b/crates/tensor/tests/d3d11_tensor.rs
@@ -25,7 +25,7 @@ fn report_skip(reason: &str) {
 #[test]
 fn image_with_dmabuf_on_windows_is_a_texture_tensor() {
     if !edgefirst_tensor::is_gpu_buffer_available() {
-        eprintln!("no D3D11 device on this box -- skipping");
+        report_skip("no D3D11 device on this box");
         return;
     }
     let t = Tensor::<u8>::image(
@@ -839,7 +839,7 @@ fn child_imports_the_exported_blob(path: &str) {
                 !m.device_ptr().is_null(),
                 "the CUDA map has a device pointer"
             ),
-            None => eprintln!("no CUDA registration on the imported texture -- skipping"),
+            None => report_skip("no CUDA registration on the imported texture"),
         }
     }
 }

--- a/crates/tensor/tests/dynamic_primitives.rs
+++ b/crates/tensor/tests/dynamic_primitives.rs
@@ -47,6 +47,17 @@ use edgefirst_tensor::{
     TensorMemory, TensorTrait,
 };
 
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it -- see `edgefirst_tensor`'s (crate-internal) `test_support` module
+/// for the same mechanism in the library's own `#[cfg(test)]` code; this
+/// integration test binary is a separate compilation unit and cannot reach
+/// that `pub(crate)` helper, so it carries a local copy.
+fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}
+
 /// Allocate a bare (formatless) `TensorDyn` of the given shape/dtype code,
 /// the same way `ef_tensor_new` does -- the smallest live handle every test
 /// below builds on before attaching format/quantization metadata.
@@ -351,9 +362,9 @@ fn family5_from_planes_is_genuinely_multiplane_and_chroma_is_independently_writa
 #[test]
 fn dma_multiplane_from_planes_makes_is_multiplane_and_chroma_honest() {
     if !edgefirst_tensor::is_dma_available() {
-        eprintln!(
-            "SKIPPED: dma_multiplane_from_planes_makes_is_multiplane_and_chroma_honest - \
-                    DMA not available"
+        report_skip(
+            "dma_multiplane_from_planes_makes_is_multiplane_and_chroma_honest - \
+                    DMA not available",
         );
         return;
     }
@@ -409,9 +420,9 @@ fn dma_multiplane_from_planes_makes_is_multiplane_and_chroma_honest() {
 #[test]
 fn dma_buffer_identity_is_derived_from_the_inode_not_the_handle_address() {
     if !edgefirst_tensor::is_dma_available() {
-        eprintln!(
-            "SKIPPED: dma_buffer_identity_is_derived_from_the_inode_not_the_handle_address \
-                    - DMA not available"
+        report_skip(
+            "dma_buffer_identity_is_derived_from_the_inode_not_the_handle_address \
+                    - DMA not available",
         );
         return;
     }
@@ -478,12 +489,11 @@ fn a_texture_handles_identity_names_its_texture_not_its_recyclable_handle_addres
         ) {
             Ok(t) if t.d3d11_texture().is_some() => drop(t),
             other => {
-                eprintln!(
-                    "SKIPPED: \
+                report_skip(&format!("\
                      a_texture_handles_identity_names_its_texture_not_its_recyclable_handle_address \
                      - no D3D11 {format:?} texture tensors on this host ({:?})",
                     other.map(|t| t.memory())
-                );
+                ));
                 return;
             }
         }
@@ -560,7 +570,7 @@ fn two_distinct_views_of_one_dma_parent_share_one_identity_and_do_not_collide_wi
     // sharing an identity with something that is not actually the same
     // buffer would be the ABA hazard this fix closes).
     if !edgefirst_tensor::is_dma_available() {
-        eprintln!("SKIPPED: two_distinct_views_of_one_dma_parent... - DMA not available");
+        report_skip("two_distinct_views_of_one_dma_parent... - DMA not available");
         return;
     }
     let (w, h) = (64usize, 32usize);

--- a/crates/tensor/tests/no_global_state.rs
+++ b/crates/tensor/tests/no_global_state.rs
@@ -14,6 +14,17 @@
 
 use std::path::{Path, PathBuf};
 
+/// Reports a test skip with `reason`, writing `SKIPPED: {reason}` directly
+/// to stderr (not via `eprintln!`) so libtest's output capture cannot hide
+/// it -- see `edgefirst_tensor`'s (crate-internal) `test_support` module
+/// for the same mechanism in the library's own `#[cfg(test)]` code; this
+/// integration test binary is a separate compilation unit and cannot reach
+/// that `pub(crate)` helper, so it carries a local copy.
+fn report_skip(reason: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {reason}");
+}
+
 const ALLOWED: &[(&str, &str)] = &[
     (
         "SHARED_DRM_FD",
@@ -244,11 +255,11 @@ fn edgefirst_tensor_declares_no_new_global_state() {
     // board, which is the exact failure mode this gate exists to catch.
     let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     if !src.is_dir() {
-        eprintln!(
-            "SKIP: {} - source tree not present at {} (deployed test binary)",
+        report_skip(&format!(
+            "{} - source tree not present at {} (deployed test binary)",
             module_path!(),
             src.display()
-        );
+        ));
         return;
     }
 

--- a/scripts/on-target-test.sh
+++ b/scripts/on-target-test.sh
@@ -311,6 +311,25 @@ for i in "${!OK_HOSTS[@]}"; do
     echo "    syncing testdata"
     rsync -az --delete --info=none "${ROOT}/testdata/" "${target}:${REMOTE_DIR}/testdata/" || {
       echo "SKIP: testdata sync failed"; SUMMARY+=("${target}|SYNCFAIL|${arch}|-"); continue; }
+
+    # Per-crate testdata (e.g. `crates/decoder/testdata/infer/`) merges into
+    # the SAME remote testdata/ tree above, not a separate location: every
+    # `EDGEFIRST_TESTDATA_DIR`-aware fixture loader resolves relative to one
+    # deploy root (see e.g. `infer.rs`'s `infer_fixture_dir()`), so a second
+    # root here would just be a place fixtures are never looked for. No
+    # `--delete`: each crate contributes a disjoint subtree of the merged
+    # tree, so a stale file left by a DIFFERENT crate's sync must not be
+    # pruned by this one.
+    crate_testdata_sync_failed=0
+    for crate_testdata in "${ROOT}"/crates/*/testdata; do
+      [[ -d "${crate_testdata}" ]] || continue
+      echo "    syncing $(basename "$(dirname "${crate_testdata}")")'s testdata"
+      rsync -az --info=none "${crate_testdata}/" "${target}:${REMOTE_DIR}/testdata/" || {
+        crate_testdata_sync_failed=1; break; }
+    done
+    if [[ "${crate_testdata_sync_failed}" == "1" ]]; then
+      echo "SKIP: per-crate testdata sync failed"; SUMMARY+=("${target}|SYNCFAIL|${arch}|-"); continue
+    fi
   fi
 
   # Deploy the five C-API libraries + their `.so.0` symlinks + the G3

--- a/scripts/on-target-test.sh
+++ b/scripts/on-target-test.sh
@@ -308,18 +308,36 @@ for i in "${!OK_HOSTS[@]}"; do
     echo "SKIP: binary sync failed"; SUMMARY+=("${target}|SYNCFAIL|${arch}|-"); continue; }
 
   if [[ "${SYNC_TESTDATA}" == "1" && -d "${ROOT}/testdata" ]]; then
-    echo "    syncing testdata"
-    rsync -az --delete --info=none "${ROOT}/testdata/" "${target}:${REMOTE_DIR}/testdata/" || {
-      echo "SKIP: testdata sync failed"; SUMMARY+=("${target}|SYNCFAIL|${arch}|-"); continue; }
-
     # Per-crate testdata (e.g. `crates/decoder/testdata/infer/`) merges into
-    # the SAME remote testdata/ tree above, not a separate location: every
+    # the SAME remote testdata/ tree below, not a separate location: every
     # `EDGEFIRST_TESTDATA_DIR`-aware fixture loader resolves relative to one
     # deploy root (see e.g. `infer.rs`'s `infer_fixture_dir()`), so a second
-    # root here would just be a place fixtures are never looked for. No
-    # `--delete`: each crate contributes a disjoint subtree of the merged
-    # tree, so a stale file left by a DIFFERENT crate's sync must not be
-    # pruned by this one.
+    # root here would just be a place fixtures are never looked for.
+    #
+    # The root sync below runs with `--delete` (to prune fixtures this repo
+    # no longer ships), which would otherwise delete every merged crate
+    # subtree on every single invocation -- it isn't present in the LOCAL
+    # `${ROOT}/testdata/` source, so `--delete` reads it as removed on the
+    # remote, immediately undone by the per-crate merge that follows. Excludes
+    # derived from this same `crates/*/testdata` loop keep `--delete` from
+    # ever touching what the merge owns, so a run that doesn't change any
+    # crate's fixtures doesn't re-transfer them either.
+    crate_testdata_excludes=()
+    for crate_testdata in "${ROOT}"/crates/*/testdata; do
+      [[ -d "${crate_testdata}" ]] || continue
+      for entry in "${crate_testdata}"/*; do
+        [[ -e "${entry}" ]] || continue
+        crate_testdata_excludes+=(--exclude "$(basename "${entry}")")
+      done
+    done
+
+    echo "    syncing testdata"
+    rsync -az --delete --info=none "${crate_testdata_excludes[@]}"         "${ROOT}/testdata/" "${target}:${REMOTE_DIR}/testdata/" || {
+      echo "SKIP: testdata sync failed"; SUMMARY+=("${target}|SYNCFAIL|${arch}|-"); continue; }
+
+    # No `--delete` here: each crate contributes a disjoint subtree of the
+    # merged tree, so a stale file left by a DIFFERENT crate's sync must not
+    # be pruned by this one.
     crate_testdata_sync_failed=0
     for crate_testdata in "${ROOT}"/crates/*/testdata; do
       [[ -d "${crate_testdata}" ]] || continue

--- a/tests/python/test_gil_release.py
+++ b/tests/python/test_gil_release.py
@@ -92,7 +92,7 @@ def _gil_holding_control(duration_s):
 
 
 def _assert_releases_gil(
-    op_name, run_alongside, duration_s=0.4, min_gap=0.2, attempts=3, n_rounds=6
+    op_name, run_alongside, duration_s=0.4, min_gap=0.1, attempts=3, n_rounds=6
 ):
     """Shared assertion for the throughput formulation: an unrelated Python
     thread must keep making most of its normal progress while `run_alongside`
@@ -159,9 +159,10 @@ def _assert_releases_gil(
     that low outlier was itself an artifact of comparing raw counts to a
     fixed `slice_s`: a round whose window ran a little long under the old
     scheme distorted denominator and numerator asymmetrically depending on
-    which leg overran, and rates remove that asymmetry. `min_gap=0.2`
-    still sits comfortably below the mean gap on both legs' current
-    numbers.
+    which leg overran, and rates remove that asymmetry. `min_gap` was
+    `0.2` at this point in the history below and comfortably below the
+    mean gap on both legs' figures above; see "Lowered to 0.1", further
+    down, for why it no longer is.
 
     4 unpinned busy-loop processes barely move the numbers on this 16-core
     box -- there are far more free cores than competitors -- so as a
@@ -181,9 +182,11 @@ def _assert_releases_gil(
     for the full ~10-17s multi-row suite rather than one filtered row) the
     residual risk is real and not confined to the shortest calls. It did
     not reproduce under the literal 4-unpinned-process scenario in either
-    direction across 5 repeated full-suite runs (0/5 failures), and
-    `min_gap=0.2` sits clear of every gap measured there (mutation
-    best-of-3 gap 0.01-0.02; real op 0.44-0.53 mean).
+    direction across 5 repeated full-suite runs (0/5 failures), and the
+    `min_gap` in force at the time (0.2, since lowered to 0.1 -- see
+    "Lowered to 0.1" below) sat clear of every gap measured there
+    (mutation best-of-3 gap 0.01-0.02; real op 0.44-0.53 mean); the lower
+    floor clears the same numbers with even more margin.
 
     Tried and rejected as a way to close this gap: raising
     `sys.setswitchinterval()` for the duration of the measurement, to make
@@ -234,6 +237,23 @@ def _assert_releases_gil(
     alternating) rather than 2 gives each leg's median enough samples
     that one noisy round can't dominate it; `attempts=3` retries a
     genuinely unlucky attempt the same way the previous design did.
+
+    Lowered to 0.1 (from 0.2): on PR #181's `Build & Test (x86_64)` lane
+    (run 34467062991, job 102838083120), `test_merge_tiled_detections_
+    releases_the_gil` failed with `best gap 19.42% (real median 72.61%
+    vs. control median 53.20%) is not > 20%`, gaps of 17.17%, 19.42%,
+    17.15% across the three attempts (real per-round 69.57%/73.09%/
+    72.61%, control 53.35%/53.20%/53.12%). Three tight, consistent gaps
+    clustered around 17-19% are a systematic headroom shortfall on that
+    runner's two cores for a short CPU-bound op, not scheduler noise --
+    noise would scatter, not repeat to within 2.3 points three times. The
+    GIL-holding mutation is what a real regression looks like (the
+    calibration table above measures it at a ~0.01 gap, "both directions
+    tested"), so a 0.1 floor still discriminates a genuine hold from a
+    genuine release by roughly an order of magnitude while clearing the
+    ~17% floor this runner actually has -- 0.2 asked for more headroom
+    than a two-vCPU hosted runner can give a sub-millisecond-scale
+    CPU-bound op, not more discrimination against an actual regression.
     """
     slice_s = duration_s / n_rounds
     control_op = _gil_holding_control(slice_s)


### PR DESCRIPTION
## Root cause

The imx8mp hardware lane has executed zero Rust test binaries since **2026-05-14**, commit `a87ae59c` ("Strip debug info from hardware deployment artifacts"). That commit moved the uploaded artifact and the execution loop to `hardware-test-binaries-stripped/` but left the `chmod` behind on the old `hardware-test-binaries/` path — a directory that only ever existed on the build-arm side and that the artifact never delivers to the runner. The GitHub artifact round trip does not preserve the executable bit, so all 76 binaries arrive `0644`; the `chmod` glob expanded to nothing, its error was swallowed by `2>/dev/null || true`, and the loop's `[[ -x "$test_bin" ]] || continue` guard then skipped every binary in complete silence — no `Running` line, no `Skipping` line, no output at all. The junit generator globbed an empty results directory and wrote `tests="0"`. Direct evidence on run `34435075152` (job `102740999474`, the last passing `release/0.31.0` hardware job): the `Debug environment info` step lists every binary as `-rw-r--r--`, the whole Rust test step elapsed ~11 s without printing a single `=== Running` or `=== Skipping` line, and the artifact's `rust_hardware_results.xml` reads `tests="0" failures="0"`. The `Test (aarch64)` job in the same run uses the identical loop with a matching `chmod` and reported 1601 tests, which is the positive control.

## Consequence

Four months of a green-but-empty gate. Every `edgefirst-image` and `edgefirst-tensor` hardware test has been unexecuted since May, including the three `dma_test_formats`-gated float tests added in `c34af93e` which have never run in CI at all. The junit artifact retention is 30 days, so no run with `tests > 0` survives to compare against; the commit diff is the authoritative evidence.

## What the lane now runs

- **The `chmod` names the directory the loop iterates**, with no error suppression. The step shell is `bash --noprofile --norc -e -o pipefail`, so a missing directory now fails the job instead of being swallowed.
- **The two lib-test binaries** keep their filter split: `edgefirst_image-*` runs the `g2d` and `opengl` filters, `edgefirst_tensor-*` runs `dma`.
- **15 integration binaries are routed out of the "CPU-only, covered by the aarch64 runner" skip branch** and run unfiltered, since each is a single dedicated whole-binary GPU/EGL or DMA-BUF test rather than a multi-category lib suite. Nine from `crates/image/tests/`: `dst_view_stride`, `offset_nv_source_upload`, `offset_source_view_alignment`, `gl_concurrent_stress`, `reconstructed_view_convert`, `pin_convert`, `crop_golden`, `mask_golden`, `odd_dim_cpu`. Six from `crates/tensor/tests/`: `pin`, `protocol`, `protocol_roundtrip`, `dynamic_primitives`, `identity`, `vocabulary`.
- **`reconstructed_planar_dst` and `reconstructed_view_draw` get their own explicit skip branch**, naming each file's exact `#![cfg(...)]` (macOS/iOS, and macOS/iOS/Windows respectively). Neither cfg includes Linux, so running them here would be a guaranteed zero-test no-op, not coverage. Every other routed binary was checked the same way.
- **A zero-tests guard** after the loop: `find build/rust-test-results -maxdepth 1 -name '*.txt' | wc -l`, and `::error::imx8mp hardware lane executed 0 test binaries` plus `exit 1` when it is zero. This is what would have caught the bug in May.
- **A junit floor.** `generate_junit_xml.py` gains an optional `--min-tests N`: it writes the XML exactly as before, then emits `::error::` and exits 1 if the parsed count is below the floor. Behaviour is byte-identical when the flag is absent. Wired at `--min-tests 40` on imx8mp and `--min-tests 1000` on `Test (aarch64)` (observed 1601). **The imx8mp 40 is a placeholder** — a follow-up commit on this branch sets it from the first real run's count minus 15%.
- **The skip-branch comment was corrected.** It claimed the fourteen `edgefirst-image` `[[bench]]` targets land there; Cargo defaults `[[bench]]` to `test = false`, so nextest never builds them as test binaries. What actually lands there is every other crate's lib-test and integration binaries, because the earlier `Build runner test binaries` step and this one share `CARGO_TARGET_DIR=target/llvm-cov-target` and the `find … -type f -executable` that populates the artifact has no package filter.

## Capture-proof skips

`eprintln!` routes through `std::io::_eprint`, which libtest hooks to capture per-test output and replay it only for a *failing* test. A hardware-gated test that prints its reason and returns early therefore reports a plain `ok` with the reason silently discarded — indistinguishable from having actually exercised the code, both locally and in CI. `pbo_reports_why_it_cannot_pin` already wrote to `std::io::stderr()` directly, which is what `scripts/on-target-test.sh` greps for.

A `report_skip(reason: &str)` helper (direct `std::io::stderr()` write of `SKIPPED: {reason}`) now backs every reported skip: **316 sites converted in the first pass, 28 more in follow-up rounds, 344 total** across `edgefirst-image`, `edgefirst-tensor`, `edgefirst-codec` and `edgefirst-decoder`. The follow-up rounds also caught skip-shaped messages that lacked a `SKIP` token entirely (`-- skipping`, `not available`, `no device`), found by parsing the literal after each `eprintln!(` rather than a single-line grep, so multi-line calls were not missed. Proof: one skipping test run with and without `--nocapture` prints the `SKIPPED:` line in both.

**16 `eprintln!` skip sites are deliberately left**, all in the C-API crates, whose hardware coverage is a separate C `test_all` binary rather than one of the Rust nextest binaries this PR is about:

| File | Lines |
|---|---|
| `crates/image-capi/src/lib.rs` | 116 |
| `crates/image-capi/src/processor.rs` | 967 |
| `crates/tensor-capi/src/builder.rs` | 801, 841, 874, 898, 926, 949, 973, 999 |
| `crates/tensor-capi/src/d3d11.rs` | 1415 |
| `crates/tensor-capi/src/image.rs` | 487, 494 |
| `crates/tensor-capi/src/lib.rs` | 102, 132, 501 |

## Per-crate testdata

`scripts/on-target-test.sh` rsynced only the repository-root `testdata/`, so `crates/decoder/testdata/infer/` never reached `/tmp/hal-ontarget` and `edgefirst_decoder` plus `infer_builder` panicked on a missing fixture on all three boards. The script now merges every `crates/*/testdata` into the deploy root, and `infer.rs`/`infer_builder.rs` resolve `EDGEFIRST_TESTDATA_DIR` first before falling back to the manifest-relative path. The same omission existed in `.github/workflows/test.yml`'s checkout-lfs step and is fixed there too — the aarch64 lane was passing only by a runner-path coincidence. A `cp -a` collision check guards the merge, and the rsync `--delete` ordering was corrected so the per-crate merge is not deleted by the root sync.

## `EDGEFIRST_TENSOR_LIB_DIR`

`crates/tensor/build.rs` emitted a fixed `cargo:rustc-link-search=../../target/debug` under `dynamic-test-link`, so cross-building the dynamic lane for aarch64 needed a hand-written `RUSTFLAGS` workaround. It now honours `EDGEFIRST_TENSOR_LIB_DIR` when set and otherwise derives the path from `OUT_DIR`, with `cargo:rerun-if-env-changed`. `make test-tensor-dynamic` is unchanged; the aarch64 zigbuild cross-link now works with no `RUSTFLAGS`. Documented in `TESTING.md`.

## GIL-release floor

`tests/python/test_gil_release.py` asserted a 20% throughput gap. On PR #181's `Build & Test (x86_64)` lane (run `34467062991`, job `102838083120`), `test_merge_tiled_detections_releases_the_gil` failed with gaps of 17.17%, 19.42% and 17.15% across three attempts — real per-round medians 69.57/73.09/72.61%, control 53.35/53.20/53.12%. Three tight, consistent gaps on a two-core runner for a short CPU-bound op are a systematic headroom shortfall, not noise. The floor is now 0.1, which still discriminates by an order of magnitude: the mutation that makes the op hold the GIL measures a gap of -3.37%.

> **`0e78d5a4` is shared.** That commit was cherry-picked onto `feat/pbo-efclientstate` (#180) and `feat/mali-zero-copy-fold` (#181), both of which were red on the same runner headroom. After either merges, rebasing this branch onto `release/0.31.0` drops the duplicate (identical patch, empty commit, `--empty=drop`).

## Expected failures on the first real run

**PR #181 (Stage G, the Mali zero-copy fold) gates three float tests that `unwrap` on Vivante's missing F16 render.** Those three have never executed in CI, so this is the first run that will surface them. If #181 has not merged when this lane first runs, exactly these three are expected to fail on imx8mp and nothing else:

- `float_dma_src_import_matches_upload`
- `float_dma_src_pool_steady_state`
- `float_src_feed_alternating_frames`

Any other failure is a real finding.

## The exit 139 on the previous `release/0.31.0` run

Run `34436010747` (job `102743953640`, head `485dc6e9`) exited 139. **Judged a flake, not a regression.** It is a SIGSEGV during *pytest collection* while dlopen'ing `_image.abi3.so` (`edgefirst/image/__init__.py:30`, `from ._image import *`), before a single test ran — not a GPU test failure and not a Vivante shutdown crash. `485dc6e9` was built twice from duplicate triggers and the sibling run `34436007348` (job `102743915517`) passed on the same board with the same code. The concurrency explanation does not hold mechanically either: module import never reaches the GPU, since both EGL and GBM are loaded lazily via `libloading` rather than `DT_NEEDED`, and GitHub serialized every hardware job on `imx8mpevk-08` with no overlap. Full evidence in the investigation note, section 3.

---

## First real run of the lane (run `34472605256`, job `102858670856`)

The Rust hardware step ran for **15 min 27 s** and printed `=== Running` lines for 36 binary invocations. The junit reports **`tests="574"`** (752 passed across the summary lines, 5 failed). Compare with `~11 s` and `tests="0"` before this PR. The imx8mp floor is now `--min-tests 487`, which is 574 minus 15% rounded down.

| Binary | Invocation | Result |
|---|---|---|
| `edgefirst_image-a1c50af7c29eecfb` | G2D filter | **FAILED** — 29 passed, 2 failed, 3 ignored, 515 filtered |
| `edgefirst_image-a1c50af7c29eecfb` | OpenGL filter | **FAILED** — 239 passed, 3 failed, 5 ignored, 302 filtered |
| `edgefirst_image-e8540dff86ce8c34` | G2D filter | ok — 12 passed, 2 ignored |
| `edgefirst_image-e8540dff86ce8c34` | OpenGL filter | ok — 162 passed, 1 ignored |
| `edgefirst_tensor-*` (both) | DMA filter | ok — 14 passed each |
| `dst_view_stride-*` (both) | GL integration | ok — 21 passed each |
| `odd_dim_cpu-*` (both) | GL integration | ok — 41 passed each |
| `offset_source_view_alignment-*` (both) | GL integration | ok — 3 passed each |
| `pin_convert-*` (both) | GL integration | ok — 2 passed each |
| `crop_golden-*` (both) | GL integration | ok — 1 passed, 1 ignored each |
| `mask_golden-*` (both) | GL integration | ok — 1 passed, 1 ignored each |
| `offset_nv_source_upload-*` (both) | GL integration | ok — 1 passed each |
| `reconstructed_view_convert-*` (both) | GL integration | ok — 1 passed each |
| `gl_concurrent_stress-*` (both) | GL integration | ok — 0 passed, 3 ignored each |
| `pin-*` (both) | tensor integration | ok — 15 passed each |
| `protocol-*` (both) | tensor integration | ok — 18 passed each |
| `protocol_roundtrip-*` (both) | tensor integration | ok — 15 passed each |
| `vocabulary-*` (both) | tensor integration | ok — 18 passed each |
| `identity-*` (both) | tensor integration | ok — 4 passed each |
| `dynamic_primitives-*` (both) | tensor integration | ok — 0 tests (`dynamic` feature off, as documented) |
| `reconstructed_planar_dst-*`, `reconstructed_view_draw-*` | — | skipped, macOS/iOS/Windows-only cfg |
| 29 other binaries (codec, decoder, tracker, bench, egl, gl, gpu-probe, abi/ffi, capi, non-DMA tensor tests) | — | skipped, CPU-only |

### The three expected Stage G failures did occur, exactly and only

```
opengl_headless::tests::gl_tests::float_dma_src_import_matches_upload
opengl_headless::tests::gl_tests::float_dma_src_pool_steady_state
opengl_headless::tests::gl_tests::float_src_feed_alternating_frames
```

### Two further failures the lane surfaced, both pre-existing

```
g2d::g2d_tests::d01_nv12_odd_w_g2d_vs_cpu
g2d::g2d_tests::d03_nv12_odd_both_g2d_vs_cpu
```

```
D-01 NV12 odd-W G2D vs CPU: max_diff=255
thread 'g2d::g2d_tests::d01_nv12_odd_w_g2d_vs_cpu' panicked at crates/image/src/g2d.rs:2012:9:
D-01: gross NV12 odd-W G2D vs CPU mismatch max_diff=255 (>35); first bad at Some((26, 0, 1))
```

Both compare G2D output against the CPU reference on an odd-width NV12 source (65 px wide, and 65×63) and assert `max_diff <= 35`. Both measure 255 — saturation, first divergence at row 0 — which is a geometry or stride divergence, not the fixed-point rounding the tolerance was written for.

These are **not** caused by this PR, and they are **not** a harness defect. The tests were added on 2026-06-02 (`7a7f61d3`), three weeks after the lane stopped executing anything, so they have never run in CI. The bound was tightened from 64 to 35 on 2026-06-06 (`920e3da7`, the colorimetry fix) on the reasoning that the YUV-matrix delta had closed and only rounding remained — a tightening that CI could not have verified. They are being reported here rather than fixed, because the divergence lives in `crates/image` product code, not in the lane.

### Re-run with the floor in place (run `34477168418`, job `102875132963`)

Reproduced exactly: `tests="574"`, 752 passed, 5 failed, same two binaries, same five test names. The junit step concluded success, so `--min-tests 487` passes with the intended margin, and neither guard fired. Two independent runs on the board producing an identical failure set rules out transient GPU state as an explanation for the two G2D failures.
