### PR TITLE
Fall back on a refused destination import, fix the mapped-texture view path, and assert the GL route in every OpenGL test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `view()` destination on the GPU's mapped-texture readback got the wrong
+  pixels and wrote over its parent (#177).** The mapped-texture lowering
+  renders into an offscreen texture that *is* the tile, at origin (0, 0), and
+  places the tile afterwards by reading back through the view's `map()` at the
+  parent's pitch. It nevertheless inherited the band `glScissor` that places a
+  tile inside a shared zero-copy parent import, which clipped away the tile's
+  own left and top edges — those pixels kept whatever the previous frame had
+  left in the reused texture. The readback then wrote outside the view as well:
+  `glReadPixels` packs its rows tight, so the read filled the head of the
+  view's window and the rows were re-spaced to the parent's pitch afterwards,
+  leaving the read's own tail in the gaps between them, which for a view are
+  the parent's columns to the right of the tile. Measured on i.MX 8M Plus with
+  a 320x240 view of a 512x320 parent: 4416 wrong tile pixels at view origin
+  (8, 8), 23552 at (64, 32), and 28800 parent pixels overwritten per convert at
+  every origin including (0, 0).
+
+  The band now reaches the renderer only where the render target really is the
+  shared parent import, and the readback places each row at the pitch and
+  writes nothing between them — through `GL_PACK_ROW_LENGTH` where the pitch is
+  a whole number of pixels (what the PBO readback has always done) and
+  otherwise by reading the frame tight into the existing scratch buffer. Both
+  defects are ordinary software errors, not driver behaviour: the issue's
+  Vivante attribution was an artefact of how it was found, since the commit
+  that exposed the path routed only Vivante down it, so Mali and V3D were green
+  for want of ever entering it.
+
+- **A zero-copy destination the driver refuses now falls back instead of
+  failing the convert (#175).** A failed *source* import has always lowered to
+  the upload path; a failed *destination* import was propagated as the
+  convert's error, which is why the driver that refuses one had to be predicted
+  by name. `bind_dst` now lowers to the mapped-texture readback when the
+  zero-copy setup fails — the import, the attach, or the framebuffer binding —
+  and the packed-RGB plan asks for its destination import before pass 1 renders
+  so a refusal re-plans rather than throwing pass 1 away. The lowering the
+  engine decided is what `bind_dst` binds, rather than being re-derived from
+  the placement rule, so a re-plan is honoured instead of silently
+  contradicted. The decline is warned once per buffer and counted in
+  `ConvertStats::dst_import_fallbacks`, the destination-side twin of
+  `zero_copy_declines`, and recorded as `dst_feed` on the `image.convert.gl`
+  span.
+
+  The Vivante predicate is gone with it: `eglCreateImage` returning
+  `EGL_BAD_ACCESS` for a destination at an offset that is not 64-byte aligned
+  is now simply the fallback's trigger, so a future driver quirk of the same
+  kind needs no new trait. What stays is `dst_import_places`, which asks
+  whether an import would *succeed but place the destination wrongly* (ANGLE
+  binds a whole buffer from its origin) — a wrong placement produces no error
+  to fall back from. The Mali source-offset rule stays for the same reason: it
+  predicts a driver that samples zeros silently. Float destinations still
+  decline to the CPU converter when their import is refused; there is no
+  mapped-texture readback for a float DMA destination to lower to.
+
+  **A refused destination import is retried on every convert.** Nothing
+  remembers the refusal, so an unaligned destination on i.MX 8M Plus pays one
+  failed `eglCreateImage` per frame rather than skipping the attempt the way
+  the removed predicate did. Measured on that board — 1280x720 RGBA into a
+  320x240 tile at an unaligned offset in a 640x480 parent, 200 frames after
+  warmup — the retry costs about 28 us on a 3.29 ms convert, or 0.9%. What a
+  refusal does cost is the copy it falls back to: 3.29 ms against 0.71 ms for
+  the same convert into an aligned destination the driver imports. That is the
+  price of a destination the GPU will not render into directly, not of the
+  retry.
+
+  A packed-RGB or planar `view()`/`batch()` destination is now refused before
+  the lowering is chosen rather than after. Neither route can place one — the
+  zero-copy band is a viewport in destination pixels the `W*3/4` packed
+  surface does not have, and the readback writes `dst_w`-wide rows — and
+  keying the refusal on the lowering left it reading a decision a refused
+  import can still change underneath it.
+
 - **Bright highlights rendered as black on Cortex-A53 CPU conversion.** Any
   NV12/NV16/NV24 → RGB(A) convert on a core without the ARMv8.1 `rdm` feature
   — Cortex-A53/A35-class, which includes the i.MX8MP — takes the `yuv` crate's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "yuv",
 ]
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -247,8 +247,9 @@ passed to `cargo nextest run`. `-j 1` is forced: ANGLE takes the Full GL
 serialization policy.
 
 `-RequireCuda` sets `HAL_TEST_REQUIRE_CUDA=1`, turning a silent
-`SKIP: no CUDA runtime` in `crates/tensor/tests/d3d11_tensor.rs`'s three
-D3D11 CUDA interop tests into a failure naming the test and the reason. The
+`SKIPPED: <test> - no CUDA runtime …` in
+`crates/tensor/tests/d3d11_tensor.rs`'s three D3D11 CUDA interop tests into
+a failure naming the test and the reason. The
 WARP-adapter skip is unaffected — it is correct by design, and those tests
 check the adapter *before* the gate so an armed gate cannot convert it into a
 failure.
@@ -732,6 +733,20 @@ what and why — never summarise a run that skipped every DMA test as
 > does. Both hold their own handle to the real stderr. Cross-check against
 > the board's `capabilities.txt` before claiming a hardware path was
 > exercised.
+>
+> **Start that line with `SKIPPED: `.** That literal prefix is what
+> `scripts/on-target-test.sh` greps each board's captured log for to report
+> the per-board skip count, so a skip announced under any other spelling is
+> invisible to the summary even when it reaches the log. Prefer the helper
+> your crate already has — `edgefirst-image`'s
+> `crate::test_support::report_skip`, or `artifacts::skip` in the two C-API
+> leaves that carry the `artifacts` module, `edgefirst-tensor-capi` and
+> `edgefirst-image-capi`. The other three modular leaves
+> (`edgefirst-codec-capi`, `edgefirst-decoder-capi`,
+> `edgefirst-tracker-capi`) do not include that module, so their tests write
+> the `writeln!(std::io::stderr(), "SKIPPED: …")` by hand; do the same
+> anywhere else an integration test cannot reach a helper, as
+> `crates/tensor/tests/support/cuda_require.rs` does.
 
 The `--test-threads=1` flag is mandatory on target for the same reasons
 as local development — CMA pool exhaustion risk is higher on embedded

--- a/crates/codec-capi/src/lib.rs
+++ b/crates/codec-capi/src/lib.rs
@@ -49,7 +49,7 @@ mod tests {
             Ok(o) => Some(o),
             Err(e) => {
                 use std::io::Write;
-                let _ = writeln!(std::io::stderr(), "SKIP: no C compiler ({cc}: {e})");
+                let _ = writeln!(std::io::stderr(), "SKIPPED: no C compiler ({cc}: {e})");
                 None
             }
         }
@@ -109,7 +109,7 @@ mod tests {
                     use std::io::Write;
                     let _ = writeln!(
                         std::io::stderr(),
-                        "SKIP: libedgefirst_{name} not built; collision check not run"
+                        "SKIPPED: libedgefirst_{name} not built; collision check not run"
                     );
                     return;
                 }
@@ -209,7 +209,7 @@ mod tests {
             .unwrap_or_default();
         if found.is_empty() {
             use std::io::Write;
-            let _ = writeln!(std::io::stderr(), "SKIP: nothing built; name not checked");
+            let _ = writeln!(std::io::stderr(), "SKIPPED: nothing built; name not checked");
             return;
         }
         assert!(

--- a/crates/decoder-capi/src/lib.rs
+++ b/crates/decoder-capi/src/lib.rs
@@ -59,7 +59,7 @@ mod tests {
             Ok(o) => Some(o),
             Err(e) => {
                 use std::io::Write;
-                let _ = writeln!(std::io::stderr(), "SKIP: no C compiler ({cc}: {e})");
+                let _ = writeln!(std::io::stderr(), "SKIPPED: no C compiler ({cc}: {e})");
                 None
             }
         }
@@ -92,7 +92,7 @@ mod tests {
             Ok(o) => Some(o),
             Err(e) => {
                 use std::io::Write;
-                let _ = writeln!(std::io::stderr(), "SKIP: no C compiler ({cc}: {e})");
+                let _ = writeln!(std::io::stderr(), "SKIPPED: no C compiler ({cc}: {e})");
                 None
             }
         }
@@ -187,7 +187,7 @@ mod tests {
             .unwrap_or_default();
         if found.is_empty() {
             use std::io::Write;
-            let _ = writeln!(std::io::stderr(), "SKIP: nothing built; name not checked");
+            let _ = writeln!(std::io::stderr(), "SKIPPED: nothing built; name not checked");
             return;
         }
         assert!(

--- a/crates/image-capi/src/lib.rs
+++ b/crates/image-capi/src/lib.rs
@@ -113,7 +113,7 @@ mod tests {
         {
             Ok(o) => Some(o),
             Err(e) => {
-                eprintln!("SKIP: no C compiler ({cc}: {e}); header not syntax-checked");
+                skip(&format!("no C compiler ({cc}: {e}); header not syntax-checked"));
                 None
             }
         }

--- a/crates/image-capi/src/processor.rs
+++ b/crates/image-capi/src/processor.rs
@@ -964,7 +964,7 @@ mod tests {
     #[test]
     fn convert_fence_handle_returns_an_owned_event_set_on_completion() {
         if !edgefirst_tensor::is_gpu_buffer_available() {
-            eprintln!("SKIP: no D3D11 device on this host");
+            crate::artifacts::skip("no D3D11 device on this host");
             return;
         }
         let p = processor();

--- a/crates/image/ARCHITECTURE.md
+++ b/crates/image/ARCHITECTURE.md
@@ -369,29 +369,57 @@ assumed: rendering into an unaligned base at the same offsets is correct on
 i.MX 95, so the defect is in sampling and not in the render target. The
 driver that does fail on the destination side is Vivante, and it fails
 loudly — `eglCreateImage` returns `EGL_BAD_ACCESS` for a destination at
-offset 2080 while offset 2048 renders — so
-`vivante_rejects_dst_import_offset` joins `Platform::dst_import_places` in
-the `places` term that `bind_dst`, `convert_via_engine` and the float
-dispatch share. An unaligned Vivante destination therefore lowers to the
-mapped-texture path, whose readback writes through `map()` at the offset,
-instead of letting the EGL error end the convert; the float paths, which
-have no mapped-texture readback to lower to, decline to the CPU converter.
+offset 2080 while offset 2048 renders. **A loud failure needs no
+prediction.** The destination arms fall back the way the source arms always
+have: `bind_dst` lowers to the mapped-texture path — render to a texture,
+read back through `map()` at the destination's offset and pitch — when the
+zero-copy setup fails, whatever the driver and whatever its reason, warning
+once per buffer and counting the decline in
+`ConvertStats::dst_import_fallbacks`. The guard covers the whole setup, not
+just `eglCreateImage`: attaching the image to the texture and the FBO can
+fail after the import succeeded, and nothing has been written to the
+destination yet either way. So there is no per-driver destination predicate,
+and a future driver quirk of the same kind needs no new trait (#175).
 
-Each site must ask the rule about the offset **its own** import bases at,
-and the two destination routes differ. `bind_dst` imports through
+The one destination question that must still be asked **before** the import
+is `Platform::dst_import_places`, because the import it guards *succeeds* and
+places the destination wrongly, producing no error to fall back from: ANGLE
+over a D3D11 texture or an IOSurface binds a whole buffer from its origin, so
+a destination rebuilt from a descriptor — carrying a plane offset but no
+`view_origin` to lower to a viewport — would be rendered at the buffer's
+origin. That question is about the offset **its own** import bases at, and
+the two destination routes differ. `bind_dst` imports through
 `Platform::import_buffer(.., for_dst = true)`, which collapses a fresh
 `view()`/`batch()` onto its parent at offset 0 and places the tile by
 viewport, so that site asks `view_collapsed_dst_base` and a tile view is
 never gated however unaligned its own bytes are.
 `convert_via_engine`'s packed-RGB plan and the zero-copy float paths import
-through `import_buffer_packed`, which passes `plane_offset()` straight to
-EGL with no collapse, so those sites ask the raw offset and a view
-destination there IS gated. Asking the collapsed base everywhere would
-under-fire on the packed routes; asking the raw offset everywhere over-fires
-on `bind_dst`, and that is not merely a lost fast path — the mapped-texture
-readback returns wrong pixels for a view destination on Vivante, so the
-over-fire silently corrupted unaligned tile views until
-`a_fresh_unaligned_view_destination_keeps_the_zero_copy_import` caught it.
+through `import_buffer_packed`, which passes `plane_offset()` straight to EGL
+with no collapse, so those sites ask the raw offset.
+
+A packed-RGB or planar `view()`/`batch()` destination is refused before the
+lowering is chosen at all, because neither route can place one: the zero-copy
+band is a `glViewport` in destination pixels that the `W*3/4` packed surface
+does not have, and the mapped route's readback writes `dst_w`-wide rows at the
+parent's pitch. Keying that refusal on the lowering would leave it reading a
+decision a refused import can still change underneath it.
+
+The packed-RGB plan asks for its destination import in `convert_via_engine`,
+before pass 1 renders, rather than in the pass 2 that uses it: a
+texture-lowered RGB destination is a different plan (one genuine RGB pass, no
+`W*3/4` reinterpretation), so a refusal has to re-plan, and re-planning after
+pass 1 would throw its work away. The import is cached, so pass 2's own call
+is a hit. The float paths have no mapped-texture readback to lower to —
+`read_pixels_into` packs `UNSIGNED_BYTE` — so a refused float destination
+propagates and `ImageProcessor` runs the CPU converter.
+
+The mapped-texture path had to be made correct for a `view()` destination
+before any of this was safe to adopt (#177): it renders into an offscreen
+texture that IS the tile, at origin (0, 0), so it must not carry the band
+`glScissor` that places a tile inside a shared parent import, and its readback
+must place each row at the destination's pitch and write nothing between the
+rows — for a view those bytes are the parent's columns to the right of the
+tile.
 
 Folding the pixel remainder into the sampling rectangle to keep the aligned
 case zero-copy — the source-side counterpart of the viewport band a
@@ -1474,7 +1502,9 @@ image.convert                                           [user-facing fn, orchest
 │ fields: src_fmt, dst_fmt, src_memory, dst_memory, rotation, flip
 │
 ├── image.convert.gl                                    [OpenGL backend, picked first]
-│   │ fields: src_fmt, dst_fmt, is_int8, src_memory, dst_memory, src_feed (import | pbo | upload)
+│   │ fields: src_fmt, dst_fmt, is_int8, src_memory, dst_memory, src_feed (import | pbo | upload),
+│   │         dst_feed (zero_copy | mapped_texture | pbo)
+│   │         both feed fields are u8-route only; the float route enters no convert span
 │   ├── image.convert.gl.engine                         ← plan + destination lowering for the convert ({plan, lowering, src_pbo})
 │   ├── image.convert.gl.egl_import                     ← one actual eglCreateImageKHR (cache MISS only; zero in steady state)
 │   ├── image.convert.gl.pack_rgb.pass1_rgba            ← NV* → intermediate RGBA (resize + crop + flip)
@@ -1541,7 +1571,7 @@ image.tile_one                                          [user-facing fn — rend
 |--------------------------------------------------------|--------------------------|------------------|
 | `image.gl_init`                                        | One-time shared-display bring-up: ANGLE dylib discovery + Metal display on macOS/iOS, system EGL default display on Android. An `info_span`, not a trace span. | Fires once per process, not per processor. A second occurrence means the `OnceLock` was re-entered — worth investigating. Linux brings its display up through `context.rs` and emits no span here. |
 | `image.convert`                                        | Orchestration: probe backends, pick OpenGL → G2D → CPU, dispatch. | The `src_memory` and `dst_memory` fields reveal whether you're on a zero-copy DMA-buf path, the PBO path, or the heap fallback. Cache-miss EGLImage imports show up as outliers here when callers reuse fds without reusing tensors. |
-| `image.convert.gl`                                     | The chosen GL backend's full shader pipeline: bind/import source, set up FBO/renderbuffer, run conversion shader, `glFinish`. | First call at a new (src_fmt, dst_fmt, dims) tuple includes shader compile/link cost. Steady-state cost is dominated by the GPU draw and the `glFinish` at the end. `src_feed` is recorded at the source-feed site (`import` / `pbo` / `upload`) and is the per-call zero-copy observable — anything but `import` on a DMA source means the frame paid a copy. |
+| `image.convert.gl`                                     | The chosen GL backend's full shader pipeline: bind/import source, set up FBO/renderbuffer, run conversion shader, `glFinish`. | First call at a new (src_fmt, dst_fmt, dims) tuple includes shader compile/link cost. Steady-state cost is dominated by the GPU draw and the `glFinish` at the end. Both feed fields land on `image.convert.gl` itself for **u8 converts**, and both are recorded on every one — including the single-pass planar route, whose source import is unconditional and which used to be the one convert with no `src_feed` at all: `src_feed` (`import` / `pbo` / `upload`) says how the source was fed, `dst_feed` (`zero_copy` / `mapped_texture` / `pbo`) how the output reached the destination. `dst_feed` is recorded where the route is COMMITTED, not where the destination is bound, so a bind the engine then re-plans away from does not put a stale value on the span. `dst_feed` is deliberately NOT an import-refusal marker — it is recorded in `bind_dst`, the one place a `DstTarget` is decided, plus the packed-RGB plan's pre-flight, which is the only destination import that does not go through it. A field that appeared only on the refused route would read as "zero-copy" whenever it was absent, which is how an ordinary texture-lowered convert, or a DMA destination that `dst_import_places` pre-lowered without attempting an import, could pass for a zero-copy one in a trace. `ConvertStats::dst_import_fallbacks` is the refusal count. Anything but `import` on a DMA source means the frame paid a copy. The recording sites take the span's handle rather than `Span::current()`, which inside the engine names `image.convert.gl.engine` (and on the two-pass plans a pass span); `tracing` drops a record against a field the span does not declare, so a record through `Span::current()` there is silently lost. **The float route records neither field**: it returns before `image.convert.gl` is entered and so has no convert span at all (follow-up: give it one). Use `ConvertStats` (`src_imports` / `src_pbo_uploads` / `src_uploads` / `zero_copy_declines` / `dst_import_fallbacks`) for counts on any route. |
 | `image.convert.gl.engine`                              | The convert engine's decision record: which `ConvertPlan` (`SinglePass` / `TwoPassPackedRgb` / `TwoPassNvPlanar`) and which destination lowering (`ZeroCopy` / `TextureMem` / `TexturePbo`) this convert took, plus whether the source is PBO-backed. | The plan/lowering pair maps 1:1 onto the GL work performed — filter traces by these fields to isolate one lowering's latency. Both decisions are pure host-tested tables in `render.rs` (`plan_convert`, `lower_dst`). |
 | `image.convert.gl.egl_import`                          | One actual `eglCreateImageKHR` — every EGLImage creation (DMA-BUF, NV R8, RGB renderbuffer paths) funnels through this single choke point. | The cache-behaviour observable: a steady-state frame loop over a fixed buffer pool must emit ZERO of these after warmup. Any per-frame occurrence means the EGLImage cache stopped hitting (key drift, geometry churn, or pool misuse). The `GLProcessorThreaded::egl_cache_stats()` counters (`src`/`dst`/`nv_r8` hits/misses) are the assertable form, pinned by the `dma_pool_steady_state_zero_imports` test. |
 | `image.convert.gl.pack_rgb.pass1_rgba`                 | NV12 → intermediate RGBA texture (full geometry: resize, crop, rotation, flip, letterbox). | Reused for the "packed RGB" output path (DMA destination with 3-byte-per-pixel width × 3 / 4 render geometry). |

--- a/crates/image/Cargo.toml
+++ b/crates/image/Cargo.toml
@@ -121,6 +121,11 @@ image-compare = { workspace = true }
 safetensors = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+# The span-field capture in `gl/tests.rs` needs a subscriber with a real
+# current-span stack: `Span::current()` asks through `Subscriber::current_span`,
+# whose default is `Current::unknown()`, so a hand-rolled subscriber would make
+# every `Span::current().record()` under test look like a no-op.
+tracing-subscriber = { workspace = true }
 
 [[bench]]
 name = "image_benchmark"

--- a/crates/image/TESTING.md
+++ b/crates/image/TESTING.md
@@ -18,6 +18,10 @@ crates/image/
 │       └── tests.rs        # OpenGL backend tests (gated via OnceLock probe)
 ├── tests/
 │   ├── crop_golden.rs      # Frozen per-architecture cropped-convert fixtures
+│   ├── convert_span_feed_fields.rs  # src_feed/dst_feed land on image.convert.gl
+│   │                       # (own binary + a GLOBAL subscriber: tracing caches
+│   │                       #  callsite interest per PROCESS, so a scoped one
+│   │                       #  among parallel tests is a coin flip)
 │   ├── odd_dim_cpu.rs      # End-to-end odd-dimension CPU conversion
 │   └── data/               # crop_golden.{aarch64,x86_64}.json
 └── benches/

--- a/crates/image/src/gl/cache.rs
+++ b/crates/image/src/gl/cache.rs
@@ -101,6 +101,14 @@ pub struct ConvertStats {
     /// copy path (import/attach failure). A nonzero value with Dma
     /// sources means the platform/driver refused the fast path.
     pub zero_copy_declines: u64,
+    /// Times a zero-copy DESTINATION import was attempted and DECLINED into
+    /// the mapped-texture readback (render to a texture, read back through
+    /// `map()` at the destination's offset and pitch). The destination-side
+    /// twin of [`zero_copy_declines`](Self::zero_copy_declines): a nonzero
+    /// value with a Dma destination means the driver refused to render into
+    /// the buffer directly and the convert still produced correct pixels,
+    /// through a copy.
+    pub dst_import_fallbacks: u64,
 }
 
 /// Buffer-import cache owned by the GL processor.

--- a/crates/image/src/gl/processor/mod.rs
+++ b/crates/image/src/gl/processor/mod.rs
@@ -115,6 +115,29 @@ enum DstReadback {
     Pbo(u32),
 }
 
+impl DstTarget {
+    /// The `dst_feed` value for this target: how the convert's OUTPUT reached
+    /// the destination tensor.
+    ///
+    /// Recorded for every target, so the field's absence never has to be
+    /// interpreted. `zero_copy` is the render writing the destination buffer
+    /// itself; `mapped_texture` is a render into an offscreen texture read
+    /// back through the tensor's `map()`, whether the destination was always
+    /// host memory or the driver refused its import; `pbo` is the same render
+    /// read back into the destination PBO's PACK binding, with no CPU visit.
+    fn feed(self) -> &'static str {
+        match self {
+            DstTarget::ZeroCopyImage => "zero_copy",
+            DstTarget::Texture {
+                readback: DstReadback::Mem,
+            } => "mapped_texture",
+            DstTarget::Texture {
+                readback: DstReadback::Pbo(_),
+            } => "pbo",
+        }
+    }
+}
+
 impl DstReadback {
     /// The PBO id in the `Option` shape `readback_rendered` consumes.
     fn pbo_id(self) -> Option<u32> {
@@ -297,6 +320,31 @@ pub struct GLProcessorST {
     /// (drivers whose implementation read-pair rejects direct RGB/RED
     /// reads — ANGLE/Metal, V3D). Grown on demand, kept at high-water mark.
     readback_scratch: Vec<u8>,
+    /// Test hook: make every zero-copy DESTINATION import fail, the way a
+    /// driver that refuses the buffer does, so the fallback to the
+    /// mapped-texture readback is exercised on hosts whose driver accepts
+    /// every destination. Injected at the import itself
+    /// (`get_or_create_egl_image` for `CacheKind::Dst` and
+    /// `get_or_create_egl_image_rgb`), not at the routing decision, so what a
+    /// test drives is the real trigger.
+    #[cfg(test)]
+    pub(super) fail_dst_import: bool,
+    /// While set, a failed zero-copy destination import PROPAGATES instead of
+    /// falling back to the mapped-texture readback — at both sites that can
+    /// fall back, `bind_dst` and the packed-RGB pre-flight. Exactly one caller
+    /// sets it: `verify_dma_buf_roundtrip`, whose whole question is whether
+    /// this display can render into a DMA-BUF at all. Serving that convert through
+    /// the fallback would answer the question with the fallback's own output
+    /// and leave a display that cannot import a destination believing it can —
+    /// and would run a texture upload over the shared render texture before
+    /// the first real convert, which is state the probe has no business
+    /// leaving behind.
+    probe_dst_import_only: bool,
+    /// Buffers whose destination import has already been reported as declined
+    /// into the mapped-texture readback. Warn once per buffer, debug on the
+    /// repeats — the same shape as `nv_import_warned` on the source side, so a
+    /// per-frame decline on a pooled buffer does not flood the log.
+    dst_import_warned: std::collections::HashSet<u64>,
     /// Whether the GPU is a Verisilicon/Vivante core (detected via GL_RENDERER).
     /// Used to block operations known to cause unrecoverable GPU hangs.
     pub(super) is_vivante: bool,
@@ -1271,20 +1319,79 @@ unsafe fn read_pixels_rgba_scratch(w: usize, h: usize, scratch: &mut Vec<u8>) {
 /// the bounds the robust variant checked hold by construction as long as
 /// the caller sized `out`.
 ///
-/// `scratch` is the caller's reusable RGBA staging buffer
+/// `scratch` is the caller's reusable staging buffer
 /// (`GLProcessorST::readback_scratch`) — grown on demand and kept at its
-/// high-water mark, so the fallback path costs no per-call allocation
+/// high-water mark, so neither indirect route costs a per-call allocation
 /// after the first read of a given size.
+///
+/// `stride` is how far apart `out`'s rows sit, and **only the first
+/// `w * channels` bytes of each are ever written**. The bytes between one
+/// row's end and the next row's start belong to somebody else whenever `out`
+/// is a `view()`'s window into a wider parent — they are the sibling columns
+/// to the right of the tile — so a read that packs `h` tight rows at the head
+/// of `out` and re-spaces them afterwards leaves its own tail sitting in
+/// them. It did: a 320-wide tile read into a 512-wide parent overwrote 192
+/// parent pixels on each of the first 150 rows (issue #177). Where the pitch
+/// is a whole number of pixels GL lays the rows out itself through
+/// `GL_PACK_ROW_LENGTH` — which is what the PBO readback has always done —
+/// and where it is not (a 3-byte pixel never divides a 64- or 128-byte
+/// aligned pitch) the frame is read tight into `scratch` and the rows are
+/// copied out one at a time.
+///
+/// The pixel count converts back to the byte pitch only because
+/// `PACK_ALIGNMENT` is 1 (set once in `new`) — see [`pack_row_length`].
 ///
 /// # Safety
 /// Must run on the GL thread with a complete read framebuffer bound and
-/// `ReadBuffer` selected, and `out` must hold `w * h * channels` bytes for
-/// the pack format (nothing here can check it — the read goes through a raw
-/// pointer).
-unsafe fn read_pixels_into(w: usize, h: usize, format: u32, scratch: &mut Vec<u8>, out: &mut [u8]) {
+/// `ReadBuffer` selected, and `out` must hold `(h - 1) * stride + w *
+/// channels` bytes for the pack format (nothing here can check it — the read
+/// goes through a raw pointer).
+unsafe fn read_pixels_into(
+    w: usize,
+    h: usize,
+    format: u32,
+    scratch: &mut Vec<u8>,
+    out: &mut [u8],
+    stride: usize,
+) {
+    let channels = pack_channels(format);
+    let tight_row = w * channels;
     unsafe {
-        let direct = direct_read_supported(format);
-        if direct {
+        if direct_read_supported(format) {
+            if stride == tight_row {
+                edgefirst_gl::gl::ReadPixels(
+                    0,
+                    0,
+                    w as i32,
+                    h as i32,
+                    format,
+                    edgefirst_gl::gl::UNSIGNED_BYTE,
+                    out.as_mut_ptr() as *mut c_void,
+                );
+                return;
+            }
+            if let Some(px) = pack_row_length(tight_row, stride, channels) {
+                edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::PACK_ROW_LENGTH, px);
+                edgefirst_gl::gl::ReadPixels(
+                    0,
+                    0,
+                    w as i32,
+                    h as i32,
+                    format,
+                    edgefirst_gl::gl::UNSIGNED_BYTE,
+                    out.as_mut_ptr() as *mut c_void,
+                );
+                // Back to GL's own "rows are `width` pixels" default, so the
+                // next read of a tight destination is unaffected.
+                edgefirst_gl::gl::PixelStorei(edgefirst_gl::gl::PACK_ROW_LENGTH, 0);
+                return;
+            }
+            // A pitch `GL_PACK_ROW_LENGTH` cannot express. The scratch is
+            // otherwise unused on this branch, so the tight frame lands there
+            // and each row is copied to its place.
+            if scratch.len() < h * tight_row {
+                scratch.resize(h * tight_row, 0);
+            }
             edgefirst_gl::gl::ReadPixels(
                 0,
                 0,
@@ -1292,23 +1399,27 @@ unsafe fn read_pixels_into(w: usize, h: usize, format: u32, scratch: &mut Vec<u8
                 h as i32,
                 format,
                 edgefirst_gl::gl::UNSIGNED_BYTE,
-                out.as_mut_ptr() as *mut c_void,
+                scratch.as_mut_ptr() as *mut c_void,
             );
+            for y in 0..h {
+                out[y * stride..y * stride + tight_row]
+                    .copy_from_slice(&scratch[y * tight_row..y * tight_row + tight_row]);
+            }
             return;
         }
-        let channels = pack_channels(format);
         read_pixels_rgba_scratch(w, h, scratch);
-        // `take(w * h)`: the scratch keeps its high-water mark from earlier,
-        // larger reads and `out` may be a padded mapping, so without a bound
-        // the zip would write stale pixels past the frame.
-        for (px, dst_px) in scratch
-            .as_chunks::<4>()
-            .0
-            .iter()
-            .take(w * h)
-            .zip(out.chunks_exact_mut(channels))
-        {
-            dst_px.copy_from_slice(&px[..channels]);
+        // Row by row, at the destination's pitch. The scratch keeps its
+        // high-water mark from earlier, larger reads, so each row is taken
+        // from its own `w`-pixel window rather than walked continuously.
+        let rgba = scratch.as_chunks::<4>().0;
+        for y in 0..h {
+            for (px, dst_px) in rgba[y * w..]
+                .iter()
+                .take(w)
+                .zip(out[y * stride..y * stride + tight_row].chunks_exact_mut(channels))
+            {
+                dst_px.copy_from_slice(&px[..channels]);
+            }
         }
     }
 }
@@ -1331,20 +1442,22 @@ fn classify_renderer(renderer: &str) -> RendererTraits {
     }
 }
 
-/// The plane-offset alignment the two embedded drivers that have been measured
-/// need from a DMA-BUF import. Both landed on the same 64 bytes, from opposite
-/// symptoms:
+/// The plane-offset alignment Mali needs from a DMA-BUF **source** import.
 ///
-/// * **Mali** (i.MX 95, source sampling, issue #165): offsets 32 and 2080
-///   sample zeros with no EGL error at all; 64, 256 and 2048 sample correctly,
-///   and offset 0 (the whole image, not a window) is the control.
-/// * **Vivante GC7000UL** (i.MX 8M Plus, destination import): offset 2048
-///   imports and renders correctly, offset 2080 fails `eglCreateImage` with
-///   `EGL_BAD_ACCESS`.
+/// Measured on i.MX 95 (issue #165): offsets 32 and 2080 sample zeros with no
+/// EGL error at all; 64, 256 and 2048 sample correctly, and offset 0 (the
+/// whole image, not a window) is the control. Two data points bracket the rule
+/// rather than pin it — the true requirement is somewhere in `(32, 2048]` — so
+/// 64 is the tightest value consistent with the measurements rather than a
+/// documented driver constant.
 ///
-/// Two data points bracket the Vivante rule rather than pin it — the true
-/// requirement is somewhere in `(32, 2048]` — so 64 is the tightest value
-/// consistent with both drivers rather than a documented driver constant.
+/// Sources only, and deliberately: this is a rule about a driver that fails
+/// SILENTLY, which nothing downstream can detect, so it has to be predicted.
+/// Vivante refuses a *destination* at an unaligned offset the opposite way —
+/// `eglCreateImage` returns `EGL_BAD_ACCESS`, measured at offset 2080 against
+/// 2048 rendering correctly — and a refusal that loud needs no prediction: the
+/// destination arms fall back to the mapped-texture readback when the import
+/// fails, whatever the driver and whatever its reason (issue #175).
 pub(super) const DMA_IMPORT_OFFSET_ALIGN: usize = 64;
 
 /// Whether `plane_offset` is one of the offsets no measured embedded driver
@@ -1395,31 +1508,14 @@ fn source_import_plane0_offset(img: &Tensor<u8>, img_fmt: PixelFormat) -> usize 
     }
 }
 
-/// Whether Vivante would fail to import a DESTINATION at `plane_offset`.
-///
-/// Distinct from [`mali_rejects_import_offset`] in symptom and in side: this is
-/// a hard `EGL_BAD_ACCESS` from `eglCreateImage`, not silent zero-sampling, and
-/// it hits the destination import, which Mali handles correctly at the same
-/// offsets (measured on i.MX 95 by
-/// `tests/offset_source_view_alignment.rs`). The engine already has a seam for
-/// "this platform cannot place a destination at its offset" —
-/// `Platform::dst_import_places` — and this joins it, so an unaligned Vivante
-/// destination lowers to the mapped-texture path, whose readback writes through
-/// `map()` at the offset, instead of letting the EGL error end the convert.
-///
-/// Takes the offset the import being guarded actually bases at, which differs
-/// by route: [`view_collapsed_dst_base`] for `bind_dst`'s import, and the raw
-/// `plane_offset()` for the `import_buffer_packed` ones.
-fn vivante_rejects_dst_import_offset(is_vivante: bool, plane_offset: usize) -> bool {
-    is_vivante && unaligned_import_offset(plane_offset)
-}
-
 /// The byte offset a destination import bases at **on the route that collapses
 /// a view to its parent** — `bind_dst`'s `get_or_create_egl_image(Dst)`.
 ///
 /// The engine has two zero-copy destination import routes and they treat a
-/// `view()` differently, so a driver rule about the base offset has to know
-/// which one it guards:
+/// `view()` differently, so [`GlPlatform::dst_import_places`] — the one
+/// destination question that must be answered BEFORE the import, because the
+/// import it guards succeeds and places the buffer wrongly — has to know which
+/// route it is guarding:
 ///
 /// * **`bind_dst` → `get_or_create_egl_image(CacheKind::Dst)` →
 ///   `Platform::import_buffer(.., for_dst = true)`.** A fresh `view()`/`batch()`
@@ -1435,11 +1531,11 @@ fn vivante_rejects_dst_import_offset(is_vivante: bool, plane_offset: usize) -> b
 ///   destination there IS imported at its own offset. Those sites pass the raw
 ///   `plane_offset()` and must NOT use this function.
 ///
-/// Getting the first case wrong is not merely a lost fast path: asking
-/// `plane_offset()` there made [`vivante_rejects_dst_import_offset`] fire on
-/// every tile view whose byte offset happened to be unaligned (an RGBA `x0` of
-/// 8 is 32 bytes), and the mapped-texture readback it lowered to returns wrong
-/// pixels for a view destination on that driver.
+/// Getting the first case wrong costs the zero-copy path for nothing: asking
+/// `plane_offset()` there declines every tile view whose byte offset happens
+/// to be unaligned (an RGBA `x0` of 8 is 32 bytes) although its import bases
+/// at 0 and would have succeeded. It cost correctness too, until the
+/// mapped-texture path it lowered to was fixed for a view destination (#177).
 ///
 /// Pure, and takes the two field values rather than a tensor, so it serves both
 /// `Tensor<u8>` and `TensorDyn` call sites and is unit-testable without either.
@@ -1865,6 +1961,10 @@ impl GLProcessorST {
             dst_egl_cache: ImportCache::new(egl_cache_capacity),
             bgra_warned: false,
             readback_scratch: Vec::new(),
+            #[cfg(test)]
+            fail_dst_import: false,
+            probe_dst_import_only: false,
+            dst_import_warned: std::collections::HashSet::new(),
             is_vivante,
             is_mali,
             is_virtual_gpu,
@@ -2035,7 +2135,14 @@ impl GLProcessorST {
 
         // Run the full DMA-buf EGLImage render pipeline (RGBA→RGBA DMA is a
         // single-pass zero-copy plan through the engine).
-        if let Err(e) = self.convert_via_engine(
+        // The probe declines the fallback the real converts take (issue #175):
+        // its question is whether this display can render into a DMA-BUF at
+        // all, and the answer demotes the whole transfer backend to PBO,
+        // sources included. A convert serviced by the mapped-texture readback
+        // would answer that question with the fallback's own output. The flag
+        // clears before the `?`-free early return below either way.
+        self.probe_dst_import_only = true;
+        let outcome = self.convert_via_engine(
             &mut dst,
             PixelFormat::Rgba,
             &src,
@@ -2044,7 +2151,9 @@ impl GLProcessorST {
             Rotation::None,
             Flip::None,
             ResolvedCrop::no_crop(),
-        ) {
+        );
+        self.probe_dst_import_only = false;
+        if let Err(e) = outcome {
             log::info!("verify_dma_buf_roundtrip: convert failed: {e}");
             return false;
         }
@@ -2222,23 +2331,17 @@ impl GLProcessorST {
                         Platform::dst_import_places(dst.as_typed::<f32>().expect("dtype checked"))
                     }
                     _ => unreachable!("dst_dtype is F16 or F32 in this branch"),
-                }
-                // Same driver-side term as `bind_dst`: Vivante cannot import a
-                // destination at an unaligned offset at all. There is no
-                // mapped-texture readback for a float DMA destination to lower
-                // to, so this declines to the CPU converter rather than letting
-                // `EGL_BAD_ACCESS` escape.
-                // The RAW `plane_offset`, not the view-collapsed base: these
-                // four float paths import through `import_buffer_packed`,
-                // which passes `plane_offset()` straight to
-                // `EGL_DMA_BUF_PLANE0_OFFSET_EXT` with no `view_origin`
-                // collapse (`platform/linux.rs` ~`:199`). Only `bind_dst`'s
-                // `get_or_create_egl_image(Dst)` route collapses a view to 0 —
-                // see `view_collapsed_dst_base`.
-                && !vivante_rejects_dst_import_offset(
-                    self.is_vivante,
-                    dst.plane_offset().unwrap_or(0),
-                );
+                };
+                // No driver-refusal term here, unlike the u8 arms: there is no
+                // mapped-texture readback for a FLOAT DMA destination to fall
+                // back to (`read_pixels_into` packs `UNSIGNED_BYTE`), so a
+                // driver that refuses such a destination has nothing to lower
+                // to inside GL. Its `eglCreateImage` failure propagates out of
+                // the convert and `ImageProcessor` runs the CPU converter,
+                // which is where the removed Vivante predicate sent it too --
+                // by a cleaner route, but to the same place (issue #175).
+                // What stays is the PLACEMENT question, which no import
+                // failure can answer because such an import succeeds.
                 if !places {
                     return Err(Error::NotSupported(format!(
                         "GL float destination at plane offset {} cannot be placed by \
@@ -2376,6 +2479,15 @@ impl GLProcessorST {
             // Recorded at the source-feed site: import | pbo | upload —
             // the zero-copy observable (see ConvertStats).
             src_feed = tracing::field::Empty,
+            // Recorded at the destination-feed site for EVERY u8 destination:
+            // zero_copy | mapped_texture | pbo -- how the convert's output
+            // reached the tensor (see `DstTarget::feed`). It is deliberately
+            // not a refusal marker: `zero_copy` and `mapped_texture` are both
+            // stated, so a trace never has to read an absent field as "written
+            // directly". Absent means only the float route, which enters no
+            // convert span at all. The field has to be declared here or the
+            // record would be a silent no-op.
+            dst_feed = tracing::field::Empty,
         )
         .entered();
         if !Self::check_src_format_supported(self.gl_context.transfer_backend, src, src_fmt) {
@@ -2440,25 +2552,44 @@ impl GLProcessorST {
         flip: Flip,
         crop: ResolvedCrop,
     ) -> crate::Result<()> {
-        // Same gate as `bind_dst`, for the two destination imports that do
-        // not go through it: the packed-RGB two-pass plan's pass 2
-        // (`convert_to_packed_rgb` -> `get_or_create_egl_image_rgb`) and the
-        // planar two-pass plan, both zero-copy imports via
-        // `import_buffer_packed`, which on ANGLE binds the whole buffer from
-        // its origin. A destination rebuilt from a descriptor carries a
-        // plane offset but no `view_origin`, so without this it would still
-        // take `DstLowering::ZeroCopy` here and render at the buffer's
-        // origin.
-        // Vivante's driver-side half of the same question: an unaligned
-        // destination offset fails `eglCreateImage` (see `bind_dst`). The RAW
-        // `plane_offset` here, not the view-collapsed base: this plan imports
-        // through `import_buffer_packed`, which passes `plane_offset()` straight
-        // to EGL with no `view_origin` collapse (`platform/linux.rs` ~`:199`),
-        // so a view destination on this route really is imported at its own
-        // offset. See `view_collapsed_dst_base` for the route that differs.
-        let dst_offset = dst.plane_offset().unwrap_or(0);
-        let places = Platform::dst_import_places(dst)
-            && !vivante_rejects_dst_import_offset(self.is_vivante, dst_offset);
+        // Same gate as `bind_dst`, for the destination import that does not go
+        // through it: the packed-RGB two-pass plan's pass 2
+        // (`convert_to_packed_rgb` -> `get_or_create_egl_image_rgb`), a
+        // zero-copy import via `import_buffer_packed`, which on ANGLE binds
+        // the whole buffer from its origin. A destination rebuilt from a
+        // descriptor carries a plane offset but no `view_origin`, so without
+        // this it would still take `DstLowering::ZeroCopy` here and render at
+        // the buffer's origin. The RAW `plane_offset` here, not the
+        // view-collapsed base: this route passes `plane_offset()` straight to
+        // EGL with no `view_origin` collapse (`platform/linux.rs` ~`:199`), so
+        // a view destination on it really is imported at its own offset. See
+        // `view_collapsed_dst_base` for the route that differs.
+        // v1 view()/batch() destination support covers only the SINGLE-PASS
+        // PACKED formats. Packed RGB and every planar layout reinterpret the
+        // destination geometry (`W*3/4 × H`, `H*3` bands), which neither
+        // destination route places a tile in: the zero-copy route's
+        // `glViewport`/`glScissor` band is computed in the destination's own
+        // pixels, and the mapped-texture route's readback writes `dst_w`-wide
+        // rows at the parent's pitch. So such a destination declines here and
+        // the CPU backend takes it. (Band tiling for those is a follow-up.)
+        //
+        // Asked of the destination alone, BEFORE the lowering is chosen, and
+        // deliberately: keying it on `lowering == ZeroCopy` left the refusal
+        // depending on a decision that can still change underneath it — a
+        // refused import re-plans onto the mapped-texture route below, and the
+        // guard would then wave the very destination it exists to refuse
+        // straight onto a path that cannot place it either.
+        if dst.view_origin().is_some()
+            && (dst_fmt == PixelFormat::Rgb || dst_fmt.layout() == PixelLayout::Planar)
+        {
+            return Err(crate::Error::NotSupported(
+                "GL view()/batch() destination not yet supported for packed-RGB / \
+                 planar formats (CPU fallback handles it)"
+                    .into(),
+            ));
+        }
+        let dst_offset = view_collapsed_dst_base(dst.view_origin(), dst.plane_offset());
+        let places = Platform::dst_import_places(dst);
         if !places {
             log::debug!(
                 "convert_via_engine: zero-copy destination importing at base offset \
@@ -2466,11 +2597,45 @@ impl GLProcessorST {
                  to a texture and reading back through map()"
             );
         }
-        let lowering = super::render::lower_dst(
+        // The `image.convert.gl` span, captured BEFORE the engine span below is
+        // entered, because that is the span the feed fields belong to. A
+        // `Span::current()` inside the engine span (or inside a two-pass
+        // pass span) names a child that does not declare them, and a record
+        // against an undeclared field is a silent no-op.
+        let convert_span = tracing::Span::current();
+        let mut lowering = super::render::lower_dst(
             self.gl_context.transfer_backend.is_zero_copy() && places,
             dst.memory(),
         );
-        let plan = super::render::plan_convert(src_fmt, dst_fmt, lowering);
+        let mut plan = super::render::plan_convert(src_fmt, dst_fmt, lowering);
+        // The packed-RGB plan imports the destination in its pass 2, AFTER
+        // pass 1 has rendered, and a texture-lowered RGB destination is a
+        // different plan entirely (one genuine RGB pass, no W*3/4
+        // reinterpretation). So the import is asked for here, before any
+        // rendering: a refusal re-plans onto the mapped-texture path instead
+        // of ending the convert, and the pass-2 call that follows is a cache
+        // hit. `bind_dst` needs no equivalent — it can fall back in place,
+        // and its guard covers the attach as well as the import.
+        if plan == super::render::ConvertPlan::TwoPassPackedRgb {
+            match self.probe_packed_rgb_dst_import(dst, dst_fmt) {
+                // The packed-RGB plan never reaches `bind_dst` -- its pass 2
+                // attaches the import itself -- so the feed is recorded here
+                // instead, with the same vocabulary, rather than leaving this
+                // one route silent.
+                Ok(()) => {
+                    convert_span.record("dst_feed", DstTarget::ZeroCopyImage.feed());
+                }
+                // The probe declines the fallback too, for the same reason
+                // `bind_dst` does: it is answering the probe's question, not
+                // serving a caller's convert.
+                Err(e) if self.probe_dst_import_only => return Err(e),
+                Err(e) => {
+                    self.note_dst_import_fallback(dst, dst_fmt, &e);
+                    lowering = super::render::lower_dst(false, dst.memory());
+                    plan = super::render::plan_convert(src_fmt, dst_fmt, lowering);
+                }
+            }
+        }
         let _span = tracing::trace_span!(
             "image.convert.gl.engine",
             ?plan,
@@ -2479,38 +2644,82 @@ impl GLProcessorST {
         )
         .entered();
 
-        // v1 view()/batch() destination support covers only the single-pass
-        // PACKED zero-copy path (the glViewport/scissor band set in
-        // bind_dst). Packed RGB and every planar layout reinterpret the
-        // destination geometry (`W*3/4 × H`, `H*3` bands), which the band
-        // lowering does not yet handle, so a view destination declines them
-        // → CPU fallback. (Band tiling for those is a follow-up.)
-        if dst.view_origin().is_some()
-            && lowering == super::render::DstLowering::ZeroCopy
-            && (dst_fmt == PixelFormat::Rgb || dst_fmt.layout() == PixelLayout::Planar)
-        {
-            return Err(crate::Error::NotSupported(
-                "GL view()/batch() destination not yet supported for two-pass packed-RGB / \
-                 planar formats (CPU fallback handles it)"
-                    .into(),
-            ));
-        }
-
         match plan {
             super::render::ConvertPlan::TwoPassPackedRgb => {
                 return self.convert_to_packed_rgb(
-                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
+                    src,
+                    src_fmt,
+                    dst,
+                    dst_fmt,
+                    is_int8,
+                    rotation,
+                    flip,
+                    crop,
+                    &convert_span,
                 )
             }
             super::render::ConvertPlan::TwoPassNvPlanar => {
                 return self.convert_nv_to_planar_two_pass(
-                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
+                    src,
+                    src_fmt,
+                    dst,
+                    dst_fmt,
+                    is_int8,
+                    rotation,
+                    flip,
+                    crop,
+                    lowering,
+                    &convert_span,
                 )
             }
             super::render::ConvertPlan::SinglePass => {}
         }
 
-        let target = self.bind_dst(dst, dst_fmt, crop)?;
+        let (target, bound) = self.bind_dst(dst, dst_fmt, crop, lowering)?;
+        // A refused import changed the lowering underneath the plan that was
+        // chosen against `ZeroCopy`. Re-plan against what was actually bound:
+        // the pair `(SinglePass, TextureMem)` is legal for a PACKED
+        // destination and not for a planar one, where the single-pass planar
+        // shader imports its source unconditionally -- so a heap source would
+        // have failed out to the CPU backend instead of completing through
+        // the fallback that had just been set up for it.
+        //
+        // The two-pass plan binds the destination itself, at its pass 2, so
+        // the bind above is discarded; that costs one texture setup on a path
+        // the driver has already made slow, and keeps the "one plan, one
+        // route" invariant `plan_convert` documents.
+        let replanned = super::render::plan_convert(src_fmt, dst_fmt, bound);
+        if replanned != super::render::ConvertPlan::SinglePass {
+            debug_assert_eq!(
+                replanned,
+                super::render::ConvertPlan::TwoPassNvPlanar,
+                "a texture lowering can only re-plan onto the planar two-pass route"
+            );
+            return self.convert_nv_to_planar_two_pass(
+                src,
+                src_fmt,
+                dst,
+                dst_fmt,
+                is_int8,
+                rotation,
+                flip,
+                crop,
+                bound,
+                &convert_span,
+            );
+        }
+        Self::record_dst_feed(&convert_span, target);
+        // A `view()`/`batch()` destination is placed by a band viewport ONLY
+        // where the render target is the shared parent import
+        // (`setup_renderbuffer_dma`). The texture lowerings render into an
+        // offscreen target that is the tile itself, at origin (0, 0), and
+        // place it in the readback instead, so they must not carry the band
+        // into `glScissor` — doing so clipped away the tile's own left/top
+        // edge and left the previous frame's pixels there (issue #177).
+        let band = match target {
+            DstTarget::ZeroCopyImage => dst.view_origin(),
+            DstTarget::Texture { .. } => None,
+        };
 
         // Bias the letterbox clear colour for int8 on every lowering: the
         // fragment shader XORs rendered pixels and no readback un-biases,
@@ -2537,11 +2746,21 @@ impl GLProcessorST {
                     rotation,
                     flip,
                     crop,
+                    &convert_span,
                 )?;
             }
             None => {
                 self.render_packed_or_planar(
-                    src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop,
+                    src,
+                    src_fmt,
+                    dst,
+                    dst_fmt,
+                    band,
+                    is_int8,
+                    rotation,
+                    flip,
+                    crop,
+                    &convert_span,
                 )?;
             }
         }
@@ -3082,6 +3301,79 @@ impl GLProcessorST {
         self.camera_normal_texture.invalidate_egl_binding();
     }
 
+    /// Ask the driver for the packed-RGB plan's destination import before any
+    /// rendering happens, so a refusal can re-plan.
+    ///
+    /// Exactly the import `convert_to_packed_rgb`'s pass 2 makes — same
+    /// surface geometry, same packed format — so a success here is the cache
+    /// entry pass 2 will hit and costs nothing twice.
+    ///
+    /// `Ok(())` when there is nothing to ask: a geometry that does not resolve
+    /// (a width whose `W*3` bytes do not divide into whole RGBA texels) is not
+    /// a driver refusal, so it is left for pass 2 to report exactly as it does
+    /// today rather than being reported here as a fallback.
+    fn probe_packed_rgb_dst_import(
+        &mut self,
+        dst: &Tensor<u8>,
+        dst_fmt: PixelFormat,
+    ) -> crate::Result<()> {
+        let (Some(dst_w), Some(dst_h)) = (dst.width(), dst.height()) else {
+            return Ok(());
+        };
+        let Some(layout) = edgefirst_tensor::packed_rgb888_layout(dst_w, dst_h) else {
+            return Ok(());
+        };
+        self.get_or_create_egl_image_rgb(
+            dst,
+            dst_fmt,
+            layout.surface_w,
+            layout.surface_h,
+            super::platform::PackedImportFormat::Rgba8888,
+        )
+        .map(|_| ())
+    }
+
+    /// Record a zero-copy destination import that the driver refused, and
+    /// leave GL in a state the mapped-texture setup can start from.
+    ///
+    /// The destination-side twin of the source arms' decline handling: count
+    /// it in [`ConvertStats::dst_import_fallbacks`], warn once per buffer and
+    /// debug on the repeats (`dst_import_warned`, the shape `nv_import_warned`
+    /// already has), and drain the GL error queue. Draining matters because
+    /// the refusal can be a GL error rather than an EGL one — attaching the
+    /// image raises `GL_INVALID_OPERATION` on some desktop drivers — and
+    /// `check_gl_error` reads one flag per call, so a leftover flag would
+    /// surface as a spurious failure of the fallback that follows.
+    ///
+    /// [`ConvertStats::dst_import_fallbacks`]: super::cache::ConvertStats::dst_import_fallbacks
+    fn note_dst_import_fallback(&mut self, dst: &Tensor<u8>, dst_fmt: PixelFormat, e: &Error) {
+        self.convert_stats.dst_import_fallbacks += 1;
+        let w = dst.width().unwrap_or(0);
+        let h = dst.height().unwrap_or(0);
+        let offset = dst.plane_offset().unwrap_or(0);
+        if self.dst_import_warned.insert(dst.buffer_identity().id()) {
+            log::warn!(
+                "zero-copy destination import refused for {dst_fmt} ({w}x{h}) at plane \
+                 offset {offset}; rendering to a texture and reading back through map() \
+                 (slower, still correct): {e}"
+            );
+        } else {
+            log::debug!(
+                "zero-copy destination import refused for {dst_fmt} ({w}x{h}) at plane \
+                 offset {offset} (repeat): {e}"
+            );
+        }
+        // Bounded: a driver reports a small fixed set of flags, and the loop
+        // ends at the first NO_ERROR either way.
+        unsafe {
+            for _ in 0..8 {
+                if edgefirst_gl::gl::GetError() == edgefirst_gl::gl::NO_ERROR {
+                    break;
+                }
+            }
+        }
+    }
+
     /// Classify and bind the destination render target — the single entry
     /// point absorbing the per-memory `setup_renderbuffer_*` fan-out. The
     /// pure classification lives in [`super::render::lower_dst`]; this
@@ -3091,32 +3383,52 @@ impl GLProcessorST {
         dst: &Tensor<u8>,
         dst_fmt: PixelFormat,
         crop: ResolvedCrop,
-    ) -> crate::Result<DstTarget> {
-        // A zero-copy destination the platform cannot place -- one carrying a
-        // plane offset with no `view_origin` to lower to a viewport -- takes
-        // the mapped texture path, whose readback writes through `map()` at
-        // the offset. Vivante joins that rule from the driver side: its
-        // `eglCreateImage` fails outright on an unaligned destination offset,
-        // and without this the EGL error ended the convert instead of lowering
-        // it (measured on i.MX 8M Plus: offset 2048 renders, 2080 is
-        // `EGL_BAD_ACCESS`).
-        let dst_offset = view_collapsed_dst_base(dst.view_origin(), dst.plane_offset());
-        let places = Platform::dst_import_places(dst)
-            && !vivante_rejects_dst_import_offset(self.is_vivante, dst_offset);
-        if !places {
-            log::debug!(
-                "bind_dst: zero-copy destination importing at base offset {dst_offset} \
-                 cannot be placed by this platform/driver; rendering to a texture and \
-                 reading back through map()"
-            );
-        }
-        match super::render::lower_dst(
-            self.gl_context.transfer_backend.is_zero_copy() && places,
-            dst.memory(),
-        ) {
+        lowering: super::render::DstLowering,
+    ) -> crate::Result<(DstTarget, super::render::DstLowering)> {
+        // The lowering goes IN as the caller's and comes back as the effective
+        // one, and both halves matter.
+        //
+        // In, because `convert_via_engine` pairs it with a `ConvertPlan`: a
+        // refused packed-RGB import re-plans onto the mapped route, and asking
+        // `dst_import_places` again here would answer `true` (the IMPORT
+        // failed, the PLACEMENT is fine), bind a zero-copy destination under a
+        // plan chosen for a texture one.
+        //
+        // Out, because a refusal DISCOVERED here changes it: the caller's plan
+        // was chosen against `ZeroCopy` and may not be legal against the
+        // texture lowering the fallback just took. Returning it lets the
+        // caller re-plan instead of rendering the stale route.
+        let effective = match lowering {
             super::render::DstLowering::ZeroCopy => {
-                self.setup_renderbuffer_dma(dst, dst_fmt)?;
-                Ok(DstTarget::ZeroCopyImage)
+                // A destination import that FAILS lowers the convert to the
+                // mapped-texture readback, exactly as a failed source import
+                // lowers to the upload path -- rather than ending the convert
+                // and sending the whole thing to the CPU backend. That is what
+                // replaced the per-driver refusal predicates: Vivante's
+                // `eglCreateImage` returns `EGL_BAD_ACCESS` for a destination
+                // at an offset that is not 64-byte aligned, and the refusal
+                // itself is now the trigger, so a future driver quirk of the
+                // same kind needs no new trait (issue #175).
+                //
+                // The whole zero-copy setup is guarded, not just the import
+                // call: attaching the image to the texture and the FBO can
+                // fail after `eglCreateImage` succeeded (a desktop NVIDIA EGL
+                // raises `GL_INVALID_OPERATION` there), and either way the
+                // destination has not been written yet.
+                match self.setup_renderbuffer_dma(dst, dst_fmt) {
+                    Ok(()) => (DstTarget::ZeroCopyImage, lowering),
+                    Err(e) if self.probe_dst_import_only => return Err(e),
+                    Err(e) => {
+                        self.note_dst_import_fallback(dst, dst_fmt, &e);
+                        self.setup_renderbuffer_non_dma(dst, dst_fmt, crop)?;
+                        (
+                            DstTarget::Texture {
+                                readback: DstReadback::Mem,
+                            },
+                            super::render::DstLowering::TextureMem,
+                        )
+                    }
+                }
             }
             super::render::DstLowering::TexturePbo => {
                 let id = dst.pbo_id().ok_or_else(|| {
@@ -3130,17 +3442,38 @@ impl GLProcessorST {
                     ));
                 }
                 self.setup_renderbuffer_from_pbo(dst, dst_fmt, id)?;
-                Ok(DstTarget::Texture {
-                    readback: DstReadback::Pbo(id),
-                })
+                (
+                    DstTarget::Texture {
+                        readback: DstReadback::Pbo(id),
+                    },
+                    lowering,
+                )
             }
             super::render::DstLowering::TextureMem => {
                 self.setup_renderbuffer_non_dma(dst, dst_fmt, crop)?;
-                Ok(DstTarget::Texture {
-                    readback: DstReadback::Mem,
-                })
+                (
+                    DstTarget::Texture {
+                        readback: DstReadback::Mem,
+                    },
+                    lowering,
+                )
             }
-        }
+        };
+        Ok(effective)
+    }
+
+    /// Record how the convert's output will reach the destination, for EVERY
+    /// target and not only a refused import: a field present on some routes
+    /// and absent on others reads as "zero-copy" when it really means "nobody
+    /// said", which is how an ordinary texture-lowered convert could pass for
+    /// a zero-copy one in a trace.
+    ///
+    /// Called where the route is COMMITTED rather than inside `bind_dst`,
+    /// because a bind whose lowering the caller then re-plans away from is not
+    /// the route the convert took -- recording there put the same value on the
+    /// span twice, which an `fmt` subscriber prints twice.
+    fn record_dst_feed(convert_span: &tracing::Span, target: DstTarget) {
+        convert_span.record("dst_feed", target.feed());
     }
 
     fn setup_renderbuffer_dma(
@@ -3327,15 +3660,38 @@ impl GLProcessorST {
         src_fmt: PixelFormat,
         dst: &mut Tensor<u8>,
         dst_fmt: PixelFormat,
+        band: Option<edgefirst_tensor::ViewOrigin>,
         is_int8: bool,
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
+        convert_span: &tracing::Span,
     ) -> crate::Result<()> {
         if dst_fmt.layout() == PixelLayout::Planar {
-            self.convert_to_planar(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
+            self.convert_to_planar(
+                src,
+                src_fmt,
+                dst,
+                dst_fmt,
+                is_int8,
+                rotation,
+                flip,
+                crop,
+                convert_span,
+            )
         } else {
-            self.convert_to(src, src_fmt, dst, dst_fmt, is_int8, rotation, flip, crop)
+            self.convert_to(
+                src,
+                src_fmt,
+                dst,
+                dst_fmt,
+                band,
+                is_int8,
+                rotation,
+                flip,
+                crop,
+                convert_span,
+            )
         }
     }
 
@@ -3350,6 +3706,13 @@ impl GLProcessorST {
     /// the D3D11 staging texture behind a Windows `TensorMemory::DmaBuf`
     /// tensor, an IOSurface, a tensor carrying a declared stride -- and a tight
     /// write into a padded window shears every row after the first.
+    ///
+    /// A `view()` destination is the case where the padding is not the
+    /// destination's own: its window's rows sit at the PARENT's pitch and what
+    /// separates them is the parent's columns to the right of the tile. So the
+    /// readback places each row at the pitch and writes nothing between them
+    /// -- see [`read_pixels_into`], which owns that rule for both of its
+    /// routes (issue #177).
     fn read_pixels_into_tensor(
         &mut self,
         dst: &mut Tensor<u8>,
@@ -3372,10 +3735,10 @@ impl GLProcessorST {
         }
         let mut dst_map = dst.map_mut()?;
         let out = dst_map.as_mut_slice();
-        // `read_pixels_into` writes `rows * tight_row` bytes at the head of
-        // `out` whatever the pitch, and the spread then reaches the padded
-        // span. Both bounds are checked before the read, because the read
-        // itself goes through a raw pointer and cannot check anything.
+        // `read_pixels_into` writes `tight_row` bytes at every `stride`, so the
+        // last row's end is the far bound. It is checked before the read,
+        // because the read itself goes through a raw pointer and cannot check
+        // anything.
         let needed = padded_readback_bytes(rows, tight_row, stride).unwrap_or(rows * tight_row);
         if out.len() < needed {
             return Err(crate::Error::OpenGl(format!(
@@ -3384,14 +3747,13 @@ impl GLProcessorST {
             )));
         }
         // SAFETY: called on the GL thread with a complete read framebuffer
-        // bound; the tight read fits `out` by the check above, which covers the
-        // unpadded case as well as the padded one.
+        // bound; the rows fit `out` at this pitch by the check above, which
+        // covers the unpadded case as well as the padded one.
         unsafe {
             edgefirst_gl::gl::ReadBuffer(edgefirst_gl::gl::COLOR_ATTACHMENT0);
-            read_pixels_into(width, rows, format, &mut self.readback_scratch, out);
+            read_pixels_into(width, rows, format, &mut self.readback_scratch, out, stride);
         }
         check_gl_error(function!(), line!())?;
-        spread_rows(out, rows, tight_row, stride);
         if swap_rb {
             // Row by row: the swap must not walk the padding between rows, and
             // a padded pitch need not be a multiple of the 4-byte chunk.
@@ -3659,9 +4021,26 @@ impl GLProcessorST {
         let map;
         let mut swapped_buf;
 
-        let pixels = if crop.dst_rect.is_none_or(|crop| {
-            crop.top == 0 && crop.left == 0 && crop.height == dst_h && crop.width == dst_w
-        }) {
+        // Seed the render target with the destination's current pixels, so a
+        // letterbox band that is neither cleared nor drawn keeps what the
+        // destination already held.
+        //
+        // Skipped whenever a fill colour was asked for, which is every
+        // letterbox `Crop` the public API can build: `convert_to`'s
+        // `glClear` covers the whole target before anything is drawn, so the
+        // upload would be read back out of the framebuffer having been
+        // overwritten in full — pure cost, and on a strided or `view()`
+        // destination a misleading one, since `TexImage2D` reads the map
+        // tight and would shear the rows it uploaded.
+        let seeded = crop.dst_color.is_none()
+            && crop.dst_rect.is_some_and(|c| {
+                c.top != 0 || c.left != 0 || c.height != dst_h || c.width != dst_w
+            });
+        // No public `Crop` reaches this arm today: `Crop::resolve` returns a
+        // partial `dst_rect` only for `Fit::Letterbox`, which always carries
+        // its pad colour, so a partial rect without one can only come from a
+        // `ResolvedCrop` built inside the crate.
+        let pixels = if !seeded {
             std::ptr::null()
         } else {
             map = dst.map_read()?;
@@ -3751,7 +4130,19 @@ impl GLProcessorST {
                 false,
             )
         } else {
-            self.draw_src_texture(bg, bg_fmt, full_src, full_dst, 0, crate::Flip::None, false)
+            // An overlay background, not a convert: there is no
+            // `image.convert.gl` span to record a source feed on, and
+            // `ConvertStats` counts it either way.
+            self.draw_src_texture(
+                bg,
+                bg_fmt,
+                full_src,
+                full_dst,
+                0,
+                crate::Flip::None,
+                false,
+                &tracing::Span::none(),
+            )
         }
     }
 
@@ -4005,6 +4396,7 @@ impl GLProcessorST {
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
+        convert_span: &tracing::Span,
     ) -> Result<(), Error> {
         let src_w = src.width().ok_or(Error::NotAnImage)?;
         let src_h = src.height().ok_or(Error::NotAnImage)?;
@@ -4023,7 +4415,7 @@ impl GLProcessorST {
         };
 
         self.convert_stats.src_pbo_uploads += 1;
-        tracing::Span::current().record("src_feed", "pbo");
+        convert_span.record("src_feed", "pbo");
 
         let has_crop = crop
             .dst_rect
@@ -4398,6 +4790,17 @@ impl GLProcessorST {
         }
     }
 
+    /// `band` is the destination tile's origin **inside the bound render
+    /// target**, and is `Some` only when that target is the shared parent
+    /// import a `view()`/`batch()` destination is placed in by
+    /// `setup_renderbuffer_dma`'s viewport. It is NOT `dst.view_origin()`:
+    /// the mapped-texture and PBO lowerings render into an offscreen target
+    /// that IS the tile, at origin (0, 0), and place it afterwards in the
+    /// readback, so scissoring them to the view's parent coordinates would
+    /// clip away the tile's own left/top edge (issue #177). The two-pass
+    /// plans' pass 1 renders into an engine-internal intermediate for the
+    /// same reason and passes `None` too. Callers derive it from what
+    /// [`Self::bind_dst`] classified the destination as.
     #[allow(clippy::too_many_arguments)]
     fn convert_to(
         &mut self,
@@ -4405,10 +4808,12 @@ impl GLProcessorST {
         src_fmt: PixelFormat,
         dst: &Tensor<u8>,
         _dst_fmt: PixelFormat,
+        band: Option<edgefirst_tensor::ViewOrigin>,
         is_int8: bool,
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
+        convert_span: &tracing::Span,
     ) -> Result<(), crate::Error> {
         let dst_w = dst.width().ok_or(Error::NotAnImage)?;
         let dst_h = dst.height().ok_or(Error::NotAnImage)?;
@@ -4417,12 +4822,13 @@ impl GLProcessorST {
             src_fmt,
             dst_w,
             dst_h,
-            dst.view_origin(),
+            band,
             _dst_fmt,
             is_int8,
             rotation,
             flip,
             crop,
+            convert_span,
         )
     }
 
@@ -4445,6 +4851,7 @@ impl GLProcessorST {
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
+        convert_span: &tracing::Span,
     ) -> Result<(), crate::Error> {
         let src_w = src.width().ok_or(Error::NotAnImage)?;
         let src_h = src.height().ok_or(Error::NotAnImage)?;
@@ -4552,6 +4959,7 @@ impl GLProcessorST {
                     rotation_offset,
                     flip,
                     is_int8,
+                    convert_span,
                 )?;
             } else if chosen == NvConvertPath::ShaderR8 {
                 match self.get_or_create_nv_r8_egl_image(src, src_fmt) {
@@ -4562,7 +4970,7 @@ impl GLProcessorST {
                             "image.convert.gl.nv_path"
                         );
                         self.convert_stats.src_imports += 1;
-                        tracing::Span::current().record("src_feed", "import");
+                        convert_span.record("src_feed", "import");
                         // Recorded from the draw's result, not before it: a
                         // failed draw must not leave a ShaderR8 claim, and it
                         // must not leave the PREVIOUS convert's value either.
@@ -4616,7 +5024,7 @@ impl GLProcessorST {
                         // no PBO can reach here anyway, this arm being inside
                         // the `TensorMemory::DmaBuf` branch.
                         self.convert_stats.src_uploads += 1;
-                        tracing::Span::current().record("src_feed", "upload");
+                        convert_span.record("src_feed", "upload");
                         let start = Instant::now();
                         // The R8 import declined (Mali's alignment rule, the
                         // ANGLE leaves' offset refusal, or a driver that cannot
@@ -4654,7 +5062,7 @@ impl GLProcessorST {
                             tracing::trace!(path = "ExternalSampler", src_fmt = ?src_fmt, "image.convert.gl.nv_path");
                         }
                         self.convert_stats.src_imports += 1;
-                        tracing::Span::current().record("src_feed", "import");
+                        convert_span.record("src_feed", "import");
                         // Recorded from the draw's result (see the ShaderR8
                         // arm): a failed draw records neither ExternalSampler
                         // nor the previous convert's value.
@@ -4721,7 +5129,7 @@ impl GLProcessorST {
                             // `draw_nv_texture_2d(.., None, ..)` refuses a PBO
                             // source itself in any case.
                             self.convert_stats.src_uploads += 1;
-                            tracing::Span::current().record("src_feed", "upload");
+                            convert_span.record("src_feed", "upload");
                             // Recorded from the result: a drawn upload is still
                             // a GPU convert (ShaderR8), a failed one records Cpu
                             // rather than keeping the previous convert's value.
@@ -4757,6 +5165,7 @@ impl GLProcessorST {
                                 rotation_offset,
                                 flip,
                                 is_int8,
+                                convert_span,
                             )?;
                             log::debug!("draw_src_texture takes {:?}", start.elapsed());
                         }
@@ -4776,7 +5185,7 @@ impl GLProcessorST {
             // buffers) cannot be uploaded as one R8 texture → CPU below.
             tracing::trace!(path = "ShaderR8-upload", src_fmt = ?src_fmt, "image.convert.gl.nv_path");
             self.convert_stats.src_uploads += 1;
-            tracing::Span::current().record("src_feed", "upload");
+            convert_span.record("src_feed", "upload");
             // Recorded from the draw's result, like the four DMA arms above: a
             // failed upload records Cpu rather than leaving a ShaderR8 claim or
             // the previous convert's value.
@@ -4813,6 +5222,7 @@ impl GLProcessorST {
                 rotation_offset,
                 flip,
                 is_int8,
+                convert_span,
             )?;
             log::debug!("draw_src_texture takes {:?}", start.elapsed());
         }
@@ -4840,6 +5250,7 @@ impl GLProcessorST {
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
+        convert_span: &tracing::Span,
     ) -> Result<(), crate::Error> {
         let src_w = src.width().ok_or(Error::NotAnImage)?;
         let src_h = src.height().ok_or(Error::NotAnImage)?;
@@ -4937,6 +5348,13 @@ impl GLProcessorST {
 
         let src_key = BufferImportKey::from_tensor(src, src_fmt, false);
         let src_egl = self.get_or_create_egl_image(CacheKind::Src, src, src_fmt)?;
+        // This route imports unconditionally -- there is no upload arm to
+        // choose between -- but it is still a source feed, and a field
+        // recorded on every convert except one is worse than no field: the
+        // single-pass planar route would be the only u8 convert whose
+        // `src_feed` is absent, which reads as "not fed by GL at all".
+        self.convert_stats.src_imports += 1;
+        convert_span.record("src_feed", "import");
         // As in `draw_src_texture`: the import may cover more of the texture
         // than the logical image, and may start it partway in. One cache
         // lookup feeds both the source rectangle and the sampling clamp.
@@ -4981,6 +5399,7 @@ impl GLProcessorST {
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
+        convert_span: &tracing::Span,
     ) -> crate::Result<()> {
         let dst_w = dst.width().ok_or(Error::NotAnImage)?;
         let dst_h = dst.height().ok_or(Error::NotAnImage)?;
@@ -5029,7 +5448,18 @@ impl GLProcessorST {
         // The flag restores before `?` so an error cannot leak defer state.
         let saved_defer = self.defer_finish;
         self.defer_finish = true;
-        let pass1 = self.convert_to(src, src_fmt, dst, dst_fmt, false, rotation, flip, crop);
+        let pass1 = self.convert_to(
+            src,
+            src_fmt,
+            dst,
+            dst_fmt,
+            None,
+            false,
+            rotation,
+            flip,
+            crop,
+            convert_span,
+        );
         self.defer_finish = saved_defer;
         pass1?;
         drop(_pass1);
@@ -5149,6 +5579,8 @@ impl GLProcessorST {
         rotation: crate::Rotation,
         flip: Flip,
         crop: ResolvedCrop,
+        lowering: super::render::DstLowering,
+        convert_span: &tracing::Span,
     ) -> crate::Result<()> {
         let dst_w = dst.width().ok_or(Error::NotAnImage)?;
         let dst_h = dst.height().ok_or(Error::NotAnImage)?;
@@ -5196,7 +5628,18 @@ impl GLProcessorST {
         // finished intermediate, and the convert syncs once at pass 2's end.
         let saved_defer = self.defer_finish;
         self.defer_finish = true;
-        let pass1 = self.convert_to(src, src_fmt, dst, dst_fmt, false, rotation, flip, crop);
+        let pass1 = self.convert_to(
+            src,
+            src_fmt,
+            dst,
+            dst_fmt,
+            None,
+            false,
+            rotation,
+            flip,
+            crop,
+            convert_span,
+        );
         self.defer_finish = saved_defer;
         pass1?;
         drop(_pass1);
@@ -5213,7 +5656,8 @@ impl GLProcessorST {
             dst_h
         )
         .entered();
-        let target = self.bind_dst(dst, dst_fmt, crop)?;
+        let (target, _bound) = self.bind_dst(dst, dst_fmt, crop, lowering)?;
+        Self::record_dst_feed(convert_span, target);
 
         // Pass 2 is a fullscreen blit from the intermediate to the planar
         // destination. Pass 1 (convert_to above) already placed the image
@@ -5666,6 +6110,7 @@ impl GLProcessorST {
         rotation_offset: usize,
         flip: Flip,
         is_int8: bool,
+        convert_span: &tracing::Span,
     ) -> Result<(), Error> {
         let src_w = src.width().ok_or(Error::NotAnImage)?;
         let src_h = src.height().ok_or(Error::NotAnImage)?;
@@ -5823,7 +6268,7 @@ impl GLProcessorST {
                 // TexSubImage2D into the attached client buffer.
                 self.camera_normal_texture.target = 0;
                 self.convert_stats.src_imports += 1;
-                tracing::Span::current().record("src_feed", "import");
+                convert_span.record("src_feed", "import");
             } else {
                 let src_bpp = src_fmt.channels().max(1);
                 // A recorded pitch that is not a whole number of pixels
@@ -5840,7 +6285,7 @@ impl GLProcessorST {
                     &format!("{src_fmt:?}"),
                 )?;
                 self.convert_stats.src_uploads += 1;
-                tracing::Span::current().record("src_feed", "upload");
+                convert_span.record("src_feed", "upload");
                 // Map before touching pixel-store state: a `?` here must not
                 // leave `UNPACK_ROW_LENGTH` set for the next upload.
                 let pixels = src.map_read()?;
@@ -6445,6 +6890,16 @@ impl GLProcessorST {
         img: &Tensor<u8>,
         img_fmt: PixelFormat,
     ) -> Result<PlatformHandle, crate::Error> {
+        // Test hook: stand in for a driver that refuses this destination, so
+        // the fallback to the mapped-texture readback is exercised on hosts
+        // whose driver accepts every destination (issue #175). Destinations
+        // only — the source arms have their own decline paths.
+        #[cfg(test)]
+        if cache == CacheKind::Dst && self.fail_dst_import {
+            return Err(crate::Error::OpenGl(
+                "EDGEFIRST test hook: zero-copy destination import refused".to_string(),
+            ));
+        }
         // Before the lookup, not inside the miss arm: a hit returns a cached
         // import without consulting the platform at all, so an identity that
         // has stopped naming its buffer would be served a stale image.
@@ -6742,6 +7197,15 @@ impl GLProcessorST {
         // Before the lookup, not inside the miss arm: a hit returns a cached
         // import without consulting the platform at all, so an identity that
         // has stopped naming its buffer would be served a stale image.
+        // Test hook: stand in for a driver that refuses this destination, so
+        // the fallback to the mapped-texture readback is exercised on hosts
+        // whose driver accepts every destination (issue #175).
+        #[cfg(test)]
+        if self.fail_dst_import {
+            return Err(crate::Error::OpenGl(
+                "EDGEFIRST test hook: zero-copy destination import refused".to_string(),
+            ));
+        }
         Platform::validate_import_identity(img, "packed destination")?;
         // Keyed identically to `cached_dst_renderbuffer` and the logical-dims
         // dst path: the packed render dims derive deterministically from the
@@ -8267,6 +8731,11 @@ impl GLProcessorST {
             rotation,
             flip,
             crop,
+            // The FLOAT route: it returns before `image.convert.gl` is
+            // entered, so there is no convert span for the source feed to land
+            // on. Documented in ARCHITECTURE.md's span catalog; giving this
+            // route its own span is a follow-up.
+            &tracing::Span::none(),
         );
         self.defer_finish = saved_defer;
         pass1?;
@@ -8714,44 +9183,37 @@ mod tests {
         }
     }
 
-    // The destination-side rule, which is Vivante's and NOT Mali's: Mali was
-    // measured rendering into offset 2080 correctly, Vivante fails to import it
-    // (`EGL_BAD_ACCESS`). Both halves matter, so both are asserted -- gating
-    // Mali destinations would cost it the zero-copy path for nothing.
+    // The offset rule is a SOURCE rule, and only Mali's. Vivante's refusal of
+    // an unaligned destination is loud (`EGL_BAD_ACCESS` from
+    // `eglCreateImage`) and is handled by falling back when the import fails,
+    // so no predicate predicts it and no driver is gated on the destination
+    // side -- Mali least of all, which was measured rendering into offset 2080
+    // correctly (issue #175).
     #[test]
-    fn only_vivante_declines_an_unaligned_destination_import() {
-        use super::{mali_rejects_import_offset, vivante_rejects_dst_import_offset as dst_rejects};
+    fn the_offset_rule_is_a_source_rule_and_only_malis() {
+        use super::mali_rejects_import_offset;
 
-        // Vivante: 2048 imports, 2080 is EGL_BAD_ACCESS -- the two measured
-        // points on i.MX 8M Plus.
-        assert!(!dst_rejects(true, 2048));
-        assert!(dst_rejects(true, 2080));
-        assert!(!dst_rejects(true, 0));
-        assert!(dst_rejects(true, 32));
-
-        // Not Vivante: no destination gate at all. Mali included -- its
-        // destination renders correctly at 2080, and only its SOURCE sampling
-        // is affected.
-        assert!(!dst_rejects(false, 2080));
-        assert!(!dst_rejects(false, 32));
         assert!(
             mali_rejects_import_offset(true, 2080),
-            "the Mali rule is the source rule, and 2080 is in it"
+            "the Mali source rule covers 2080"
         );
+        assert!(mali_rejects_import_offset(true, 32));
+        assert!(!mali_rejects_import_offset(true, 2048));
+        assert!(!mali_rejects_import_offset(true, 0));
+        // Every other driver samples an unaligned source correctly.
+        assert!(!mali_rejects_import_offset(false, 2080));
+        assert!(!mali_rejects_import_offset(false, 32));
     }
 
     // The offset a destination import actually bases at, which is what the
-    // Vivante rule must be asked of -- and which of the two routes is being
-    // guarded. `bind_dst`'s import collapses a fresh view() to 0 however far
-    // into the buffer its own bytes start, so asking `plane_offset()` there
-    // made the rule fire on tile views the driver handles perfectly. The
-    // `import_buffer_packed` routes do NOT collapse, so they must keep asking
-    // the raw offset; both shapes are asserted here.
+    // PLACEMENT question must be asked of -- and which of the two routes is
+    // being guarded. `bind_dst`'s import collapses a fresh view() to 0 however
+    // far into the buffer its own bytes start; the `import_buffer_packed`
+    // routes do NOT collapse and really do import at the tensor's own offset.
+    // Both shapes are asserted here.
     #[test]
-    fn a_view_destination_imports_at_base_zero_and_escapes_the_offset_rule() {
-        use super::{
-            view_collapsed_dst_base as base, vivante_rejects_dst_import_offset as dst_rejects,
-        };
+    fn a_view_destination_imports_at_base_zero() {
+        use super::view_collapsed_dst_base as base;
         use edgefirst_tensor::ViewOrigin;
 
         // A fresh view: `view_origin` is Some, so the import bases at 0 -- even
@@ -8764,45 +9226,26 @@ mod tests {
             y: 8,
         });
         assert_eq!(base(vo, Some(2080)), 0);
-        assert!(
-            !dst_rejects(true, base(vo, Some(2080))),
-            "a fresh view destination must KEEP zero-copy on Vivante"
-        );
         // Still 0 at an aligned offset, and 0 even if the offset is absent.
         assert_eq!(base(vo, Some(2048)), 0);
         assert_eq!(base(vo, None), 0);
 
         // No view_origin -- rebuilt from a descriptor, or a whole tensor at a
-        // foreign offset. Now the import really does base at the offset, and
-        // the rule applies.
+        // foreign offset. Now the import really does base at the offset.
         assert_eq!(base(None, Some(2080)), 2080);
-        assert!(dst_rejects(true, base(None, Some(2080))));
         assert_eq!(base(None, Some(2048)), 2048);
-        assert!(!dst_rejects(true, base(None, Some(2048))));
         // A whole tensor with no offset at all is base 0.
         assert_eq!(base(None, None), 0);
-        assert!(!dst_rejects(true, base(None, None)));
-
-        // Nothing here touches a non-Vivante driver.
-        assert!(!dst_rejects(false, base(None, Some(2080))));
 
         // THE OTHER ROUTE. `import_buffer_packed` passes `plane_offset()`
         // straight to EGL with no collapse, so `convert_via_engine`'s packed
-        // plan and the float paths ask the RAW offset -- and a view destination
-        // there really is imported at its own offset, so the rule must fire on
-        // it. Collapsing at those sites would under-fire and hand Vivante the
-        // `EGL_BAD_ACCESS` this rule exists to avoid.
+        // plan and the float paths ask the RAW offset. The two routes
+        // genuinely disagree for the same tensor, which is the whole reason
+        // the helper is route-specific: `dst_import_places` asks whether an
+        // import will PLACE the destination correctly, and the answer differs
+        // by which offset the import will actually base at.
         let raw = |plane_offset: Option<usize>| plane_offset.unwrap_or(0);
         assert_eq!(raw(Some(2080)), 2080);
-        assert!(
-            dst_rejects(true, raw(Some(2080))),
-            "a view destination on the packed route imports at its own offset, \
-             so the rule must still fire there"
-        );
-        assert!(!dst_rejects(true, raw(Some(2048))));
-        assert!(!dst_rejects(true, raw(None)));
-        // The two routes genuinely disagree for the same tensor: that is the
-        // whole reason the helper is route-specific.
         assert_ne!(base(vo, Some(2080)), raw(Some(2080)));
     }
 

--- a/crates/image/src/gl/tests.rs
+++ b/crates/image/src/gl/tests.rs
@@ -3701,11 +3701,24 @@ mod gl_tests {
     /// to hide behind — and it equally catches the inverse bug (letterbox
     /// dropped entirely: pad rows would hold content). Covers PlanarRgb /
     /// PlanarRgba × u8 / i8 × Dma (the GL TwoPassNvPlanar plan) and Mem
-    /// destinations — GL has no planar texture destination, so the Mem legs
-    /// pin the backend `ImageProcessor` resolves instead (CPU fallback),
-    /// guarding the whole dispatch surface against the bug class.
-    /// (`dma_test_formats` gate matches the helpers it uses; the Mem legs
-    /// still run on the llvmpipe coverage lane, which enables the feature.)
+    /// destinations, guarding the whole dispatch surface against the bug
+    /// class. (`dma_test_formats` gate matches the helpers it uses; the Mem
+    /// legs still run on the llvmpipe coverage lane, which enables the
+    /// feature.)
+    ///
+    /// **Each leg asserts its own route** (issue #179).
+    /// `ComputeBackend::OpenGl` leaves `forced_backend` at `None`, so a GL
+    /// decline logs at debug and the CPU serves the same convert — and the
+    /// CPU places the content band correctly, so a silent decline reads as
+    /// a pass here. The route each leg is entitled to comes from
+    /// `check_dst_format_supported`: it accepts `PlanarRgb` on both the
+    /// zero-copy DMA arm and the texture arm, so every `PlanarRgb` leg must
+    /// stay on GL and `convert_fallback_count()` must not move across it.
+    /// It accepts `PlanarRgba` on neither, so those legs take the CPU
+    /// fallback **by design** — they are the CPU half of the dispatch
+    /// surface this test exists to cover, and are asserted to fall back
+    /// rather than left unasserted, so the day GL grows a four-plane
+    /// readback this test says so instead of quietly changing meaning.
     #[test]
     #[cfg(all(target_os = "linux", feature = "dma_test_formats"))]
     fn letterbox_nv_to_planar_content_band_geometry() {
@@ -3728,6 +3741,18 @@ mod gl_tests {
                 return;
             }
         };
+        // Without this the route assertions below go vacuous in one
+        // direction and wrong in the other: with no GL backend at all
+        // nothing ever declines, so every `PlanarRgb` leg would pass having
+        // run on the CPU while every `PlanarRgba` leg would fail for the
+        // wrong reason.
+        if proc.opengl.is_none() {
+            crate::test_support::report_skip(&format!(
+                "{} - ImageProcessor resolved no GL backend",
+                function!()
+            ));
+            return;
+        }
 
         // Synthetic NV12: Y=200, U=V=128 is neutral grey, so BT.601 vs BT.709
         // coefficients cancel and the converted RGB is ~200 (full range) to
@@ -3770,8 +3795,27 @@ mod gl_tests {
                             edgefirst_tensor::CpuAccess::ReadWrite,
                         )
                         .unwrap();
+                    let fallbacks_before = proc.convert_fallback_count();
                     proc.convert(&src, &mut dst, Rotation::None, Flip::None, lb)
                         .unwrap_or_else(|e| panic!("{label}: convert failed: {e}"));
+                    let declines = proc.convert_fallback_count() - fallbacks_before;
+                    if dst_fmt == PixelFormat::PlanarRgb {
+                        assert_eq!(
+                            declines, 0,
+                            "{label}: the GL backend declined this convert and the \
+                             CPU served it — the band probes below would pass on the \
+                             CPU answer, so this leg proved nothing about the GL \
+                             two-pass plan"
+                        );
+                    } else {
+                        assert_eq!(
+                            declines, 1,
+                            "{label}: GL was expected to decline PlanarRgba (no \
+                             four-plane readback geometry) and leave this leg to the \
+                             CPU; it did not, so either the GL gate changed or the \
+                             fallback counter did"
+                        );
+                    }
 
                     // Raw bytes; undo the int8 XOR-0x80 bias so both dtypes
                     // share one set of thresholds.
@@ -7037,12 +7081,12 @@ mod gl_tests {
         // so without the check the test reported a pass having exercised no
         // GL at all.
         if proc.convert_fallback_count() != fallbacks_before {
-            eprintln!(
-                "SKIPPED: {} - the GL float path declined this DMA-BUF \
-                 destination and ImageProcessor fell back to the CPU; there is \
-                 no zero-copy coverage to check here",
+            crate::test_support::report_skip(&format!(
+                "{} - the GL float path declined this DMA-BUF destination and \
+                 ImageProcessor fell back to the CPU; there is no zero-copy \
+                 coverage to check here",
                 function!()
-            );
+            ));
             return;
         }
 
@@ -7306,10 +7350,10 @@ mod gl_tests {
         proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())
             .unwrap();
         if proc.convert_fallback_count() != fallbacks_before {
-            eprintln!(
-                "SKIPPED: convert_f32_pbo_cuda_map_roundtrip - the GL float path \
-                 declined and the convert was served by the CPU; there is no \
-                 GL coverage to check here"
+            crate::test_support::report_skip(
+                "convert_f32_pbo_cuda_map_roundtrip - the GL float path declined \
+                 and the convert was served by the CPU; there is no GL coverage \
+                 to check here",
             );
             return;
         }
@@ -7432,10 +7476,10 @@ mod gl_tests {
         proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())
             .unwrap();
         if proc.convert_fallback_count() != fallbacks_before {
-            eprintln!(
-                "SKIPPED: convert_f32_pbo_cuda_map_numeric - the GL float path \
-                 declined and the convert was served by the CPU; there is no \
-                 GL coverage to check here"
+            crate::test_support::report_skip(
+                "convert_f32_pbo_cuda_map_numeric - the GL float path declined \
+                 and the convert was served by the CPU; there is no GL coverage \
+                 to check here",
             );
             return;
         }
@@ -7500,6 +7544,13 @@ mod gl_tests {
     /// end to end. On a Jetson (no `/dev/dma_heap`) the NV source has no GPU
     /// path, so `convert()` runs on the CPU and writes into the CUDA-registered
     /// output PBO; this test exercises exactly that CPU→PBO→CUDA hand-off.
+    ///
+    /// **Exercising the CPU fallback is the point here, so this one asserts
+    /// no route** (issue #179). The subject and the reference are the same
+    /// `convert()` on the same processor, differing only in where the
+    /// destination lives, so whichever backend serves them serves both; the
+    /// claim under test is about the device pointer's contents, not about
+    /// which engine produced them.
     #[cfg(target_os = "linux")]
     fn jpeg_cuda_devptr_check(fixture: &str, expect_fmt: PixelFormat, w: usize, h: usize) {
         use crate::{ComputeBackend, ImageProcessor, ImageProcessorConfig};
@@ -10923,9 +10974,12 @@ mod gl_tests {
     /// full scale.
     ///
     /// Each frame drives both float destination kinds: an F32 `Rgb` PBO (the
-    /// readback float path) and a zero-copy F32 `PlanarRgb` texture, which
+    /// readback float path) and a zero-copy F16 `PlanarRgb` texture, which
     /// the packed float path renders into directly. They share the uv
-    /// builder, so the mapping has to hold on both. The last frame upscales,
+    /// builder, so the mapping has to hold on both. The two halves ask for
+    /// different render capabilities -- F32 for the PBO, F16 for the
+    /// zero-copy texture -- because those are what their respective
+    /// `float_dispatch` arms are gated on. The last frame upscales,
     /// which reaches the sample clamp (`src_extent`) on the narrowed axis;
     /// that axis is half the pool so the scaled coordinates are exact and the
     /// clamp is the only difference from the fresh buffer.
@@ -10935,6 +10989,22 @@ mod gl_tests {
         if !is_gpu_image_buffer_available() || !is_opengl_available() {
             crate::test_support::report_skip(&format!(
                 "{} - no zero-copy GPU buffers or OpenGL",
+                function!()
+            ));
+            return;
+        }
+        // A lane that has declared it has a working GL stack must not lose
+        // this test's zero-copy coverage to a driver decline, so the decline
+        // below is a failure there and a skip elsewhere. The macOS coverage
+        // lane sets the flag for BOTH passes but deliberately hobbles pass 1
+        // (unsigned binaries, the ANGLE dlopen gate closed), so pass 1 is
+        // excluded the same way `gl_backend_available_canary` and the
+        // sibling test below exclude it.
+        let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+        #[cfg(target_os = "macos")]
+        if require_gl && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+            crate::test_support::report_skip(&format!(
+                "{} - ANGLE dlopen gate closed (coverage pass 1)",
                 function!()
             ));
             return;
@@ -10964,6 +11034,17 @@ mod gl_tests {
                 function!()
             ));
             return;
+        }
+        // The zero-copy half below needs the F16 planar render specifically,
+        // which is a separate capability from the F32 the PBO half needs: a
+        // GPU can report one without the other. Asked once rather than per
+        // frame, since it cannot change between frames.
+        let zero_copy_float = proc.supported_render_dtypes().f16;
+        if !zero_copy_float {
+            crate::test_support::report_skip(&format!(
+                "(zero-copy float dst): {} - F16 render not supported",
+                function!()
+            ));
         }
         let mut pool = TensorDyn::image(
             128,
@@ -11063,32 +11144,49 @@ mod gl_tests {
                  fresh buffer by up to {worst}"
             );
 
-            // ── The same source into a zero-copy float destination: an F32
+            // ── The same source into a zero-copy float destination: an F16
             // PlanarRgb texture, rendered straight into by the packed float
             // path rather than read back through a PBO. The extent mapping
             // lives in the shared uv builder, so both destinations must show
             // it; this one is the path that exists only where the platform
             // renders float zero-copy.
+            //
+            // F16 rather than F32, because `(Rgba, PlanarRgb, F16, DmaBuf)` is
+            // the one zero-copy float tuple BOTH capability sets serve --
+            // `FloatRenderPath::ZeroCopyF16Nchw`. The F32 zero-copy
+            // destinations are gated on `ZeroCopyFloatSet::All`, which only
+            // the Windows leaf reports; Linux, Android and ANGLE/macOS report
+            // `PlanarF16`, so an F32 PlanarRgb DMA destination classifies as
+            // `FloatRenderPath::None` there, the u8 route rejects the dtype
+            // and the CPU serves the convert. `float_dispatch.rs`'s
+            // `the_planar_set_leaves_the_windows_only_shaders_unreachable`
+            // pins that decision. Allocating such a destination still succeeds
+            // on Mali and V3D, so a successful allocation cannot stand in for
+            // the routing question -- which is why this half asks the
+            // capability rather than inferring it from the allocator.
+            if !zero_copy_float {
+                continue;
+            }
             let planar_dst = || {
                 TensorDyn::image(
                     dw,
                     dh,
                     PixelFormat::PlanarRgb,
-                    DType::F32,
+                    DType::F16,
                     Some(TensorMemory::DmaBuf),
                     edgefirst_tensor::CpuAccess::ReadWrite,
                 )
             };
             let (Ok(mut zc_recycled), Ok(mut zc_oracle)) = (planar_dst(), planar_dst()) else {
                 crate::test_support::report_skip(&format!(
-                    "(zero-copy float dst): {} - no F32 PlanarRgb texture",
+                    "(zero-copy float dst): {} - no F16 PlanarRgb texture",
                     function!()
                 ));
                 continue;
             };
             if zc_recycled.memory() != TensorMemory::DmaBuf {
                 crate::test_support::report_skip(&format!(
-                    "(zero-copy float dst): {} - F32 PlanarRgb dst is not zero-copy",
+                    "(zero-copy float dst): {} - F16 PlanarRgb dst is not zero-copy",
                     function!()
                 ));
                 continue;
@@ -11096,9 +11194,9 @@ mod gl_tests {
             // Both sides are read through `copy_to_flat`: a Windows texture
             // destination spaces its rows at a padded pitch, whose bytes are
             // not written by the render.
-            let flat_f32 = |t: &TensorDyn| -> Vec<u8> {
-                let typed = t.as_typed::<f32>().expect("F32 image");
-                let mut out = vec![0u8; typed.shape().iter().product::<usize>() * 4];
+            let flat_f16 = |t: &TensorDyn| -> Vec<u8> {
+                let typed = t.as_typed::<half::f16>().expect("F16 image");
+                let mut out = vec![0u8; typed.shape().iter().product::<usize>() * 2];
                 typed.copy_to_flat(&mut out).expect("compact padded rows");
                 out
             };
@@ -11119,16 +11217,34 @@ mod gl_tests {
                 Crop::no_crop(),
             )
             .unwrap();
+            // A driver that refuses the zero-copy float destination has
+            // nothing inside GL to lower to -- there is no mapped-texture
+            // readback for a float DMA destination -- so the CPU serves the
+            // convert and both sides become the same CPU answer, which would
+            // make the comparison below prove nothing. That is a property of
+            // the host's driver and not of this code (this desktop's NVIDIA
+            // EGL fails its DMA-BUF roundtrip check and drops to PBO
+            // transfers), so it is reported as a skip -- except under
+            // `HAL_TEST_REQUIRE_GL=1`, where a lane that has asserted it has a
+            // working GL stack must not quietly lose this coverage. The boards
+            // run with it set.
+            if proc.convert_fallback_count() != fallbacks_before {
+                assert!(
+                    !require_gl,
+                    "HAL_TEST_REQUIRE_GL=1 but frame {i}'s zero-copy float destination \
+                     convert fell back to the CPU"
+                );
+                crate::test_support::report_skip(&format!(
+                    "(zero-copy float dst): {} - the GL float path declined and the \
+                     CPU served the convert",
+                    function!()
+                ));
+                continue;
+            }
             assert_eq!(
-                proc.convert_fallback_count(),
-                fallbacks_before,
-                "frame {i}: a zero-copy float destination convert fell back to \
-                 the CPU; both sides would then be the same CPU answer"
-            );
-            assert_eq!(
-                flat_f32(&zc_recycled),
-                flat_f32(&zc_oracle),
-                "frame {i} ({w}x{h} -> {dw}x{dh}): narrowed source into a zero-copy F32 \
+                flat_f16(&zc_recycled),
+                flat_f16(&zc_oracle),
+                "frame {i} ({w}x{h} -> {dw}x{dh}): narrowed source into a zero-copy F16 \
                  PlanarRgb destination differs from a fresh buffer"
             );
         }
@@ -11355,11 +11471,12 @@ mod gl_tests {
     /// A destination `view()` imports its PARENT and places the tile with
     /// `glViewport`, so its import bases at 0 however far into the buffer its
     /// own bytes start (`DmaImportAttrs::from_tensor` with `for_dst = true`,
-    /// `BufferImportKey::from_tensor`). The Vivante offset rule must therefore
-    /// be asked of `dst_import_base`, not of `plane_offset()`; asking the latter
-    /// made it fire on every tile view whose byte offset was unaligned -- an
-    /// RGBA `x0` of 8 is 32 bytes -- and silently cost Vivante the zero-copy
-    /// path for a case its driver handles perfectly.
+    /// `BufferImportKey::from_tensor`). Any rule about the base offset --
+    /// `dst_import_places` today -- must therefore be asked of
+    /// `view_collapsed_dst_base`, not of `plane_offset()`; asking the latter
+    /// fires on every tile view whose byte offset is unaligned -- an RGBA `x0`
+    /// of 8 is 32 bytes -- and costs the zero-copy path for an import that
+    /// bases at 0 and would have succeeded.
     ///
     /// `convert_fallback_count` cannot see this: the over-fire lowers WITHIN
     /// GL, to the mapped-texture readback, and never reaches the CPU backend.
@@ -11593,32 +11710,27 @@ mod gl_tests {
     /// A GL processor that allocates PBOs, or `None` with a skip line.
     /// Nothing about it is host-dependent beyond having GL at all.
     ///
-    /// The skip lines below go to `std::io::stderr()` directly rather than
-    /// through `eprintln!`. `eprintln!` passes through libtest's per-test
-    /// output capture, which is discarded for a test that passes -- and a
-    /// skip *is* a pass -- so a board that skipped all four PBO gates read
-    /// green in the fleet log with no line saying so. This is the shape
-    /// `pbo_reports_why_it_cannot_pin` (`crates/image/src/lib.rs`) already
-    /// uses. The `SKIPPED:` prefix is load-bearing: TESTING.md and the
-    /// on-target harness both key off it. Written out at each site rather
-    /// than behind a local helper on purpose -- a house-wide sweep with a
-    /// shared helper is landing separately, and a second helper here would
-    /// collide with it.
+    /// The skip lines go through [`crate::test_support::report_skip`], which
+    /// writes to `std::io::stderr()` directly rather than through
+    /// `eprintln!`. `eprintln!` passes through libtest's per-test output
+    /// capture, which is discarded for a test that passes -- and a skip *is*
+    /// a pass -- so a board that skipped all four PBO gates read green in
+    /// the fleet log with no line saying so. The `SKIPPED:` prefix is
+    /// load-bearing: `scripts/on-target-test.sh` counts a board's skips by
+    /// grepping its log for that literal, and TESTING.md's "Reading the
+    /// results" section states it as the rule.
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     fn pbo_gl_or_skip(what: &str) -> Option<GLProcessorThreaded> {
-        use std::io::Write;
         if !is_opengl_available() {
-            let mut err = std::io::stderr();
-            let _ = writeln!(&mut err, "SKIPPED: {what} - OpenGL not available");
-            let _ = err.flush();
+            crate::test_support::report_skip(&format!("{what} - OpenGL not available"));
             return None;
         }
         match GLProcessorThreaded::new(None) {
             Ok(gl) => Some(gl),
             Err(e) => {
-                let mut err = std::io::stderr();
-                let _ = writeln!(&mut err, "SKIPPED: {what} - GL processor unavailable: {e}");
-                let _ = err.flush();
+                crate::test_support::report_skip(&format!(
+                    "{what} - GL processor unavailable: {e}"
+                ));
                 None
             }
         }
@@ -11626,15 +11738,12 @@ mod gl_tests {
 
     /// [`pbo_gl_or_skip`] plus the F32 render capability the float gates
     /// need. Separate so the u8 gates do not inherit a skip they have no
-    /// reason to take. Same raw-stderr rule for the skip line, same reason.
+    /// reason to take. Same skip-reporting rule, same reason.
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     fn float_pbo_gl_or_skip(what: &str) -> Option<GLProcessorThreaded> {
-        use std::io::Write;
         let gl = pbo_gl_or_skip(what)?;
         if !gl.supported_render_dtypes().f32 {
-            let mut err = std::io::stderr();
-            let _ = writeln!(&mut err, "SKIPPED: {what} - F32 render not supported");
-            let _ = err.flush();
+            crate::test_support::report_skip(&format!("{what} - F32 render not supported"));
             return None;
         }
         Some(gl)
@@ -12001,5 +12110,608 @@ mod gl_tests {
                 );
             }
         }
+    }
+
+    /// Issue #177: a `view()` destination lowered to the **mapped-texture
+    /// readback** must receive exactly the pixels a whole destination of the
+    /// same size receives on the same path, at the parent's pitch, with
+    /// nothing outside the view touched.
+    ///
+    /// The mapped path renders into an offscreen texture that IS the tile —
+    /// its origin is (0, 0), not the view's origin in the parent — so the
+    /// band `glViewport`/`glScissor` that places a tile inside a shared
+    /// zero-copy parent import must NOT be applied here. The placement
+    /// happens afterwards, in the readback, which writes through the view's
+    /// own `map()` at the parent's pitch.
+    ///
+    /// The path is reached the way production reaches it: the destination
+    /// import FAILS and the convert lowers instead of ending. The hook
+    /// (`set_fail_dst_import`) injects that failure at the import itself,
+    /// because a driver that accepts every destination never produces one —
+    /// a fresh `view()` collapses its import base to 0, so `dst_import_places`
+    /// sees an aligned base and keeps the zero-copy route. The route is
+    /// asserted with `dst_import_fallbacks`, so the test cannot pass by
+    /// quietly taking the zero-copy import it means to avoid.
+    ///
+    /// The oracle is the SAME convert into a whole destination on the SAME
+    /// mapped path, so a difference isolates the view-ness of the
+    /// destination rather than the readback path itself.
+    #[test]
+    fn mapped_texture_readback_places_a_view_destination() {
+        const PARENT_W: usize = 512;
+        const PARENT_H: usize = 320;
+        const VIEW_W: usize = 320;
+        const VIEW_H: usize = 240;
+        const BPP: usize = 4;
+        const POISON: u8 = 0xAB;
+
+        if !is_opengl_available() {
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
+            return;
+        }
+        #[cfg(target_os = "macos")]
+        if std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none() {
+            crate::test_support::report_skip(&format!(
+                "{} - ANGLE dlopen gate closed (coverage pass 1)",
+                function!()
+            ));
+            return;
+        }
+        let dma_rgba = |w: usize, h: usize| {
+            TensorDyn::image(
+                w,
+                h,
+                PixelFormat::Rgba,
+                DType::U8,
+                Some(TensorMemory::DmaBuf),
+                edgefirst_tensor::CpuAccess::ReadWrite,
+            )
+        };
+
+        // Distinct per-row and per-column values so a tile that lands at the
+        // wrong origin, or a row that lands at the wrong pitch, cannot
+        // coincidentally match.
+        let src = TensorDyn::image(
+            VIEW_W,
+            VIEW_H,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Mem),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .expect("source");
+        {
+            let stride = src.effective_row_stride().expect("source stride");
+            let mut m = src
+                .map_bytes(edgefirst_tensor::CpuAccess::Write)
+                .expect("map source");
+            let b = m.as_mut_slice();
+            for y in 0..VIEW_H {
+                for x in 0..VIEW_W {
+                    let i = y * stride + x * BPP;
+                    b[i] = ((y * 3) % 256) as u8;
+                    b[i + 1] = ((x * 5) % 256) as u8;
+                    b[i + 2] = 255;
+                    b[i + 3] = 255;
+                }
+            }
+        }
+
+        // A DIFFERENT image, converted into a whole destination immediately
+        // before each subject: the mapped path renders into a REUSED offscreen
+        // texture, so any tile pixel the subject fails to redraw shows this
+        // decoy instead of silently matching the oracle that ran before it.
+        let decoy = TensorDyn::image(
+            VIEW_W,
+            VIEW_H,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Mem),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .expect("decoy source");
+        {
+            let mut m = decoy
+                .map_bytes(edgefirst_tensor::CpuAccess::Write)
+                .expect("map decoy");
+            for px in m.as_mut_slice().as_chunks_mut::<BPP>().0 {
+                px.copy_from_slice(&[7, 11, 13, 255]);
+            }
+        }
+
+        let mut gl = GLProcessorThreaded::new(None).expect("GL processor");
+
+        // CALIBRATION, with the hook OFF: a whole zero-copy destination says
+        // whether this host imports destinations at all. A host that imports
+        // none cannot run the subject either -- the engine declines a `view()`
+        // destination outright unless the transfer backend is zero-copy -- so
+        // it skips, which is what a desktop whose EGL cannot import a DMA-BUF
+        // does. Same self-calibration as
+        // `a_fresh_unaligned_view_destination_keeps_the_zero_copy_import`.
+        let imports = |g: &GLProcessorThreaded| {
+            let c = g.egl_cache_stats().expect("cache stats").dst;
+            c.misses + c.hits
+        };
+        let mut oracle = match dma_rgba(VIEW_W, VIEW_H) {
+            Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+            other => {
+                let what = match &other {
+                    Ok(t) => format!("fell back to {:?}", t.memory()),
+                    Err(e) => format!("failed: {e}"),
+                };
+                crate::test_support::report_skip(&format!(
+                    "{} - no zero-copy RGBA image here ({what})",
+                    function!()
+                ));
+                return;
+            }
+        };
+        let before = imports(&gl);
+        gl.convert(
+            &src,
+            &mut oracle,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        )
+        .expect("calibration convert into a whole zero-copy destination");
+        if imports(&gl) - before == 0 {
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy destination import on this host, so a view() \
+                 destination is declined by the engine and the mapped path cannot \
+                 be reached for one",
+                function!()
+            ));
+            return;
+        }
+
+        gl.set_fail_dst_import(true)
+            .expect("make the destination import fail");
+        let fallbacks = |g: &GLProcessorThreaded| {
+            g.convert_stats()
+                .expect("convert stats")
+                .dst_import_fallbacks
+        };
+
+        // The letterbox case carries the `glClear` the band scissor used to
+        // confine, so the two crops together cover both halves of the render.
+        let mut failures = Vec::new();
+        for (label, crop) in [
+            ("stretch", Crop::default()),
+            (
+                "letterbox",
+                Crop::letterbox([114, 114, 114, 255]).with_source(Some(
+                    edgefirst_tensor::Region::new(0, 0, VIEW_W, VIEW_H / 2),
+                )),
+            ),
+        ] {
+            // ORACLE: the same convert into the same WHOLE destination, on the same
+            // mapped-texture path. Comparing the view against this isolates the
+            // view-ness of the destination from the readback path itself.
+            gl.convert(&src, &mut oracle, Rotation::None, Flip::None, crop)
+                .expect("oracle convert into a whole destination on the mapped path");
+            let oracle_stride = oracle.effective_row_stride().expect("oracle stride");
+            let oracle_bytes = oracle
+                .map_bytes(edgefirst_tensor::CpuAccess::Read)
+                .expect("map oracle")
+                .as_slice()
+                .to_vec();
+
+            for (x0, y0) in [(0usize, 0usize), (8, 8), (64, 32)] {
+                let parent = dma_rgba(PARENT_W, PARENT_H).expect("parent");
+                assert_eq!(
+                    parent.memory(),
+                    TensorMemory::DmaBuf,
+                    "the parent must be the zero-copy backing under test"
+                );
+                let pitch = parent.effective_row_stride().expect("parent pitch");
+                {
+                    let mut m = parent
+                        .map_bytes(edgefirst_tensor::CpuAccess::Write)
+                        .expect("map parent");
+                    m.as_mut_slice().fill(POISON);
+                }
+                let mut scratch = dma_rgba(VIEW_W, VIEW_H).expect("decoy destination");
+                gl.convert(
+                    &decoy,
+                    &mut scratch,
+                    Rotation::None,
+                    Flip::None,
+                    Crop::default(),
+                )
+                .expect("decoy convert");
+                let before = fallbacks(&gl);
+                {
+                    let mut view = parent
+                        .view(edgefirst_tensor::Region::new(x0, y0, VIEW_W, VIEW_H))
+                        .expect("destination view");
+                    if let Err(e) = gl.convert(&src, &mut view, Rotation::None, Flip::None, crop) {
+                        failures.push(format!("{label} ({x0},{y0}): GL declined the view: {e}"));
+                        continue;
+                    }
+                }
+                // The route, not just the pixels: without this the test would
+                // still pass if the convert quietly took the zero-copy import
+                // it exists to bypass.
+                let took = fallbacks(&gl) - before;
+                if took != 1 {
+                    failures.push(format!(
+                        "{label} ({x0},{y0}): expected exactly one destination-import \
+                         fallback for this convert, saw {took}"
+                    ));
+                }
+
+                let out = parent
+                    .map_bytes(edgefirst_tensor::CpuAccess::Read)
+                    .expect("map parent")
+                    .as_slice()
+                    .to_vec();
+                let mut wrong = 0usize;
+                let mut first: Option<(usize, usize, Vec<u8>, Vec<u8>)> = None;
+                // Bounding box of the wrong pixels, and whether every one of them
+                // lies in the band a view-origin `glScissor` on an origin-(0,0)
+                // render target would have clipped away.
+                let (mut lx, mut ly, mut hx, mut hy) = (usize::MAX, usize::MAX, 0usize, 0usize);
+                let mut all_in_scissor_band = true;
+                for y in 0..VIEW_H {
+                    for x in 0..VIEW_W {
+                        let got = &out[(y0 + y) * pitch + (x0 + x) * BPP..][..BPP];
+                        let want = &oracle_bytes[y * oracle_stride + x * BPP..][..BPP];
+                        if got != want {
+                            wrong += 1;
+                            first.get_or_insert((x, y, got.to_vec(), want.to_vec()));
+                            lx = lx.min(x);
+                            ly = ly.min(y);
+                            hx = hx.max(x);
+                            hy = hy.max(y);
+                            all_in_scissor_band &= x < x0 || y < y0;
+                        }
+                    }
+                }
+                if let Some((x, y, got, want)) = first {
+                    failures.push(format!(
+                    "{label} ({x0},{y0}) pitch {pitch}: {wrong}/{} tile pixels differ from the \
+                     whole-destination oracle; first at tile ({x},{y}) got={got:?} \
+                     want={want:?}; wrong-pixel bbox x[{lx}..={hx}] y[{ly}..={hy}]; \
+                     every wrong pixel inside the x<{x0}||y<{y0} band: {all_in_scissor_band}",
+                    VIEW_W * VIEW_H,
+                ));
+                }
+                // Nothing outside the view region moved.
+                let mut outside = 0usize;
+                let mut first_outside = None;
+                for y in 0..PARENT_H {
+                    for x in 0..PARENT_W {
+                        if y >= y0 && y < y0 + VIEW_H && x >= x0 && x < x0 + VIEW_W {
+                            continue;
+                        }
+                        let i = y * pitch + x * BPP;
+                        if out[i..i + BPP] != [POISON; BPP] {
+                            outside += 1;
+                            first_outside.get_or_insert((x, y, out[i..i + BPP].to_vec()));
+                        }
+                    }
+                }
+                if let Some((x, y, got)) = first_outside {
+                    failures.push(format!(
+                        "{label} ({x0},{y0}): {outside} parent pixels OUTSIDE the view were \
+                     overwritten; first at ({x},{y}) = {got:?}"
+                    ));
+                }
+            }
+        }
+
+        // A packed-RGB (or planar) view destination has no placement on EITHER
+        // route: the zero-copy band is a `glViewport` in destination pixels
+        // that the `W*3/4` packed surface does not have, and this readback
+        // writes `dst_w`-wide rows at the parent's pitch. So it must be refused
+        // however the destination import went. The hook makes the packed-RGB
+        // plan's import fail, which is the case that used to slip through --
+        // the refusal was keyed on the lowering, and a refused import re-plans
+        // onto the mapped route, flipping the very term the guard read.
+        // Asserted with the counter too: the refusal must come BEFORE the
+        // engine spends an import on a destination it is going to decline.
+        #[cfg(target_os = "linux")]
+        if let Ok(rgb_parent) = TensorDyn::image(
+            PARENT_W,
+            PARENT_H,
+            PixelFormat::Rgb,
+            DType::U8,
+            Some(TensorMemory::DmaBuf),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        ) {
+            if rgb_parent.memory() == TensorMemory::DmaBuf {
+                let rgb_src = TensorDyn::image(
+                    VIEW_W,
+                    VIEW_H,
+                    PixelFormat::Rgb,
+                    DType::U8,
+                    Some(TensorMemory::Mem),
+                    edgefirst_tensor::CpuAccess::ReadWrite,
+                )
+                .expect("packed-RGB source");
+                let mut view = rgb_parent
+                    .view(edgefirst_tensor::Region::new(8, 8, VIEW_W, VIEW_H))
+                    .expect("packed-RGB destination view");
+                let before = fallbacks(&gl);
+                let outcome = gl.convert(
+                    &rgb_src,
+                    &mut view,
+                    Rotation::None,
+                    Flip::None,
+                    Crop::default(),
+                );
+                match outcome {
+                    Err(crate::Error::NotSupported(_)) => {}
+                    other => failures.push(format!(
+                        "a packed-RGB view() destination must be declined on every \
+                         destination route, got {other:?}"
+                    )),
+                }
+                let spent = fallbacks(&gl) - before;
+                if spent != 0 {
+                    failures.push(format!(
+                        "a packed-RGB view() destination was declined only after \
+                         spending {spent} destination import(s) on it"
+                    ));
+                }
+            }
+        }
+        // A WHOLE packed-RGB destination whose import is refused re-plans onto
+        // the mapped route, and must spend exactly ONE destination import
+        // doing so. The re-plan happens in `convert_via_engine`, before pass 1
+        // renders; `bind_dst` then has to BIND what was re-planned. Re-deriving
+        // the lowering there instead answers "zero-copy" (the import failed,
+        // the placement is fine), binds a zero-copy destination under a plan
+        // chosen for a texture one, and self-corrects only because the second
+        // import fails too -- at the cost of a wasted import, a second tick
+        // here, and an engine span whose `lowering` field says the opposite of
+        // what happened.
+        #[cfg(target_os = "linux")]
+        if let Ok(mut rgb_dst) = TensorDyn::image(
+            VIEW_W,
+            VIEW_H,
+            PixelFormat::Rgb,
+            DType::U8,
+            Some(TensorMemory::DmaBuf),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        ) {
+            if rgb_dst.memory() == TensorMemory::DmaBuf {
+                let rgb_src = TensorDyn::image(
+                    VIEW_W,
+                    VIEW_H,
+                    PixelFormat::Rgb,
+                    DType::U8,
+                    Some(TensorMemory::Mem),
+                    edgefirst_tensor::CpuAccess::ReadWrite,
+                )
+                .expect("packed-RGB source");
+                {
+                    let mut m = rgb_src
+                        .map_bytes(edgefirst_tensor::CpuAccess::Write)
+                        .expect("map packed-RGB source");
+                    m.as_mut_slice().fill(0x5A);
+                }
+                let before = fallbacks(&gl);
+                match gl.convert(
+                    &rgb_src,
+                    &mut rgb_dst,
+                    Rotation::None,
+                    Flip::None,
+                    Crop::default(),
+                ) {
+                    Ok(()) => {
+                        let spent = fallbacks(&gl) - before;
+                        if spent != 1 {
+                            failures.push(format!(
+                                "a refused packed-RGB destination import must re-plan \
+                                 after exactly one attempt, spent {spent}"
+                            ));
+                        }
+                        let out = rgb_dst
+                            .map_bytes(edgefirst_tensor::CpuAccess::Read)
+                            .expect("map packed-RGB destination")
+                            .as_slice()
+                            .to_vec();
+                        if out.iter().all(|&b| b == 0) {
+                            failures.push(
+                                "the re-planned packed-RGB convert wrote nothing".to_string(),
+                            );
+                        }
+                    }
+                    Err(e) => failures.push(format!(
+                        "a refused packed-RGB destination import must re-plan onto the \
+                         mapped route, not end the convert: {e}"
+                    )),
+                }
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+    }
+
+    /// A refused destination import must re-plan, not just re-bind.
+    ///
+    /// A non-NV source into a `PlanarRgb` destination is planned `SinglePass`
+    /// against the zero-copy lowering. When the import is then refused,
+    /// `bind_dst` falls back to the mapped-texture readback -- but the plan was
+    /// chosen for a lowering that no longer holds, and the single-pass planar
+    /// shader (`convert_to_planar`) imports its source UNCONDITIONALLY. A heap
+    /// source therefore failed there and the whole convert fell out to the CPU
+    /// backend, throwing away the fallback that had just been set up for it.
+    /// `plan_convert` calls that pair impossible; the engine has to re-plan
+    /// against what `bind_dst` actually bound.
+    ///
+    /// Both triggers are exercised: the hook, which reaches the case on any
+    /// host with a zero-copy destination import, and a real driver refusal at
+    /// an unaligned plane offset, which is what Vivante does on i.MX 8M Plus.
+    #[test]
+    fn a_refused_planar_destination_import_replans_onto_the_mapped_route() {
+        const W: usize = 320;
+        const H: usize = 240;
+
+        if !is_opengl_available() {
+            crate::test_support::report_skip(&format!("{} - OpenGL not available", function!()));
+            return;
+        }
+        let src = TensorDyn::image(
+            W,
+            H,
+            PixelFormat::Rgba,
+            DType::U8,
+            Some(TensorMemory::Mem),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .expect("host source");
+        {
+            let mut m = src
+                .map_bytes(edgefirst_tensor::CpuAccess::Write)
+                .expect("map source");
+            for (i, px) in m
+                .as_mut_slice()
+                .as_chunks_mut::<4>()
+                .0
+                .iter_mut()
+                .enumerate()
+            {
+                px.copy_from_slice(&[(i % 251) as u8, (i % 199) as u8, (i % 157) as u8, 255]);
+            }
+        }
+
+        // The oracle: the same convert on the CPU backend.
+        let mut reference = TensorDyn::image(
+            W,
+            H,
+            PixelFormat::PlanarRgb,
+            DType::U8,
+            Some(TensorMemory::Mem),
+            edgefirst_tensor::CpuAccess::ReadWrite,
+        )
+        .expect("reference destination");
+        crate::CPUProcessor::new()
+            .convert(
+                &src,
+                &mut reference,
+                Rotation::None,
+                Flip::None,
+                Crop::default(),
+            )
+            .expect("CPU reference convert");
+        let want = reference
+            .map_bytes(edgefirst_tensor::CpuAccess::Read)
+            .expect("map reference")
+            .as_slice()
+            .to_vec();
+
+        let mut gl = GLProcessorThreaded::new(None).expect("GL processor");
+        let planar_dma = || {
+            TensorDyn::image(
+                W,
+                H,
+                PixelFormat::PlanarRgb,
+                DType::U8,
+                Some(TensorMemory::DmaBuf),
+                edgefirst_tensor::CpuAccess::ReadWrite,
+            )
+            .ok()
+            .filter(|t| t.memory() == TensorMemory::DmaBuf)
+        };
+        let Some(mut dst) = planar_dma() else {
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy PlanarRgb destination here",
+                function!()
+            ));
+            return;
+        };
+
+        let mut failures: Vec<String> = Vec::new();
+        let measure = |gl: &mut GLProcessorThreaded,
+                       label: &str,
+                       dst: &mut TensorDyn,
+                       failures: &mut Vec<String>|
+         -> u64 {
+            let before = gl
+                .convert_stats()
+                .expect("convert stats")
+                .dst_import_fallbacks;
+            let outcome = gl.convert(&src, dst, Rotation::None, Flip::None, Crop::default());
+            let spent = gl
+                .convert_stats()
+                .expect("convert stats")
+                .dst_import_fallbacks
+                - before;
+            match outcome {
+                Ok(()) if spent > 0 => {
+                    if spent != 1 {
+                        failures.push(format!(
+                            "{label}: expected exactly one destination-import fallback, \
+                             saw {spent}"
+                        ));
+                    }
+                    let got = dst
+                        .map_bytes(edgefirst_tensor::CpuAccess::Read)
+                        .expect("map destination")
+                        .as_slice()
+                        .to_vec();
+                    if got.len() != want.len() || got != want {
+                        let first = got
+                            .iter()
+                            .zip(want.iter())
+                            .position(|(a, b)| a != b)
+                            .unwrap_or(0);
+                        failures.push(format!(
+                            "{label}: the re-planned convert does not match the CPU \
+                             reference; first differing byte {first} got={} want={}",
+                            got[first], want[first]
+                        ));
+                    }
+                }
+                Ok(()) => {}
+                Err(e) => failures.push(format!(
+                    "{label}: a refused planar destination import must complete through the \
+                     mapped-texture route, not end the convert ({spent} fallback(s) spent): {e}"
+                )),
+            }
+            spent
+        };
+
+        // TRIGGER 1 -- the hook, so the case is reachable on any host whose
+        // driver accepts every destination.
+        gl.set_fail_dst_import(true).expect("arm the hook");
+        let hooked = measure(&mut gl, "hooked refusal", &mut dst, &mut failures);
+        gl.set_fail_dst_import(false).expect("disarm the hook");
+        if hooked == 0 {
+            crate::test_support::report_skip(&format!(
+                "{} - no zero-copy destination import is attempted on this host",
+                function!()
+            ));
+            return;
+        }
+
+        // TRIGGER 2 -- a real driver refusal: a plane offset that is not
+        // 64-byte aligned, which Vivante answers with `EGL_BAD_ACCESS`. Where
+        // the driver accepts it there is no refusal and nothing to assert, so
+        // the arm reports what it saw and stays silent.
+        if let Some(mut offset_dst) = planar_dma() {
+            offset_dst.set_plane_offset(32);
+            let real = measure(
+                &mut gl,
+                "driver refusal at offset 32",
+                &mut offset_dst,
+                &mut failures,
+            );
+            if real == 0 {
+                // Mali and V3D import an unaligned destination happily, so
+                // there is no refusal here and this arm asserted nothing. Said
+                // out loud, because a silent no-op arm is how a lane stops
+                // covering the production trigger without anyone noticing.
+                crate::test_support::report_skip(&format!(
+                    "{} - this driver accepts an unaligned PlanarRgb destination, so the \
+                     real-refusal arm had nothing to measure (the hooked arm still ran)",
+                    function!()
+                ));
+            }
+        }
+
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
     }
 }

--- a/crates/image/src/gl/threaded.rs
+++ b/crates/image/src/gl/threaded.rs
@@ -70,6 +70,9 @@ enum GLProcessorMessage {
         crate::ColorimetryMode,
         tokio::sync::oneshot::Sender<Result<(), Error>>,
     ),
+    /// Test hook (issue #175): make every zero-copy destination import fail.
+    #[cfg(test)]
+    SetFailDstImport(bool, tokio::sync::oneshot::Sender<Result<(), Error>>),
     /// Snapshot the EGLImage cache counters (steady-state import assertions).
     EglCacheStats(tokio::sync::oneshot::Sender<Result<super::cache::GlCacheStats, Error>>),
     /// Snapshot the per-convert source-feed counters (zero-copy observability).
@@ -341,6 +344,10 @@ fn reject_poisoned_message(msg: GLProcessorMessage) {
             let _ = resp.send(Err(poison_err));
         }
         GLProcessorMessage::SetColorimetryMode(_, resp) => {
+            let _ = resp.send(Err(poison_err));
+        }
+        #[cfg(test)]
+        GLProcessorMessage::SetFailDstImport(_, resp) => {
             let _ = resp.send(Err(poison_err));
         }
         GLProcessorMessage::EglCacheStats(resp) => {
@@ -640,6 +647,14 @@ fn handle_gl_message(
                 Ok(())
             }));
             reply_caught(result, resp, poisoned, "SetInt8Interpolation");
+        }
+        #[cfg(test)]
+        GLProcessorMessage::SetFailDstImport(fail, resp) => {
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                gl_converter.fail_dst_import = fail;
+                Ok(())
+            }));
+            reply_caught(result, resp, poisoned, "SetFailDstImport");
         }
         GLProcessorMessage::EglCacheStats(resp) => {
             let result =
@@ -1158,6 +1173,24 @@ impl GLProcessorThreaded {
             .as_ref()
             .ok_or_else(|| Error::Internal("GL processor is shutting down".to_string()))?
             .blocking_send(GLProcessorMessage::SetColorimetryMode(mode, err_send))
+            .map_err(|_| Error::Internal("GL converter thread exited".to_string()))?;
+        err_recv.blocking_recv().map_err(|_| {
+            Error::Internal("GL converter error messaging closed without update".to_string())
+        })?
+    }
+
+    /// Test hook (issue #175): make every zero-copy DESTINATION import fail,
+    /// the way a driver that refuses the buffer does, so the fallback to the
+    /// mapped-texture readback is exercised on a host whose driver accepts
+    /// every destination. The failure is injected at the import itself, so
+    /// what a test drives is the production trigger.
+    #[cfg(test)]
+    pub(crate) fn set_fail_dst_import(&mut self, fail: bool) -> Result<(), Error> {
+        let (err_send, err_recv) = tokio::sync::oneshot::channel();
+        self.sender
+            .as_ref()
+            .ok_or_else(|| Error::Internal("GL processor is shutting down".to_string()))?
+            .blocking_send(GLProcessorMessage::SetFailDstImport(fail, err_send))
             .map_err(|_| Error::Internal("GL converter thread exited".to_string()))?;
         err_recv.blocking_recv().map_err(|_| {
             Error::Internal("GL converter error messaging closed without update".to_string())

--- a/crates/image/src/lib.rs
+++ b/crates/image/src/lib.rs
@@ -12757,10 +12757,29 @@ mod image_tests {
 
     /// GL-vs-CPU identity parity for `Rgba → PlanarRgb F16`.
     ///
-    /// Converts the same RGBA8 source via forced `OpenGl` and forced `Cpu`,
-    /// then verifies the two F16 output tensors agree element-wise within
-    /// 2^-8 (two F16 ULPs at 0.5). Skipped when OpenGL or F16 render is
-    /// unavailable.
+    /// Converts the same RGBA8 source via the `OpenGl` backend and the
+    /// forced `Cpu` backend, then verifies the two F16 output tensors agree
+    /// element-wise within 2^-8 (two F16 ULPs at 0.5). Skipped when OpenGL
+    /// or F16 render is unavailable, and when the host cannot hold the
+    /// zero-copy F16 destination the GL float route needs.
+    ///
+    /// **The GL route is asserted, not assumed** (issue #179).
+    /// `ComputeBackend::OpenGl` is not a forced backend: it leaves
+    /// `forced_backend` at `None`, so a GL decline logs at debug and the CPU
+    /// serves the same convert. Both sides of the comparison would then be
+    /// the CPU's answer and the parity claim would be a tautology — which is
+    /// exactly how a host whose RGBA16F FBO is incomplete (desktop NVIDIA:
+    /// `GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT`) passed while proving nothing,
+    /// `supported_render_dtypes().f16` above notwithstanding: that flag is
+    /// an extension query, not a completed render. `convert_fallback_count()`
+    /// staying flat across the GL convert is the proof, and a decline is
+    /// reported as a skip rather than a failure because it is a property of
+    /// the host's driver, not of this code — except under
+    /// `HAL_TEST_REQUIRE_GL=1`, which turns it into a named failure, the
+    /// same opt-in `crates/image/tests/dst_view_stride.rs` and
+    /// `reconstructed_view_draw.rs` carry for a GL backend that fails to
+    /// come up. A lane that has asserted it has GL should not be quietly
+    /// losing this test's coverage.
     #[test]
     #[cfg(all(
         any(
@@ -12773,6 +12792,20 @@ mod image_tests {
         feature = "opengl"
     ))]
     fn convert_f16_gl_cpu_parity_identity() {
+        // The macOS coverage lane sets `HAL_TEST_REQUIRE_GL=1` for both
+        // passes but deliberately hobbles pass 1 (unsigned binaries, the
+        // ANGLE dlopen gate closed). Excluded there the same way
+        // `gl_backend_available_canary` excludes it, so the gate below
+        // enforces in pass 2 only.
+        #[cfg(target_os = "macos")]
+        if std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1")
+            && std::env::var_os("HAL_TEST_ALLOW_DLOPEN_ANGLE").is_none()
+        {
+            crate::test_support::report_skip(
+                "convert_f16_gl_cpu_parity_identity - ANGLE dlopen gate closed (coverage pass 1)",
+            );
+            return;
+        }
         if !is_opengl_available() {
             crate::test_support::report_skip(
                 "convert_f16_gl_cpu_parity_identity - OpenGL not available",
@@ -12830,17 +12863,75 @@ mod image_tests {
                 return;
             }
 
-            let mut dst = TensorDyn::image(
+            // A destination the GL float route actually serves. A
+            // `TensorMemory::Mem` float destination has no arm in
+            // `float_dispatch::classify_float_render` at all: it classifies as
+            // `FloatRenderPath::None`, the u8 route rejects the dtype, and the
+            // CPU serves every convert. With a host destination the GL half
+            // below was therefore unreachable and this test could only ever
+            // skip. `(Rgba, PlanarRgb, F16, DmaBuf)` -- `ZeroCopyF16Nchw` --
+            // is the zero-copy float tuple EVERY platform's capability set
+            // serves: it is unconditional in `classify_float_render`, so it
+            // holds for the `PlanarF16` set Linux, Android and ANGLE/macOS
+            // declare as well as the `All` set Windows declares.
+            //
+            // One spelling covers all of them. `TensorMemory::DmaBuf` is the
+            // portable name for the platform-native zero-copy GPU buffer --
+            // a DMA-BUF on Linux, an IOSurface on macOS/iOS, an
+            // AHardwareBuffer on Android, an `ID3D11Texture2D` on Windows --
+            // and the classifier matches on that one variant for all of them,
+            // so this needs no `cfg`. Where the platform cannot hold one the
+            // allocation fails or falls back, and both are reported below.
+            let mut dst = match TensorDyn::image(
                 W,
                 H,
                 PixelFormat::PlanarRgb,
                 DType::F16,
-                Some(TensorMemory::Mem),
+                Some(TensorMemory::DmaBuf),
                 edgefirst_tensor::CpuAccess::ReadWrite,
-            )
-            .unwrap();
+            ) {
+                Ok(t) if t.memory() == TensorMemory::DmaBuf => t,
+                // No routable float destination on this host. Reported here,
+                // BEFORE the `HAL_TEST_REQUIRE_GL` gate below: that gate
+                // exists to catch a GL backend declining a destination it
+                // should serve, not a host that cannot hold one.
+                Ok(t) => {
+                    crate::test_support::report_skip(&format!(
+                        "convert_f16_gl_cpu_parity_identity - the zero-copy F16 \
+                         destination fell back to {:?}",
+                        t.memory()
+                    ));
+                    return;
+                }
+                Err(e) => {
+                    crate::test_support::report_skip(&format!(
+                        "convert_f16_gl_cpu_parity_identity - no zero-copy F16 \
+                         destination on this host: {e}"
+                    ));
+                    return;
+                }
+            };
+            let require_gl = std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1");
+            let fallbacks_before = gl_proc.convert_fallback_count();
             match gl_proc.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default()) {
-                Ok(()) => dst,
+                Ok(()) => {
+                    if gl_proc.convert_fallback_count() != fallbacks_before {
+                        assert!(
+                            !require_gl,
+                            "HAL_TEST_REQUIRE_GL=1 but \
+                             convert_f16_gl_cpu_parity_identity would have skipped \
+                             while reporting success: the GL F16 path declined and \
+                             the CPU served the convert"
+                        );
+                        crate::test_support::report_skip(
+                            "convert_f16_gl_cpu_parity_identity - the GL F16 path \
+                             declined and the CPU served the convert; comparing that \
+                             against the forced-CPU result would prove nothing",
+                        );
+                        return;
+                    }
+                    dst
+                }
                 Err(e) => {
                     crate::test_support::report_skip(&format!(
                         "convert_f16_gl_cpu_parity_identity - GL convert failed: {e}"
@@ -12872,11 +12963,25 @@ mod image_tests {
             dst
         };
 
-        // Compare element-wise.
-        let gl_map = gl_result.as_typed::<half::f16>().unwrap().map().unwrap();
-        let cpu_map = cpu_result.as_typed::<half::f16>().unwrap().map().unwrap();
-        let gl_halfs = gl_map.as_slice();
-        let cpu_halfs = cpu_map.as_slice();
+        // Compare element-wise. Both sides are read through `copy_to_flat`:
+        // the GL destination is a packed zero-copy surface whose rows can be
+        // spaced at a driver pitch, so its mapping is not a flat run of the
+        // logical elements.
+        let flat_f16 = |t: &TensorDyn| -> Vec<half::f16> {
+            let typed = t.as_typed::<half::f16>().expect("F16 image");
+            let mut bytes = vec![0u8; typed.shape().iter().product::<usize>() * 2];
+            typed
+                .copy_to_flat(&mut bytes)
+                .expect("compact any padded rows");
+            bytes
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|&c| half::f16::from_le_bytes(c))
+                .collect()
+        };
+        let gl_halfs = flat_f16(&gl_result);
+        let cpu_halfs = flat_f16(&cpu_result);
 
         assert_eq!(
             gl_halfs.len(),

--- a/crates/image/tests/convert_span_feed_fields.rs
+++ b/crates/image/tests/convert_span_feed_fields.rs
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: Copyright 2026 Au-Zone Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+//! The convert span must actually CARRY `src_feed` and `dst_feed`, and
+//! `dst_feed` must be recorded for EVERY destination, not only a refused
+//! import.
+//!
+//! Both fields are declared on `image.convert.gl`, and every recording site
+//! reaches that span through the handle the engine captures rather than through
+//! `Span::current()` — which inside the engine names `image.convert.gl.engine`,
+//! and on the two-pass plans a pass span. `tracing` drops a record against a
+//! field the span does not declare, silently, so the wrong span means the
+//! catalog promises an observable nothing emits. Both fields were in exactly
+//! that state (#175).
+//!
+//! **This is its own test binary, and it holds exactly one test, deliberately.**
+//! `tracing` caches callsite interest process-wide: the first evaluation of a
+//! callsite decides its `Interest`, and a thread with no subscriber caches
+//! `never`, which no later scoped subscriber undoes. As a lib test among ~470
+//! others running in parallel it therefore failed about four runs in nine —
+//! seeing `image.convert.gl.engine` (a callsite first evaluated inside the
+//! scoped subscriber, during the processor's own DMA-BUF probe) but never
+//! `image.convert.gl` (one another thread had already reached). A dedicated
+//! process with a GLOBAL subscriber installed before the first span removes the
+//! race rather than narrowing it, and lets the public `GLProcessorThreaded` be
+//! the thing under test: a global subscriber is visible from its GL worker
+//! thread, where a thread-local one is not.
+//!
+//! No test hook either. The `dst_feed` half is driven by a driver that really
+//! refuses a destination — Vivante returns `EGL_BAD_ACCESS` for an import at an
+//! offset that is not 64-byte aligned — so the trigger under test is the
+//! production one. Where the driver accepts that destination (Mali, V3D) there
+//! is nothing refused and that half self-skips; `src_feed` is asserted on every
+//! host, including a desktop whose EGL cannot import a DMA-BUF at all.
+//!
+//! The FLOAT route is out of scope by construction: it returns before
+//! `image.convert.gl` is entered, so it has no convert span and records
+//! neither field. That is what `ARCHITECTURE.md`'s span catalog says; giving
+//! the route its own span is a follow-up.
+
+#![cfg(all(target_os = "linux", feature = "opengl"))]
+
+use edgefirst_image::{Crop, Flip, GLProcessorThreaded, ImageProcessorTrait, Rotation};
+use edgefirst_tensor::{
+    CpuAccess, DType, PixelFormat, Region, TensorDyn, TensorMapTrait, TensorMemory,
+};
+use std::sync::{Arc, Mutex};
+use tracing_subscriber::layer::SubscriberExt;
+
+const W: usize = 320;
+const H: usize = 240;
+const BPP: usize = 4;
+/// Pseudo-field marking a span creation rather than a field record.
+const NEW_SPAN: &str = "<new_span>";
+
+/// `(span name, field, value)` for every `record` call, plus one entry per span
+/// creation so an absent field can be told from a dead capture.
+type Records = Arc<Mutex<Vec<(String, String, String)>>>;
+
+struct Capture(Records);
+struct Visit<'a>(&'a str, &'a Records);
+
+impl tracing::field::Visit for Visit<'_> {
+    fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+        self.1
+            .lock()
+            .unwrap()
+            .push((self.0.to_string(), f.name().to_string(), format!("{v:?}")));
+    }
+    fn record_str(&mut self, f: &tracing::field::Field, v: &str) {
+        self.1
+            .lock()
+            .unwrap()
+            .push((self.0.to_string(), f.name().to_string(), v.to_string()));
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for Capture
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        _id: &tracing::span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        self.0.lock().unwrap().push((
+            attrs.metadata().name().to_string(),
+            NEW_SPAN.to_string(),
+            String::new(),
+        ));
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let name = ctx
+            .span(id)
+            .map(|s| s.name().to_string())
+            .unwrap_or_default();
+        values.record(&mut Visit(&name, &self.0));
+    }
+}
+
+fn skip(why: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {why}");
+}
+
+fn image(w: usize, h: usize, memory: TensorMemory) -> Option<TensorDyn> {
+    match TensorDyn::image(
+        w,
+        h,
+        PixelFormat::Rgba,
+        DType::U8,
+        Some(memory),
+        CpuAccess::ReadWrite,
+    ) {
+        Ok(t) if t.memory() == memory => Some(t),
+        _ => None,
+    }
+}
+
+/// Values recorded for `field` on the `image.convert.gl` span.
+fn values_for(seen: &[(String, String, String)], field: &str) -> Vec<String> {
+    seen.iter()
+        .filter(|(span, f, _)| span == "image.convert.gl" && f == field)
+        .map(|(_, _, v)| v.clone())
+        .collect()
+}
+
+#[test]
+fn the_convert_span_records_the_feed_fields() {
+    let records: Records = Arc::new(Mutex::new(Vec::new()));
+    // GLOBAL, not scoped: the convert runs on `GLProcessorThreaded`'s worker
+    // thread, and it must be installed before the first span so this process
+    // cannot have cached `Interest::never()` for any callsite under test.
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::registry().with(Capture(records.clone())),
+    )
+    .expect("install the capturing subscriber");
+
+    let mut gl = match GLProcessorThreaded::new(None) {
+        Ok(gl) => gl,
+        Err(e) => {
+            assert!(
+                !std::env::var("HAL_TEST_REQUIRE_GL").is_ok_and(|v| v == "1"),
+                "HAL_TEST_REQUIRE_GL=1 but the GL backend failed to come up: {e}"
+            );
+            skip(&format!("no GL backend: {e}"));
+            return;
+        }
+    };
+
+    // ── src_feed: asserted on every host ────────────────────────────────
+    // A host-memory source and destination need no zero-copy anything, so
+    // this half runs on a desktop whose EGL cannot import a DMA-BUF.
+    let src = image(W, H, TensorMemory::Mem).expect("host source");
+    {
+        let mut m = src.map_bytes(CpuAccess::Write).expect("map source");
+        m.as_mut_slice().fill(0x5A);
+    }
+    let mut dst = image(W, H, TensorMemory::Mem).expect("host destination");
+    gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default())
+        .expect("host-memory convert");
+
+    let seen = records.lock().unwrap().clone();
+    assert!(
+        seen.iter()
+            .any(|(span, field, _)| span == "image.convert.gl" && field == NEW_SPAN),
+        "the capture never saw an image.convert.gl span, so it cannot testify about \
+         the feed fields; records seen: {seen:?}"
+    );
+    let feeds = values_for(&seen, "src_feed");
+    assert!(
+        !feeds.is_empty(),
+        "a u8 convert recorded no src_feed on image.convert.gl; records seen: {seen:?}"
+    );
+    assert!(
+        feeds
+            .iter()
+            .all(|v| matches!(v.as_str(), "import" | "pbo" | "upload")),
+        "src_feed must be one of import|pbo|upload, saw {feeds:?}"
+    );
+
+    // A zero-copy source, so the `import` arm is covered where a host has one.
+    if let Some(dma_src) = image(W, H, TensorMemory::DmaBuf) {
+        {
+            let mut m = dma_src.map_bytes(CpuAccess::Write).expect("map dma source");
+            m.as_mut_slice().fill(0x33);
+        }
+        let _ = gl.convert(
+            &dma_src,
+            &mut dst,
+            Rotation::None,
+            Flip::None,
+            Crop::default(),
+        );
+    }
+    let src_feeds = values_for(&records.lock().unwrap().clone(), "src_feed");
+    eprintln!("CAPTURE src_feed on image.convert.gl: {src_feeds:?}");
+
+    // ── dst_feed: stated for every destination ──────────────────────────
+    // The host-memory convert above is a `mapped_texture` destination, and the
+    // field must SAY so. An absent field used to be the only signal for an
+    // ordinary texture-lowered convert, which reads exactly like a zero-copy
+    // one that never recorded anything.
+    let dst_feeds = values_for(&records.lock().unwrap().clone(), "dst_feed");
+    assert!(
+        dst_feeds.iter().any(|v| v == "mapped_texture"),
+        "a host-memory destination recorded no dst_feed; values seen: {dst_feeds:?}"
+    );
+    assert!(
+        dst_feeds
+            .iter()
+            .all(|v| matches!(v.as_str(), "zero_copy" | "mapped_texture" | "pbo")),
+        "dst_feed must be one of zero_copy|mapped_texture|pbo, saw {dst_feeds:?}"
+    );
+
+    // A zero-copy destination the driver ACCEPTS must say `zero_copy` -- the
+    // half an import-refusal marker could never state, and the one that makes
+    // the field readable without inference.
+    //
+    // Reachable only where the display can render into a DMA-BUF at all: on a
+    // host whose transfer backend fell back to PBO, a DMA-BUF destination is
+    // lowered to the mapped route with no import attempted, and
+    // `mapped_texture` is then the correct answer. The value is checked
+    // against the vocabulary on every host either way, which is what catches a
+    // missing or misspelled record.
+    if let Some(mut zc) = image(W, H, TensorMemory::DmaBuf) {
+        let _ = gl.convert(&src, &mut zc, Rotation::None, Flip::None, Crop::default());
+    }
+    let feeds = values_for(&records.lock().unwrap().clone(), "dst_feed");
+    assert!(
+        feeds
+            .iter()
+            .all(|v| matches!(v.as_str(), "zero_copy" | "mapped_texture" | "pbo")),
+        "dst_feed must be one of zero_copy|mapped_texture|pbo, saw {feeds:?}"
+    );
+    if feeds.iter().any(|v| v == "zero_copy") {
+        eprintln!("CAPTURE dst_feed zero_copy: present");
+    } else {
+        skip("no zero-copy destination render on this host, so dst_feed=zero_copy is unreachable");
+    }
+    eprintln!("CAPTURE dst_feed values: {feeds:?}");
+
+    // ── dst_feed on the REFUSED route, where a driver really refuses ─────
+    // The rebuilt-view shape `offset_source_view_alignment.rs` pins: it
+    // carries the byte offset and no `view_origin`, so the import bases at
+    // that offset, and Vivante refuses it when it is not 64-byte aligned.
+    let Some(canvas) = image(64, 64, TensorMemory::DmaBuf) else {
+        skip("no zero-copy RGBA image here, so no destination import to refuse");
+        return;
+    };
+    let pitch = canvas.effective_row_stride().unwrap_or(64 * BPP);
+    let offset = 8 * pitch + 8 * BPP;
+    assert!(
+        !offset.is_multiple_of(64),
+        "precondition: (8,8) at pitch {pitch} is byte offset {offset}, which must be \
+         unaligned for a driver to have anything to refuse"
+    );
+    let fresh = canvas
+        .view(Region::new(8, 8, 16, 16))
+        .expect("destination view");
+    let mut tile = TensorDyn::import_descriptor(&fresh.descriptor_pinned(None))
+        .expect("rebuild the destination view from its descriptor");
+    tile.set_plane_offset(offset);
+    let tile_src = image(16, 16, TensorMemory::Mem).expect("tile source");
+
+    let before = gl
+        .convert_stats()
+        .expect("convert stats")
+        .dst_import_fallbacks;
+    let _ = gl.convert(
+        &tile_src,
+        &mut tile,
+        Rotation::None,
+        Flip::None,
+        Crop::default(),
+    );
+    let refused = gl
+        .convert_stats()
+        .expect("convert stats")
+        .dst_import_fallbacks
+        - before;
+    if refused == 0 {
+        skip(&format!(
+            "no destination import was refused at offset {offset} — either this \
+             driver accepts it (Mali, V3D) or this host attempts no zero-copy \
+             destination import at all — so there is no dst_feed to observe"
+        ));
+        return;
+    }
+    let seen = records.lock().unwrap().clone();
+    assert!(
+        values_for(&seen, "dst_feed")
+            .iter()
+            .any(|v| v == "mapped_texture"),
+        "the refused destination import recorded no dst_feed on image.convert.gl; \
+         records seen: {seen:?}"
+    );
+    eprintln!("CAPTURE dst_feed on the refused route: mapped_texture");
+}

--- a/crates/image/tests/offset_source_view_alignment.rs
+++ b/crates/image/tests/offset_source_view_alignment.rs
@@ -54,7 +54,8 @@ const SIDE: usize = 16;
 const BPP: usize = 4;
 
 /// The alignment Mali's DMA-BUF import needs; mirrored from the engine so the
-/// NV12 case can build one offset on either side of it.
+/// NV12 case can build one offset on either side of it, and reused by the
+/// destination case to say which of its two offsets is the aligned one.
 const MALI_ALIGN: usize = 64;
 
 /// The origins the imx95 probe classified; the two unaligned ones (offsets 32
@@ -498,12 +499,15 @@ fn nv12_offset_sources_convert_through_gl_at_aligned_and_unaligned_offsets() {
 /// destination exemption in `get_or_create_egl_image` claims it is safe, so it
 /// is measured here rather than assumed.
 ///
-/// Measured: Mali (i.MX 95) and V3D render into offset 2080 correctly, so Mali
-/// destinations keep the zero-copy import. Vivante does NOT — `eglCreateImage`
-/// returns `EGL_BAD_ACCESS` at 2080 while 2048 renders — which this test found
-/// and `vivante_rejects_dst_import_offset` now lowers to the mapped-texture
-/// path. Both offsets are asserted on every driver, so either half regressing
-/// is caught here.
+/// Measured: Mali (i.MX 95) and V3D render into offset 2080 correctly, so their
+/// import succeeds and the destination stays zero-copy. Vivante does NOT —
+/// `eglCreateImage` returns `EGL_BAD_ACCESS` at 2080 while 2048 renders — and
+/// since issue #175 that refusal is itself the trigger rather than something a
+/// per-driver predicate has to predict: the convert falls back to the
+/// mapped-texture readback, which writes through `map()` at the offset, and
+/// still lands the correct pixels. Both offsets are asserted on every driver,
+/// and so is the route (`dst_import_fallbacks`), so a regression on either
+/// half is caught here whichever way it falls.
 ///
 /// The destination is rebuilt from a `view()`'s descriptor, which is the only
 /// shape that reaches the import at a nonzero offset: a fresh `view()` collapses
@@ -522,6 +526,7 @@ fn rgba_offset_destinations_place_their_tile_at_aligned_and_unaligned_offsets() 
     let pitch = canvas.effective_row_stride().unwrap_or(W * BPP);
 
     let mut failures = Vec::new();
+    let mut routes: Vec<(usize, usize, usize, u64)> = Vec::new();
     // (0, 8) is 8 * pitch, aligned whenever the pitch is; (8, 8) adds
     // 8 * BPP = 32, which is never 64-aligned. Same construction as the source
     // test, so the two halves are measured at the same two offsets.
@@ -565,10 +570,39 @@ fn rgba_offset_destinations_place_their_tile_at_aligned_and_unaligned_offsets() 
                 }
             }
         }
+        let before = gl
+            .convert_stats()
+            .expect("convert stats")
+            .dst_import_fallbacks;
         if let Err(e) = gl.convert(&src, &mut dst, Rotation::None, Flip::None, Crop::default()) {
             failures.push(format!("({x0},{y0}) offset {offset}: convert failed: {e}"));
             continue;
         }
+        // The route this destination took. A driver that imports it renders
+        // into the buffer directly (0); one that refuses it — Vivante at an
+        // unaligned offset — falls back to the mapped-texture readback (1),
+        // and the pixel assertions below must hold either way. What is NOT
+        // acceptable is a fallback at an offset the driver imports happily:
+        // that would mean the convert quietly stopped being zero-copy.
+        let took = gl
+            .convert_stats()
+            .expect("convert stats")
+            .dst_import_fallbacks
+            - before;
+        if took > 1 {
+            failures.push(format!(
+                "({x0},{y0}) offset {offset}: {took} destination-import fallbacks for \
+                 one convert; at most one is expected"
+            ));
+        }
+        if offset.is_multiple_of(MALI_ALIGN) && took != 0 {
+            failures.push(format!(
+                "({x0},{y0}) offset {offset}: the destination import was refused at an \
+                 ALIGNED offset, so this driver lost the zero-copy destination path \
+                 for a buffer it should accept"
+            ));
+        }
+        routes.push((x0, y0, offset, took));
         let out = bytes(&canvas);
         let px = |x: usize, y: usize| &out[y * pitch + x * BPP..][..BPP];
         if px(0, 0) != [BLANK; BPP] {
@@ -614,6 +648,11 @@ fn rgba_offset_destinations_place_their_tile_at_aligned_and_unaligned_offsets() 
             ));
         }
     }
+    eprintln!(
+        "destination routes (x0, y0, offset, import fallbacks): {routes:?} \
+         -- 1 means the driver refused the import and the mapped-texture \
+         readback served the convert"
+    );
     assert!(
         failures.is_empty(),
         "pitch {pitch}:\n{}",

--- a/crates/tensor-capi/src/builder.rs
+++ b/crates/tensor-capi/src/builder.rs
@@ -798,7 +798,7 @@ mod tests {
         // silently wipe it. Proves the offset survives a `wrap` call that
         // ALSO carries a format, not just one that omits it.
         if !edgefirst_tensor::is_shm_available() {
-            eprintln!("SKIPPED: SHM not available");
+            crate::artifacts::skip("SHM not available");
             return;
         }
         // 720x640 NV12 (480p, combined-plane height 720) plus one extra row
@@ -838,7 +838,7 @@ mod tests {
         // plane `stride` failed unconditionally with `EINVAL`, even when the
         // stride was perfectly valid for that format.
         if !edgefirst_tensor::is_shm_available() {
-            eprintln!("SKIPPED: SHM not available");
+            crate::artifacts::skip("SHM not available");
             return;
         }
         // 720x640 NV12 with a padded stride (768, wider than the tight 640
@@ -871,7 +871,7 @@ mod tests {
     #[test]
     fn wrap_rejects_a_size_smaller_than_shape_and_stride_imply() {
         if !edgefirst_tensor::is_shm_available() {
-            eprintln!("SKIPPED: SHM not available");
+            crate::artifacts::skip("SHM not available");
             return;
         }
         let handle = shm_fd(16);
@@ -895,7 +895,7 @@ mod tests {
         // buffer is a normal thing to hand a wrapper and must not be
         // rejected merely for being bigger than the tight requirement.
         if !edgefirst_tensor::is_shm_available() {
-            eprintln!("SKIPPED: SHM not available");
+            crate::artifacts::skip("SHM not available");
             return;
         }
         let handle = shm_fd(64);
@@ -923,7 +923,7 @@ mod tests {
         // the tensor has no partial-fill/`bytes_used` concept, so `used <
         // size` cannot be represented either.
         if !edgefirst_tensor::is_shm_available() {
-            eprintln!("SKIPPED: SHM not available");
+            crate::artifacts::skip("SHM not available");
             return;
         }
         let handle = shm_fd(16);
@@ -946,7 +946,7 @@ mod tests {
         // compressed buffer silently reinterpreted as linear is exactly the
         // "wrong data disguised as an answer" shape this task exists to fix.
         if !edgefirst_tensor::is_shm_available() {
-            eprintln!("SKIPPED: SHM not available");
+            crate::artifacts::skip("SHM not available");
             return;
         }
         let handle = shm_fd(16);
@@ -970,7 +970,7 @@ mod tests {
         // not something this builder composes; an honest refusal beats a
         // silent truncation to the first plane.
         if !edgefirst_tensor::is_shm_available() {
-            eprintln!("SKIPPED: SHM not available");
+            crate::artifacts::skip("SHM not available");
             return;
         }
         let handle = shm_fd(16);
@@ -996,7 +996,7 @@ mod tests {
         // `add_plane` with offset/stride/size/used/modifier all zero. None
         // of this task's new rejections may fire on that shape of call.
         if !edgefirst_tensor::is_shm_available() {
-            eprintln!("SKIPPED: SHM not available");
+            crate::artifacts::skip("SHM not available");
             return;
         }
         let handle = shm_fd(16);

--- a/crates/tensor-capi/src/d3d11.rs
+++ b/crates/tensor-capi/src/d3d11.rs
@@ -1412,7 +1412,7 @@ mod tests {
         access: u32,
     ) -> Option<*mut EfTensor> {
         if crate::probe::ef_is_gpu_buffer_available() == 0 {
-            eprintln!("SKIP: no D3D11 device on this host");
+            crate::artifacts::skip("no D3D11 device on this host");
             return None;
         }
         let f = std::ffi::CString::new(format).unwrap();

--- a/crates/tensor-capi/src/image.rs
+++ b/crates/tensor-capi/src/image.rs
@@ -484,14 +484,14 @@ mod tests {
     #[test]
     fn image_with_stride_alloc_reports_the_padded_pitch() {
         if !edgefirst_tensor::is_dma_available() {
-            eprintln!("SKIPPED: DMA not available on this host");
+            crate::artifacts::skip("DMA not available on this host");
             return;
         }
         let fmt = u8_c("Rgba");
         // Natural pitch is 64*4=256; pad to 320.
         let t = unsafe { ef_tensor_image_with_stride_alloc(64, 64, fmt.as_ptr(), 0, 320, 1, 2, 3) };
         if t.is_null() {
-            eprintln!("SKIPPED: image_with_stride_alloc unavailable on this host");
+            crate::artifacts::skip("image_with_stride_alloc unavailable on this host");
             return;
         }
         assert_eq!(inner_of(t).effective_row_stride(), Some(320));

--- a/crates/tensor-capi/src/lib.rs
+++ b/crates/tensor-capi/src/lib.rs
@@ -100,7 +100,7 @@ mod tests {
         {
             Ok(o) => Some(o),
             Err(e) => {
-                eprintln!("SKIP: no C compiler ({cc}: {e}); header not syntax-checked");
+                skip(&format!("no C compiler ({cc}: {e}); header not syntax-checked"));
                 None
             }
         }
@@ -130,7 +130,7 @@ mod tests {
         {
             Ok(o) => Some(o),
             Err(e) => {
-                eprintln!("SKIP: no C compiler ({cc}: {e}); header not syntax-checked");
+                skip(&format!("no C compiler ({cc}: {e}); header not syntax-checked"));
                 None
             }
         }
@@ -499,7 +499,7 @@ mod tests {
         // consumer linking `libedgefirst_tensor.a` directly), not a
         // hypothetical.
         let Some(cxx) = find_cpp17_compiler() else {
-            eprintln!("SKIP: no working C++17 toolchain (c++/clang++); header not C++17-checked");
+            skip("no working C++17 toolchain (c++/clang++); header not C++17-checked");
             return;
         };
 

--- a/crates/tensor-capi/src/map.rs
+++ b/crates/tensor-capi/src/map.rs
@@ -799,17 +799,16 @@ mod tests {
         // that exercises the map window's `DMA_BUF_IOCTL_SYNC` sync-bracket
         // arm, which a `Mem`-backed tensor never reaches.
         if !edgefirst_tensor::is_dma_available() {
-            // Straight to stderr, not `eprintln!`: libtest swallows
-            // `eprintln!` output for passing tests (see check_abi.rs's
+            // Through `artifacts::skip`, which writes straight to stderr
+            // rather than through `eprintln!`: libtest swallows `eprintln!`
+            // output for passing tests (see check_abi.rs's
             // `artifact_is_fresh`, which documents this exact trap), and this
             // is the plan's only executable evidence for the
             // `DMA_BUF_IOCTL_SYNC` sync-bracket arm -- a skip nobody sees is
             // indistinguishable from a pass.
-            use std::io::Write;
-            let _ = writeln!(
-                std::io::stderr(),
-                "SKIP: dma_buf_map_write_unmap_copy_to_round_trip -- no usable \
-                 dma-heap on this host (missing or unprivileged)"
+            crate::artifacts::skip(
+                "dma_buf_map_write_unmap_copy_to_round_trip -- no usable \
+                 dma-heap on this host (missing or unprivileged)",
             );
             return;
         }

--- a/crates/tensor-capi/tests/check_abi.rs
+++ b/crates/tensor-capi/tests/check_abi.rs
@@ -53,9 +53,13 @@ fn artifact_is_fresh(artifact: &std::path::Path) -> bool {
         panic!("{msg}");
     }
     // Straight to stderr: libtest swallows `eprintln!` for passing tests,
-    // and a skip nobody sees is indistinguishable from a pass.
+    // and a skip nobody sees is indistinguishable from a pass. `SKIPPED:` is
+    // the wire format `scripts/on-target-test.sh` counts; written out here
+    // rather than through `artifacts::skip` for the reason this file's
+    // header gives -- an integration test cannot see the library crate's
+    // `#[cfg(test)]` items.
     use std::io::Write;
-    let _ = writeln!(std::io::stderr(), "SKIP: {msg}");
+    let _ = writeln!(std::io::stderr(), "SKIPPED: {msg}");
     false
 }
 

--- a/crates/tensor-capi/tests/support/artifacts.rs
+++ b/crates/tensor-capi/tests/support/artifacts.rs
@@ -15,14 +15,31 @@
 
 use std::path::{Path, PathBuf};
 
-/// Report a skipped check on stderr.
+/// Report a skipped check on stderr as `SKIPPED: {reason}`.
 ///
 /// Straight to the handle, not `eprintln!`: libtest captures a passing
 /// test's `eprintln!`, and a skip nobody sees is indistinguishable from a
 /// pass.
+///
+/// The `SKIPPED:` spelling is the wire format, not a nicety --
+/// `scripts/on-target-test.sh` greps each board's captured log for that
+/// literal to report a skip count, and `edgefirst-image`'s
+/// `test_support::report_skip` emits the same line. The earlier `SKIP:`
+/// prefix here was invisible to that count.
+///
+/// Every skip line the five leaves EMIT carries that prefix. Three places
+/// cannot call this function and write it themselves, each for a stated
+/// reason: `msvc.rs` beside this file (its own `#[path]`-included twin),
+/// `tests/check_abi.rs` (an integration test cannot see the library
+/// crate's `#[cfg(test)]` items -- its header says so), and the
+/// `codec`/`decoder`/`tracker` leaves, which do not `#[path]`-include this
+/// module at all. The `SKIP:` lines left in `tests/c/*.c` are not an
+/// exception to that: a C leaf test's output is captured into the
+/// `std::process::Output` its Rust caller inspects and prints only on
+/// failure, so those lines never reach a board log in the first place.
 pub fn skip(reason: &str) {
     use std::io::Write;
-    let _ = writeln!(std::io::stderr(), "SKIP: {reason}");
+    let _ = writeln!(std::io::stderr(), "SKIPPED: {reason}");
 }
 
 /// Directories that may hold this leaf's built C libraries, in the order

--- a/crates/tensor-capi/tests/support/msvc.rs
+++ b/crates/tensor-capi/tests/support/msvc.rs
@@ -81,14 +81,16 @@ pub struct Toolchain {
     scratch: PathBuf,
 }
 
-/// Report a skipped check on stderr.
+/// Report a skipped check on stderr as `SKIPPED: {reason}`.
 ///
 /// Straight to the handle, not `eprintln!`: libtest captures a passing
 /// test's `eprintln!` and a skip nobody sees is indistinguishable from a
-/// pass.
+/// pass. Same wire format as `artifacts::skip` beside it -- both are
+/// `#[path]`-included per leaf, and `scripts/on-target-test.sh` counts a
+/// board's skips by grepping for the literal `SKIPPED`.
 pub fn skip(reason: &str) {
     use std::io::Write;
-    let _ = writeln!(std::io::stderr(), "SKIP: {reason}");
+    let _ = writeln!(std::io::stderr(), "SKIPPED: {reason}");
 }
 
 /// The toolchain for this process, or the reason there is none.

--- a/crates/tensor/src/blob.rs
+++ b/crates/tensor/src/blob.rs
@@ -1938,7 +1938,6 @@ mod tests {
     /// A reference-capable tensor, or `None` on a host that has no shareable
     /// backing (no dma-heap, or one this user cannot open).
     fn reference_capable(w: usize, h: usize) -> Option<TensorDyn> {
-        use std::io::Write;
         match Tensor::<u8>::image(
             w,
             h,
@@ -1948,11 +1947,10 @@ mod tests {
         ) {
             Ok(t) => Some(TensorDyn::from(t)),
             Err(e) => {
-                let _ = writeln!(
-                    std::io::stderr(),
-                    "SKIP: no shareable backing on this host ({e:?}); \
-                     reference transport not exercised"
-                );
+                crate::test_support::report_skip(&format!(
+                    "no shareable backing on this host ({e:?}); reference \
+                     transport not exercised"
+                ));
                 None
             }
         }

--- a/crates/tensor/src/shm.rs
+++ b/crates/tensor/src/shm.rs
@@ -584,10 +584,10 @@ mod tests {
         // than asserting a property this platform cannot provide.
         let a = ShmTensor::<u8>::new(&[8], None).unwrap();
         if a.buffer_identity().kind() != crate::IdentityKind::Shm {
-            println!(
-                "SKIP: a_dup_of_the_same_shm_segment_has_the_same_identity - \
-                 this platform's fstat gives no usable shm inode, so identity \
-                 falls back to the fd number (see identity_from_stat)"
+            crate::test_support::report_skip(
+                "a_dup_of_the_same_shm_segment_has_the_same_identity - this \
+                 platform's fstat gives no usable shm inode, so identity falls \
+                 back to the fd number (see identity_from_stat)",
             );
             return;
         }

--- a/crates/tensor/tests/dynamic_primitives.rs
+++ b/crates/tensor/tests/dynamic_primitives.rs
@@ -1546,7 +1546,7 @@ fn dmabuf_clone_refuses_host_memory_and_dups_a_real_dma_fd() {
             use std::io::Write;
             let _ = writeln!(
                 std::io::stderr(),
-                "SKIP: dmabuf_clone_refuses_host_memory_and_dups_a_real_dma_fd -- \
+                "SKIPPED: dmabuf_clone_refuses_host_memory_and_dups_a_real_dma_fd -- \
                  no usable dma-buf heap on this host"
             );
             return;
@@ -1786,7 +1786,7 @@ fn clone_fd_works_for_shm_not_only_dma() {
             use std::io::Write;
             let _ = writeln!(
                 std::io::stderr(),
-                "SKIP: clone_fd_works_for_shm_not_only_dma -- no usable /dev/shm here"
+                "SKIPPED: clone_fd_works_for_shm_not_only_dma -- no usable /dev/shm here"
             );
             return;
         }
@@ -1958,7 +1958,7 @@ fn a_dma_tensor_answers_both_questions_the_gpu_import_sites_ask() {
             use std::io::Write;
             let _ = writeln!(
                 std::io::stderr(),
-                "SKIP: a_dma_tensor_answers_both_questions_the_gpu_import_sites_ask -- \
+                "SKIPPED: a_dma_tensor_answers_both_questions_the_gpu_import_sites_ask -- \
                  no usable dma-buf heap here ({e:?})"
             );
             return;

--- a/crates/tensor/tests/identity.rs
+++ b/crates/tensor/tests/identity.rs
@@ -6,6 +6,21 @@ use edgefirst_tensor::{Tensor, TensorMemory, TensorTrait};
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use edgefirst_tensor::{Tensor, TensorMemory, TensorTrait};
 
+/// Report a skip as `SKIPPED: {why}`, straight to stderr.
+///
+/// Not `println!`/`eprintln!`: libtest captures both and replays them only
+/// for a *failing* test, and a skip is a pass, so the reason was discarded
+/// exactly when it mattered. The `SKIPPED:` prefix is what
+/// `scripts/on-target-test.sh` greps a board's log for to count skips.
+/// Written out here rather than shared: an integration test is its own
+/// compilation unit and cannot reach `edgefirst-tensor`'s `pub(crate)`
+/// `test_support::report_skip`.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+fn skip(why: &str) {
+    use std::io::Write;
+    let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {why}");
+}
+
 /// Allocates a small DMA-BUF tensor, or reports why it could not and returns
 /// `None`. A dma-heap is a host resource, not something every CI runner or
 /// dev machine provides, so absence must be a loud, visible skip rather than
@@ -15,7 +30,7 @@ fn dma_tensor_or_skip() -> Option<Tensor<u8>> {
     match Tensor::<u8>::new(&[4096], Some(TensorMemory::DmaBuf), None) {
         Ok(t) => Some(t),
         Err(e) => {
-            println!("SKIP: no dma-heap on this host ({e})");
+            skip(&format!("no dma-heap on this host ({e})"));
             None
         }
     }
@@ -47,7 +62,7 @@ fn iosurface_tensor_or_skip() -> Option<Tensor<u8>> {
     match Tensor::<u8>::new(&[4096], Some(TensorMemory::DmaBuf), None) {
         Ok(t) => Some(t),
         Err(e) => {
-            println!("SKIP: no IOSurface support on this host ({e})");
+            skip(&format!("no IOSurface support on this host ({e})"));
             None
         }
     }

--- a/crates/tensor/tests/protocol.rs
+++ b/crates/tensor/tests/protocol.rs
@@ -342,7 +342,7 @@ fn descriptor_carries_dmabuf_fd_as_handle() {
             use std::io::Write;
             let _ = writeln!(
                 std::io::stderr(),
-                "SKIP: descriptor_carries_dmabuf_fd_as_handle -- this platform has no \
+                "SKIPPED: descriptor_carries_dmabuf_fd_as_handle -- this platform has no \
                  DMA-BUF heap (Tensor::image(.., TensorMemory::DmaBuf, ..) returned \
                  NotFound); dma-buf allocation is unavailable here, not broken."
             );

--- a/crates/tensor/tests/protocol_roundtrip.rs
+++ b/crates/tensor/tests/protocol_roundtrip.rs
@@ -318,7 +318,7 @@ fn dmabuf_import_has_no_coverage_off_linux() {
     use std::io::Write;
     let _ = writeln!(
         std::io::stderr(),
-        "SKIP: TensorDyn::import_descriptor's kind::DMABUF arm is untested on \
+        "SKIPPED: TensorDyn::import_descriptor's kind::DMABUF arm is untested on \
          this platform (dma-buf is Linux-only). No aliasing coverage for the \
          dma-buf import path outside a Linux run."
     );
@@ -350,7 +350,7 @@ fn dmabuf_roundtrip_sees_the_same_bytes() {
             use std::io::Write;
             let _ = writeln!(
                 std::io::stderr(),
-                "SKIP: dmabuf_roundtrip_sees_the_same_bytes -- this platform has no \
+                "SKIPPED: dmabuf_roundtrip_sees_the_same_bytes -- this platform has no \
                  DMA-BUF heap (Tensor::image(.., TensorMemory::DmaBuf, ..) returned \
                  NotFound); dma-buf allocation is unavailable here, not broken."
             );
@@ -406,7 +406,7 @@ fn imported_dmabuf_with_a_recorded_stride_is_still_cpu_mappable() {
             use std::io::Write;
             let _ = writeln!(
                 std::io::stderr(),
-                "SKIP: imported_dmabuf_with_a_recorded_stride_is_still_cpu_mappable -- \
+                "SKIPPED: imported_dmabuf_with_a_recorded_stride_is_still_cpu_mappable -- \
                  this platform has no DMA-BUF heap; dma-buf allocation is unavailable \
                  here, not broken."
             );
@@ -469,7 +469,7 @@ fn dmabuf_import_preserves_the_producers_row_stride_for_pool_reuse() {
             use std::io::Write;
             let _ = writeln!(
                 std::io::stderr(),
-                "SKIP: dmabuf_import_preserves_the_producers_row_stride_for_pool_reuse -- \
+                "SKIPPED: dmabuf_import_preserves_the_producers_row_stride_for_pool_reuse -- \
                  this platform has no DMA-BUF heap; dma-buf allocation is unavailable \
                  here, not broken."
             );

--- a/crates/tensor/tests/support/cuda_require.rs
+++ b/crates/tensor/tests/support/cuda_require.rs
@@ -27,7 +27,7 @@
 //! the very function the Windows guard calls, on every lane -- the Linux
 //! ones included, where `d3d11_tensor.rs` compiles to nothing -- rather
 //! than a copy that could drift from it.
-//! [`cuda_available_or_skip`] is the one env-reading, printing caller
+//! [`cuda_available_or_skip`] is the one env-reading, skip-reporting caller
 //! `d3d11_tensor.rs` uses.
 
 /// `true` when `HAL_TEST_REQUIRE_CUDA=1` is set -- the opt-in that turns a
@@ -39,7 +39,7 @@ fn required() -> bool {
 /// The pure decision: `true` when `satisfied`; otherwise a failure or a skip
 /// depending on `require`. No environment access and no output -- the
 /// caller reads `HAL_TEST_REQUIRE_CUDA` and passes the result in as
-/// `require`, and prints the `SKIP` line itself on a `false` return. That
+/// `require`, and reports the skip itself on a `false` return. That
 /// purity is what lets `crates/tensor/tests/cuda_require_policy.rs` test
 /// this exact function on hosts with no CUDA and no D3D11.
 ///
@@ -61,18 +61,31 @@ pub fn decide(satisfied: bool, require: bool, what: &str, why: &str) -> bool {
 }
 
 /// `true` when the caller should run; `false` when it should return early.
-/// Prints `SKIP {what}: {why}` to stderr on a `false` return.
+/// Reports `SKIPPED: {what} - {why}` on a `false` return.
+///
+/// The line is written straight to `std::io::stderr()`, not through
+/// `eprintln!`. `eprintln!` routes via `std::io::_eprint`, which libtest
+/// hooks for per-test output capture and replays only for a *failing*
+/// test -- and a skip is a pass, so the reason was discarded exactly when
+/// it mattered. The `SKIPPED:` prefix is the one `scripts/
+/// on-target-test.sh` greps for to count skips per board, so the previous
+/// `SKIP {what}:` spelling was invisible to it twice over. This is the
+/// same rule (and the same wire format) as `edgefirst-image`'s
+/// `test_support::report_skip`, written out here because an integration
+/// test is its own compilation unit and cannot reach that crate-private
+/// helper.
 ///
 /// # Panics
 ///
 /// When `HAL_TEST_REQUIRE_CUDA=1` and CUDA is unavailable -- see [`decide`].
 pub fn cuda_available_or_skip(what: &str) -> bool {
+    use std::io::Write;
     let why = "no CUDA runtime (a supported soname missing from cuda.rs's \
          probe list -- cudart64_13.dll, cudart64_12.dll, cudart64_110.dll -- \
          or it is not on PATH or CUDA_PATH\\bin)";
     let run = decide(edgefirst_tensor::is_cuda_available(), required(), what, why);
     if !run {
-        eprintln!("SKIP {what}: {why}");
+        let _ = writeln!(&mut std::io::stderr(), "SKIPPED: {what} - {why}");
     }
     run
 }

--- a/crates/tracker-capi/src/lib.rs
+++ b/crates/tracker-capi/src/lib.rs
@@ -51,7 +51,7 @@ mod tests {
             Ok(o) => Some(o),
             Err(e) => {
                 use std::io::Write;
-                let _ = writeln!(std::io::stderr(), "SKIP: no C compiler ({cc}: {e})");
+                let _ = writeln!(std::io::stderr(), "SKIPPED: no C compiler ({cc}: {e})");
                 None
             }
         }
@@ -125,7 +125,7 @@ mod tests {
             .unwrap_or_default();
         if found.is_empty() {
             use std::io::Write;
-            let _ = writeln!(std::io::stderr(), "SKIP: nothing built; name not checked");
+            let _ = writeln!(std::io::stderr(), "SKIPPED: nothing built; name not checked");
             return;
         }
         assert!(

--- a/scripts/on-target-test.sh
+++ b/scripts/on-target-test.sh
@@ -414,6 +414,11 @@ for i in "${!OK_HOSTS[@]}"; do
   # a regression in whatever you just changed.
   extra_env=""
   [[ "${caps}" == *"galcore=yes"* ]] && extra_env="EDGEFIRST_SKIP_VIVANTE_KNOWN_BUGS=1"
+  # A board with a DRM render node has a GPU, so "the GL backend did not come
+  # up" is a defect there and not a fact of the machine. Without this every
+  # require-gated test -- the `gl_backend_available_canary` most visibly --
+  # skips on every board and the run stays green through a broken GL stack.
+  [[ "${caps}" =~ render=[1-9] ]] && extra_env="${extra_env} HAL_TEST_REQUIRE_GL=1"
 
   pass=0; fail=0; failed_bins=()
   for bin in "${bins[@]}"; do

--- a/scripts/test-windows.ps1
+++ b/scripts/test-windows.ps1
@@ -29,7 +29,7 @@
 .PARAMETER RequireCuda
   Set HAL_TEST_REQUIRE_CUDA=1 so the D3D11 CUDA interop tests in
   crates/tensor/tests/d3d11_tensor.rs fail loudly, naming the test and the
-  reason, instead of printing `SKIP: no CUDA runtime` when the probe in
+  reason, instead of reporting a skip for `no CUDA runtime` when the probe in
   crates/tensor/src/cuda.rs cannot load a runtime. The WARP-adapter skip
   (no CUDA device on the software adapter) is correct by design and is
   unaffected: those tests check the adapter before the gate.


### PR DESCRIPTION
Closes #175, #177 and #179 (close by hand after merge; auto-close only fires on `main`). One commit.

## Refused destination imports fall back (#175)

A zero-copy destination import that the driver refuses (Vivante: `EGL BadAccess` at a plane offset that is not 64-byte aligned) now falls back to the mapped-texture lowering instead of failing the convert, mirroring what a refused source import already did. The Vivante-specific predicate that skipped the attempt is removed; `dst_import_places` stays for ANGLE, whose import would succeed and place wrongly with no error. The fallback is logged once per buffer and counted in `ConvertStats::dst_import_fallbacks` (import attempts declined). The refusal is retried every convert: measured on the i.MX 8M Plus at 28 µs on a 3.29 ms convert (0.86%), so no negative memo is kept; an aligned destination converts in 0.71 ms, which is the cost that matters. The float route still declines to the CPU on a refused import (a float mapped readback is new machinery).

## The mapped-texture path was wrong for view destinations on every driver (#177)

Two software defects, not a Vivante quirk: `convert_to_dims` applied the zero-copy band scissor to an offscreen texture that is the tile itself, clipping its first columns and rows; and the readback packed rows tight and re-spaced them afterwards, spilling the read's tail into the parent's columns beside the tile (28,800 parent pixels per convert). The band now follows the lowering `bind_dst` chose, and the readback places each row at the destination pitch (`GL_PACK_ROW_LENGTH` when the pitch is a whole number of pixels, a scratch copy otherwise) writing nothing between rows. A packed-RGB or planar view destination is refused on every route before any import is spent; the letterbox seed is skipped when the crop carries a fill colour.

## Every OpenGL test asserts its route (#179)

All thirteen tests that build an `ImageProcessor` with `ComputeBackend::OpenGl` now assert the GL route (`convert_stats` deltas or an unchanged fallback counter) or document that they exercise the fallback on purpose. The F16 parity test fails under `HAL_TEST_REQUIRE_GL=1` when the GL path declines instead of reporting a pass. Every test skip in the workspace goes through a stderr helper with the `SKIPPED:` prefix that `scripts/on-target-test.sh` counts, including the C-API leaves, the CUDA gate, and thirteen tensor sites that were hidden by output capture.

## Two float tests pointed at destinations the platform never serves

`dma_recycle_narrowed_source_into_float_dst_matches_fresh` allocated an F32 zero-copy destination, which only Windows serves, and had failed on Mali and V3D since the D3D11 change; `convert_f16_gl_cpu_parity_identity` allocated a host float destination that never routes to GL, so its GL half compared CPU against CPU. Both now allocate the F16 zero-copy destination every platform's float set serves, skip with a stated reason where none is routable, and only then apply `HAL_TEST_REQUIRE_GL`. `scripts/on-target-test.sh` exports `HAL_TEST_REQUIRE_GL=1` on every board with a render node, so the GL canary and every require-gated skip now fire on the boards.

## Tracing

`src_feed` and `dst_feed` are recorded on `image.convert.gl` for u8 converts (they previously landed on a span that does not declare them). The float route enters no convert span and records neither; `ConvertStats` carries the counts on every route.

## Verification

- imx8mp-frdm (Vivante): whole `edgefirst-image` suite 558 lib tests, 0 failures; destination routes `(0,8,2048)` imported, `(8,8,2080)` refused then served by the fallback with correct pixels. imx95 (Mali) and rpi5-hailo (V3D): import succeeds at both offsets, 0 fallbacks; 0 failures with the `dma_test_formats` build (557 lib tests each) and the default build (469 each, GL canary running).
- Desktop: image lib 467 with the two known NVIDIA `src_rect_crop` failures; the span-catalog tests; clippy `-D warnings`; every C-API leaf's tests.
- CI: see the checks on this PR.
